### PR TITLE
fix: surface real setAdminClaim errors + soft-fail getUser for self-bootstrap (#139)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -477,21 +477,58 @@ exports.setAdminClaim = onCall(
       );
     }
 
-    let existing;
+    let existingClaims = {};
     try {
-      existing = await admin.auth().getUser(targetUid);
+      const existing = await admin.auth().getUser(targetUid);
+      existingClaims = existing.customClaims || {};
     } catch (e) {
-      throw new HttpsError(
-        "not-found",
-        `No Auth user for uid=${targetUid}.`
-      );
+      // Surface the real error instead of squashing everything to "not-found".
+      // Expected firebase-admin error codes include `auth/user-not-found`,
+      // `auth/insufficient-permission`, and generic network errors. We still
+      // proceed to `setCustomUserClaims` for self-bootstrap so a transient
+      // `getUser` permission hiccup doesn't block the first admin — the
+      // caller's UID was already validated by the callable auth layer above.
+      const code =
+        typeof e?.code === "string" ? e.code : e?.errorInfo?.code || "unknown";
+      const msg = e?.message || String(e);
+      logger.warn("setAdminClaim.getUser failed", {
+        targetUid,
+        code,
+        msg,
+      });
+      if (targetUid !== callerUid) {
+        // Only fail hard when delegating to someone else — we can't be sure
+        // the target really exists in that case.
+        throw new HttpsError(
+          code === "auth/insufficient-permission"
+            ? "permission-denied"
+            : "not-found",
+          `Lookup failed for uid=${targetUid} (${code}): ${msg}`
+        );
+      }
     }
-    const existingClaims = existing.customClaims || {};
     const nextClaims = { ...existingClaims, admin: grant };
     if (!grant) {
       delete nextClaims.admin;
     }
-    await admin.auth().setCustomUserClaims(targetUid, nextClaims);
+    try {
+      await admin.auth().setCustomUserClaims(targetUid, nextClaims);
+    } catch (e) {
+      const code =
+        typeof e?.code === "string" ? e.code : e?.errorInfo?.code || "unknown";
+      const msg = e?.message || String(e);
+      logger.error("setAdminClaim.setCustomUserClaims failed", {
+        targetUid,
+        code,
+        msg,
+      });
+      throw new HttpsError(
+        code === "auth/insufficient-permission"
+          ? "permission-denied"
+          : "internal",
+        `setCustomUserClaims failed for uid=${targetUid} (${code}): ${msg}`
+      );
+    }
 
     logger.info("setAdminClaim", {
       callerUid,


### PR DESCRIPTION
## Summary
- `setAdminClaim` was masking every `admin.auth().getUser` failure as a misleading `No Auth user for uid=...` error. Staging click reproduced this: token verified `auth: VALID` in the callable layer but `getUser` still threw, producing the wrong user-facing message.
- Now logs the real firebase-admin error code + message on both `getUser` and `setCustomUserClaims` failures so Cloud Logging tells us exactly what's missing (typically \`auth/insufficient-permission\` on the Gen-2 compute service account).
- For **self-bootstrap** (\`targetUid === callerUid\`) we now treat \`getUser\` as soft — the callable already verified the UID is real, and \`setCustomUserClaims\` only needs the write scope. Delegation paths still fail hard.

## Test plan
- [x] \`npm test\` in \`functions/\` — 58/58 pass.
- [ ] Merge to \`staging\`.
- [ ] \`firebase deploy --only functions:setAdminClaim\` from \`staging\`.
- [ ] Sign in as \`pat@road2media.com\`, click "Grant admin claim to myself" on \`/admin\`.
  - If it succeeds → card flips to green "Admin claim active". Done.
  - If it fails → Cloud Logging now shows the real error code (expected \`auth/insufficient-permission\`). Follow-up will be a one-time IAM grant of \`roles/firebaseauth.admin\` to the 927420107250-compute@ service account.

Part of #139 — unblocks the PR A bootstrap UI shipped in #196.

Made with [Cursor](https://cursor.com)