### PR TITLE
feat(functions): tighten live setlist poll window, calendar gate, cad…

### DIFF
--- a/docs/PHISHNET_CALLABLE_RUNBOOK.md
+++ b/docs/PHISHNET_CALLABLE_RUNBOOK.md
@@ -113,6 +113,7 @@ Deploy with **`npm run deploy:functions:phishnet`** (includes setlist + show-cal
 ## 9. Files to touch when changing behavior
 
 - **Callable, secret, invoker, Phish.net URL:** `functions/index.js`
+- **Live setlist scheduled automation (window, calendar gate, cadence):** `functions/phishnetLiveSetlistAutomation.js`
 - **Show calendar fetch + grouping:** `functions/phishnetShowCalendar.js`
 - **Client region + callable wiring + error extraction:** `src/features/admin-setlist-config/api/phishApiClient.js`
 - **Local key smoke test (no Firebase):** `scripts/diagnose-phishnet-local.mjs`
@@ -120,16 +121,21 @@ Deploy with **`npm run deploy:functions:phishnet`** (includes setlist + show-cal
 
 ---
 
-## 10. Live-night automation (issue #164)
+## 10. Live-night automation (issues #164, #180)
 
 | Item | Location / value |
 |------|------------------|
 | Scheduled poller | `scheduledPhishnetLiveSetlistPoll` (`functions/index.js`) |
-| Poll cadence | Every 2 minutes, `America/New_York` |
-| Target dates | ET today + ET yesterday (`candidateShowDates`) |
+| ET window | **4:00 PM–3:00 AM** `America/New_York` (hour ≥ 16 or hour < 3). Outside the window the job **no-ops** with **no** Phish.net HTTP calls. |
+| Cron wake | Every **3** minutes (`*/3 * * * *`, `America/New_York`). Actual spacing vs Phish.net is **3–5 minutes** per show date via `live_setlist_automation/{showDate}.nextPollAt` jitter after each **scheduled** fetch (success, no-change, or empty rows). |
+| Calendar (scheduled only) | **`show_calendar/snapshot.showDates`** — scheduled polling **only** considers dates in this set (strict). Missing/empty/unreadable snapshot → scheduled path skips (**no** Phish.net). |
+| Target dates (scheduled) | `scheduledCandidateShowDates` in `functions/phishnetLiveSetlistAutomation.js`: ET **today** if a show date; ET **yesterday** only in the **0:00–2:59 AM** ET slice **and** only if that date is still in the calendar (late encore / post-midnight updates). **Not** “compare two setlists” — each date is still diffed only against its own last saved payload/signature. |
+| Admin / force poll | `pollLiveSetlistNow` stays **unrestricted**: default still uses ET today + yesterday (`candidateShowDates`) with **no** calendar gate — recovery when the calendar is stale, you’re outside the ET window, or scheduled strict mode would skip. Optional explicit `showDate` unchanged. |
 | Pause/resume callable | `setLiveSetlistAutomationState` |
 | Manual recovery callable | `pollLiveSetlistNow` (forces one poll + one score recompute) |
 | Per-show state doc | `live_setlist_automation/{showDate}` |
+
+**Rate limit triage (Phish.net `error: 4`):** Watch Cloud Logging for `live setlist poll failed` and Phish.net logical errors. Existing **exponential backoff** on failures still stamps `nextPollAt`. If `error: 4` appears often, widen spacing (code: `randomScheduledPollDelayMs` / cron) or pause automation for the date until traffic cools. See [Phish.net errors](https://docs.phish.net/errors) and [API terms](https://api.phish.net/).
 
 **Admin UI vs global show picker:** The dashboard “Select Show” list only includes dates from `show_calendar`. War Room uses **War Room show date** (`<input type="date">`) so you can load or poll **any** `YYYY-MM-DD` that exists in Firestore / Phish.net (e.g. Mexico) even when that date is missing from the global picker.
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -158,6 +158,9 @@ function assertShowDateString(showDate) {
   return showDate.trim();
 }
 
+/** Firestore batch write limit (same invariant as `adminRollupApi.js` / `profileApi.js`). */
+const MAX_FIRESTORE_BATCH_WRITES = 500;
+
 async function recomputeLiveScoresForShow(showDate, actualSetlistFromWrite = null) {
   const setlistDoc =
     actualSetlistFromWrite ||
@@ -173,10 +176,16 @@ async function recomputeLiveScoresForShow(showDate, actualSetlistFromWrite = nul
     return { updatedPicks: 0 };
   }
 
-  const batch = db.batch();
+  let batch = db.batch();
+  let opCount = 0;
   let updatedPicks = 0;
 
-  picksSnap.forEach((pickDoc) => {
+  for (const pickDoc of picksSnap.docs) {
+    if (opCount >= MAX_FIRESTORE_BATCH_WRITES) {
+      await batch.commit();
+      batch = db.batch();
+      opCount = 0;
+    }
     const pickData = pickDoc.data() || {};
     const userPicks = pickData.picks || {};
     const score = calculateTotalScore(userPicks, setlistDoc);
@@ -187,10 +196,13 @@ async function recomputeLiveScoresForShow(showDate, actualSetlistFromWrite = nul
       update.gradedAt = admin.firestore.FieldValue.delete();
     }
     batch.update(pickDoc.ref, update);
+    opCount += 1;
     updatedPicks += 1;
-  });
+  }
 
-  await batch.commit();
+  if (opCount > 0) {
+    await batch.commit();
+  }
   return { updatedPicks };
 }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -13,7 +13,10 @@ const {
 } = require("./phishnetSongCatalog");
 const {
   candidateShowDates,
+  isWithinLiveSetlistPollWindow,
+  parseShowCalendarSnapshotToDateSet,
   pollSingleShowDate,
+  scheduledCandidateShowDates,
 } = require("./phishnetLiveSetlistAutomation");
 
 /** Must match admin setlist gate in `src/features/admin/model/useAdminSetlistForm.js`. */
@@ -250,7 +253,9 @@ exports.refreshLiveScoresForShow = onCall(
 
 exports.scheduledPhishnetLiveSetlistPoll = onSchedule(
   {
-    schedule: "*/2 * * * *",
+    // Wake every 3m; in-window spacing vs Phish.net is enforced by per-date
+    // `nextPollAt` (3–5m jitter after each scheduled fetch — issue #180).
+    schedule: "*/3 * * * *",
     timeZone: "America/New_York",
     region: PHISHNET_FUNCTIONS_REGION,
     secrets: [phishnetApiKey],
@@ -263,7 +268,28 @@ exports.scheduledPhishnetLiveSetlistPoll = onSchedule(
       );
       return null;
     }
-    const dates = candidateShowDates(new Date());
+    const now = new Date();
+    if (!isWithinLiveSetlistPollWindow(now)) {
+      logger.info("scheduledPhishnetLiveSetlistPoll: outside 4pm–3am ET window; skip.");
+      return null;
+    }
+    const calSnap = await db.collection("show_calendar").doc("snapshot").get();
+    const calendarSet = parseShowCalendarSnapshotToDateSet(
+      calSnap.exists ? calSnap.data() : null
+    );
+    if (!calendarSet) {
+      logger.info(
+        "scheduledPhishnetLiveSetlistPoll: show_calendar snapshot missing/empty; strict skip (no Phish.net)."
+      );
+      return null;
+    }
+    const dates = scheduledCandidateShowDates(now, calendarSet);
+    if (!dates.length) {
+      logger.info(
+        "scheduledPhishnetLiveSetlistPoll: no matching show dates in calendar; skip."
+      );
+      return null;
+    }
     const started = Date.now();
     const results = [];
     for (const showDate of dates) {

--- a/functions/phishnetLiveSetlistAutomation.js
+++ b/functions/phishnetLiveSetlistAutomation.js
@@ -12,6 +12,27 @@ function formatEtShowDate(now = new Date()) {
   return String(asEt).slice(0, 10);
 }
 
+/** Wall-clock hour 0–23 in `America/New_York` for `now`. */
+function getEtHour(now = new Date()) {
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York",
+    hour: "numeric",
+    hour12: false,
+  });
+  const parts = dtf.formatToParts(now);
+  const hPart = parts.find((p) => p.type === "hour");
+  return Number.parseInt(String(hPart?.value ?? "0"), 10);
+}
+
+/**
+ * Live setlist scheduled polling window: 4:00 PM ET through 3:00 AM ET the next
+ * calendar day (active when hour ≥ 16 or hour < 3, America/New_York wall clock).
+ */
+function isWithinLiveSetlistPollWindow(now = new Date()) {
+  const h = getEtHour(now);
+  return h >= 16 || h < 3;
+}
+
 function ymdDaysAgo(ymd, days) {
   const [y, m, d] = String(ymd)
     .split("-")
@@ -20,9 +41,63 @@ function ymdDaysAgo(ymd, days) {
   return new Date(t).toISOString().slice(0, 10);
 }
 
+/**
+ * Admin / manual recovery: ET today + ET yesterday (not gated on show_calendar).
+ * Used by `pollLiveSetlistNow` when no explicit date is passed.
+ */
 function candidateShowDates(now = new Date()) {
   const etToday = formatEtShowDate(now);
   return [etToday, ymdDaysAgo(etToday, 1)];
+}
+
+/**
+ * Parse `show_calendar/snapshot` into a Set of YYYY-MM-DD show dates.
+ * Returns `null` if missing, empty, or unreadable (strict — scheduled poller must skip).
+ */
+function parseShowCalendarSnapshotToDateSet(snapshotData) {
+  if (!snapshotData || typeof snapshotData !== "object") return null;
+  const raw = snapshotData.showDates;
+  if (!Array.isArray(raw) || raw.length === 0) return null;
+  const set = new Set();
+  for (const item of raw) {
+    const d =
+      typeof item === "string"
+        ? item
+        : item && typeof item === "object" && typeof item.date === "string"
+        ? item.date
+        : null;
+    if (d && /^\d{4}-\d{2}-\d{2}$/.test(d)) set.add(d);
+  }
+  return set.size > 0 ? set : null;
+}
+
+/**
+ * Scheduled poller target dates (intersected with show_calendar in the caller).
+ *
+ * - Always consider ET "today" when it is a show date in the calendar set.
+ * - Do not include "yesterday" by default (before local ET midnight).
+ * - After local midnight ET (hours 0–2), also include "yesterday" when that date
+ *   is still a show date — same gig can receive encore/post-midnight updates until
+ *   the 3 AM window end. This is **not** comparing two setlists: each `showDate`
+ *   doc is still diffed only against its own last saved official payload/signature.
+ */
+function scheduledCandidateShowDates(now, calendarDateSet) {
+  const etToday = formatEtShowDate(now);
+  const etYesterday = ymdDaysAgo(etToday, 1);
+  const hourEt = getEtHour(now);
+  const out = [];
+  if (calendarDateSet.has(etToday)) out.push(etToday);
+  if (hourEt >= 0 && hourEt < 3 && calendarDateSet.has(etYesterday)) {
+    out.push(etYesterday);
+  }
+  return out;
+}
+
+/** Uniform random delay in [3, 5] minutes — scheduled cadence jitter (issue #180). */
+function randomScheduledPollDelayMs(rng = Math.random) {
+  const min = 3 * 60 * 1000;
+  const max = 5 * 60 * 1000;
+  return min + Math.floor(rng() * (max - min + 1));
 }
 
 function phishNetResponseOk(data) {
@@ -210,10 +285,33 @@ async function pollSingleShowDate({
     return { showDate, skipped: "backoff", changed: false, updatedPicks: 0 };
   }
 
+  const scheduledCadenceStamp = () =>
+    !force
+      ? {
+          nextPollAt: admin.firestore.Timestamp.fromDate(
+            new Date(Date.now() + randomScheduledPollDelayMs())
+          ),
+        }
+      : {};
+
   try {
     const payload = await fetchPhishnetSetlistForDate(showDate, apiKey);
     const rows = normalizeSetlistRows(payload);
     if (rows.length === 0) {
+      if (!force) {
+        await automationRef.set(
+          {
+            showDate,
+            enabled: automation.enabled !== false,
+            failureCount: 0,
+            lastPolledAt: admin.firestore.FieldValue.serverTimestamp(),
+            lastResult: "no-rows",
+            updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+            ...scheduledCadenceStamp(),
+          },
+          { merge: true }
+        );
+      }
       return { showDate, changed: false, updatedPicks: 0, reason: "no-rows" };
     }
 
@@ -235,6 +333,7 @@ async function pollSingleShowDate({
           lastResult: "no-change",
           lastNoChangeAt: admin.firestore.FieldValue.serverTimestamp(),
           updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+          ...scheduledCadenceStamp(),
         },
         { merge: true }
       );
@@ -264,6 +363,7 @@ async function pollSingleShowDate({
       lastPolledAt: admin.firestore.FieldValue.serverTimestamp(),
       lastResult: "changed",
       updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      ...scheduledCadenceStamp(),
     };
     const batch = db.batch();
     batch.set(setlistRef, setlistPayload, { merge: true });
@@ -307,8 +407,13 @@ async function pollSingleShowDate({
 module.exports = {
   buildSetlistDocFromRows,
   candidateShowDates,
+  getEtHour,
+  isWithinLiveSetlistPollWindow,
   normalizeSetlistRows,
+  parseShowCalendarSnapshotToDateSet,
   pollSingleShowDate,
+  randomScheduledPollDelayMs,
+  scheduledCandidateShowDates,
   setlistPayloadEqual,
   signatureFromRows,
 };

--- a/functions/phishnetLiveSetlistAutomation.test.js
+++ b/functions/phishnetLiveSetlistAutomation.test.js
@@ -4,17 +4,120 @@ const assert = require("node:assert/strict");
 const {
   buildSetlistDocFromRows,
   candidateShowDates,
+  isWithinLiveSetlistPollWindow,
   normalizeSetlistRows,
+  parseShowCalendarSnapshotToDateSet,
+  randomScheduledPollDelayMs,
+  scheduledCandidateShowDates,
   setlistPayloadEqual,
   signatureFromRows,
 } = require("./phishnetLiveSetlistAutomation");
 
-test("candidateShowDates returns ET today and previous day", () => {
+/** Fixture: `show_calendar/snapshot`-shaped doc (subset). */
+const SHOW_CALENDAR_SNAPSHOT_FIXTURE = {
+  schemaVersion: 2,
+  showDates: [
+    { date: "2026-07-03", venue: "A" },
+    { date: "2026-07-04", venue: "B" },
+  ],
+};
+
+test("candidateShowDates returns ET today and previous day (admin / force poll)", () => {
   const dates = candidateShowDates(new Date("2026-04-15T01:30:00.000Z"));
   assert.equal(dates.length, 2);
   assert.match(dates[0], /^\d{4}-\d{2}-\d{2}$/);
   assert.match(dates[1], /^\d{4}-\d{2}-\d{2}$/);
   assert.notEqual(dates[0], dates[1]);
+});
+
+test("parseShowCalendarSnapshotToDateSet reads flat showDates", () => {
+  const set = parseShowCalendarSnapshotToDateSet(SHOW_CALENDAR_SNAPSHOT_FIXTURE);
+  assert.ok(set);
+  assert.equal(set.has("2026-07-03"), true);
+  assert.equal(set.has("2026-07-04"), true);
+});
+
+test("parseShowCalendarSnapshotToDateSet accepts string dates", () => {
+  const set = parseShowCalendarSnapshotToDateSet({
+    showDates: ["2026-08-01", "2026-08-02"],
+  });
+  assert.ok(set);
+  assert.equal(set.has("2026-08-01"), true);
+});
+
+test("parseShowCalendarSnapshotToDateSet returns null when strict-invalid", () => {
+  assert.equal(parseShowCalendarSnapshotToDateSet(null), null);
+  assert.equal(parseShowCalendarSnapshotToDateSet({}), null);
+  assert.equal(parseShowCalendarSnapshotToDateSet({ showDates: [] }), null);
+  assert.equal(parseShowCalendarSnapshotToDateSet({ showDates: [{ venue: "x" }] }), null);
+});
+
+test("isWithinLiveSetlistPollWindow: 4pm–3am ET (summer EDT)", () => {
+  assert.equal(
+    isWithinLiveSetlistPollWindow(new Date("2026-07-04T20:00:00-04:00")),
+    true
+  );
+  assert.equal(
+    isWithinLiveSetlistPollWindow(new Date("2026-07-04T15:00:00-04:00")),
+    false
+  );
+  assert.equal(
+    isWithinLiveSetlistPollWindow(new Date("2026-07-04T02:30:00-04:00")),
+    true
+  );
+  assert.equal(
+    isWithinLiveSetlistPollWindow(new Date("2026-07-04T03:00:00-04:00")),
+    false
+  );
+});
+
+test("isWithinLiveSetlistPollWindow: winter EST", () => {
+  assert.equal(
+    isWithinLiveSetlistPollWindow(new Date("2026-01-15T21:00:00-05:00")),
+    true
+  );
+  assert.equal(
+    isWithinLiveSetlistPollWindow(new Date("2026-01-15T14:00:00-05:00")),
+    false
+  );
+});
+
+test("scheduledCandidateShowDates: evening uses today only when in calendar", () => {
+  const cal = parseShowCalendarSnapshotToDateSet(SHOW_CALENDAR_SNAPSHOT_FIXTURE);
+  const dates = scheduledCandidateShowDates(
+    new Date("2026-07-04T22:00:00-04:00"),
+    cal
+  );
+  assert.deepEqual(dates, ["2026-07-04"]);
+});
+
+test("scheduledCandidateShowDates: after midnight adds yesterday when still a show date", () => {
+  const cal = parseShowCalendarSnapshotToDateSet(SHOW_CALENDAR_SNAPSHOT_FIXTURE);
+  const dates = scheduledCandidateShowDates(
+    new Date("2026-07-04T01:30:00-04:00"),
+    cal
+  );
+  assert.deepEqual(dates, ["2026-07-04", "2026-07-03"]);
+});
+
+test("scheduledCandidateShowDates: post-midnight only prior night when today not on calendar", () => {
+  const cal = parseShowCalendarSnapshotToDateSet({
+    showDates: [{ date: "2026-07-03", venue: "x" }],
+  });
+  const dates = scheduledCandidateShowDates(
+    new Date("2026-07-04T01:00:00-04:00"),
+    cal
+  );
+  assert.deepEqual(dates, ["2026-07-03"]);
+});
+
+test("randomScheduledPollDelayMs is within 3–5 minutes", () => {
+  for (let i = 0; i < 50; i += 1) {
+    const ms = randomScheduledPollDelayMs(Math.random);
+    assert.ok(ms >= 3 * 60 * 1000 && ms <= 5 * 60 * 1000);
+  }
+  assert.equal(randomScheduledPollDelayMs(() => 0), 3 * 60 * 1000);
+  assert.equal(randomScheduledPollDelayMs(() => 0.999999), 5 * 60 * 1000);
 });
 
 test("normalizeSetlistRows parses + sorts phish.net row shape", () => {


### PR DESCRIPTION
…ence (#180)

- Gate scheduledPhishnetLiveSetlistPoll on 4pm–3am ET and show_calendar/snapshot
- scheduledCandidateShowDates: today + yesterday only 0–3am ET when in calendar
- 3–5min jitter via nextPollAt after each scheduled fetch; cron */3
- Force poll unchanged (candidateShowDates, no calendar gate)
- Tests + PHISHNET_CALLABLE_RUNBOOK §10

Made-with: Cursor