### PR TITLE
fix(landing): prevent focus() from fighting splash section scroll

### DIFF
--- a/src/features/landing/lib/splashScrollMargin.js
+++ b/src/features/landing/lib/splashScrollMargin.js
@@ -1,6 +1,0 @@
-/**
- * Scroll offset for splash `<section>` elements targeted with `scrollIntoView({ block: 'start' })`.
- * Matches fixed `SplashHeader` height so each section’s top (colored background) sits flush under the bar.
- */
-export const splashSectionScrollMarginClassName =
-  'scroll-mt-[5.35rem] sm:scroll-mt-[5.25rem]';

--- a/src/features/landing/lib/splashScrollPadding.js
+++ b/src/features/landing/lib/splashScrollPadding.js
@@ -1,0 +1,6 @@
+/**
+ * Fixed `SplashHeader` height — applied as `scroll-padding-top` on `<html>` for splash
+ * in-app navigation (`scrollIntoView`). Keep in sync with `SplashHeader` `h-*` classes.
+ */
+export const SPLASH_DOCUMENT_SCROLL_PADDING_MOBILE = '5.35rem';
+export const SPLASH_DOCUMENT_SCROLL_PADDING_SM = '5.25rem';

--- a/src/features/landing/model/useScrollToSectionFocus.js
+++ b/src/features/landing/model/useScrollToSectionFocus.js
@@ -17,7 +17,9 @@ export default function useScrollToSectionFocus({ onCreateAccountRequest } = {})
     });
     const delay = shouldReduceMotion ? 0 : 350;
     window.setTimeout(() => {
-      focusRef?.current?.focus();
+      // Avoid a second scroll: default focus() scrolls the target into view and
+      // fights smooth scrollIntoView + section scroll-margin (feels glitchy).
+      focusRef?.current?.focus({ preventScroll: true });
     }, delay);
   }, []);
 

--- a/src/features/landing/model/useSplashDocumentScrollPadding.js
+++ b/src/features/landing/model/useSplashDocumentScrollPadding.js
@@ -1,0 +1,30 @@
+import { useLayoutEffect } from 'react';
+
+import {
+  SPLASH_DOCUMENT_SCROLL_PADDING_MOBILE,
+  SPLASH_DOCUMENT_SCROLL_PADDING_SM,
+} from '../lib/splashScrollPadding.js';
+
+/**
+ * Applies `scroll-padding-top` on `<html>` while the splash shell is mounted so
+ * `scrollIntoView({ block: 'start' })` clears the fixed header without per-section
+ * `scroll-margin-top`. Large scroll margins on multiple blocks can interact badly
+ * with scroll anchoring during normal touch/wheel scrolling.
+ */
+export default function useSplashDocumentScrollPadding() {
+  useLayoutEffect(() => {
+    const html = document.documentElement;
+    const mq = window.matchMedia('(min-width: 640px)');
+    const apply = () => {
+      html.style.scrollPaddingTop = mq.matches
+        ? SPLASH_DOCUMENT_SCROLL_PADDING_SM
+        : SPLASH_DOCUMENT_SCROLL_PADDING_MOBILE;
+    };
+    apply();
+    mq.addEventListener('change', apply);
+    return () => {
+      mq.removeEventListener('change', apply);
+      html.style.scrollPaddingTop = '';
+    };
+  }, []);
+}

--- a/src/features/landing/ui/SplashAboutSection.jsx
+++ b/src/features/landing/ui/SplashAboutSection.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import Button from '../../../shared/ui/Button';
 
