### PR TITLE
feat(security): tighten firestore.rules + drop legacy admin email fallback (#139 PR B)

### DIFF
--- a/docs/ADMIN_CLAIMS_RUNBOOK.md
+++ b/docs/ADMIN_CLAIMS_RUNBOOK.md
@@ -2,7 +2,7 @@
 
 Operational guide for granting, revoking, and auditing the `admin: true` Firebase Auth custom claim used by Set Picks.
 
-Introduced in issue #139 PR A. In PR A the claim is the preferred signal for admin UI gating (`useAuth().isAdmin`) but a **legacy email fallback** (`pat@road2media.com`) is still accepted so existing admin flows keep working during transition. PR B removes the email fallback and tightens Firestore rules to require the claim.
+Introduced in issue #139 PR A as the preferred admin signal, with a transitional `pat@road2media.com` email fallback. **PR B (this milestone) tightened Firestore rules to require the claim and removed the email fallback everywhere** — from `resolveIsAdmin` (client), from `resolveAdminCallerRole` / `resolveSetAdminClaimCallerRole` (functions), from `assertAdminClaim` (formerly `assertAdminEmail` / `assertAdminClaimOrEmail`), and from `firestore.rules`. The claim is now the single source of truth.
 
 ---
 
@@ -13,19 +13,21 @@ Both live in `functions/index.js`:
 | Function | Type | Purpose |
 |---------|------|---------|
 | `setAdminClaim` | HTTPS callable | Grant or revoke `admin: true` on a target Auth user |
-| `rollupScoresForShow` | HTTPS callable | Server-side replacement for `adminRollupApi.js`; gated by `admin: true` claim OR legacy email |
+| `rollupScoresForShow` | HTTPS callable | Server-side replacement for `adminRollupApi.js`; gated by the `admin: true` claim |
+
+Every other admin-only callable (`refreshLiveScoresForShow`, `setLiveSetlistAutomationState`, `pollLiveSetlistNow`, `getPhishnetSetlist`, `refreshPhishnetShowCalendar`, `refreshPhishnetSongCatalog`) is gated on the same `assertAdminClaim(request)` helper.
 
 `setAdminClaim` authorization:
 
 - Caller must be signed in.
-- Caller must be a **super-admin** — either `SUPER_ADMIN_UIDS` env var listed, or the legacy `pat@road2media.com` email holder (transition only) — **or** caller must already hold `admin: true`.
+- Caller must be a **super-admin** (UID listed in `SUPER_ADMIN_UIDS` env var — bootstrap / break-glass path) **or** already hold `admin: true`.
 - Callers can set the claim on themselves (bootstrap) or on another uid (delegation).
 
 ---
 
 ## 2. One-time bootstrap (first admin)
 
-The first time you roll this out, no one has the claim yet. Seed the first admin via the super-admin env var.
+The first time you roll this out — or after an accidental revocation that removes the last admin — no one has the claim. Seed the first admin via `SUPER_ADMIN_UIDS`.
 
 ### 2a. Set `SUPER_ADMIN_UIDS`
 
@@ -44,11 +46,11 @@ Then redeploy:
 firebase deploy --only functions:setAdminClaim --project <alias>
 ```
 
-> The legacy `pat@road2media.com` email holder is implicitly treated as a super-admin in PR A, so you can skip this env var during initial rollout and still bootstrap from the browser as that user. Remove that fallback in PR B.
+> **PR B note:** the legacy email shortcut (previously let `pat@road2media.com` skip this env-var step) is gone. `SUPER_ADMIN_UIDS` is now the only bootstrap path — don't forget to populate it before deploying PR B to a new project.
 
 ### 2b. Self-grant the claim (preferred: in-app UI)
 
-As the super-admin (or legacy email holder), sign into the app and navigate to `/admin`. If your account does **not** yet hold the `admin: true` claim, the `AdminClaimBootstrap` card (amber) renders above the "Locking the official setlist" warning with a single button:
+As the super-admin, sign into the app and navigate to `/admin`. If your account does **not** yet hold the `admin: true` claim, the `AdminClaimBootstrap` card (amber) renders above the "Locking the official setlist" warning with a single button:
 
 **Grant admin claim to myself**
 
@@ -57,7 +59,7 @@ Click it. The UI:
 2. Force-refreshes the ID token (`getIdTokenResult(true)`) so the new claim is visible to the client without re-login.
 3. Flips the card to green: "Admin claim active on your account."
 
-`useAuth().isAdmin` now resolves via the claim, not the legacy email fallback.
+`useAuth().isAdmin` now resolves via the claim.
 
 > **Note:** An earlier version of this runbook documented a devtools `import()` snippet for bootstrap. That snippet worked against source paths (`/src/shared/lib/firebase.js`) that **don't exist** in the Vite production bundle on Vercel, so it's not viable in deployed environments. The in-app button replaces it. If you're working against the local dev server and want to script the call, see §4 (Admin SDK).
 
@@ -88,6 +90,8 @@ await fn({ admin: false, targetUid: '<uid>' });
 
 Revocations remove the `admin` key from custom claims entirely.
 
+> **Break-glass:** If the last admin is revoked accidentally, a user listed in `SUPER_ADMIN_UIDS` can still call `setAdminClaim`. If `SUPER_ADMIN_UIDS` is empty, re-bootstrap from a machine with Admin SDK credentials using `setCustomUserClaims(uid, { admin: true })` directly.
+
 ---
 
 ## 5. Audit current claims
@@ -117,23 +121,48 @@ Cloud Logging also records every `setAdminClaim` call with caller uid, target ui
 
 - `setAdminClaim` only manipulates Auth custom claims; it never touches `picks`, `users`, or `official_setlists`.
 - A token refresh is required for client-side `isAdmin` to flip. The app's `useAuth` subscribes to `onIdTokenChanged` so this propagates automatically after `getIdTokenResult(true)` without re-login.
-- Firestore rules in PR A are **unchanged**; the claim is purely for UI gating and for `rollupScoresForShow` authorization. PR B makes the rules require the claim for writes to `picks` / `users` / `official_setlists`.
-- If you accidentally revoke your own claim and no longer match the email fallback or `SUPER_ADMIN_UIDS`, re-bootstrap from a machine with Admin SDK credentials using `setCustomUserClaims(uid, { admin: true })` directly.
+- Firestore rules require the claim for writes to `picks` (admin-override only; owners write their own), `users` (admin-override only; owners write their own), `official_setlists` (admin-only write), `live_setlist_automation` (admin-only read, server-only write), and `rollup_audit` (admin-only read, server-only write). See `firestore.rules`.
+- Admin SDK writes from scheduled / callable Cloud Functions (`gradePicksOnSetlistWrite`, `recomputeLiveScoresForShow`, `rollupScoresForShow`, `pollLiveSetlistNow`, show-calendar sync) bypass rules entirely, so server-side grading and automation are unaffected by the tightened rules.
 
 ---
 
-## 7. PR B follow-ups
+## 7. PR B deployment checklist
 
-After soaking PR A in staging:
+PR B tightens Firestore rules and drops the legacy email fallback. Before merging to `main`:
 
-1. Grant the claim to every current admin via `setAdminClaim`.
-2. Remove the legacy email fallback from `resolveIsAdmin` in `src/features/auth/api/authApi.js` and from `assertAdminClaimOrEmail` in `functions/index.js`.
-3. Tighten `firestore.rules` (claim-only). Include a rule for the new `rollup_audit/{showDate}` collection — admin-read-only, no client writes (Admin SDK writes from `rollupScoresForShow` bypass rules).
-4. Keep `SUPER_ADMIN_UIDS` so the break-glass path exists.
+1. **Grant the claim to every current admin** (via the in-app bootstrap UI on staging, or `setAdminClaim` from an existing admin). Double-check in Firebase console → Authentication → Users → "Custom claims" that every required admin has `admin: true`.
+2. **Populate `SUPER_ADMIN_UIDS`** on the `setAdminClaim` function so the break-glass path exists if the last admin revokes themselves. Redeploy `setAdminClaim` if this changed.
+3. **Staging QA** (see §8 checklist below).
+4. Deploy rules **after** functions: `firebase deploy --only functions && firebase deploy --only firestore:rules`. Rolling out rules before the new functions means Admin-SDK writes still work but client-side admin UI breaks for the email-only holder.
+5. **Rollback plan:** if anything misbehaves, revert with `firebase deploy --only firestore:rules` after checking out the pre-PR-B `firestore.rules` file (`git show HEAD~1:firestore.rules > /tmp/r.rules && firebase deploy --only firestore:rules --project <alias>` after replacing). Callable code can roll back via `firebase deploy --only functions --project <alias>` from the pre-PR-B commit.
 
 ---
 
-## 8. Rollup audit collection
+## 8. PR B staging QA checklist
+
+Verify each of these flows against staging with a real non-admin user AND the admin claim holder, before deploying PR B to production.
+
+| Surface | Who | Expected |
+|---|---|---|
+| Sign up → create profile | New user (no claim) | `users/{uid}` created (self-write rule) |
+| Submit picks | Any signed-in user | `picks/{date_uid}` created/updated (userId matches auth.uid) |
+| Attempt to edit another user's pick via DevTools | Non-admin | Rejected by rules |
+| Attempt to edit another user's users doc via DevTools | Non-admin | Rejected by rules |
+| Attempt to write `official_setlists` via DevTools | Non-admin | Rejected by rules |
+| Attempt to read `live_setlist_automation/{showDate}` | Non-admin | Rejected by rules |
+| Global standings | Any signed-in user | Loads (reads `users` + `picks`) |
+| Pool details + member profiles | Any signed-in user | Loads (reads `users`) |
+| Public profile by handle | Any signed-in user | Loads (reads `users`) |
+| Admin setlist save | Admin (claim) | `official_setlists/{showDate}` write succeeds |
+| Admin Finalize and rollup | Admin (claim) | `rollupScoresForShow` callable succeeds; `rollup_audit/{showDate}` timestamp advances |
+| Live-scoring trigger | N/A (Admin SDK) | `gradePicksOnSetlistWrite` still runs on setlist write |
+| Live setlist automation UI | Admin (claim) | Reads `live_setlist_automation/{showDate}` pause/backoff metadata |
+
+Also confirm: an admin who already grants themselves the claim via the `AdminClaimBootstrap` card in PR A sees the green "Admin claim active" pill and all admin surfaces continue to work after the rules tighten (no email fallback regression).
+
+---
+
+## 9. Rollup audit collection
 
 Each successful `rollupScoresForShow` invocation writes a record to `rollup_audit/{showDate}` with:
 
@@ -141,17 +170,17 @@ Each successful `rollupScoresForShow` invocation writes a record to `rollup_audi
 |-------|------|---------|
 | `lastRolledUpAt` | serverTimestamp | When the rollup committed. Updated on every run. |
 | `processedPicks` | number | Picks regraded in this run. |
-| `skippedPicks`   | number | Picks skipped (missing `userId`). |
-| `totalPicks`     | number | Total matching `picks` docs for this `showDate`. |
-| `callerUid`      | string \| null | Firebase UID of the admin who triggered it. |
+| `skippedPicks` | number | Picks skipped (missing `userId`). |
+| `totalPicks` | number | Total matching `picks` docs for this `showDate`. |
+| `callerUid` | string \| null | Firebase UID of the admin who triggered it. |
 
 This is a **Firestore-visible "when did the last rollup run"** signal, separate from per-pick `gradedAt` which only stamps the first grade. Useful for PM-level sanity-checking after idempotent re-runs (where pick `score` and `gradedAt` may not visibly change even though the batch committed).
 
-Do not write to this collection from the client. It's a pure server-side audit log.
+PR B rules: admin-only read, no client writes. The Admin SDK bypasses rules on the write path.
 
 ---
 
-## 9. Troubleshooting
+## 10. Troubleshooting
 
 ### `setCustomUserClaims failed … (auth/insufficient-permission): Credential implementation provided to initializeApp() via the "credential" property has insufficient permission to access the requested resource.`
 
@@ -175,4 +204,17 @@ The v1 PR A code masked every `admin.auth().getUser` failure as a misleading "No
 
 ### Finalize and rollup "succeeded" but Firestore looks unchanged
 
-Expected when re-running Finalize on an already-graded show: `gradedAt` is only stamped on the first grade (`isFirstGrade` check in `rollupScoresForShow`), and scores/user totals don't visibly change if the computation is deterministic and the inputs haven't changed. Check `rollup_audit/{showDate}.lastRolledUpAt` (added in §8) for a current timestamp, or filter Cloud Logging for `jsonPayload.message="rollupScoresForShow"`.
+Expected when re-running Finalize on an already-graded show: `gradedAt` is only stamped on the first grade (`isFirstGrade` check in `rollupScoresForShow`), and scores/user totals don't visibly change if the computation is deterministic and the inputs haven't changed. Check `rollup_audit/{showDate}.lastRolledUpAt` (§9) for a current timestamp, or filter Cloud Logging for `jsonPayload.message="rollupScoresForShow"`.
+
+### `permission-denied: Only an admin can perform this action.` from a callable that used to work
+
+PR B expectation. The calling user no longer has the `admin: true` claim. Either (a) grant the claim via `setAdminClaim`, or (b) if the account was relying on the legacy email fallback, self-grant via the `AdminClaimBootstrap` card on `/admin`.
+
+### `FirebaseError: Missing or insufficient permissions.` on a client write that used to work
+
+PR B expectation if the caller is not the document owner. Check:
+- `picks` writes: incoming payload must carry `userId == auth.uid`; on update, the existing doc's `userId` must already match.
+- `users` writes: path `userId` segment must equal `auth.uid`.
+- `official_setlists` / `live_setlist_automation` / `rollup_audit` writes from the client are always rejected (admin claim required, or server-only).
+
+If a legitimate admin flow hits this, confirm the admin holds the claim (§2c) and that `useAuth().isAdmin` shows `true` in React DevTools before writing.

--- a/firestore.rules
+++ b/firestore.rules
@@ -7,6 +7,15 @@ service cloud.firestore {
     }
 
     /**
+     * Admin custom claim (issue #139 PR B). Set via `setAdminClaim` callable.
+     * The legacy email fallback is removed in PR B; the claim is the single
+     * source of truth for write authorization against admin surfaces.
+     */
+    function isAdmin() {
+      return signedIn() && request.auth.token.admin == true;
+    }
+
+    /**
      * Join flow: only `members` may change; array grows by one and includes the caller.
      */
     function isPoolSelfJoin() {
@@ -32,29 +41,72 @@ service cloud.firestore {
     }
 
     /**
-     * Remaining collections: authenticated read/write so existing admin rollups, profile setup,
-     * and Cloud Function grading (Admin SDK) keep working. Tighten per-collection when you add
-     * custom claims or server-only admin paths.
+     * `users/{uid}` — profile docs (issue #139 PR B).
+     * Reads stay auth'd-only so peer lookups (`fetchPoolMemberProfiles`,
+     * `fetchPublicProfileByUid/Handle`) keep working. Writes are restricted to
+     * the owning user or an admin claim holder. Admin-SDK writes from
+     * `rollupScoresForShow` bypass rules entirely.
      */
     match /users/{userId} {
-      allow read, write: if signedIn();
-    }
-
-    match /picks/{pickId} {
-      allow read, write: if signedIn();
-    }
-
-    match /official_setlists/{showDate} {
-      allow read, write: if signedIn();
+      allow read: if signedIn();
+      allow create: if signedIn() && request.auth.uid == userId;
+      allow update: if signedIn()
+        && (request.auth.uid == userId || isAdmin());
+      allow delete: if isAdmin();
     }
 
     /**
-     * Live setlist automation state (issue #164). Written by Cloud Functions (Admin SDK);
-     * admin UI reads pause/backoff metadata. Same admin email as admin setlist tooling.
+     * `picks/{pickId}` — per-user pick docs (issue #139 PR B).
+     * Create/update must carry `userId == auth.uid` on the incoming payload,
+     * and update/delete additionally require the existing owner to match
+     * (prevents ownership handoff via overwrite). Admin claim holders can
+     * recover/repair any pick. Admin-SDK writes (grading) bypass rules.
+     */
+    match /picks/{pickId} {
+      allow read: if signedIn();
+      allow create: if signedIn()
+        && request.resource.data.userId == request.auth.uid;
+      allow update: if signedIn()
+        && (
+          (
+            resource.data.userId == request.auth.uid
+            && request.resource.data.userId == request.auth.uid
+          )
+          || isAdmin()
+        );
+      allow delete: if signedIn()
+        && (resource.data.userId == request.auth.uid || isAdmin());
+    }
+
+    /**
+     * `official_setlists/{showDate}` — authoritative, admin-authored setlists
+     * (issue #139 PR B). Reads stay auth'd-only so every user can see the
+     * live/final setlist; writes require the admin claim. Admin-SDK writes
+     * from scheduled / manual live-setlist automation bypass rules.
+     */
+    match /official_setlists/{showDate} {
+      allow read: if signedIn();
+      allow write: if isAdmin();
+    }
+
+    /**
+     * Live setlist automation state (issue #164). Written by Cloud Functions
+     * (Admin SDK); admin UI reads pause/backoff metadata. Gated on the admin
+     * claim as of PR B (previously: hard-coded email).
      */
     match /live_setlist_automation/{showDate} {
-      allow read: if signedIn()
-        && request.auth.token.email == 'pat@road2media.com';
+      allow read: if isAdmin();
+      allow write: if false;
+    }
+
+    /**
+     * Rollup audit log (issue #139 PR B). Written server-side by
+     * `rollupScoresForShow` after every invocation; surfaces a
+     * Firestore-visible "last rollup ran at…" signal. Admin-only reads; no
+     * client writes (Admin SDK bypasses rules on the write path).
+     */
+    match /rollup_audit/{showDate} {
+      allow read: if isAdmin();
       allow write: if false;
     }
 

--- a/functions/adminAuth.js
+++ b/functions/adminAuth.js
@@ -1,13 +1,17 @@
 /**
- * Admin authorization helpers for HTTPS callables (issue #139 PR A).
+ * Admin authorization helpers for HTTPS callables (issue #139).
  *
  * Pure functions — no `firebase-admin` dependency so they can be unit-tested
  * without spinning up the Firebase Functions test harness. Consumed by
- * `functions/index.js` to gate `rollupScoresForShow` and `setAdminClaim`.
+ * `functions/index.js` to gate `rollupScoresForShow`, `setAdminClaim`, and
+ * every other admin-only callable.
+ *
+ * PR B tightening: the legacy `pat@road2media.com` email fallback was removed
+ * from the admin caller check alongside the Firestore rules tightening. The
+ * `admin: true` custom claim is now the single source of truth. The break-
+ * glass `SUPER_ADMIN_UIDS` env-var path is retained so the claim can still be
+ * bootstrapped on a fresh project or recovered after accidental revocation.
  */
-
-/** Must match `src/features/auth/api/authApi.js` legacy fallback. */
-const ADMIN_EMAIL_FOR_SETLIST_PROXY = "pat@road2media.com";
 
 /**
  * Parse `SUPER_ADMIN_UIDS` (comma-separated uids) from the given env into a
@@ -29,30 +33,27 @@ function parseSuperAdminUidsEnv(env = process.env) {
 
 /**
  * Decide whether the caller of an admin-gated callable qualifies as admin.
- * Accepts either the `admin: true` custom claim (#139 target state) or the
- * legacy hard-coded admin email (transition only; drop in PR B).
+ * As of PR B this is claim-only. Returns `null` when the caller does not
+ * qualify. Callers in `functions/index.js` convert `null` into an
+ * `HttpsError("permission-denied")`.
  *
- * Returns `null` when neither qualifies. Callers in `functions/index.js`
- * convert `null` into an `HttpsError("permission-denied")`.
- *
- * @param {{ uid?: string, token?: { admin?: boolean, email?: string } } | null | undefined} authLike
- * @returns {"admin-claim" | "legacy-email" | null}
+ * @param {{ uid?: string, token?: { admin?: boolean } } | null | undefined} authLike
+ * @returns {"admin-claim" | null}
  */
 function resolveAdminCallerRole(authLike) {
   if (!authLike) return null;
   const token = authLike.token || {};
   if (token.admin === true) return "admin-claim";
-  if (token.email === ADMIN_EMAIL_FOR_SETLIST_PROXY) return "legacy-email";
   return null;
 }
 
 /**
  * Decide whether the caller of `setAdminClaim` qualifies to grant/revoke the
- * claim. Super-admins are `SUPER_ADMIN_UIDS` members **or** the legacy email
- * holder (bootstrap only). Anyone already holding `admin: true` can also grant
+ * claim. Super-admins are `SUPER_ADMIN_UIDS` members (the bootstrap /
+ * break-glass path). Anyone already holding `admin: true` can also grant
  * (delegation).
  *
- * @param {{ uid?: string, token?: { admin?: boolean, email?: string } } | null | undefined} authLike
+ * @param {{ uid?: string, token?: { admin?: boolean } } | null | undefined} authLike
  * @param {Set<string>} superAdminUids
  * @returns {"super-admin" | "admin" | null}
  */
@@ -60,10 +61,7 @@ function resolveSetAdminClaimCallerRole(authLike, superAdminUids) {
   if (!authLike) return null;
   const uid = authLike.uid;
   const token = authLike.token || {};
-  if (
-    (uid && superAdminUids.has(uid)) ||
-    token.email === ADMIN_EMAIL_FOR_SETLIST_PROXY
-  ) {
+  if (uid && superAdminUids.has(uid)) {
     return "super-admin";
   }
   if (token.admin === true) return "admin";
@@ -71,7 +69,6 @@ function resolveSetAdminClaimCallerRole(authLike, superAdminUids) {
 }
 
 module.exports = {
-  ADMIN_EMAIL_FOR_SETLIST_PROXY,
   parseSuperAdminUidsEnv,
   resolveAdminCallerRole,
   resolveSetAdminClaimCallerRole,

--- a/functions/adminAuth.test.js
+++ b/functions/adminAuth.test.js
@@ -2,7 +2,6 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
-  ADMIN_EMAIL_FOR_SETLIST_PROXY,
   parseSuperAdminUidsEnv,
   resolveAdminCallerRole,
   resolveSetAdminClaimCallerRole,
@@ -31,20 +30,20 @@ test("resolveAdminCallerRole: null when no auth", () => {
   assert.equal(resolveAdminCallerRole(undefined), null);
 });
 
-test("resolveAdminCallerRole: admin-claim takes precedence over email", () => {
+test("resolveAdminCallerRole: admin-claim qualifies", () => {
   const role = resolveAdminCallerRole({
     uid: "u1",
-    token: { admin: true, email: "random@example.com" },
+    token: { admin: true, email: "whatever@example.com" },
   });
   assert.equal(role, "admin-claim");
 });
 
-test("resolveAdminCallerRole: legacy email accepted when no claim", () => {
+test("resolveAdminCallerRole: legacy email no longer qualifies (PR B)", () => {
   const role = resolveAdminCallerRole({
     uid: "u1",
-    token: { email: ADMIN_EMAIL_FOR_SETLIST_PROXY },
+    token: { email: "pat@road2media.com" },
   });
-  assert.equal(role, "legacy-email");
+  assert.equal(role, null);
 });
 
 test("resolveAdminCallerRole: admin=false is not admin", () => {
@@ -72,15 +71,15 @@ test("resolveSetAdminClaimCallerRole: super-admin via env UID", () => {
   assert.equal(role, "super-admin");
 });
 
-test("resolveSetAdminClaimCallerRole: super-admin via legacy email (bootstrap)", () => {
+test("resolveSetAdminClaimCallerRole: legacy email no longer bootstraps (PR B)", () => {
   const role = resolveSetAdminClaimCallerRole(
     {
       uid: "whatever",
-      token: { email: ADMIN_EMAIL_FOR_SETLIST_PROXY },
+      token: { email: "pat@road2media.com" },
     },
     new Set()
   );
-  assert.equal(role, "super-admin");
+  assert.equal(role, null);
 });
 
 test("resolveSetAdminClaimCallerRole: admin claim delegates", () => {
@@ -91,7 +90,7 @@ test("resolveSetAdminClaimCallerRole: admin claim delegates", () => {
   assert.equal(role, "admin");
 });
 
-test("resolveSetAdminClaimCallerRole: no claim + no env + no legacy email → null", () => {
+test("resolveSetAdminClaimCallerRole: no claim + no env → null", () => {
   const role = resolveSetAdminClaimCallerRole(
     { uid: "rando", token: { email: "rando@example.com" } },
     new Set(["other-uid"])
@@ -111,12 +110,7 @@ test("resolveSetAdminClaimCallerRole: null auth returns null", () => {
   assert.equal(resolveSetAdminClaimCallerRole(null, new Set()), null);
 });
 
-test("resolveSetAdminClaimCallerRole: missing uid falls back to email/claim", () => {
-  const viaEmail = resolveSetAdminClaimCallerRole(
-    { token: { email: ADMIN_EMAIL_FOR_SETLIST_PROXY } },
-    new Set()
-  );
-  assert.equal(viaEmail, "super-admin");
+test("resolveSetAdminClaimCallerRole: missing uid + claim still delegates", () => {
   const viaClaim = resolveSetAdminClaimCallerRole(
     { token: { admin: true } },
     new Set()

--- a/functions/index.js
+++ b/functions/index.js
@@ -20,7 +20,6 @@ const {
 } = require("./phishnetLiveSetlistAutomation");
 const { loadSongCatalogSongs } = require("./songCatalogSource");
 const {
-  ADMIN_EMAIL_FOR_SETLIST_PROXY,
   parseSuperAdminUidsEnv,
   resolveAdminCallerRole,
   resolveSetAdminClaimCallerRole,
@@ -166,26 +165,12 @@ function calculateTotalScore(userPicks, actualSetlist, catalogSongs) {
   }, 0);
 }
 
-function assertAdminEmail(request) {
-  if (!request.auth) {
-    throw new HttpsError("unauthenticated", "Sign in required.");
-  }
-  const email = request.auth.token?.email;
-  if (email !== ADMIN_EMAIL_FOR_SETLIST_PROXY) {
-    throw new HttpsError(
-      "permission-denied",
-      "Only the designated admin can perform this action."
-    );
-  }
-}
-
 /**
- * Accepts either the hard-coded admin email (legacy transition) or a Firebase
- * custom claim `admin: true` (target state for #139). Callables that use this
- * can be tightened to claim-only after PR B lands and the claim is granted to
- * every real admin.
+ * Gate an admin-only callable on the `admin: true` custom claim (issue #139).
+ * PR B dropped the legacy email fallback — the claim is the only signal. Use
+ * `setAdminClaim` to grant the claim (bootstrap via `SUPER_ADMIN_UIDS`).
  */
-function assertAdminClaimOrEmail(request) {
+function assertAdminClaim(request) {
   if (!request.auth) {
     throw new HttpsError("unauthenticated", "Sign in required.");
   }
@@ -302,7 +287,7 @@ exports.refreshLiveScoresForShow = onCall(
     enforceAppCheck: false,
   },
   async (request) => {
-    assertAdminEmail(request);
+    assertAdminClaim(request);
     const showDate = assertShowDateString(request.data?.showDate);
 
     const setlistSnap = await db
@@ -343,7 +328,7 @@ exports.rollupScoresForShow = onCall(
     enforceAppCheck: false,
   },
   async (request) => {
-    assertAdminClaimOrEmail(request);
+    assertAdminClaim(request);
     const showDate = assertShowDateString(request.data?.showDate);
 
     const setlistSnap = await db
@@ -508,13 +493,12 @@ async function writeRollupAuditDoc({
 /**
  * Grant or revoke the `admin: true` Firebase custom claim on a target user.
  *
- * Authorization rules:
+ * Authorization rules (PR B — claim-only):
  *   - Caller must be signed in.
  *   - Caller must either already hold `admin: true`, **or** have a UID listed
- *     in the `SUPER_ADMIN_UIDS` env var (comma-separated). Bootstrap-only.
- *   - The legacy `ADMIN_EMAIL_FOR_SETLIST_PROXY` email holder is implicitly
- *     treated as super-admin so #139 PR A doesn't require env-var changes on
- *     day one; remove after PR B.
+ *     in the `SUPER_ADMIN_UIDS` env var (comma-separated). `SUPER_ADMIN_UIDS`
+ *     is the bootstrap / break-glass path — required on a fresh project or
+ *     after an accidental revocation removes the last admin claim holder.
  *
  * Caller can set the claim on their own UID (self-bootstrap) or on another
  * UID (delegate). The target user must refresh their ID token before the new
@@ -810,7 +794,7 @@ exports.setLiveSetlistAutomationState = onCall(
     enforceAppCheck: false,
   },
   async (request) => {
-    assertAdminEmail(request);
+    assertAdminClaim(request);
     const showDate = assertShowDateString(request.data?.showDate);
     const enabled = request.data?.enabled;
     if (typeof enabled !== "boolean") {
@@ -846,7 +830,7 @@ exports.pollLiveSetlistNow = onCall(
     enforceAppCheck: false,
   },
   async (request) => {
-    assertAdminEmail(request);
+    assertAdminClaim(request);
     const key = phishnetApiKey.value();
     if (!key || !String(key).trim()) {
       throw new HttpsError(
@@ -906,7 +890,7 @@ exports.getPhishnetSetlist = onCall(
   },
   async (request) => {
     try {
-      assertAdminEmail(request);
+      assertAdminClaim(request);
 
       const showDate = request.data?.showDate;
       if (
@@ -1037,16 +1021,7 @@ exports.refreshPhishnetShowCalendar = onCall(
   },
   async (request) => {
     try {
-      if (!request.auth) {
-        throw new HttpsError("unauthenticated", "Sign in required.");
-      }
-      const email = request.auth.token?.email;
-      if (email !== ADMIN_EMAIL_FOR_SETLIST_PROXY) {
-        throw new HttpsError(
-          "permission-denied",
-          "Only the designated admin can refresh the show calendar."
-        );
-      }
+      assertAdminClaim(request);
 
       const key = phishnetApiKey.value();
       if (!key || !String(key).trim()) {
@@ -1123,7 +1098,7 @@ exports.refreshPhishnetSongCatalog = onCall(
   },
   async (request) => {
     try {
-      assertAdminEmail(request);
+      assertAdminClaim(request);
 
       const key = phishnetApiKey.value();
       if (!key || !String(key).trim()) {

--- a/src/features/auth/api/authApi.js
+++ b/src/features/auth/api/authApi.js
@@ -3,9 +3,6 @@ import { doc, getDoc } from 'firebase/firestore';
 
 import { auth, db } from '../../../shared/lib/firebase';
 
-/** Transition-only fallback while rolling out admin custom claims (issue #139). */
-const LEGACY_ADMIN_EMAIL = 'pat@road2media.com';
-
 export function subscribeToAuthState(onChange) {
   return onAuthStateChanged(auth, onChange);
 }
@@ -21,10 +18,9 @@ export function subscribeToIdTokenChanges(onChange) {
 }
 
 /**
- * Resolve whether the given Firebase user is an admin. Prefers the
- * `admin: true` custom claim (#139 target state); falls back to the legacy
- * hard-coded admin email during PR A so existing flows keep working until the
- * claim is granted to every real admin.
+ * Resolve whether the given Firebase user is an admin. Claim-only as of
+ * issue #139 PR B — the transitional hard-coded admin email fallback from
+ * PR A was removed alongside the Firestore rules tightening.
  *
  * Pass `forceRefresh` when you need to pick up a freshly-granted claim without
  * waiting for the next automatic token refresh.
@@ -37,11 +33,10 @@ export async function resolveIsAdmin(user, { forceRefresh = false } = {}) {
   if (!user) return false;
   try {
     const tokenResult = await user.getIdTokenResult(forceRefresh);
-    if (tokenResult?.claims?.admin === true) return true;
+    return tokenResult?.claims?.admin === true;
   } catch {
-    // fall through to email fallback
+    return false;
   }
-  return user.email === LEGACY_ADMIN_EMAIL;
 }
 
 export async function fetchUserProfile(uid) {

--- a/src/features/auth/model/useAuth.js
+++ b/src/features/auth/model/useAuth.js
@@ -9,11 +9,10 @@ import {
 
 /**
  * Session-scoped auth hook. Exposes the Firebase user, the Firestore profile
- * doc, a loading flag, and `isAdmin` — the latter prefers the `admin: true`
- * custom claim (issue #139) and falls back to the legacy hard-coded admin
- * email while the claim rollout is in progress. `isAdmin` refreshes whenever
- * the ID token refreshes, so `setAdminClaim` callable writes propagate into
- * the UI without a full re-login (after `getIdTokenResult(true)`).
+ * doc, a loading flag, and `isAdmin` — resolved from the `admin: true` custom
+ * claim (issue #139; PR B made the claim the sole signal). `isAdmin` refreshes
+ * whenever the ID token refreshes, so `setAdminClaim` callable writes
+ * propagate into the UI without a full re-login (after `getIdTokenResult(true)`).
  */
 export function useAuth() {
   const [user, setUser] = useState(null);


### PR DESCRIPTION
[SKIP-PRD]

Closes the remaining AC 4.2 checkboxes on #139. PR A (#195 / #196 / #198) shipped the admin-claim foundation (`rollupScoresForShow` + `setAdminClaim` callables, `useAuth().isAdmin`, `AdminClaimBootstrap` UI, `rollup_audit`). PR A soak on staging confirmed the claim path works end-to-end. This PR B makes the claim the sole signal and tightens Firestore rules accordingly.

## Scope

### Firestore rules (`firestore.rules`)
- `picks`: read auth'd; create requires payload `userId == auth.uid`; update/delete require existing owner match (or admin claim) and on-update `userId` preserved (prevents ownership handoff via overwrite).
- `users`: read auth'd (keeps `fetchPoolMemberProfiles` / `fetchPublicProfileByUid/Handle` working); write restricted to owner or admin claim.
- `official_setlists`: read auth'd; write admin claim only.
- `live_setlist_automation`: read switched from hard-coded email to admin claim; write stays `false`.
- `rollup_audit` (new): admin-only read, server-only write. Admin SDK from `rollupScoresForShow` bypasses rules.
- Added shared `isAdmin()` rules helper; `pools` block unchanged.

### Functions (`functions/adminAuth.js`, `functions/index.js`)
- Drop `ADMIN_EMAIL_FOR_SETLIST_PROXY`. `resolveAdminCallerRole` is claim-only; `resolveSetAdminClaimCallerRole` keeps `SUPER_ADMIN_UIDS` as the sole bootstrap / break-glass path.
- Unify `assertAdminEmail` + `assertAdminClaimOrEmail` into a single `assertAdminClaim`. Migrated every admin callable: `rollupScoresForShow`, `setAdminClaim`, `refreshLiveScoresForShow`, `setLiveSetlistAutomationState`, `pollLiveSetlistNow`, `getPhishnetSetlist`, `refreshPhishnetShowCalendar`, `refreshPhishnetSongCatalog`.
- Rewrote `adminAuth.test.js` to pin PR B semantics (legacy email no longer qualifies; `SUPER_ADMIN_UIDS` retained as bootstrap; claim delegation intact).

### Client (`src/features/auth/api/authApi.js`, `src/features/auth/model/useAuth.js`)
- `resolveIsAdmin` reads only `claims.admin`; removed `LEGACY_ADMIN_EMAIL`.
- `useAuth` docblock updated to reflect claim-only sourcing.

### Docs (`docs/ADMIN_CLAIMS_RUNBOOK.md`)
- PR B deployment checklist (§7): grant claim to every current admin, populate `SUPER_ADMIN_UIDS`, deploy functions **before** rules, rollback plan.
- Staging QA matrix (§8) covering every collection touched.
- Troubleshooting entries (§10) for the two new rule-based denials users may hit.

## Verification

- `cd functions && npm test` → 78/78 pass.
- `npx vitest run` → 21/21 pass.
- `npm run lint` / `verify:dashboard-meta` / `verify:dashboard-ui` → clean.
- `npm run build` → succeeds.
- `node -e "require('./functions/index.js')"` → loads cleanly.

## Pre-merge checklist

- [ ] Every current admin has been granted `admin: true` on staging (Firebase console → Authentication → Users → Custom claims).
- [ ] `SUPER_ADMIN_UIDS` env var populated on `setAdminClaim` so break-glass exists.
- [ ] Staging QA matrix (runbook §8) walked end-to-end with both a non-admin and an admin account.

## Rollout order on merge

1. `firebase deploy --only functions` (deploys the new `assertAdminClaim` behavior; with rules still permissive, nothing regresses).
2. `firebase deploy --only firestore:rules` (tightens rules; admin writes continue via the claim granted during PR A soak).

## Rollback plan

`git show HEAD~1:firestore.rules > /tmp/rollback.rules` then `firebase deploy --only firestore:rules --project <alias>` with `firestore.rules` replaced. Functions roll back via `firebase deploy --only functions` from the pre-PR-B commit.

## Notes

- Does not change grading logic, points, field names (#145 is still deferred), live-night poll cadence, or any UI copy.
- #138 server-side pool delete already sits on the admin-claim foundation, so no coupling concern.
- `src/shared/lib/migrations/runPoolMigration.js` is unreferenced dead code and would fail under the new rules if invoked — flagged for a follow-up cleanup rather than bundled here.

Addresses #139 (closes the PR B half of the issue scope).

Made with [Cursor](https://cursor.com)