### PR TITLE
feat(functions,pools): server-side pool delete with full member cleanup (#138)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -25,6 +25,11 @@ const {
   resolveAdminCallerRole,
   resolveSetAdminClaimCallerRole,
 } = require("./adminAuth");
+const {
+  MAX_POOL_DELETE_BATCH_WRITES,
+  findPoolPickActivity,
+  parseShowCalendarDates,
+} = require("./poolDelete");
 
 const phishnetApiKey = defineSecret("PHISHNET_API_KEY");
 
@@ -609,6 +614,131 @@ exports.setAdminClaim = onCall(
     });
 
     return { ok: true, targetUid, admin: grant };
+  }
+);
+
+/**
+ * Server-side delete of a pool with full member cleanup (issue #138).
+ *
+ * Required because Firestore rules only let a user update their own `users`
+ * doc — a pool owner cannot clear the pool id from every other member's
+ * `users.pools` array from the client. Admin SDK bypasses rules; authz is
+ * enforced here.
+ *
+ * Guarantees:
+ *   - Caller must be signed in (`unauthenticated` otherwise).
+ *   - Caller must match `pools/{poolId}.ownerId` (`permission-denied` otherwise).
+ *   - Pool must have **no qualifying pick activity**; otherwise the client is
+ *     told to archive instead (`failed-precondition`). Activity is the same
+ *     rule as the client walk (`pickDocHasPoolActivity`) using
+ *     `show_calendar/snapshot` as the authoritative date source.
+ *   - Every member of `pools/{poolId}.members` has `poolId` removed from
+ *     `users/{uid}.pools` via `FieldValue.arrayRemove`, then the pool doc
+ *     is deleted in the same logical operation (batched; split at
+ *     `MAX_POOL_DELETE_BATCH_WRITES`).
+ *
+ * NB: We intentionally re-walk the calendar server-side instead of trusting
+ * a client-provided list, so a stale client can't bypass the activity guard.
+ */
+exports.deletePoolWithCleanup = onCall(
+  {
+    region: PHISHNET_FUNCTIONS_REGION,
+    invoker: "public",
+    enforceAppCheck: false,
+  },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError("unauthenticated", "Sign in required.");
+    }
+    const callerUid = request.auth.uid;
+    const rawPoolId = request.data?.poolId;
+    const poolId =
+      typeof rawPoolId === "string" && rawPoolId.trim() ? rawPoolId.trim() : "";
+    if (!poolId) {
+      throw new HttpsError("invalid-argument", "poolId is required.");
+    }
+
+    const poolRef = db.collection("pools").doc(poolId);
+    const poolSnap = await poolRef.get();
+    if (!poolSnap.exists) {
+      throw new HttpsError("not-found", `Pool ${poolId} does not exist.`);
+    }
+    const poolData = poolSnap.data() || {};
+    const ownerId =
+      typeof poolData.ownerId === "string" ? poolData.ownerId.trim() : "";
+    if (!ownerId || ownerId !== callerUid) {
+      throw new HttpsError(
+        "permission-denied",
+        "Only the pool owner can delete this pool."
+      );
+    }
+
+    const rawMembers = Array.isArray(poolData.members) ? poolData.members : [];
+    const memberIds = [
+      ...new Set(
+        rawMembers
+          .filter((u) => typeof u === "string" && u.trim())
+          .map((u) => u.trim())
+      ),
+    ];
+    if (!memberIds.includes(ownerId)) memberIds.push(ownerId);
+
+    const calendarSnap = await db
+      .collection("show_calendar")
+      .doc("snapshot")
+      .get();
+    const showDates = parseShowCalendarDates(
+      calendarSnap.exists ? calendarSnap.data() : null
+    );
+
+    const hasActivity = await findPoolPickActivity({
+      db,
+      poolId,
+      memberIds,
+      showDates,
+    });
+    if (hasActivity) {
+      throw new HttpsError(
+        "failed-precondition",
+        "This pool has pick history. Archive it instead of deleting."
+      );
+    }
+
+    // Split at the Firestore 500-write batch limit. Pool delete is its own
+    // write, so we reserve one slot for it before committing.
+    let batch = db.batch();
+    let opCount = 0;
+    let memberUpdates = 0;
+    for (const uid of memberIds) {
+      if (opCount >= MAX_POOL_DELETE_BATCH_WRITES) {
+        await batch.commit();
+        batch = db.batch();
+        opCount = 0;
+      }
+      batch.set(
+        db.collection("users").doc(uid),
+        { pools: admin.firestore.FieldValue.arrayRemove(poolId) },
+        { merge: true }
+      );
+      opCount += 1;
+      memberUpdates += 1;
+    }
+    if (opCount >= MAX_POOL_DELETE_BATCH_WRITES) {
+      await batch.commit();
+      batch = db.batch();
+      opCount = 0;
+    }
+    batch.delete(poolRef);
+    opCount += 1;
+    if (opCount > 0) await batch.commit();
+
+    logger.info("deletePoolWithCleanup", {
+      poolId,
+      callerUid,
+      memberUpdates,
+    });
+
+    return { ok: true, poolId, memberUpdates };
   }
 );
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
-    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js",
+    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js poolDelete.test.js",
     "serve": "firebase emulators:start --only functions",
     "shell": "firebase functions:shell",
     "start": "npm run shell",

