### PR TITLE
feat(functions,docs): rollup observability + runbook troubleshooting (#139)

### DIFF
--- a/docs/ADMIN_CLAIMS_RUNBOOK.md
+++ b/docs/ADMIN_CLAIMS_RUNBOOK.md
@@ -46,39 +46,24 @@ firebase deploy --only functions:setAdminClaim --project <alias>
 
 > The legacy `pat@road2media.com` email holder is implicitly treated as a super-admin in PR A, so you can skip this env var during initial rollout and still bootstrap from the browser as that user. Remove that fallback in PR B.
 
-### 2b. Self-grant the claim (from the browser)
+### 2b. Self-grant the claim (preferred: in-app UI)
 
-As the super-admin (or legacy email holder), open the app while signed in and run in devtools:
+As the super-admin (or legacy email holder), sign into the app and navigate to `/admin`. If your account does **not** yet hold the `admin: true` claim, the `AdminClaimBootstrap` card (amber) renders above the "Locking the official setlist" warning with a single button:
 
-```js
-import('firebase/functions').then(async ({ getFunctions, httpsCallable }) => {
-  const { app } = await import('/src/shared/lib/firebase.js');
-  const fn = httpsCallable(getFunctions(app, 'us-central1'), 'setAdminClaim');
-  const res = await fn({ admin: true });
-  console.log(res.data);
-});
-```
+**Grant admin claim to myself**
 
-> The exact import path for `app` will vary with Vite/import config. Alternatively, call from a temporary admin-only button (acceptable during bootstrap) or use the Firebase Functions emulator + Admin SDK script (see §4).
+Click it. The UI:
+1. Invokes `setAdminClaim({ admin: true })` against your own uid.
+2. Force-refreshes the ID token (`getIdTokenResult(true)`) so the new claim is visible to the client without re-login.
+3. Flips the card to green: "Admin claim active on your account."
 
-Force a token refresh so the claim is visible to the client and Firestore rules:
+`useAuth().isAdmin` now resolves via the claim, not the legacy email fallback.
 
-```js
-await firebase.auth().currentUser.getIdTokenResult(true);
-```
-
-Or simply sign out and back in.
+> **Note:** An earlier version of this runbook documented a devtools `import()` snippet for bootstrap. That snippet worked against source paths (`/src/shared/lib/firebase.js`) that **don't exist** in the Vite production bundle on Vercel, so it's not viable in deployed environments. The in-app button replaces it. If you're working against the local dev server and want to script the call, see §4 (Admin SDK).
 
 ### 2c. Verify
 
-In the app devtools:
-
-```js
-const t = await firebase.auth().currentUser.getIdTokenResult();
-console.log(t.claims.admin); // expect: true
-```
-
-`useAuth().isAdmin` should now return `true` via the claim (not the email fallback).
+The green "Admin claim active" pill on `/admin` is sufficient — it's rendered by reading the live ID token's `claims.admin`. If the page still shows the amber bootstrap card after clicking, see the Troubleshooting section below.
 
 ---
 
@@ -143,5 +128,51 @@ After soaking PR A in staging:
 
 1. Grant the claim to every current admin via `setAdminClaim`.
 2. Remove the legacy email fallback from `resolveIsAdmin` in `src/features/auth/api/authApi.js` and from `assertAdminClaimOrEmail` in `functions/index.js`.
-3. Tighten `firestore.rules` (claim-only).
+3. Tighten `firestore.rules` (claim-only). Include a rule for the new `rollup_audit/{showDate}` collection — admin-read-only, no client writes (Admin SDK writes from `rollupScoresForShow` bypass rules).
 4. Keep `SUPER_ADMIN_UIDS` so the break-glass path exists.
+
+---
+
+## 8. Rollup audit collection
+
+Each successful `rollupScoresForShow` invocation writes a record to `rollup_audit/{showDate}` with:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `lastRolledUpAt` | serverTimestamp | When the rollup committed. Updated on every run. |
+| `processedPicks` | number | Picks regraded in this run. |
+| `skippedPicks`   | number | Picks skipped (missing `userId`). |
+| `totalPicks`     | number | Total matching `picks` docs for this `showDate`. |
+| `callerUid`      | string \| null | Firebase UID of the admin who triggered it. |
+
+This is a **Firestore-visible "when did the last rollup run"** signal, separate from per-pick `gradedAt` which only stamps the first grade. Useful for PM-level sanity-checking after idempotent re-runs (where pick `score` and `gradedAt` may not visibly change even though the batch committed).
+
+Do not write to this collection from the client. It's a pure server-side audit log.
+
+---
+
+## 9. Troubleshooting
+
+### `setCustomUserClaims failed … (auth/insufficient-permission): Credential implementation provided to initializeApp() via the "credential" property has insufficient permission to access the requested resource.`
+
+**Cause:** The Cloud Functions runtime service account lacks `roles/firebaseauth.admin`. This is a **fresh-project** / **first-time-deploy** symptom — Gen-2 Cloud Functions run as `<project-number>-compute@developer.gserviceaccount.com`, which gets `roles/editor` by default but not always the Firebase Auth management role needed to read users or set custom claims.
+
+**Fix:** Grant the role once per project. Either run `scripts/grant-functions-auth-admin.sh <project-id>` (preferred) or the raw gcloud command:
+
+```bash
+PROJECT_ID=set-picks
+PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
+  --role="roles/firebaseauth.admin"
+```
+
+IAM changes propagate to the running function within ~30–60s. No redeploy needed. Retry the **Grant admin claim to myself** button.
+
+### `No Auth user for uid=…` or generic `Lookup failed …`
+
+The v1 PR A code masked every `admin.auth().getUser` failure as a misleading "No Auth user" error. If you see that exact message, your deployed function is pre-fix — redeploy from a branch that includes the error-surface fix (PR #197). The current code logs the real firebase-admin error code (`auth/insufficient-permission`, etc.) via `logger.warn("setAdminClaim.getUser failed", ...)` — filter Cloud Logging on that message to diagnose.
+
+### Finalize and rollup "succeeded" but Firestore looks unchanged
+
+Expected when re-running Finalize on an already-graded show: `gradedAt` is only stamped on the first grade (`isFirstGrade` check in `rollupScoresForShow`), and scores/user totals don't visibly change if the computation is deterministic and the inputs haven't changed. Check `rollup_audit/{showDate}.lastRolledUpAt` (added in §8) for a current timestamp, or filter Cloud Logging for `jsonPayload.message="rollupScoresForShow"`.

--- a/functions/index.js
+++ b/functions/index.js
@@ -359,7 +359,23 @@ exports.rollupScoresForShow = onCall(
       .where("showDate", "==", showDate)
       .get();
 
+    const callerUid = request.auth?.uid || null;
+
     if (picksSnap.empty) {
+      await writeRollupAuditDoc({
+        showDate,
+        processedPicks: 0,
+        skippedPicks: 0,
+        totalPicks: 0,
+        callerUid,
+      });
+      logger.info("rollupScoresForShow", {
+        showDate,
+        processedPicks: 0,
+        skippedPicks: 0,
+        totalPicks: 0,
+        callerUid,
+      });
       return {
         ok: true,
         processedPicks: 0,
@@ -420,14 +436,69 @@ exports.rollupScoresForShow = onCall(
       await batch.commit();
     }
 
+    const totalPicks = picksSnap.size;
+    await writeRollupAuditDoc({
+      showDate,
+      processedPicks,
+      skippedPicks,
+      totalPicks,
+      callerUid,
+    });
+    logger.info("rollupScoresForShow", {
+      showDate,
+      processedPicks,
+      skippedPicks,
+      totalPicks,
+      callerUid,
+    });
+
     return {
       ok: true,
       processedPicks,
       skippedPicks,
-      totalPicks: picksSnap.size,
+      totalPicks,
     };
   }
 );
+
+/**
+ * Writes an audit record to `rollup_audit/{showDate}` with the counts and
+ * timestamp of the most recent `rollupScoresForShow` invocation. Standalone
+ * top-level collection (not under `official_setlists`) so it never re-triggers
+ * `gradePicksOnSetlistWrite`. PR B will add a rule that makes this collection
+ * admin-read-only; Admin SDK writes bypass rules so this still works under
+ * tightened policy. Soft-fails on error so a transient audit write failure
+ * never loses a successful grading pass.
+ */
+async function writeRollupAuditDoc({
+  showDate,
+  processedPicks,
+  skippedPicks,
+  totalPicks,
+  callerUid,
+}) {
+  try {
+    await db
+      .collection("rollup_audit")
+      .doc(showDate)
+      .set(
+        {
+          lastRolledUpAt: admin.firestore.FieldValue.serverTimestamp(),
+          processedPicks,
+          skippedPicks,
+          totalPicks,
+          callerUid: callerUid || null,
+        },
+        { merge: true }
+      );
+  } catch (e) {
+    const msg = e?.message || String(e);
+    logger.warn("rollupScoresForShow.auditWrite failed", {
+      showDate,
+      msg,
+    });
+  }
+}
 
 /**
  * Grant or revoke the `admin: true` Firebase custom claim on a target user.

--- a/scripts/grant-functions-auth-admin.sh
+++ b/scripts/grant-functions-auth-admin.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Grant `roles/firebaseauth.admin` to the Cloud Functions Gen-2 runtime service
+# account for a given Firebase project. Required one-time setup for the
+# `setAdminClaim` and `rollupScoresForShow` callables (issue #139 PR A) so they
+# can call `admin.auth().getUser` / `setCustomUserClaims`.
+#
+# Gen-2 Cloud Functions run as `<project-number>-compute@developer.gserviceaccount.com`
+# by default, which gets `roles/editor` but NOT the Firebase Auth management
+# permissions needed by the Admin SDK to read or update users. Symptom without
+# this grant: `auth/insufficient-permission` from `setCustomUserClaims`.
+#
+# Usage:
+#   scripts/grant-functions-auth-admin.sh <project-id>
+# Example:
+#   scripts/grant-functions-auth-admin.sh set-picks
+#
+# Idempotent — re-running on a project that already has the binding is a no-op
+# (gcloud will report "Updated IAM policy for project [...]." with no change).
+#
+# Requires: gcloud CLI authenticated as a principal with
+# `resourcemanager.projects.setIamPolicy` on the target project (typically
+# Project Owner or IAM Admin).
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <project-id>" >&2
+  exit 64
+fi
+
+PROJECT_ID="$1"
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "error: gcloud CLI not found on PATH" >&2
+  echo "install: https://cloud.google.com/sdk/docs/install" >&2
+  exit 127
+fi
+
+echo "Resolving project number for '${PROJECT_ID}'..."
+PROJECT_NUMBER=$(gcloud projects describe "${PROJECT_ID}" --format='value(projectNumber)')
+
+if [[ -z "${PROJECT_NUMBER}" ]]; then
+  echo "error: could not resolve project number for '${PROJECT_ID}'" >&2
+  exit 1
+fi
+
+SERVICE_ACCOUNT="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+ROLE="roles/firebaseauth.admin"
+
+echo "Granting ${ROLE} to ${SERVICE_ACCOUNT} on project ${PROJECT_ID}..."
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${SERVICE_ACCOUNT}" \
+  --role="${ROLE}" \
+  --condition=None \
+  >/dev/null
+
+echo "Done. IAM propagation to running functions takes ~30-60s."
+echo "Verify: gcloud projects get-iam-policy ${PROJECT_ID} \\"
+echo "          --flatten='bindings[].members' \\"
+echo "          --format='value(bindings.role)' \\"
+echo "          --filter=\"bindings.members:${SERVICE_ACCOUNT}\""


### PR DESCRIPTION
## Summary
Observability + docs follow-up to PR A #139 (post-soak). No behavior change to scoring/grading.

### Why
During PR A soak, a Finalize+rollup against an already-graded show left \`picks\` docs visually unchanged (idempotent re-grade: same \`score\`, \`gradedAt\` stamped once on first grade, \`totalPoints: increment(0)\`, \`showsPlayed: increment(0)\`). The success message was the only PM-visible signal that anything happened. This PR closes that observability gap.

### Changes

**\`functions/index.js\` — \`rollupScoresForShow\`:**
- Writes an audit record to a new top-level collection \`rollup_audit/{showDate}\` on each successful run: \`{ lastRolledUpAt, processedPicks, skippedPicks, totalPicks, callerUid }\`.
  - Top-level (not nested under \`official_setlists\`) so it **doesn't re-trigger** \`gradePicksOnSetlistWrite\`.
  - Soft-fails — an audit write error never loses a successful grading pass.
- Adds \`logger.info(\"rollupScoresForShow\", { ... })\` so Cloud Logging now carries structured counts. Previously the callable was silent; only the HTTP access log showed that it ran.

**\`docs/ADMIN_CLAIMS_RUNBOOK.md\`:**
- **§2b rewrite** — replaces the DevTools \`import()\` snippet (which imported \`/src/shared/lib/firebase.js\`, a path that doesn't exist in the Vite production bundle on Vercel) with the in-app \`AdminClaimBootstrap\` flow shipped in #196. Left a note about why the snippet was removed.
- **New §8** — documents the \`rollup_audit/{showDate}\` collection (schema + purpose).
- **New §9** — Troubleshooting section covering:
  - \`auth/insufficient-permission\` on first deploy (the Gen-2 compute SA issue we hit).
  - Legacy \`No Auth user for uid=...\` message (indicates deployed code pre-dates PR #197).
  - \"Finalize succeeded but Firestore looks unchanged\" (idempotent re-run on already-graded show; direct users to \`rollup_audit\` / Cloud Logging).

**\`scripts/grant-functions-auth-admin.sh\` (new):**
- Idempotent \`gcloud\` wrapper that grants \`roles/firebaseauth.admin\` to \`<project-number>-compute@developer.gserviceaccount.com\`. Captures the one-time IAM grant we did manually during the bootstrap fix so future projects/forks don't relive the debugging arc.

### PR B follow-ups noted in runbook §7
Add \`rollup_audit/{showDate}\` to \`firestore.rules\` — admin-read-only, no client writes (Admin SDK bypasses rules).

### Test plan
- [x] \`functions/\` — \`npm test\`, 58/58 pass.
- [x] Root — \`npm run lint\`, clean.
- [x] Root — \`npm run build\`, clean.
- [x] \`bash -n scripts/grant-functions-auth-admin.sh\` — syntax OK.
- [ ] Merge to \`staging\`.
- [ ] \`firebase deploy --only functions:rollupScoresForShow\` from staging.
- [ ] Click Finalize and rollup against a real show on \`/admin\`.
- [ ] Confirm Firestore now shows a new \`rollup_audit/<showDate>\` doc with counts + fresh \`lastRolledUpAt\`.
- [ ] Confirm Cloud Logging shows \`jsonPayload.message=\"rollupScoresForShow\"\` with the same counts.

Part of #139 — completes PR A soak by adding the observability scaffolding needed before PR B rules tightening.

Made with [Cursor](https://cursor.com)