-import { splashSectionScrollMarginClassName } from '../lib/splashScrollMargin.js';
-
 export default function SplashAboutSection({
   sectionRef,
   headingRef,
@@ -15,7 +13,7 @@ export default function SplashAboutSection({
   return (
     <section
       ref={sectionRef}
-      className={`relative z-10 w-full bg-transparent py-20 md:py-24 lg:py-32 ${splashSectionScrollMarginClassName}`}
+      className="relative z-10 w-full bg-transparent py-20 md:py-24 lg:py-32"
     >
       <div className="w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-16 items-start">

--- a/src/features/landing/ui/SplashGetStartedSection.jsx
+++ b/src/features/landing/ui/SplashGetStartedSection.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { SplashAuthEntryCard } from '../../auth';
 
-import { splashSectionScrollMarginClassName } from '../lib/splashScrollMargin.js';
-
 export default function SplashGetStartedSection({
   sectionRef,
   headingRef,
@@ -12,7 +10,7 @@ export default function SplashGetStartedSection({
   return (
     <section
       ref={sectionRef}
-      className={`relative z-10 w-full overflow-hidden border-t border-white/5 bg-gradient-to-b from-brand-bg to-brand-bg-deep py-20 md:py-32 ${splashSectionScrollMarginClassName}`}
+      className="relative z-10 w-full overflow-hidden border-t border-white/5 bg-gradient-to-b from-brand-bg to-brand-bg-deep py-20 md:py-32"
     >
       <div className="absolute inset-0 flex justify-center items-center pointer-events-none">
         <div className="w-[600px] h-[300px] bg-teal-400/10 blur-[100px] rounded-full"></div>

--- a/src/features/landing/ui/SplashHeader.jsx
+++ b/src/features/landing/ui/SplashHeader.jsx
@@ -13,8 +13,7 @@ export default function SplashHeader({
 }) {
   const wordmarkMarkup = useMemo(() => getBrandChromeWordmarkSvgMarkup(), []);
 
-  // If `h-[5.35rem]` / `sm:h-[5.25rem]` change, update `splashSectionScrollMarginClassName`
-  // in `features/landing/lib/splashScrollMargin.js` (splash scroll-into-view offset).
+  // If `h-[5.35rem]` / `sm:h-[5.25rem]` change, update `splashScrollPadding.js` (html scroll-padding).
   return (
     <header className="fixed left-0 right-0 top-0 z-50 flex h-[5.35rem] items-center overflow-visible border-b border-white/5 bg-brand-bg/80 backdrop-blur-lg transition-all duration-300 sm:h-[5.25rem]">
       <div className="grid h-full w-full max-w-7xl min-h-0 min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 overflow-visible pl-[max(1rem,env(safe-area-inset-left,0px))] pr-4 sm:flex sm:justify-between sm:gap-3 sm:px-6 lg:px-8">

--- a/src/features/landing/ui/SplashHeroSection.jsx
+++ b/src/features/landing/ui/SplashHeroSection.jsx
@@ -5,7 +5,7 @@ import SplashHeroWordmark from './SplashHeroWordmark';
 
 export default function SplashHeroSection({ onHowItWorksClick, onPlayNowClick, onAboutClick }) {
   return (
-    <section className="relative flex min-h-[100dvh] w-full flex-col overflow-hidden bg-transparent pt-[5.35rem] pb-6 sm:min-h-screen sm:pt-[5.25rem] sm:pb-14">
+    <section className="relative flex min-h-[100svh] w-full flex-col overflow-hidden bg-transparent pt-[5.35rem] pb-6 sm:min-h-screen sm:pt-[5.25rem] sm:pb-14">
       <div className="relative z-10 mx-auto flex min-h-0 w-full max-w-7xl flex-1 flex-col px-4 pt-1 text-center sm:px-6 sm:pt-0 lg:px-8">
         <h1
           className="relative left-1/2 w-screen max-w-[100vw] shrink-0 -translate-x-1/2 overflow-visible leading-none sm:left-0 sm:w-full sm:max-w-none sm:translate-x-0"

--- a/src/features/landing/ui/SplashHeroSection.jsx
+++ b/src/features/landing/ui/SplashHeroSection.jsx
@@ -5,7 +5,7 @@ import SplashHeroWordmark from './SplashHeroWordmark';
 
 export default function SplashHeroSection({ onHowItWorksClick, onPlayNowClick, onAboutClick }) {
   return (
-    <section className="relative flex min-h-[100svh] w-full flex-col overflow-hidden bg-transparent pt-[5.35rem] pb-6 sm:min-h-screen sm:pt-[5.25rem] sm:pb-14">
+    <section className="relative flex min-h-[100svh] w-full flex-col bg-transparent pt-[5.35rem] pb-6 sm:min-h-screen sm:pt-[5.25rem] sm:pb-14">
       <div className="relative z-10 mx-auto flex min-h-0 w-full max-w-7xl flex-1 flex-col px-4 pt-1 text-center sm:px-6 sm:pt-0 lg:px-8">
         <h1
           className="relative left-1/2 w-screen max-w-[100vw] shrink-0 -translate-x-1/2 overflow-visible leading-none sm:left-0 sm:w-full sm:max-w-none sm:translate-x-0"

--- a/src/features/landing/ui/SplashHowItWorksSection.jsx
+++ b/src/features/landing/ui/SplashHowItWorksSection.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import Button from '../../../shared/ui/Button';
 
-import { splashSectionScrollMarginClassName } from '../lib/splashScrollMargin.js';
-
 export default function SplashHowItWorksSection({ sectionRef, headingRef, onCreateAccountClick }) {
   return (
     <section
       ref={sectionRef}
-      className={`relative z-10 w-full bg-slate-50 py-20 md:py-24 lg:py-32 ${splashSectionScrollMarginClassName}`}
+      className="relative z-10 w-full bg-slate-50 py-20 md:py-24 lg:py-32"
     >
       <div className="w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
         <h2

--- a/src/features/landing/ui/SplashPageShell.jsx
+++ b/src/features/landing/ui/SplashPageShell.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import useSplashDocumentScrollPadding from '../model/useSplashDocumentScrollPadding';
 import SplashAboutSection from './SplashAboutSection';
 import SplashGetStartedSection from './SplashGetStartedSection';
 import SplashHeader from './SplashHeader';
@@ -21,6 +22,8 @@ export default function SplashPageShell({
   onOpenSignInModal,
   children,
 }) {
+  useSplashDocumentScrollPadding();
+
   return (
     <>
       {/* Fixed + flex parent breaks iOS Safari; header must sit outside the flex wrapper. */}


### PR DESCRIPTION
After scrollIntoView + scroll-margin alignment, default focus() was scrolling the heading into view again and caused glitchy motion. Use preventScroll: true to keep a11y focus without a second scroll.

Made-with: Cursor