### PR TITLE
Admin claim bootstrap UI (#139 PR A follow-up)

### DIFF
--- a/src/features/admin/api/setAdminClaimApi.js
+++ b/src/features/admin/api/setAdminClaimApi.js
@@ -1,0 +1,38 @@
+import { getFunctions, httpsCallable } from 'firebase/functions';
+import { app } from '../../../shared/lib/firebase';
+
+const FUNCTIONS_REGION = 'us-central1';
+
+/**
+ * Grant or revoke the `admin: true` custom claim on a Firebase Auth user.
+ *
+ * Thin wrapper over the `setAdminClaim` HTTPS callable (`functions/index.js`,
+ * issue #139 PR A). Server-side authz:
+ *  - super-admins (UID in `SUPER_ADMIN_UIDS` env var or legacy admin email)
+ *    can grant or revoke for any target, including bootstrapping themselves,
+ *  - existing admins (`admin: true` claim already set) can delegate or revoke.
+ *
+ * `targetUid` defaults to the caller on the server, which is the primary
+ * bootstrap flow used by `AdminClaimBootstrap` in the admin page.
+ *
+ * @param {{ admin: boolean, targetUid?: string }} opts
+ * @returns {Promise<{ ok: boolean, targetUid: string, admin: boolean }>}
+ */
+export async function setAdminClaim({ admin, targetUid } = {}) {
+  if (typeof admin !== 'boolean') {
+    throw new Error('admin must be a boolean (true to grant, false to revoke).');
+  }
+  const functions = getFunctions(app, FUNCTIONS_REGION);
+  const callable = httpsCallable(functions, 'setAdminClaim');
+  const payload = { admin };
+  if (typeof targetUid === 'string' && targetUid.trim()) {
+    payload.targetUid = targetUid.trim();
+  }
+  const result = await callable(payload);
+  const data = result?.data ?? {};
+  return {
+    ok: data.ok === true,
+    targetUid: typeof data.targetUid === 'string' ? data.targetUid : '',
+    admin: data.admin === true,
+  };
+}

--- a/src/features/admin/ui/AdminClaimBootstrap.jsx
+++ b/src/features/admin/ui/AdminClaimBootstrap.jsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from 'react';
+import { ShieldCheck, ShieldAlert } from 'lucide-react';
+import Card from '../../../shared/ui/Card';
+import Button from '../../../shared/ui/Button';
+import { setAdminClaim } from '../api/setAdminClaimApi';
+
+/**
+ * One-click bootstrap for the `admin: true` custom claim (issue #139 PR A
+ * follow-up). Rendered inside `AdminForm`, which is already gated by
+ * `useAuth().isAdmin` (claim OR legacy-email fallback). This component reads
+ * the current ID token locally, and:
+ *  - if the claim is already present, shows a confirmation pill,
+ *  - if the claim is missing, renders a "Grant admin claim to myself" button
+ *    that invokes the `setAdminClaim` callable, force-refreshes the ID token
+ *    so `useAuth().isAdmin` flips to the claim-based value, and hides itself.
+ *
+ * Exists so PMs / non-engineers can complete the claim bootstrap without
+ * opening DevTools. Once every real admin has a claim and PR B has dropped
+ * the legacy-email fallback, this component can be deleted.
+ */
+export default function AdminClaimBootstrap({ user }) {
+  const [status, setStatus] = useState('checking');
+  const [isGranting, setIsGranting] = useState(false);
+  const [errorText, setErrorText] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    async function check() {
+      if (!user) {
+        if (!cancelled) setStatus('missing');
+        return;
+      }
+      try {
+        const tokenResult = await user.getIdTokenResult();
+        if (cancelled) return;
+        setStatus(tokenResult?.claims?.admin === true ? 'present' : 'missing');
+      } catch {
+        if (!cancelled) setStatus('missing');
+      }
+    }
+    check();
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  const handleGrant = async () => {
+    if (!user) return;
+    setErrorText('');
+    setIsGranting(true);
+    try {
+      await setAdminClaim({ admin: true });
+      await user.getIdTokenResult(true);
+      setStatus('present');
+    } catch (e) {
+      const msg =
+        e instanceof Error
+          ? e.message
+          : typeof e === 'object' && e !== null && 'message' in e
+            ? String(e.message)
+            : 'Failed to grant admin claim.';
+      setErrorText(msg);
+    } finally {
+      setIsGranting(false);
+    }
+  };
+
+  if (status === 'checking') return null;
+
+  if (status === 'present') {
+    return (
+      <Card variant="default" padding="sm" className="mb-4 mt-4">
+        <p className="text-xs text-emerald-400/90 font-bold uppercase tracking-wider flex items-center gap-2">
+          <ShieldCheck className="h-4 w-4 shrink-0" aria-hidden />
+          Admin claim active on your account
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card variant="default" padding="sm" className="mb-4 mt-4 space-y-3">
+      <div className="flex items-start gap-2">
+        <ShieldAlert className="h-4 w-4 shrink-0 mt-0.5 text-amber-400" aria-hidden />
+        <div className="space-y-1">
+          <p className="text-xs font-bold uppercase tracking-wider text-amber-300">
+            One-time admin claim bootstrap
+          </p>
+          <p className="text-[11px] text-slate-400 leading-relaxed">
+            You currently have admin access via legacy email. Grant the
+            <code className="text-slate-300"> admin </code>
+            custom claim to your account so access survives the upcoming
+            Firestore rules tightening (issue #139 PR B).
+          </p>
+        </div>
+      </div>
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        disabled={isGranting}
+        onClick={handleGrant}
+        className="w-full sm:w-auto uppercase tracking-widest gap-2"
+      >
+        <ShieldCheck className="h-4 w-4 shrink-0" aria-hidden />
+        {isGranting ? 'Granting claim…' : 'Grant admin claim to myself'}
+      </Button>
+      {errorText ? (
+        <p className="text-xs font-bold text-red-400 ml-1" role="alert">
+          {errorText}
+        </p>
+      ) : null}
+    </Card>
+  );
+}

--- a/src/features/admin/ui/AdminForm.jsx
+++ b/src/features/admin/ui/AdminForm.jsx
@@ -10,6 +10,7 @@ import AdminActionToggle from './AdminActionToggle';
 import AdminOfficialSetlistBuilder from './AdminOfficialSetlistBuilder';
 import AdminFinalizeAndSave from './AdminFinalizeAndSave';
 import AdminWarRoomShowDate from './AdminWarRoomShowDate';
+import AdminClaimBootstrap from './AdminClaimBootstrap';
 
 function normalizeDashboardShowDate(value) {
   if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value.trim())) return value.trim();
@@ -72,6 +73,7 @@ export default function AdminForm({ user, selectedDate }) {
         onChange={setWarRoomShowDate}
         disabled={isSaving}
       />
+      <AdminClaimBootstrap user={user} />
       <Card variant="danger" padding="sm" className="mb-6 mt-4">
         <p className="text-xs text-red-300/80 font-bold uppercase tracking-wider flex items-start gap-2">
           <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" aria-hidden />


### PR DESCRIPTION
## Summary
- Adds `AdminClaimBootstrap` card at the top of `AdminForm` so admins without the `admin: true` custom claim can grant it to themselves in one click.
- New thin API wrapper `src/features/admin/api/setAdminClaimApi.js` over the already-deployed `setAdminClaim` HTTPS callable from PR #195.
- Button path: call `setAdminClaim({ admin: true })` → force-refresh the ID token (`getIdTokenResult(true)`) → `useAuth().isAdmin` flips to the claim-backed value → card swaps to a confirmation pill.

## Why
The devtools snippet in `docs/ADMIN_CLAIMS_RUNBOOK.md` imports source-tree paths (`/src/shared/lib/firebase.js`) that don't exist in the Vite production bundle, so it's not usable in a deployed environment and requires devtools familiarity besides. This gives PMs / non-engineers an in-app path to finish the bootstrap on staging/prod before #139 PR B drops the legacy-email fallback.

Once every real admin has a claim and PR B lands, `AdminClaimBootstrap` and `setAdminClaimApi.js` can be deleted.

## FSD Compliance
- UI lives in `src/features/admin/ui/AdminClaimBootstrap.jsx` (presentational, consumes the API wrapper).
- IO lives in `src/features/admin/api/setAdminClaimApi.js` (Firebase callable).
- `AdminForm.jsx` composes the new component; no page-level or shared-layer changes.

## Test plan
- [x] `npm run lint` clean.
- [x] `npm run build` clean.
- [ ] Merge to `staging`, sign in as `pat@road2media.com`, navigate to `/admin`.
- [ ] Confirm the amber "One-time admin claim bootstrap" card shows.
- [ ] Click **Grant admin claim to myself** → card swaps to green "Admin claim active".
- [ ] Reload → card still shows green (claim persisted on the Auth user).
- [ ] Run a real "Finalize and rollup" against a show to confirm end-to-end parity.

Part of #139 — PR A follow-up; does not gate PR B but is a prerequisite before we drop the legacy-email fallback.

Made with [Cursor](https://cursor.com)