--- a/functions/poolDelete.js
+++ b/functions/poolDelete.js
@@ -1,0 +1,179 @@
+/**
+ * Pure helpers + the Firestore walk used by `deletePoolWithCleanup`
+ * (issue #138). Kept separate from `functions/index.js` so unit tests can
+ * import without spinning up the Firebase Functions harness.
+ *
+ * The activity rules mirror `src/features/pools/api/poolFirestore.js`
+ * (`pickDataCountsForPool` / `pickDocHasPoolActivity`). Keep both in sync:
+ * the server is the source of truth for delete eligibility, but the client
+ * surfaces the same message before the round trip when it has the data.
+ */
+
+/** Firestore batch write limit (same invariant as rollup + rollup audit). */
+const MAX_POOL_DELETE_BATCH_WRITES = 500;
+
+function hasNonEmptyPicksObject(picks) {
+  if (picks == null || typeof picks !== "object" || Array.isArray(picks)) {
+    return false;
+  }
+  return Object.values(picks).some(
+    (v) => v != null && String(v).trim() !== ""
+  );
+}
+
+/**
+ * Whether a pick document counts toward this pool. Legacy picks without an
+ * embedded `pools` snapshot count toward any pool (matches client).
+ *
+ * @param {Record<string, unknown> | null | undefined} pickData
+ * @param {string} poolId
+ */
+function pickDataCountsForPool(pickData, poolId) {
+  if (!poolId || typeof poolId !== "string" || !poolId.trim()) return false;
+  if (!pickData || typeof pickData !== "object") return false;
+  const pools = /** @type {unknown} */ (pickData.pools);
+  if (Array.isArray(pools) && pools.length > 0) {
+    return pools.some(
+      (p) => p && typeof p === "object" && /** @type {any} */ (p).id === poolId
+    );
+  }
+  return true;
+}
+
+/**
+ * Same rule as client `pickDocHasPoolActivity`: non-empty picks, graded,
+ * or any non-zero score counts as qualifying activity for this pool.
+ *
+ * @param {Record<string, unknown> | null | undefined} pickData
+ * @param {string} poolId
+ */
+function pickDocHasPoolActivity(pickData, poolId) {
+  if (!pickDataCountsForPool(pickData, poolId)) return false;
+  if (!pickData || typeof pickData !== "object") return false;
+  if (hasNonEmptyPicksObject(/** @type {any} */ (pickData).picks)) return true;
+  if (/** @type {any} */ (pickData).isGraded === true) return true;
+  const score = /** @type {any} */ (pickData).score;
+  if (typeof score === "number" && score > 0) return true;
+  return false;
+}
+
+/**
+ * Parses `show_calendar/snapshot` into a sorted list of `YYYY-MM-DD` strings.
+ * Accepts both the v2 `showDatesByTour` + `showDates` shape and a legacy
+ * `showDates: string[]` shape so the callable never breaks on transition.
+ *
+ * @param {Record<string, unknown> | null | undefined} snapshotData
+ * @returns {string[]}
+ */
+function parseShowCalendarDates(snapshotData) {
+  if (!snapshotData || typeof snapshotData !== "object") return [];
+  /** @type {Set<string>} */
+  const out = new Set();
+
+  const byTour = /** @type {any} */ (snapshotData).showDatesByTour;
+  if (Array.isArray(byTour)) {
+    for (const g of byTour) {
+      if (!g || typeof g !== "object") continue;
+      const shows = /** @type {any} */ (g).shows;
+      if (!Array.isArray(shows)) continue;
+      for (const s of shows) {
+        if (!s || typeof s !== "object") continue;
+        const d = typeof s.date === "string" ? s.date.trim() : "";
+        if (/^\d{4}-\d{2}-\d{2}$/.test(d)) out.add(d);
+      }
+    }
+  }
+
+  const flat = /** @type {any} */ (snapshotData).showDates;
+  if (Array.isArray(flat)) {
+    for (const s of flat) {
+      if (s && typeof s === "object") {
+        const d = typeof s.date === "string" ? s.date.trim() : "";
+        if (/^\d{4}-\d{2}-\d{2}$/.test(d)) out.add(d);
+      } else if (typeof s === "string") {
+        const d = s.trim();
+        if (/^\d{4}-\d{2}-\d{2}$/.test(d)) out.add(d);
+      }
+    }
+  }
+
+  return [...out].sort();
+}
+
+/** Pick document id convention: `{YYYY-MM-DD}_{userId}`. */
+function pickDocId(showDate, userId) {
+  return `${showDate}_${userId}`;
+}
+
+/**
+ * Walks `picks/{showDate}_{uid}` for every (date, member) pair and returns
+ * `true` as soon as one qualifies as activity for this pool. Mirrors the
+ * client walk in `poolFirestore.poolHasPickActivityApi` so the eligibility
+ * decision is identical on both sides.
+ *
+ * The optional `chunkSize` caps in-flight `getDoc` calls per round-trip
+ * (default 24, same as client). Bump only if the pool size + calendar grows
+ * enough that round-trip latency dominates.
+ *
+ * @param {{
+ *   db: import("firebase-admin").firestore.Firestore,
+ *   poolId: string,
+ *   memberIds: string[],
+ *   showDates: string[],
+ *   chunkSize?: number,
+ * }} opts
+ * @returns {Promise<boolean>}
+ */
+async function findPoolPickActivity({
+  db,
+  poolId,
+  memberIds,
+  showDates,
+  chunkSize = 24,
+}) {
+  const pid = typeof poolId === "string" ? poolId.trim() : "";
+  const members = Array.isArray(memberIds)
+    ? [
+        ...new Set(
+          memberIds.filter((u) => typeof u === "string" && u.trim())
+        ),
+      ]
+    : [];
+  const dates = Array.isArray(showDates)
+    ? showDates.filter(
+        (d) => typeof d === "string" && /^\d{4}-\d{2}-\d{2}$/.test(d)
+      )
+    : [];
+  if (!pid || members.length === 0 || dates.length === 0) return false;
+
+  /** @type {{ date: string, uid: string }[]} */
+  const tasks = [];
+  for (const date of dates) {
+    for (const uid of members) tasks.push({ date, uid });
+  }
+
+  for (let i = 0; i < tasks.length; i += chunkSize) {
+    const slice = tasks.slice(i, i + chunkSize);
+    const snaps = await Promise.all(
+      slice.map(({ date, uid }) =>
+        db.collection("picks").doc(pickDocId(date, uid)).get()
+      )
+    );
+    for (const snap of snaps) {
+      if (!snap || !snap.exists) continue;
+      const data = snap.data ? snap.data() : null;
+      if (pickDocHasPoolActivity(data || {}, pid)) return true;
+    }
+  }
+  return false;
+}
+
+module.exports = {
+  MAX_POOL_DELETE_BATCH_WRITES,
+  findPoolPickActivity,
+  hasNonEmptyPicksObject,
+  parseShowCalendarDates,
+  pickDataCountsForPool,
+  pickDocHasPoolActivity,
+  pickDocId,
+};

