### PR TITLE
feat(admin,auth): rollupScoresForShow + setAdminClaim callables (#139 PR A)

### DIFF
--- a/docs/ADMIN_CLAIMS_RUNBOOK.md
+++ b/docs/ADMIN_CLAIMS_RUNBOOK.md
@@ -1,0 +1,147 @@
+# Admin claim runbook
+
+Operational guide for granting, revoking, and auditing the `admin: true` Firebase Auth custom claim used by Set Picks.
+
+Introduced in issue #139 PR A. In PR A the claim is the preferred signal for admin UI gating (`useAuth().isAdmin`) but a **legacy email fallback** (`pat@road2media.com`) is still accepted so existing admin flows keep working during transition. PR B removes the email fallback and tightens Firestore rules to require the claim.
+
+---
+
+## 1. Related functions
+
+Both live in `functions/index.js`:
+
+| Function | Type | Purpose |
+|---------|------|---------|
+| `setAdminClaim` | HTTPS callable | Grant or revoke `admin: true` on a target Auth user |
+| `rollupScoresForShow` | HTTPS callable | Server-side replacement for `adminRollupApi.js`; gated by `admin: true` claim OR legacy email |
+
+`setAdminClaim` authorization:
+
+- Caller must be signed in.
+- Caller must be a **super-admin** — either `SUPER_ADMIN_UIDS` env var listed, or the legacy `pat@road2media.com` email holder (transition only) — **or** caller must already hold `admin: true`.
+- Callers can set the claim on themselves (bootstrap) or on another uid (delegation).
+
+---
+
+## 2. One-time bootstrap (first admin)
+
+The first time you roll this out, no one has the claim yet. Seed the first admin via the super-admin env var.
+
+### 2a. Set `SUPER_ADMIN_UIDS`
+
+Find the bootstrap admin's Firebase Auth uid (Firebase console → Authentication → Users, or `firebase auth:export` → pick the row). Then set the env var on the deployed `setAdminClaim` function.
+
+For Cloud Functions Gen 2 (v2) on Firebase, environment variables are set via `.env.<project>` files at `functions/` root, or via `firebase functions:config:set` (v1 API) / `--set-env-vars` on deploy. The simplest approach used elsewhere in this repo is a `functions/.env.<project>` file (git-ignored):
+
+```bash
+# functions/.env.setlistpickem (or whatever alias you use)
+SUPER_ADMIN_UIDS=abc123xyz,defgh456
+```
+
+Then redeploy:
+
+```bash
+firebase deploy --only functions:setAdminClaim --project <alias>
+```
+
+> The legacy `pat@road2media.com` email holder is implicitly treated as a super-admin in PR A, so you can skip this env var during initial rollout and still bootstrap from the browser as that user. Remove that fallback in PR B.
+
+### 2b. Self-grant the claim (from the browser)
+
+As the super-admin (or legacy email holder), open the app while signed in and run in devtools:
+
+```js
+import('firebase/functions').then(async ({ getFunctions, httpsCallable }) => {
+  const { app } = await import('/src/shared/lib/firebase.js');
+  const fn = httpsCallable(getFunctions(app, 'us-central1'), 'setAdminClaim');
+  const res = await fn({ admin: true });
+  console.log(res.data);
+});
+```
+
+> The exact import path for `app` will vary with Vite/import config. Alternatively, call from a temporary admin-only button (acceptable during bootstrap) or use the Firebase Functions emulator + Admin SDK script (see §4).
+
+Force a token refresh so the claim is visible to the client and Firestore rules:
+
+```js
+await firebase.auth().currentUser.getIdTokenResult(true);
+```
+
+Or simply sign out and back in.
+
+### 2c. Verify
+
+In the app devtools:
+
+```js
+const t = await firebase.auth().currentUser.getIdTokenResult();
+console.log(t.claims.admin); // expect: true
+```
+
+`useAuth().isAdmin` should now return `true` via the claim (not the email fallback).
+
+---
+
+## 3. Grant the claim to another admin
+
+Once you hold `admin: true`, you can delegate to other users:
+
+```js
+const fn = httpsCallable(getFunctions(app, 'us-central1'), 'setAdminClaim');
+await fn({ admin: true, targetUid: '<other-user-uid>' });
+```
+
+The target user must refresh their ID token (`getIdTokenResult(true)`) or sign out/in before their client sees the new claim.
+
+---
+
+## 4. Revoke the claim
+
+```js
+await fn({ admin: false, targetUid: '<uid>' });
+```
+
+Revocations remove the `admin` key from custom claims entirely.
+
+---
+
+## 5. Audit current claims
+
+From a machine with the Firebase Admin SDK and appropriate service-account credentials:
+
+```js
+const admin = require('firebase-admin');
+admin.initializeApp({ credential: admin.credential.applicationDefault() });
+const all = [];
+let next;
+do {
+  const page = await admin.auth().listUsers(1000, next);
+  for (const u of page.users) {
+    if (u.customClaims?.admin === true) all.push({ uid: u.uid, email: u.email });
+  }
+  next = page.pageToken;
+} while (next);
+console.log(all);
+```
+
+Cloud Logging also records every `setAdminClaim` call with caller uid, target uid, grant/revoke, and whether the caller was acting as a super-admin. Filter by `jsonPayload.message="setAdminClaim"`.
+
+---
+
+## 6. Safety notes
+
+- `setAdminClaim` only manipulates Auth custom claims; it never touches `picks`, `users`, or `official_setlists`.
+- A token refresh is required for client-side `isAdmin` to flip. The app's `useAuth` subscribes to `onIdTokenChanged` so this propagates automatically after `getIdTokenResult(true)` without re-login.
+- Firestore rules in PR A are **unchanged**; the claim is purely for UI gating and for `rollupScoresForShow` authorization. PR B makes the rules require the claim for writes to `picks` / `users` / `official_setlists`.
+- If you accidentally revoke your own claim and no longer match the email fallback or `SUPER_ADMIN_UIDS`, re-bootstrap from a machine with Admin SDK credentials using `setCustomUserClaims(uid, { admin: true })` directly.
+
+---
+
+## 7. PR B follow-ups
+
+After soaking PR A in staging:
+
+1. Grant the claim to every current admin via `setAdminClaim`.
+2. Remove the legacy email fallback from `resolveIsAdmin` in `src/features/auth/api/authApi.js` and from `assertAdminClaimOrEmail` in `functions/index.js`.
+3. Tighten `firestore.rules` (claim-only).
+4. Keep `SUPER_ADMIN_UIDS` so the break-glass path exists.

--- a/functions/adminAuth.js
+++ b/functions/adminAuth.js
@@ -1,0 +1,78 @@
+/**
+ * Admin authorization helpers for HTTPS callables (issue #139 PR A).
+ *
+ * Pure functions — no `firebase-admin` dependency so they can be unit-tested
+ * without spinning up the Firebase Functions test harness. Consumed by
+ * `functions/index.js` to gate `rollupScoresForShow` and `setAdminClaim`.
+ */
+
+/** Must match `src/features/auth/api/authApi.js` legacy fallback. */
+const ADMIN_EMAIL_FOR_SETLIST_PROXY = "pat@road2media.com";
+
+/**
+ * Parse `SUPER_ADMIN_UIDS` (comma-separated uids) from the given env into a
+ * Set. Defaults to `process.env` but accepts an injected env for tests.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {Set<string>}
+ */
+function parseSuperAdminUidsEnv(env = process.env) {
+  const raw = env.SUPER_ADMIN_UIDS;
+  if (!raw) return new Set();
+  return new Set(
+    String(raw)
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+  );
+}
+
+/**
+ * Decide whether the caller of an admin-gated callable qualifies as admin.
+ * Accepts either the `admin: true` custom claim (#139 target state) or the
+ * legacy hard-coded admin email (transition only; drop in PR B).
+ *
+ * Returns `null` when neither qualifies. Callers in `functions/index.js`
+ * convert `null` into an `HttpsError("permission-denied")`.
+ *
+ * @param {{ uid?: string, token?: { admin?: boolean, email?: string } } | null | undefined} authLike
+ * @returns {"admin-claim" | "legacy-email" | null}
+ */
+function resolveAdminCallerRole(authLike) {
+  if (!authLike) return null;
+  const token = authLike.token || {};
+  if (token.admin === true) return "admin-claim";
+  if (token.email === ADMIN_EMAIL_FOR_SETLIST_PROXY) return "legacy-email";
+  return null;
+}
+
+/**
+ * Decide whether the caller of `setAdminClaim` qualifies to grant/revoke the
+ * claim. Super-admins are `SUPER_ADMIN_UIDS` members **or** the legacy email
+ * holder (bootstrap only). Anyone already holding `admin: true` can also grant
+ * (delegation).
+ *
+ * @param {{ uid?: string, token?: { admin?: boolean, email?: string } } | null | undefined} authLike
+ * @param {Set<string>} superAdminUids
+ * @returns {"super-admin" | "admin" | null}
+ */
+function resolveSetAdminClaimCallerRole(authLike, superAdminUids) {
+  if (!authLike) return null;
+  const uid = authLike.uid;
+  const token = authLike.token || {};
+  if (
+    (uid && superAdminUids.has(uid)) ||
+    token.email === ADMIN_EMAIL_FOR_SETLIST_PROXY
+  ) {
+    return "super-admin";
+  }
+  if (token.admin === true) return "admin";
+  return null;
+}
+
+module.exports = {
+  ADMIN_EMAIL_FOR_SETLIST_PROXY,
+  parseSuperAdminUidsEnv,
+  resolveAdminCallerRole,
+  resolveSetAdminClaimCallerRole,
+};

--- a/functions/adminAuth.test.js
+++ b/functions/adminAuth.test.js
@@ -1,0 +1,125 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  ADMIN_EMAIL_FOR_SETLIST_PROXY,
+  parseSuperAdminUidsEnv,
+  resolveAdminCallerRole,
+  resolveSetAdminClaimCallerRole,
+} = require("./adminAuth");
+
+test("parseSuperAdminUidsEnv: returns empty set when unset", () => {
+  const set = parseSuperAdminUidsEnv({});
+  assert.ok(set instanceof Set);
+  assert.equal(set.size, 0);
+});
+
+test("parseSuperAdminUidsEnv: trims whitespace and drops empties", () => {
+  const set = parseSuperAdminUidsEnv({
+    SUPER_ADMIN_UIDS: " abc , def, , ghi ,",
+  });
+  assert.deepEqual([...set].sort(), ["abc", "def", "ghi"]);
+});
+
+test("parseSuperAdminUidsEnv: handles single uid", () => {
+  const set = parseSuperAdminUidsEnv({ SUPER_ADMIN_UIDS: "solo-uid" });
+  assert.deepEqual([...set], ["solo-uid"]);
+});
+
+test("resolveAdminCallerRole: null when no auth", () => {
+  assert.equal(resolveAdminCallerRole(null), null);
+  assert.equal(resolveAdminCallerRole(undefined), null);
+});
+
+test("resolveAdminCallerRole: admin-claim takes precedence over email", () => {
+  const role = resolveAdminCallerRole({
+    uid: "u1",
+    token: { admin: true, email: "random@example.com" },
+  });
+  assert.equal(role, "admin-claim");
+});
+
+test("resolveAdminCallerRole: legacy email accepted when no claim", () => {
+  const role = resolveAdminCallerRole({
+    uid: "u1",
+    token: { email: ADMIN_EMAIL_FOR_SETLIST_PROXY },
+  });
+  assert.equal(role, "legacy-email");
+});
+
+test("resolveAdminCallerRole: admin=false is not admin", () => {
+  assert.equal(
+    resolveAdminCallerRole({ uid: "u1", token: { admin: false } }),
+    null
+  );
+});
+
+test("resolveAdminCallerRole: random signed-in user is not admin", () => {
+  assert.equal(
+    resolveAdminCallerRole({
+      uid: "u1",
+      token: { email: "someone@else.com" },
+    }),
+    null
+  );
+});
+
+test("resolveSetAdminClaimCallerRole: super-admin via env UID", () => {
+  const role = resolveSetAdminClaimCallerRole(
+    { uid: "seed-uid", token: { email: "seed@example.com" } },
+    new Set(["seed-uid"])
+  );
+  assert.equal(role, "super-admin");
+});
+
+test("resolveSetAdminClaimCallerRole: super-admin via legacy email (bootstrap)", () => {
+  const role = resolveSetAdminClaimCallerRole(
+    {
+      uid: "whatever",
+      token: { email: ADMIN_EMAIL_FOR_SETLIST_PROXY },
+    },
+    new Set()
+  );
+  assert.equal(role, "super-admin");
+});
+
+test("resolveSetAdminClaimCallerRole: admin claim delegates", () => {
+  const role = resolveSetAdminClaimCallerRole(
+    { uid: "delegate", token: { admin: true, email: "a@b.com" } },
+    new Set()
+  );
+  assert.equal(role, "admin");
+});
+
+test("resolveSetAdminClaimCallerRole: no claim + no env + no legacy email → null", () => {
+  const role = resolveSetAdminClaimCallerRole(
+    { uid: "rando", token: { email: "rando@example.com" } },
+    new Set(["other-uid"])
+  );
+  assert.equal(role, null);
+});
+
+test("resolveSetAdminClaimCallerRole: super-admin precedence over admin claim", () => {
+  const role = resolveSetAdminClaimCallerRole(
+    { uid: "seed-uid", token: { admin: true, email: "nope@example.com" } },
+    new Set(["seed-uid"])
+  );
+  assert.equal(role, "super-admin");
+});
+
+test("resolveSetAdminClaimCallerRole: null auth returns null", () => {
+  assert.equal(resolveSetAdminClaimCallerRole(null, new Set()), null);
+});
+
+test("resolveSetAdminClaimCallerRole: missing uid falls back to email/claim", () => {
+  const viaEmail = resolveSetAdminClaimCallerRole(
+    { token: { email: ADMIN_EMAIL_FOR_SETLIST_PROXY } },
+    new Set()
+  );
+  assert.equal(viaEmail, "super-admin");
+  const viaClaim = resolveSetAdminClaimCallerRole(
+    { token: { admin: true } },
+    new Set()
+  );
+  assert.equal(viaClaim, "admin");
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -19,9 +19,12 @@ const {
   scheduledCandidateShowDates,
 } = require("./phishnetLiveSetlistAutomation");
 const { loadSongCatalogSongs } = require("./songCatalogSource");
-
-/** Must match admin setlist gate in `src/features/admin/model/useAdminSetlistForm.js`. */
-const ADMIN_EMAIL_FOR_SETLIST_PROXY = "pat@road2media.com";
+const {
+  ADMIN_EMAIL_FOR_SETLIST_PROXY,
+  parseSuperAdminUidsEnv,
+  resolveAdminCallerRole,
+  resolveSetAdminClaimCallerRole,
+} = require("./adminAuth");
 
 const phishnetApiKey = defineSecret("PHISHNET_API_KEY");
 
@@ -171,6 +174,24 @@ function assertAdminEmail(request) {
   }
 }
 
+/**
+ * Accepts either the hard-coded admin email (legacy transition) or a Firebase
+ * custom claim `admin: true` (target state for #139). Callables that use this
+ * can be tightened to claim-only after PR B lands and the claim is granted to
+ * every real admin.
+ */
+function assertAdminClaimOrEmail(request) {
+  if (!request.auth) {
+    throw new HttpsError("unauthenticated", "Sign in required.");
+  }
+  if (!resolveAdminCallerRole(request.auth)) {
+    throw new HttpsError(
+      "permission-denied",
+      "Only an admin can perform this action."
+    );
+  }
+}
+
 function assertShowDateString(showDate) {
   if (
     typeof showDate !== "string" ||
@@ -293,6 +314,193 @@ exports.refreshLiveScoresForShow = onCall(
     const actualSetlist = actualSetlistFromOfficialDoc(setlistDoc);
     const result = await recomputeLiveScoresForShow(showDate, actualSetlist);
     return { ok: true, ...result };
+  }
+);
+
+/**
+ * Admin ""Finalize and rollup"" for a show — server-side replacement for the
+ * client batched writes in `src/features/admin/api/adminRollupApi.js` (#139).
+ *
+ * Reads `official_setlists/{showDate}`, loads the Storage song catalog once,
+ * and for every `picks` doc with that `showDate`:
+ *   - computes final `score` using the same path as `gradePicksOnSetlistWrite`
+ *   - sets `isGraded: true` (with `gradedAt` on the first grade)
+ *   - increments `users.totalPoints` by the score diff and `users.showsPlayed`
+ *     by 1 on first-grade (mirrors the client batch exactly).
+ *
+ * Uses Admin SDK; rules don't apply here. This lets PR B tighten Firestore
+ * rules on `picks` + `users` without breaking Finalize.
+ */
+exports.rollupScoresForShow = onCall(
+  {
+    region: PHISHNET_FUNCTIONS_REGION,
+    invoker: "public",
+    enforceAppCheck: false,
+  },
+  async (request) => {
+    assertAdminClaimOrEmail(request);
+    const showDate = assertShowDateString(request.data?.showDate);
+
+    const setlistSnap = await db
+      .collection("official_setlists")
+      .doc(showDate)
+      .get();
+    if (!setlistSnap.exists) {
+      throw new HttpsError(
+        "failed-precondition",
+        `official_setlists/${showDate} does not exist. Save the setlist first.`
+      );
+    }
+    const setlistDoc = setlistSnap.data() || {};
+    const actualSetlist = actualSetlistFromOfficialDoc(setlistDoc);
+
+    const picksSnap = await db
+      .collection("picks")
+      .where("showDate", "==", showDate)
+      .get();
+
+    if (picksSnap.empty) {
+      return {
+        ok: true,
+        processedPicks: 0,
+        skippedPicks: 0,
+        totalPicks: 0,
+      };
+    }
+
+    const catalogSongs = await loadSongCatalogSongs({
+      fallbackSongs: phishSongs,
+      logger,
+    });
+
+    // Two writes per pick (picks doc + users doc), same as client rollup.
+    const OPS_PER_PICK = 2;
+    let batch = db.batch();
+    let opCount = 0;
+    let processedPicks = 0;
+    let skippedPicks = 0;
+
+    for (const pickDoc of picksSnap.docs) {
+      const pickData = pickDoc.data() || {};
+      if (!pickData.userId) {
+        skippedPicks += 1;
+        continue;
+      }
+      if (opCount + OPS_PER_PICK > MAX_FIRESTORE_BATCH_WRITES) {
+        await batch.commit();
+        batch = db.batch();
+        opCount = 0;
+      }
+      const userPicks = pickData.picks || {};
+      const newScore = calculateTotalScore(userPicks, actualSetlist, catalogSongs);
+      const oldScore = pickData.score || 0;
+      const scoreDiff = newScore - oldScore;
+      const isFirstGrade = pickData.isGraded !== true;
+
+      const pickUpdate = { score: newScore, isGraded: true };
+      if (isFirstGrade) {
+        pickUpdate.gradedAt = admin.firestore.FieldValue.serverTimestamp();
+      }
+      batch.update(pickDoc.ref, pickUpdate);
+      batch.set(
+        db.collection("users").doc(pickData.userId),
+        {
+          totalPoints: admin.firestore.FieldValue.increment(scoreDiff),
+          showsPlayed: admin.firestore.FieldValue.increment(
+            isFirstGrade ? 1 : 0
+          ),
+        },
+        { merge: true }
+      );
+      opCount += OPS_PER_PICK;
+      processedPicks += 1;
+    }
+
+    if (opCount > 0) {
+      await batch.commit();
+    }
+
+    return {
+      ok: true,
+      processedPicks,
+      skippedPicks,
+      totalPicks: picksSnap.size,
+    };
+  }
+);
+
+/**
+ * Grant or revoke the `admin: true` Firebase custom claim on a target user.
+ *
+ * Authorization rules:
+ *   - Caller must be signed in.
+ *   - Caller must either already hold `admin: true`, **or** have a UID listed
+ *     in the `SUPER_ADMIN_UIDS` env var (comma-separated). Bootstrap-only.
+ *   - The legacy `ADMIN_EMAIL_FOR_SETLIST_PROXY` email holder is implicitly
+ *     treated as super-admin so #139 PR A doesn't require env-var changes on
+ *     day one; remove after PR B.
+ *
+ * Caller can set the claim on their own UID (self-bootstrap) or on another
+ * UID (delegate). The target user must refresh their ID token before the new
+ * claim is visible to the client (`getIdTokenResult(true)`).
+ */
+exports.setAdminClaim = onCall(
+  {
+    region: PHISHNET_FUNCTIONS_REGION,
+    invoker: "public",
+    enforceAppCheck: false,
+  },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError("unauthenticated", "Sign in required.");
+    }
+    const callerUid = request.auth.uid;
+    const superAdminUids = parseSuperAdminUidsEnv();
+    const role = resolveSetAdminClaimCallerRole(request.auth, superAdminUids);
+    if (!role) {
+      throw new HttpsError(
+        "permission-denied",
+        "Only a super-admin or existing admin can set admin claims."
+      );
+    }
+
+    const rawTargetUid = request.data?.targetUid;
+    const targetUid =
+      typeof rawTargetUid === "string" && rawTargetUid.trim()
+        ? rawTargetUid.trim()
+        : callerUid;
+    const grant = request.data?.admin;
+    if (typeof grant !== "boolean") {
+      throw new HttpsError(
+        "invalid-argument",
+        "`admin` must be a boolean (true to grant, false to revoke)."
+      );
+    }
+
+    let existing;
+    try {
+      existing = await admin.auth().getUser(targetUid);
+    } catch (e) {
+      throw new HttpsError(
+        "not-found",
+        `No Auth user for uid=${targetUid}.`
+      );
+    }
+    const existingClaims = existing.customClaims || {};
+    const nextClaims = { ...existingClaims, admin: grant };
+    if (!grant) {
+      delete nextClaims.admin;
+    }
+    await admin.auth().setCustomUserClaims(targetUid, nextClaims);
+
+    logger.info("setAdminClaim", {
+      callerUid,
+      targetUid,
+      grant,
+      callerRole: role,
+    });
+
+    return { ok: true, targetUid, admin: grant };
   }
 );
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
-    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js",
+    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js",
     "serve": "firebase emulators:start --only functions",
     "shell": "firebase functions:shell",
     "start": "npm run shell",

