### PR TITLE
feat(pools): collapse Pool admin into disclosure + tighten pool details chrome (#140)

### DIFF
--- a/src/features/pools/index.js
+++ b/src/features/pools/index.js
@@ -6,6 +6,7 @@ export { usePoolSeasonStandings } from './model/usePoolSeasonStandings';
 export { invalidateUserPools } from './model/userPoolsRefreshBus';
 export { default as useUserPools } from './model/useUserPools';
 export { default as PoolAdminControls } from './ui/PoolAdminControls';
+export { default as PoolAdminSection } from './ui/PoolAdminSection';
 export { default as PoolHubActiveShow } from './ui/PoolHubActiveShow';
 export { default as PoolHubHeader } from './ui/PoolHubHeader';
 export { default as PoolHubLeaderboard } from './ui/PoolHubLeaderboard';

--- a/src/features/pools/ui/PoolAdminControls.jsx
+++ b/src/features/pools/ui/PoolAdminControls.jsx
@@ -23,10 +23,7 @@ export default function PoolAdminControls({
   if (!canAdmin) return null;
 
   return (
-    <section className="rounded-xl border border-amber-500/25 bg-amber-500/5 p-4">
-      <h2 className="text-xs font-bold text-amber-200/90 uppercase tracking-widest mb-3">
-        Pool admin
-      </h2>
+    <>
       {isArchived ? (
         <p className="mb-3 text-sm font-medium text-content-secondary">
           This pool is archived. You can still view history here; it no longer appears in your
@@ -93,6 +90,6 @@ export default function PoolAdminControls({
           onClose={onCloseConfirm}
         />
       ) : null}
-    </section>
+    </>
   );
 }

--- a/src/features/pools/ui/PoolAdminSection.jsx
+++ b/src/features/pools/ui/PoolAdminSection.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { ChevronDown } from 'lucide-react';
+
+import PoolAdminControls from './PoolAdminControls';
+
+/**
+ * Collapsed-by-default owner-only disclosure that wraps {@link PoolAdminControls}.
+ *
+ * Mirrors the `<details>` pattern used by `PoolHubShowArchive` and
+ * `PoolHubSeasonTotalsSection`, keeping the amber "admin zone" accent so the
+ * section still reads as a destructive-capable surface even when collapsed.
+ *
+ * Accessibility: native `<details>`/`<summary>` handles keyboard toggle + focus.
+ * The portaled `ConfirmationModal` inside `PoolAdminControls` renders above the
+ * page chrome, so opening a confirm dialog does not change disclosure state.
+ */
+export default function PoolAdminSection(props) {
+  if (!props.canAdmin) return null;
+
+  return (
+    <section>
+      <details className="group rounded-xl border border-amber-500/25 bg-amber-500/5 shadow-inset-glass">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-2 px-4 py-3 text-xs font-bold text-amber-200/90 transition-colors hover:text-amber-100 [&::-webkit-details-marker]:hidden">
+          <span className="uppercase tracking-widest">
+            Pool admin
+            <span className="ml-2 text-[0.65rem] font-medium normal-case tracking-normal text-amber-200/60">
+              Owner controls
+            </span>
+          </span>
+          <ChevronDown
+            className="h-4 w-4 shrink-0 transition-transform group-open:rotate-180"
+            aria-hidden
+          />
+        </summary>
+        <div className="border-t border-amber-500/20 px-4 py-3">
+          <PoolAdminControls {...props} />
+        </div>
+      </details>
+    </section>
+  );
+}

--- a/src/pages/pools/PoolHubPage.jsx
+++ b/src/pages/pools/PoolHubPage.jsx
@@ -4,7 +4,7 @@ import { Loader2 } from 'lucide-react';
 
 import { useNextShowPicksStatus } from '../../features/picks';
 import {
-  PoolAdminControls,
+  PoolAdminSection,
   PoolHubActiveShow,
   PoolHubHeader,
   PoolHubSeasonTotalsSection,
@@ -15,7 +15,6 @@ import {
 } from '../../features/pools';
 import { useShowCalendar } from '../../features/show-calendar';
 import BackButton from '../../shared/ui/BackButton';
-import DashboardPoolBreadcrumb from '../../shared/ui/DashboardPoolBreadcrumb';
 import { getNextShow, getShowStatus, scheduleTodayYmd } from '../../shared/utils/timeLogic.js';
 import { showOptionLabelDesktop } from '../../shared/utils/showOptionLabel.js';
 
@@ -118,7 +117,6 @@ export default function PoolHubPage({ user }) {
       <div className="flex flex-col gap-2">
         <div className="px-1">
           <BackButton />
-          <DashboardPoolBreadcrumb poolName={pool.name} />
         </div>
         <PoolHubHeader
           poolName={pool.name}
@@ -130,7 +128,7 @@ export default function PoolHubPage({ user }) {
         />
       </div>
       <div className="flex flex-col gap-6">
-        <PoolAdminControls
+        <PoolAdminSection
           canAdmin={admin.canAdmin}
           isArchived={admin.isArchived}
           editNameOpen={admin.editNameOpen}

--- a/src/shared/ui/BackButton.jsx
+++ b/src/shared/ui/BackButton.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft } from 'lucide-react';
+import { Undo2 } from 'lucide-react';
 
 export default function BackButton({ className = '', ...props }) {
   const navigate = useNavigate();
@@ -17,7 +17,7 @@ export default function BackButton({ className = '', ...props }) {
         .join(' ')}
       {...props}
     >
-      <ArrowLeft className="w-4 h-4 shrink-0" aria-hidden />
+      <Undo2 className="w-4 h-4 shrink-0" aria-hidden />
       Back
     </button>
   );


### PR DESCRIPTION
Closes #140.

## Summary

- New `PoolAdminSection` (`src/features/pools/ui/PoolAdminSection.jsx`) wraps `PoolAdminControls` in a native `<details>`/`<summary>` disclosure, collapsed by default. Amber border/bg preserved so the section still reads as an owner-only admin zone; chevron + `group-open:rotate-180` matches the existing `PoolHubShowArchive` / `PoolHubSeasonTotalsSection` pattern.
- `PoolAdminControls` stripped of its outer `<section>` + `<h2>` — now purely renders the forms, buttons, and `ConfirmationModal`, composed inside `PoolAdminSection`.
- `PoolHubPage` drops the redundant `DashboardPoolBreadcrumb` ("Pools · <poolName>") since the pool name already renders in `PoolHubHeader`. `BackButton` + dashboard nav cover wayfinding; the shared breadcrumb component is left in `src/shared/ui/` for possible future reuse.
- Shared `BackButton` switches from `ArrowLeft` to `Undo2` for a softer, more app-native back glyph. Applies everywhere `BackButton` is used (pool details, `PublicProfilePage`, `PublicProfileView`) for consistency.

## AC mapping (#140)

1. Default state collapsed — `<details>` has no `open` attribute. 
2. Expanded state matches today — `PoolAdminControls` body unchanged apart from the removed outer wrapper.
3. Owner-only — `if (!props.canAdmin) return null` preserved (defensive double-check in both `PoolAdminSection` and `PoolAdminControls`).
4. Accessibility — native `<details>`/`<summary>` (keyboard operable + visible focus). `ConfirmationModal` renders via `createPortal(..., document.body)` so opening archive/delete confirmations stays above page chrome; disclosure state is untouched by modal open/close.
5. Visual consistency — same tokens as existing disclosures (`group rounded-xl border … shadow-inset-glass`, `ChevronDown`, `group-open:rotate-180`, `uppercase tracking-widest` summary label) with amber accent to keep the admin-zone visual voice.
6. FSD — new component lives in `features/pools/ui/`; `PoolHubPage` stays composition-only.

## Dashboard meta

No dashboard route, path, or active-state changes. `npm run verify:dashboard-meta` still passes 8/8.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test -- --run` — 21/21 pass
- [x] `npm run build` — success
- [x] `npm run verify:dashboard-meta` — 8/8 OK
- [ ] Manual smoke on `/dashboard/pool/:poolId`:
  - [ ] Owner: Pool admin renders collapsed; summary row reads "Pool admin · Owner controls" with chevron; expanding reveals Edit / Archive / Delete.
  - [ ] Non-owner: No Pool admin row visible at all.
  - [ ] Archive/Delete confirm modal appears above page chrome; cancelling leaves disclosure open.
  - [ ] No "Pools · <poolName>" breadcrumb line above the pool title; Back button uses the new curved `Undo2` glyph.
  - [ ] `BackButton` on `/dashboard/profile/:handle` also shows the new icon (shared-component consistency).


Made with [Cursor](https://cursor.com)