--- a/functions/poolDelete.test.js
+++ b/functions/poolDelete.test.js
@@ -1,0 +1,272 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  findPoolPickActivity,
+  hasNonEmptyPicksObject,
+  parseShowCalendarDates,
+  pickDataCountsForPool,
+  pickDocHasPoolActivity,
+  pickDocId,
+} = require("./poolDelete");
+
+/**
+ * Minimal fake Firestore that matches the `.collection(...).doc(...).get()`
+ * shape used by `findPoolPickActivity`. Seeds pick docs by id.
+ *
+ * @param {Record<string, Record<string, unknown> | undefined>} picksById
+ */
+function createFakeDb(picksById) {
+  const reads = [];
+  return {
+    reads,
+    collection(name) {
+      if (name !== "picks") {
+        throw new Error(`unexpected collection ${name}`);
+      }
+      return {
+        doc(id) {
+          return {
+            async get() {
+              reads.push(id);
+              const data = picksById[id];
+              if (data === undefined) {
+                return { exists: false, data: () => null };
+              }
+              return { exists: true, data: () => data };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+test("hasNonEmptyPicksObject: empty / whitespace / non-object", () => {
+  assert.equal(hasNonEmptyPicksObject(null), false);
+  assert.equal(hasNonEmptyPicksObject(undefined), false);
+  assert.equal(hasNonEmptyPicksObject([]), false);
+  assert.equal(hasNonEmptyPicksObject({}), false);
+  assert.equal(hasNonEmptyPicksObject({ s1o: "", s1c: "   " }), false);
+  assert.equal(hasNonEmptyPicksObject({ s1o: "Bag" }), true);
+});
+
+test("pickDataCountsForPool: rejects empty inputs", () => {
+  assert.equal(pickDataCountsForPool(null, "p1"), false);
+  assert.equal(pickDataCountsForPool({}, ""), false);
+  assert.equal(pickDataCountsForPool({}, "   "), false);
+});
+
+test("pickDataCountsForPool: legacy picks (no pools snapshot) count everywhere", () => {
+  assert.equal(pickDataCountsForPool({ picks: { s1o: "Bag" } }, "p1"), true);
+  assert.equal(pickDataCountsForPool({ pools: [] }, "p1"), true);
+});
+
+test("pickDataCountsForPool: embedded pools snapshot scopes to id match", () => {
+  const data = { pools: [{ id: "p1", name: "A" }, { id: "p2", name: "B" }] };
+  assert.equal(pickDataCountsForPool(data, "p1"), true);
+  assert.equal(pickDataCountsForPool(data, "p3"), false);
+});
+
+test("pickDocHasPoolActivity: non-empty picks triggers activity", () => {
+  assert.equal(
+    pickDocHasPoolActivity({ picks: { s1o: "Bag" } }, "p1"),
+    true
+  );
+});
+
+test("pickDocHasPoolActivity: graded pick triggers activity even with empty picks", () => {
+  assert.equal(
+    pickDocHasPoolActivity({ picks: {}, isGraded: true }, "p1"),
+    true
+  );
+});
+
+test("pickDocHasPoolActivity: non-zero score triggers activity", () => {
+  assert.equal(
+    pickDocHasPoolActivity({ picks: {}, score: 15 }, "p1"),
+    true
+  );
+});
+
+test("pickDocHasPoolActivity: zero score + empty picks + ungraded is clean", () => {
+  assert.equal(
+    pickDocHasPoolActivity({ picks: {}, score: 0 }, "p1"),
+    false
+  );
+  assert.equal(pickDocHasPoolActivity({}, "p1"), false);
+});
+
+test("pickDocHasPoolActivity: mismatched embedded pool scopes out", () => {
+  assert.equal(
+    pickDocHasPoolActivity(
+      { picks: { s1o: "Bag" }, pools: [{ id: "other" }] },
+      "p1"
+    ),
+    false
+  );
+});
+
+test("parseShowCalendarDates: reads showDatesByTour shape", () => {
+  const dates = parseShowCalendarDates({
+    showDatesByTour: [
+      {
+        tour: "Sphere Run",
+        shows: [
+          { date: "2026-04-16", venue: "Sphere" },
+          { date: "2026-04-17", venue: "Sphere" },
+        ],
+      },
+      {
+        tour: "Summer Tour",
+        shows: [{ date: "2026-07-07", venue: "Kohl" }],
+      },
+    ],
+  });
+  assert.deepEqual(dates, ["2026-04-16", "2026-04-17", "2026-07-07"]);
+});
+
+test("parseShowCalendarDates: reads flat showDates object + string shapes", () => {
+  const dates = parseShowCalendarDates({
+    showDates: [
+      { date: "2026-04-16", venue: "Sphere" },
+      "2026-04-17",
+      { date: " 2026-04-18 ", venue: "x" },
+    ],
+  });
+  assert.deepEqual(dates, ["2026-04-16", "2026-04-17", "2026-04-18"]);
+});
+
+test("parseShowCalendarDates: empty / invalid inputs return []", () => {
+  assert.deepEqual(parseShowCalendarDates(null), []);
+  assert.deepEqual(parseShowCalendarDates({}), []);
+  assert.deepEqual(parseShowCalendarDates({ showDates: [] }), []);
+  assert.deepEqual(
+    parseShowCalendarDates({ showDates: [{ date: "bad" }] }),
+    []
+  );
+});
+
+test("parseShowCalendarDates: dedupes across both shapes", () => {
+  const dates = parseShowCalendarDates({
+    showDatesByTour: [
+      { tour: "t", shows: [{ date: "2026-04-16", venue: "x" }] },
+    ],
+    showDates: ["2026-04-16", "2026-04-17"],
+  });
+  assert.deepEqual(dates, ["2026-04-16", "2026-04-17"]);
+});
+
+test("findPoolPickActivity: returns false when no members or no dates", async () => {
+  const db = createFakeDb({});
+  assert.equal(
+    await findPoolPickActivity({
+      db,
+      poolId: "p1",
+      memberIds: [],
+      showDates: ["2026-04-16"],
+    }),
+    false
+  );
+  assert.equal(
+    await findPoolPickActivity({
+      db,
+      poolId: "p1",
+      memberIds: ["u1"],
+      showDates: [],
+    }),
+    false
+  );
+  assert.equal(db.reads.length, 0);
+});
+
+test("findPoolPickActivity: returns false when no pick docs exist", async () => {
+  const db = createFakeDb({});
+  const got = await findPoolPickActivity({
+    db,
+    poolId: "p1",
+    memberIds: ["u1", "u2"],
+    showDates: ["2026-04-16", "2026-04-17"],
+  });
+  assert.equal(got, false);
+  assert.equal(db.reads.length, 4);
+});
+
+test("findPoolPickActivity: true when any member has non-empty picks", async () => {
+  const db = createFakeDb({
+    [pickDocId("2026-04-17", "u2")]: { picks: { s1o: "Bag" } },
+  });
+  const got = await findPoolPickActivity({
+    db,
+    poolId: "p1",
+    memberIds: ["u1", "u2"],
+    showDates: ["2026-04-16", "2026-04-17"],
+  });
+  assert.equal(got, true);
+});
+
+test("findPoolPickActivity: scopes to embedded pools array when present", async () => {
+  const db = createFakeDb({
+    [pickDocId("2026-04-16", "u1")]: {
+      picks: { s1o: "Bag" },
+      pools: [{ id: "other" }],
+    },
+  });
+  const got = await findPoolPickActivity({
+    db,
+    poolId: "p1",
+    memberIds: ["u1"],
+    showDates: ["2026-04-16"],
+  });
+  assert.equal(got, false);
+});
+
+test("findPoolPickActivity: treats legacy (no pools) pick doc as in-pool activity", async () => {
+  const db = createFakeDb({
+    [pickDocId("2026-04-16", "u1")]: {
+      picks: { s1o: "Bag" },
+      // no `pools` array — legacy snapshot, should count for any pool.
+    },
+  });
+  const got = await findPoolPickActivity({
+    db,
+    poolId: "p1",
+    memberIds: ["u1"],
+    showDates: ["2026-04-16"],
+  });
+  assert.equal(got, true);
+});
+
+test("findPoolPickActivity: graded + zero picks still triggers activity", async () => {
+  const db = createFakeDb({
+    [pickDocId("2026-04-16", "u1")]: { picks: {}, isGraded: true },
+  });
+  const got = await findPoolPickActivity({
+    db,
+    poolId: "p1",
+    memberIds: ["u1"],
+    showDates: ["2026-04-16"],
+  });
+  assert.equal(got, true);
+});
+
+test("findPoolPickActivity: chunk boundary still finds activity", async () => {
+  /** @type {Record<string, Record<string, unknown>>} */
+  const picksById = {};
+  const members = Array.from({ length: 5 }, (_, i) => `u${i}`);
+  const dates = Array.from(
+    { length: 10 },
+    (_, i) => `2026-04-${String(10 + i).padStart(2, "0")}`
+  );
+  picksById[pickDocId(dates[9], members[4])] = { picks: { s1o: "Bag" } };
+  const db = createFakeDb(picksById);
+  const got = await findPoolPickActivity({
+    db,
+    poolId: "p1",
+    memberIds: members,
+    showDates: dates,
+    chunkSize: 7,
+  });
+  assert.equal(got, true);
+  assert.equal(db.reads.length, 50);
+});

--- a/src/features/pools/api/poolDeleteCallable.js
+++ b/src/features/pools/api/poolDeleteCallable.js
@@ -1,0 +1,75 @@
+import { getFunctions, httpsCallable } from 'firebase/functions';
+
+import { app } from '../../../shared/lib/firebase';
+
+const FUNCTIONS_REGION = 'us-central1';
+
+/**
+ * Callable wrapper around `deletePoolWithCleanup` (issue #138). The server
+ * is the source of truth for eligibility:
+ *   - `permission-denied` → caller is not the pool owner.
+ *   - `failed-precondition` → pool has qualifying pick history; UI should
+ *     suggest archive instead.
+ *   - `not-found` → pool doc does not exist.
+ *   - `unauthenticated` → caller is signed out.
+ *   - `invalid-argument` → missing / bad `poolId`.
+ *
+ * The Firebase Functions SDK surfaces these as either the bare `code` (e.g.
+ * `"failed-precondition"`) or a namespaced `"functions/<code>"`. We
+ * normalize to a stable set of string codes on the error so the orchestrator
+ * (`usePoolAdminControls`) can render the right message without depending on
+ * the SDK's exact code shape.
+ *
+ * @param {string} poolId
+ * @returns {Promise<{ ok: boolean, poolId: string, memberUpdates: number }>}
+ */
+export async function deletePoolWithCleanup(poolId) {
+  const value = typeof poolId === 'string' ? poolId.trim() : '';
+  if (!value) throw new Error('Missing pool id.');
+
+  const functions = getFunctions(app, FUNCTIONS_REGION);
+  const callable = httpsCallable(functions, 'deletePoolWithCleanup');
+  try {
+    const result = await callable({ poolId: value });
+    const data = /** @type {any} */ (result?.data ?? {});
+    return {
+      ok: data.ok === true,
+      poolId: typeof data.poolId === 'string' ? data.poolId : value,
+      memberUpdates:
+        typeof data.memberUpdates === 'number' ? data.memberUpdates : 0,
+    };
+  } catch (e) {
+    throw normalizeCallableError(e);
+  }
+}
+
+/**
+ * @param {unknown} e
+ * @returns {Error & { code?: string }}
+ */
+function normalizeCallableError(e) {
+  const rawMessage =
+    e instanceof Error ? e.message : 'Could not delete this pool.';
+  const rawCode =
+    e && typeof e === 'object' && 'code' in e
+      ? String(/** @type {any} */ (e).code)
+      : '';
+  const code = rawCode.includes('/') ? rawCode.split('/').pop() : rawCode;
+
+  /** @type {Error & { code?: string }} */
+  const err = new Error(rawMessage);
+  if (code === 'failed-precondition') {
+    err.code = 'pool-has-activity';
+  } else if (code === 'permission-denied') {
+    err.code = 'permission-denied';
+  } else if (code === 'not-found') {
+    err.code = 'pool-not-found';
+  } else if (code === 'unauthenticated') {
+    err.code = 'unauthenticated';
+  } else if (code === 'invalid-argument') {
+    err.code = 'invalid-argument';
+  } else {
+    err.code = code || 'unknown';
+  }
+  return err;
+}

--- a/src/features/pools/api/poolFirestore.js
+++ b/src/features/pools/api/poolFirestore.js
@@ -1,4 +1,4 @@
-import { arrayRemove, doc, getDoc, updateDoc, writeBatch } from 'firebase/firestore';
+import { doc, getDoc, updateDoc } from 'firebase/firestore';
 
 import { db } from '../../../shared/lib/firebase';
 
@@ -41,14 +41,6 @@ function pickCountsTowardPoolSeasonTotals(pickData) {
   return hasNonEmptyPicksObject(pickData.picks);
 }
 
-function pickDocHasPoolActivity(pickData, poolId) {
-  if (!pickDataCountsForPool(pickData, poolId)) return false;
-  if (hasNonEmptyPicksObject(pickData.picks)) return true;
-  if (pickData.isGraded === true) return true;
-  if (typeof pickData.score === 'number' && pickData.score > 0) return true;
-  return false;
-}
-
 export async function updatePoolNameApi(poolId, newName) {
   const trimmed = newName?.trim() ?? '';
   if (!poolId?.trim()) throw new Error('Missing pool id.');
@@ -69,92 +61,6 @@ export async function updatePoolStatusApi(poolId, status) {
     throw new Error('Invalid pool status.');
   }
   await updateDoc(doc(db, 'pools', poolId.trim()), { status });
-}
-
-/**
- * @param {{ date: string }[]} showDates — same calendar as dashboard (Phish.net or fallback).
- * @returns {Promise<boolean>}
- */
-export async function poolHasPickActivityApi(poolId, memberIds, showDates) {
-  const pid = poolId?.trim();
-  const members = Array.isArray(memberIds) ? memberIds.filter(Boolean) : [];
-  if (!pid || members.length === 0) return false;
-  if (!Array.isArray(showDates) || showDates.length === 0) return false;
-
-  const dates = showDates.map((s) => s.date);
-  const chunkSize = 24;
-  const tasks = [];
-  for (const showDate of dates) {
-    for (const userId of members) {
-      tasks.push({ showDate, userId });
-    }
-  }
-
-  for (let i = 0; i < tasks.length; i += chunkSize) {
-    const slice = tasks.slice(i, i + chunkSize);
-    const snaps = await Promise.all(
-      slice.map(({ showDate, userId }) =>
-        getDoc(doc(db, 'picks', pickDocId(showDate, userId)))
-      )
-    );
-    for (let j = 0; j < snaps.length; j += 1) {
-      const snap = snaps[j];
-      if (!snap.exists()) continue;
-      if (pickDocHasPoolActivity(snap.data(), pid)) return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Deletes the pool doc and removes the pool id from the owner’s `users.pools` only.
- * Multi-member pools cannot be fully cleaned up from the client without a Cloud Function
- * (Firestore rules keep user updates owner-scoped).
- */
-export async function deleteOwnerOnlyEmptyPoolApi(poolId, ownerId) {
-  const pid = poolId?.trim();
-  const uid = ownerId?.trim();
-  if (!pid || !uid) throw new Error('Missing pool or owner id.');
-
-  const batch = writeBatch(db);
-  batch.set(
-    doc(db, 'users', uid),
-    { pools: arrayRemove(pid) },
-    { merge: true }
-  );
-  batch.delete(doc(db, 'pools', pid));
-  await batch.commit();
-}
-
-/**
- * @param {string} ownerId — pool.ownerId (creator)
- */
-export async function deletePoolApi(poolId, memberIds, ownerId, showDates) {
-  const pid = poolId?.trim();
-  const oid = ownerId?.trim();
-  const members = Array.isArray(memberIds) ? memberIds.filter(Boolean) : [];
-  if (!pid) throw new Error('Missing pool id.');
-  if (!oid) throw new Error('Missing pool owner id.');
-
-  const unique = [...new Set(members)];
-  if (unique.length !== 1 || unique[0] !== oid) {
-    const err = new Error(
-      'You can only delete a pool that has no other members. Ask others to leave, or archive the pool.'
-    );
-    err.code = 'pool-has-members';
-    throw err;
-  }
-
-  const active = await poolHasPickActivityApi(pid, unique, showDates);
-  if (active) {
-    const err = new Error(
-      'This pool has pick history. Archive it instead of deleting.'
-    );
-    err.code = 'pool-has-activity';
-    throw err;
-  }
-
-  await deleteOwnerOnlyEmptyPoolApi(pid, oid);
 }
 
 /**

--- a/src/features/pools/model/usePoolAdminControls.js
+++ b/src/features/pools/model/usePoolAdminControls.js
@@ -1,8 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 
-import { useShowCalendar } from '../../show-calendar';
+import { deletePoolWithCleanup } from '../api/poolDeleteCallable';
 import {
-  deletePoolApi,
   POOL_NAME_MAX_LENGTH,
   updatePoolNameApi,
   updatePoolStatusApi,
@@ -16,7 +15,6 @@ import { invalidateUserPools } from './userPoolsRefreshBus';
  * @param {{ navigate: (path: string) => void, onReloadPool: () => void | Promise<void> }} callbacks
  */
 export function usePoolAdminControls(poolId, user, pool, { navigate, onReloadPool }) {
-  const { showDates } = useShowCalendar();
   const [editNameOpen, setEditNameOpen] = useState(false);
   const [confirmAction, setConfirmAction] = useState(
     /** @type {null | 'archive' | 'delete'} */ (null)
@@ -110,22 +108,28 @@ export function usePoolAdminControls(poolId, user, pool, { navigate, onReloadPoo
   const handleConfirmDelete = useCallback(async () => {
     const pid = poolId?.trim();
     const oid = pool?.ownerId?.trim();
-    const members = pool?.members;
     if (!pid || !oid) return;
     setBusy(true);
     setFormError('');
     try {
-      await deletePoolApi(pid, members, oid, showDates);
+      // Server (`deletePoolWithCleanup`, issue #138) is the source of truth:
+      // it re-checks ownership, activity, and cleans up every member's
+      // `users.pools` entry with Admin SDK. Don't duplicate that logic here.
+      await deletePoolWithCleanup(pid);
       invalidateUserPools();
       setConfirmAction(null);
       navigate('/dashboard/pools');
     } catch (e) {
       setConfirmAction(null);
       const code = e && typeof e === 'object' && 'code' in e ? e.code : '';
-      if (code === 'pool-has-activity' || code === 'pool-has-members') {
+      if (code === 'pool-has-activity') {
         setFormError(
-          e instanceof Error ? e.message : 'Cannot delete this pool.'
+          e instanceof Error
+            ? e.message
+            : 'This pool has pick history. Archive it instead of deleting.'
         );
+      } else if (code === 'permission-denied') {
+        setFormError('Only the pool owner can delete this pool.');
       } else {
         setFormError(
           e instanceof Error ? e.message : 'Could not delete this pool.'
@@ -134,7 +138,7 @@ export function usePoolAdminControls(poolId, user, pool, { navigate, onReloadPoo
     } finally {
       setBusy(false);
     }
-  }, [poolId, pool?.ownerId, pool?.members, navigate, showDates]);
+  }, [poolId, pool?.ownerId, navigate]);
 
   const confirmModalProps = useMemo(() => {
     if (confirmAction === 'archive') {
@@ -151,7 +155,7 @@ export function usePoolAdminControls(poolId, user, pool, { navigate, onReloadPoo
       return {
         title: 'Delete this pool?',
         message:
-          'You can only delete a pool you created alone, with no pick history. This cannot be undone.',
+          'This removes the pool and clears it from every member. Only allowed when no picks have been made yet; otherwise archive instead. This cannot be undone.',
         confirmLabel: 'Delete pool',
         confirmVariant: 'danger',
         onConfirm: handleConfirmDelete,


### PR DESCRIPTION
## Summary

Closes #138 (follow-up under EPIC #127). Adds a server-side pool delete so an owner can remove a multi-member pool and every member loses the pool from `users.pools` — previously impossible from the client because Firestore rules keep cross-user writes admin-only.

### Server
- `functions/poolDelete.js` — pure helpers (`pickDataCountsForPool`, `pickDocHasPoolActivity`, `parseShowCalendarDates`, `findPoolPickActivity`). Activity rule mirrors the client walk so both sides agree on eligibility.
- `functions/index.js` — new `deletePoolWithCleanup` callable: auth → owner check → server walk over `show_calendar/snapshot` × `pool.members` for qualifying pick activity → batched `arrayRemove(poolId)` on every member's `users` doc → pool delete, split at the Firestore 500-write batch limit.
- `functions/poolDelete.test.js` — unit tests for all helpers + the walk (uses a tiny fake Firestore). Full suite: 78 passing.

### Client (FSD)
- `src/features/pools/api/poolDeleteCallable.js` — thin `httpsCallable` wrapper that normalizes `HttpsError` codes (`failed-precondition` → `pool-has-activity`, `permission-denied`, etc.).
- `src/features/pools/model/usePoolAdminControls.js` — always calls the callable now; no more client-side eligibility walk. Maps structured errors to friendly messages and keeps the existing `ConfirmationModal` UX.
- Drops the now-superseded client helpers (`deletePoolApi`, `deleteOwnerOnlyEmptyPoolApi`, `poolHasPickActivityApi`) from `poolFirestore.js`.
- Confirm modal copy updated — multi-member delete is now supported (picks-free only; otherwise archive).

No new pages, no direct Firestore in pages, FSD boundaries preserved. Schema unchanged (no new `poolId` field on picks per PRD §3 / §5.1).

## Test plan
- [x] `cd functions && npm test` — 78/78 pass (includes the new `poolDelete` cases).
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean Vite build.
- [x] `npm run verify:dashboard-meta` — 8/8 OK.
- [x] Staging deploy: `firebase deploy --only functions:deletePoolWithCleanup` then manual QA per PRD §6:
  - Owner, no activity, multiple members → delete succeeds; each member's `users.pools` no longer contains the id; pool doc gone.
  - Pool with any qualifying pick activity → callable fails with "archive instead" message.
  - Non-owner → `permission-denied` surfaced as "Only the pool owner can delete this pool."
  - `gradePicksOnSetlistWrite` grading path unchanged (Admin SDK).

Made with [Cursor](https://cursor.com)