--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -46,10 +46,9 @@ import DashboardPageHeading from './ui/DashboardPageHeading';
 export default function DashboardLayout() {
   const location = useLocation();
   const [searchParams] = useSearchParams();
-  const { user } = useAuth();
+  const { user, isAdmin } = useAuth();
   const { showDates, showDatesByTour } = useShowCalendar();
   usePendingPoolJoin();
-  const isAdmin = user?.email === 'pat@road2media.com';
   
   const scrollDirection = useScrollDirection(); 
 

--- a/src/app/routes/HomeRoute.jsx
+++ b/src/app/routes/HomeRoute.jsx
@@ -10,8 +10,7 @@ import LandingPage from '../../pages/landing/LandingPage';
  * Public home: paint immediately for crawlers; redirect to dashboard once auth proves a session.
  */
 export default function HomeRoute() {
-  const { user } = useAuth();
-  const isAdminUser = user?.email === 'pat@road2media.com';
+  const { user, isAdmin: isAdminUser } = useAuth();
 
   if (user) {
     return <Navigate to={getDashboardEntryHref({ isAdminUser })} replace />;

--- a/src/app/routes/SetupRoute.jsx
+++ b/src/app/routes/SetupRoute.jsx
@@ -7,8 +7,7 @@ import { getDashboardEntryHref } from '../../shared/lib/dashboardLastPath';
 import ProfileSetupPage from '../../pages/auth/ProfileSetupPage';
 
 export default function SetupRoute() {
-  const { user, userProfile, loading } = useAuth();
-  const isAdminUser = user?.email === 'pat@road2media.com';
+  const { user, userProfile, loading, isAdmin: isAdminUser } = useAuth();
 
   if (loading) {
     return <AuthLoadingScreen />;

--- a/src/features/admin/api/adminRollupApi.js
+++ b/src/features/admin/api/adminRollupApi.js
@@ -1,72 +1,42 @@
-import {
-  collection,
-  doc,
-  getDocs,
-  increment,
-  query,
-  serverTimestamp,
-  where,
-  writeBatch,
-} from 'firebase/firestore';
-import { db } from '../../../shared/lib/firebase';
-import { calculateTotalScore } from '../../../shared/utils/scoring';
+import { getFunctions, httpsCallable } from 'firebase/functions';
+import { app } from '../../../shared/lib/firebase';
 
-const MAX_BATCH_OPS = 500;
-const OPS_PER_PICK = 2;
+const FUNCTIONS_REGION = 'us-central1';
 
-export async function rollupScoresForShow({ showDate, actualSetlistPayload }) {
-  const picksQuery = query(collection(db, 'picks'), where('showDate', '==', showDate));
-  const picksSnap = await getDocs(picksQuery);
-
-  let batch = writeBatch(db);
-  let opCount = 0;
-  let processedPicks = 0;
-  let skippedPicks = 0;
-
-  for (const pickDoc of picksSnap.docs) {
-    const pickData = pickDoc.data();
-    if (!pickData.userId) {
-      skippedPicks += 1;
-      continue;
-    }
-
-    if (opCount + OPS_PER_PICK > MAX_BATCH_OPS) {
-      await batch.commit();
-      batch = writeBatch(db);
-      opCount = 0;
-    }
-
-    const userPicks = pickData.picks || pickData;
-    const newScore = calculateTotalScore(userPicks, actualSetlistPayload);
-    const oldScore = pickData.score || 0;
-    const scoreDiff = newScore - oldScore;
-    const isFirstGrade = !pickData.isGraded;
-
-    const pickUpdate = { score: newScore, isGraded: true };
-    if (isFirstGrade) {
-      pickUpdate.gradedAt = serverTimestamp();
-    }
-    batch.update(pickDoc.ref, pickUpdate);
-    batch.set(
-      doc(db, 'users', pickData.userId),
-      {
-        totalPoints: increment(scoreDiff),
-        showsPlayed: increment(isFirstGrade ? 1 : 0),
-      },
-      { merge: true }
-    );
-
-    opCount += OPS_PER_PICK;
-    processedPicks += 1;
+/**
+ * Admin "Finalize and rollup" for a show.
+ *
+ * Thin wrapper over the `rollupScoresForShow` HTTPS callable (`functions/index.js`,
+ * issue #139 PR A). The server reads the just-saved `official_setlists/{showDate}`
+ * document with Admin SDK, recomputes every matching pick's score using the same
+ * path as live grading (`gradePicksOnSetlistWrite`), sets `isGraded: true` (plus
+ * `gradedAt` on first grade), and increments user totals — all in batched writes.
+ *
+ * Moving this server-side is a prerequisite for tightening `picks` / `users`
+ * Firestore rules in PR B (least-privilege without breaking Finalize).
+ *
+ * `actualSetlistPayload` is accepted for backward-compat with existing callers
+ * (`useAdminSetlistForm.js`) but is ignored server-side — the callable reads the
+ * authoritative payload from Firestore to avoid TOCTOU between save + rollup.
+ *
+ * @param {{
+ *   showDate: string,
+ *   actualSetlistPayload?: unknown,
+ * }} opts
+ * @returns {Promise<{ processedPicks: number, skippedPicks: number, totalPicks: number }>}
+ */
+export async function rollupScoresForShow({ showDate } = {}) {
+  const value = String(showDate ?? '').trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error('showDate must be YYYY-MM-DD.');
   }
-
-  if (opCount > 0) {
-    await batch.commit();
-  }
-
+  const functions = getFunctions(app, FUNCTIONS_REGION);
+  const callable = httpsCallable(functions, 'rollupScoresForShow');
+  const result = await callable({ showDate: value });
+  const data = result?.data ?? {};
   return {
-    processedPicks,
-    skippedPicks,
-    totalPicks: picksSnap.size,
+    processedPicks: data.processedPicks ?? 0,
+    skippedPicks: data.skippedPicks ?? 0,
+    totalPicks: data.totalPicks ?? 0,
   };
 }

--- a/src/features/admin/model/useAdminSetlistForm.js
+++ b/src/features/admin/model/useAdminSetlistForm.js
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useAuth } from '../../auth';
 import { FORM_FIELDS } from '../../../shared/data/gameConfig.js';
 import { sanitizeOfficialSongList } from '../../../shared/utils/officialSetlistSanitize.js';
 import {
@@ -42,7 +43,8 @@ export function useAdminSetlistForm({ user, selectedDate }) {
   const [encoreSongs, setEncoreSongs] = useState([]);
   const clearMessageTimeoutRef = useRef(null);
 
-  const isAdmin = user?.email === 'pat@road2media.com';
+  const { isAdmin: sessionIsAdmin } = useAuth();
+  const isAdmin = sessionIsAdmin;
   const selectedShow = selectedDate ?? '';
 
   useEffect(() => {

--- a/src/features/auth/api/authApi.js
+++ b/src/features/auth/api/authApi.js
@@ -1,10 +1,47 @@
-import { onAuthStateChanged, signOut } from 'firebase/auth';
+import { onAuthStateChanged, onIdTokenChanged, signOut } from 'firebase/auth';
 import { doc, getDoc } from 'firebase/firestore';
 
 import { auth, db } from '../../../shared/lib/firebase';
 
+/** Transition-only fallback while rolling out admin custom claims (issue #139). */
+const LEGACY_ADMIN_EMAIL = 'pat@road2media.com';
+
 export function subscribeToAuthState(onChange) {
   return onAuthStateChanged(auth, onChange);
+}
+
+/**
+ * Subscribe to ID token changes. Fires when the user signs in, signs out, or
+ * their ID token is refreshed (which is how Firebase propagates custom claim
+ * updates after `setAdminClaim`). Use alongside `subscribeToAuthState` when a
+ * feature needs claim-level freshness (e.g. admin gating).
+ */
+export function subscribeToIdTokenChanges(onChange) {
+  return onIdTokenChanged(auth, onChange);
+}
+
+/**
+ * Resolve whether the given Firebase user is an admin. Prefers the
+ * `admin: true` custom claim (#139 target state); falls back to the legacy
+ * hard-coded admin email during PR A so existing flows keep working until the
+ * claim is granted to every real admin.
+ *
+ * Pass `forceRefresh` when you need to pick up a freshly-granted claim without
+ * waiting for the next automatic token refresh.
+ *
+ * @param {import('firebase/auth').User | null | undefined} user
+ * @param {{ forceRefresh?: boolean }} [opts]
+ * @returns {Promise<boolean>}
+ */
+export async function resolveIsAdmin(user, { forceRefresh = false } = {}) {
+  if (!user) return false;
+  try {
+    const tokenResult = await user.getIdTokenResult(forceRefresh);
+    if (tokenResult?.claims?.admin === true) return true;
+  } catch {
+    // fall through to email fallback
+  }
+  return user.email === LEGACY_ADMIN_EMAIL;
 }
 
 export async function fetchUserProfile(uid) {

--- a/src/features/auth/model/useAuth.js
+++ b/src/features/auth/model/useAuth.js
@@ -1,21 +1,40 @@
 import { useState, useEffect } from 'react';
 
-import { fetchUserProfile, subscribeToAuthState } from '../api/authApi';
+import {
+  fetchUserProfile,
+  resolveIsAdmin,
+  subscribeToAuthState,
+  subscribeToIdTokenChanges,
+} from '../api/authApi';
 
+/**
+ * Session-scoped auth hook. Exposes the Firebase user, the Firestore profile
+ * doc, a loading flag, and `isAdmin` — the latter prefers the `admin: true`
+ * custom claim (issue #139) and falls back to the legacy hard-coded admin
+ * email while the claim rollout is in progress. `isAdmin` refreshes whenever
+ * the ID token refreshes, so `setAdminClaim` callable writes propagate into
+ * the UI without a full re-login (after `getIdTokenResult(true)`).
+ */
 export function useAuth() {
   const [user, setUser] = useState(null);
   const [userProfile, setUserProfile] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
     const unsubscribe = subscribeToAuthState(async (u) => {
       if (u) {
         setUser(u);
-        const profile = await fetchUserProfile(u.uid);
+        const [profile, adminFlag] = await Promise.all([
+          fetchUserProfile(u.uid),
+          resolveIsAdmin(u),
+        ]);
         setUserProfile(profile);
+        setIsAdmin(adminFlag);
       } else {
         setUser(null);
         setUserProfile(null);
+        setIsAdmin(false);
       }
       setLoading(false);
     });
@@ -23,5 +42,19 @@ export function useAuth() {
     return () => unsubscribe();
   }, []);
 
-  return { user, userProfile, loading };
+  useEffect(() => {
+    // Track ID token refreshes separately so a freshly-granted admin claim
+    // (from `setAdminClaim`) flips `isAdmin` without requiring a full re-auth.
+    const unsubscribe = subscribeToIdTokenChanges(async (u) => {
+      if (!u) {
+        setIsAdmin(false);
+        return;
+      }
+      const adminFlag = await resolveIsAdmin(u);
+      setIsAdmin(adminFlag);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  return { user, userProfile, loading, isAdmin };
 }

--- a/src/features/auth/model/useProfileSetup.js
+++ b/src/features/auth/model/useProfileSetup.js
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 
 import { fetchPublicProfileByHandle } from '../../profile';
 import { getDashboardEntryHref } from '../../../shared/lib/dashboardLastPath';
+import { resolveIsAdmin } from '../api/authApi';
 import { createInitialUserProfile } from '../api/profileSetupApi';
 
 export function useProfileSetup(user) {
@@ -35,7 +36,7 @@ export function useProfileSetup(user) {
         // Force a reload so `useAuth` re-reads the Firestore users doc.
         // Otherwise `/dashboard/*` can redirect back to `/setup` because `userProfile`
         // is not live-updated after the write.
-        const isAdminUser = user?.email === 'pat@road2media.com';
+        const isAdminUser = await resolveIsAdmin(user);
         window.location.href = getDashboardEntryHref({ isAdminUser });
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
## Summary
- **PR A of #139** — foundation for least-privilege Firestore rules. **No `firestore.rules` changes in this PR.** Rule tightening ships in a follow-up PR B after this soaks on staging.
- Moves the admin ""Finalize and rollup"" client batch writes to a server-side HTTPS callable using Admin SDK, so tightening `picks` / `users` rules in PR B won't break finalize.
- Introduces the real `admin: true` custom claim (via new `setAdminClaim` callable) and a claim-aware `useAuth().isAdmin` signal. Legacy `pat@road2media.com` email fallback is preserved during transition; removed in PR B.

## What changes

### Cloud Functions (`functions/index.js` + new `functions/adminAuth.js`)
- **`rollupScoresForShow`** HTTPS callable (admin-claim gated, Admin SDK). Reads `official_setlists/{showDate}`, loads Storage song catalog once (same loader as `gradePicksOnSetlistWrite` / `recomputeLiveScoresForShow`), recomputes score for every `picks` doc with that `showDate`, sets `isGraded: true` + `gradedAt` on first grade, and increments `users.totalPoints` / `users.showsPlayed`. Parity with existing client batching (2 writes per pick, 500-op ceiling).
- **`setAdminClaim`** HTTPS callable. Grants or revokes `admin: true` on a target Auth user. Authorization: caller must be super-admin (`SUPER_ADMIN_UIDS` env OR legacy email — bootstrap) or an existing admin. Logs `{ callerUid, targetUid, grant, callerRole }` to Cloud Logging.
- **`functions/adminAuth.js`** extracts the pure authorization decisions (`parseSuperAdminUidsEnv`, `resolveAdminCallerRole`, `resolveSetAdminClaimCallerRole`) so they're unit-testable without `firebase-functions-test`.
- **15 new tests** (`functions/adminAuth.test.js`): env parsing edge cases, legacy email acceptance, claim precedence over email, super-admin bootstrap paths, no-auth handling.

### Client
- **`src/features/admin/api/adminRollupApi.js`** is now a thin wrapper over `rollupScoresForShow` callable. Preserves the `{ processedPicks, skippedPicks, totalPicks }` return shape so `useAdminSetlistForm.js` doesn't change.
- **`src/features/auth/api/authApi.js`** adds `resolveIsAdmin(user, { forceRefresh })` (claim-first, legacy email fallback) and `subscribeToIdTokenChanges` so a freshly-granted claim propagates without re-login.
- **`src/features/auth/model/useAuth.js`** exposes `isAdmin`. Subscribes to both `onAuthStateChanged` and `onIdTokenChanged` — after `getIdTokenResult(true)`, the UI flips automatically.
- **5 email-check sites** replaced with claim-aware signal:
  - `src/app/layout/DashboardLayout.jsx`
  - `src/app/routes/SetupRoute.jsx`
  - `src/app/routes/HomeRoute.jsx`
  - `src/features/admin/model/useAdminSetlistForm.js` (via `useAuth()`)
  - `src/features/auth/model/useProfileSetup.js` (via `resolveIsAdmin` helper since the hook only receives `user` as a param)

### Docs
- **`docs/ADMIN_CLAIMS_RUNBOOK.md`** — bootstrap (`SUPER_ADMIN_UIDS` env + browser call), delegation, revocation, audit loop using `listUsers`, PR B follow-ups.

## Non-goals (deferred to PR B)
- `firestore.rules` tightening (`picks` → self-only + admin, `users` → self-only + admin, `official_setlists` → admin-only, `live_setlist_automation` read via claim).
- Dropping the legacy email fallback from `resolveIsAdmin` and `assertAdminClaimOrEmail`.
- Updating the `live_setlist_automation/{showDate}` rule.

## Test plan
- [x] `functions && npm test` — 58/58 pass (43 pre-existing + 15 new).
- [x] Root `npx vitest run` — 21/21 pass.
- [x] `npm run lint` — clean.
- [x] `npm run verify:dashboard-meta` — 8 cases OK.
- [x] `npm run verify:dashboard-ui` — ok.
- [x] `npm run build` — succeeds.
- [x] `node -e ""require('./functions/index.js')""` — loads (no admin.initializeApp errors).
- [ ] Staging deploy: bootstrap claim on legacy admin via `setAdminClaim`, verify `useAuth().isAdmin` flips without re-login, run Finalize and rollup against a real show, confirm pick scores + `users.totalPoints` match prior semantics.
- [ ] Staging deploy: hit `rollupScoresForShow` with a non-admin account → expect `permission-denied`.
- [ ] Staging deploy: hit `setAdminClaim` with a non-super-admin signed-in account → expect `permission-denied`.

## Rollout
1. Merge this PR to `staging`. Deploy functions.
2. Call `setAdminClaim({ admin: true })` as the legacy admin to self-grant the claim (runbook §2b).
3. Verify `useAuth().isAdmin` returns `true` via claim, and Finalize/rollup still works.
4. Grant the claim to every other current admin via `setAdminClaim({ admin: true, targetUid })`.
5. After ~1 live-night of soak with no regressions, open PR B (rule tightening + drop email fallback).

## Related
- Issue #139 (rewritten 2026-04-21 with current scope).
- Parent epic #127 (Pool Admin & Lifecycle Management).
- Precedents: #167 (Storage song-catalog loader, reused here), #146 (Phish.net callable pattern), #180 (live automation Admin SDK paths).

Made with [Cursor](https://cursor.com)