### PR TITLE
fix(pools): refresh list after deferred invite join

### DIFF
--- a/src/features/pool-invite/model/usePendingPoolJoin.js
+++ b/src/features/pool-invite/model/usePendingPoolJoin.js
@@ -7,6 +7,7 @@ import {
   removeLocalStorageItem,
 } from '../../../shared/lib/local-storage';
 import { showErrorToast, showSuccessToast } from '../../../shared/ui/toast';
+import { invalidateUserPools } from '../../pools';
 import { joinPoolByInviteCode } from '../api/joinPool';
 import { POOL_INVITE_STORAGE_KEY } from '../config';
 
@@ -37,11 +38,13 @@ export function usePendingPoolJoin() {
         });
 
         if (outcome === 'joined') {
+          invalidateUserPools();
           showSuccessToast('You joined the pool!');
           navigate('/dashboard/pools', { replace: true });
           return;
         }
         if (outcome === 'already-member') {
+          invalidateUserPools();
           showSuccessToast("You're already in this pool.");
           navigate('/dashboard/pools', { replace: true });
           return;

--- a/src/features/pools/index.js
+++ b/src/features/pools/index.js
@@ -1,5 +1,6 @@
 export { joinPool } from './api/poolsApi';
 export { usePoolHub } from './model/usePoolHub';
+export { invalidateUserPools } from './model/userPoolsRefreshBus';
 export { default as useUserPools } from './model/useUserPools';
 export { default as PoolHubActiveShow } from './ui/PoolHubActiveShow';
 export { default as PoolHubHeader } from './ui/PoolHubHeader';

--- a/src/features/pools/model/useUserPools.js
+++ b/src/features/pools/model/useUserPools.js
@@ -5,6 +5,7 @@ import {
   fetchPools,
   joinPool as joinPoolApi,
 } from '../api/poolsApi';
+import { subscribeUserPoolsInvalidate } from './userPoolsRefreshBus';
 
 export default function useUserPools(userId) {
   const [pools, setPools] = useState([]);
@@ -34,6 +35,12 @@ export default function useUserPools(userId) {
 
   useEffect(() => {
     refreshPools().catch(() => {});
+  }, [refreshPools]);
+
+  useEffect(() => {
+    return subscribeUserPoolsInvalidate(() => {
+      refreshPools().catch(() => {});
+    });
   }, [refreshPools]);
 
   const handleCreate = useCallback(

--- a/src/features/pools/model/userPoolsRefreshBus.js
+++ b/src/features/pools/model/userPoolsRefreshBus.js
@@ -1,0 +1,40 @@
+/**
+ * Cross-hook sync: notify mounted {@link useUserPools} instances to refetch
+ * (e.g. after deferred invite join). If nothing is subscribed yet, the next
+ * subscriber runs a refresh once (covers navigate to /pools after join).
+ */
+const listeners = new Set();
+
+let pendingInvalidate = false;
+
+export function subscribeUserPoolsInvalidate(listener) {
+  listeners.add(listener);
+  if (pendingInvalidate) {
+    pendingInvalidate = false;
+    queueMicrotask(() => {
+      try {
+        listener();
+      } catch {
+        // ignore
+      }
+    });
+  }
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function invalidateUserPools() {
+  if (listeners.size === 0) {
+    pendingInvalidate = true;
+    return;
+  }
+  pendingInvalidate = false;
+  listeners.forEach((fn) => {
+    try {
+      fn();
+    } catch {
+      // listener errors should not break other subscribers
+    }
+  });
+}


### PR DESCRIPTION
Add userPoolsRefreshBus so usePendingPoolJoin can invalidateUserPools after a successful breadcrumb join. useUserPools subscribes and refetches; pending flag covers navigate to /pools before any subscriber existed.

Made-with: Cursor