### PR TITLE
test(rules,ci): Firestore rules emulator suite + full CI test matrix (#139 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
-# Runs lint + dashboard IA/UI guardrails on every push and PR.
-# See docs/DASHBOARD_IA.md, docs/THEME_CONTRACT.md, npm run verify:dashboard-meta, npm run verify:dashboard-ui.
+# Runs lint, dashboard IA/UI guardrails, and the full test matrix on every push and PR.
+# See docs/DASHBOARD_IA.md, docs/THEME_CONTRACT.md, docs/ADMIN_CLAIMS_RUNBOOK.md §8,
+# npm run verify:dashboard-meta, npm run verify:dashboard-ui,
+# npm test, npm run test:rules, and functions/npm test.
 
 name: CI
 
@@ -31,3 +33,51 @@ jobs:
 
       - name: Dashboard UI tokens (shell drift check)
         run: npm run verify:dashboard-ui
+
+      - name: Client tests (vitest)
+        run: npm test
+
+  functions:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: functions
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: functions/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Functions unit tests
+        run: npm test
+
+  rules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Firebase CLI
+        run: npm install --no-save --prefix "$RUNNER_TEMP" firebase-tools@13
+
+      - name: Firestore rules emulator tests
+        run: "$RUNNER_TEMP/node_modules/.bin/firebase emulators:exec --only firestore --project setlist-pickem-rules-test 'node --test firestore.rules.test.cjs'"

--- a/docs/ADMIN_CLAIMS_RUNBOOK.md
+++ b/docs/ADMIN_CLAIMS_RUNBOOK.md
@@ -140,23 +140,23 @@ PR B tightens Firestore rules and drops the legacy email fallback. Before mergin
 
 ## 8. PR B staging QA checklist
 
-Verify each of these flows against staging with a real non-admin user AND the admin claim holder, before deploying PR B to production.
+Most of the rule-level rows below are now **automated** via the Firestore emulator test suite at `firestore.rules.test.cjs` (`npm run test:rules`; also runs in CI on every push/PR). Those rows are marked *(auto)*. The remaining rows still need a quick manual pass on staging because they exercise the full Auth + Cloud Functions + UI integration, not just rules.
 
-| Surface | Who | Expected |
-|---|---|---|
-| Sign up → create profile | New user (no claim) | `users/{uid}` created (self-write rule) |
-| Submit picks | Any signed-in user | `picks/{date_uid}` created/updated (userId matches auth.uid) |
-| Attempt to edit another user's pick via DevTools | Non-admin | Rejected by rules |
-| Attempt to edit another user's users doc via DevTools | Non-admin | Rejected by rules |
-| Attempt to write `official_setlists` via DevTools | Non-admin | Rejected by rules |
-| Attempt to read `live_setlist_automation/{showDate}` | Non-admin | Rejected by rules |
-| Global standings | Any signed-in user | Loads (reads `users` + `picks`) |
-| Pool details + member profiles | Any signed-in user | Loads (reads `users`) |
-| Public profile by handle | Any signed-in user | Loads (reads `users`) |
-| Admin setlist save | Admin (claim) | `official_setlists/{showDate}` write succeeds |
-| Admin Finalize and rollup | Admin (claim) | `rollupScoresForShow` callable succeeds; `rollup_audit/{showDate}` timestamp advances |
-| Live-scoring trigger | N/A (Admin SDK) | `gradePicksOnSetlistWrite` still runs on setlist write |
-| Live setlist automation UI | Admin (claim) | Reads `live_setlist_automation/{showDate}` pause/backoff metadata |
+| Surface | Who | Expected | Coverage |
+|---|---|---|---|
+| Sign up → create profile | New user (no claim) | `users/{uid}` created (self-write rule) | *(auto)* for rule, manual for full Auth flow |
+| Submit picks | Any signed-in user | `picks/{date_uid}` created/updated (userId matches auth.uid) | *(auto)* |
+| Attempt to edit another user's pick | Non-admin | Rejected by rules | *(auto)* |
+| Attempt to edit another user's users doc | Non-admin | Rejected by rules | *(auto)* |
+| Attempt to write `official_setlists` | Non-admin | Rejected by rules | *(auto)* |
+| Attempt to read `live_setlist_automation/{showDate}` | Non-admin | Rejected by rules | *(auto)* |
+| Global standings | Any signed-in user | Loads (reads `users` + `picks`) | *(auto)* rules; manual UI |
+| Pool details + member profiles | Any signed-in user | Loads (reads `users`) | *(auto)* rules; manual UI |
+| Public profile by handle | Any signed-in user | Loads (reads `users`) | *(auto)* rules; manual UI |
+| Admin setlist save | Admin (claim) | `official_setlists/{showDate}` write succeeds | *(auto)* rules; **manual** UI button |
+| Admin Finalize and rollup | Admin (claim) | `rollupScoresForShow` callable succeeds; `rollup_audit/{showDate}` timestamp advances | **manual** (callable + UI integration) |
+| Live-scoring trigger | N/A (Admin SDK) | `gradePicksOnSetlistWrite` still runs on setlist write | **manual** (scheduled / real webhook) |
+| Live setlist automation UI | Admin (claim) | Reads `live_setlist_automation/{showDate}` pause/backoff metadata | *(auto)* rules; manual UI |
 
 Also confirm: an admin who already grants themselves the claim via the `AdminClaimBootstrap` card in PR A sees the green "Admin claim active" pill and all admin surfaces continue to work after the rules tighten (no email fallback regression).
 

--- a/firebase.json
+++ b/firebase.json
@@ -18,5 +18,14 @@
         "*.local"
       ]
     }
-  ]
+  ],
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": false
+    },
+    "singleProjectMode": true
+  }
 }

--- a/firestore.rules.test.cjs
+++ b/firestore.rules.test.cjs
@@ -1,0 +1,378 @@
+/**
+ * Firestore security rules emulator tests (issue #139 PR B).
+ *
+ * Runs under `firebase emulators:exec` (see `npm run test:rules`). Covers the
+ * automatable rows from `docs/ADMIN_CLAIMS_RUNBOOK.md` §8 staging QA matrix —
+ * everything that can be asserted with the rules engine alone, without a real
+ * browser or a real Phish.net webhook.
+ *
+ * Conventions:
+ *  - `assertSucceeds` → rule must allow the operation.
+ *  - `assertFails` → rule must reject with `permission-denied`.
+ *  - Context helpers:
+ *      anonUser()                 — unauthenticated
+ *      signedInAs(uid, claims?)   — authenticated user; admin claim via claims
+ *      unsafeAdmin()              — helper to seed docs bypassing rules
+ */
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+} = require("@firebase/rules-unit-testing");
+const {
+  doc,
+  setDoc,
+  getDoc,
+  updateDoc,
+  deleteDoc,
+  collection,
+  getDocs,
+  query,
+  where,
+} = require("firebase/firestore");
+
+const PROJECT_ID = "setlist-pickem-rules-test";
+let env;
+
+test.before(async () => {
+  env = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: fs.readFileSync("firestore.rules", "utf8"),
+      host: "127.0.0.1",
+      port: 8080,
+    },
+  });
+});
+
+test.after(async () => {
+  if (env) await env.cleanup();
+});
+
+test.beforeEach(async () => {
+  await env.clearFirestore();
+});
+
+/** Signed-in user context with optional custom claims (e.g. `{ admin: true }`). */
+function signedInAs(uid, claims = {}) {
+  return env.authenticatedContext(uid, claims).firestore();
+}
+
+/** Unauthenticated context. */
+function anon() {
+  return env.unauthenticatedContext().firestore();
+}
+
+/** Seed documents bypassing rules. Used to set up preconditions. */
+async function seed(fn) {
+  await env.withSecurityRulesDisabled(async (ctx) => {
+    await fn(ctx.firestore());
+  });
+}
+
+// ─── users/{userId} ──────────────────────────────────────────────────────────
+
+test("users: owner may create their own profile", async () => {
+  const db = signedInAs("alice");
+  await assertSucceeds(
+    setDoc(doc(db, "users", "alice"), {
+      handle: "alice",
+      favoriteSong: "Tweezer",
+    })
+  );
+});
+
+test("users: cannot create another user's profile", async () => {
+  const db = signedInAs("alice");
+  await assertFails(
+    setDoc(doc(db, "users", "bob"), { handle: "impostor" })
+  );
+});
+
+test("users: signed-in user may read any profile (peer lookups)", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "users", "bob"), { handle: "bob" });
+  });
+  const db = signedInAs("alice");
+  await assertSucceeds(getDoc(doc(db, "users", "bob")));
+});
+
+test("users: anon cannot read profiles", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "users", "bob"), { handle: "bob" });
+  });
+  await assertFails(getDoc(doc(anon(), "users", "bob")));
+});
+
+test("users: owner may update their own profile", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "users", "alice"), { handle: "alice" });
+  });
+  const db = signedInAs("alice");
+  await assertSucceeds(
+    updateDoc(doc(db, "users", "alice"), { favoriteSong: "Reba" })
+  );
+});
+
+test("users: non-owner non-admin cannot update another profile", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "users", "bob"), { handle: "bob" });
+  });
+  const db = signedInAs("alice");
+  await assertFails(
+    updateDoc(doc(db, "users", "bob"), { handle: "hijacked" })
+  );
+});
+
+test("users: admin claim holder may update any profile", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "users", "bob"), { handle: "bob" });
+  });
+  const db = signedInAs("mod", { admin: true });
+  await assertSucceeds(
+    updateDoc(doc(db, "users", "bob"), { handle: "bob-fixed" })
+  );
+});
+
+test("users: non-admin cannot delete any profile", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "users", "alice"), { handle: "alice" });
+  });
+  const db = signedInAs("alice");
+  await assertFails(deleteDoc(doc(db, "users", "alice")));
+});
+
+test("users: admin claim holder may delete profiles", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "users", "ghost"), { handle: "ghost" });
+  });
+  const db = signedInAs("mod", { admin: true });
+  await assertSucceeds(deleteDoc(doc(db, "users", "ghost")));
+});
+
+// ─── picks/{pickId} ──────────────────────────────────────────────────────────
+
+test("picks: owner may create a pick with matching userId", async () => {
+  const db = signedInAs("alice");
+  await assertSucceeds(
+    setDoc(doc(db, "picks", "2026-04-23_alice"), {
+      userId: "alice",
+      showDate: "2026-04-23",
+      picks: { opener: "Tweezer" },
+    })
+  );
+});
+
+test("picks: cannot create a pick with someone else's userId", async () => {
+  const db = signedInAs("alice");
+  await assertFails(
+    setDoc(doc(db, "picks", "2026-04-23_bob"), {
+      userId: "bob",
+      showDate: "2026-04-23",
+      picks: { opener: "Tweezer" },
+    })
+  );
+});
+
+test("picks: signed-in user may read any pick (standings/pool views)", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "picks", "2026-04-23_bob"), {
+      userId: "bob",
+      showDate: "2026-04-23",
+      picks: {},
+    });
+  });
+  const db = signedInAs("alice");
+  await assertSucceeds(getDoc(doc(db, "picks", "2026-04-23_bob")));
+});
+
+test("picks: owner may update their own pick (userId preserved)", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "picks", "2026-04-23_alice"), {
+      userId: "alice",
+      showDate: "2026-04-23",
+      picks: { opener: "Tweezer" },
+    });
+  });
+  const db = signedInAs("alice");
+  await assertSucceeds(
+    updateDoc(doc(db, "picks", "2026-04-23_alice"), {
+      picks: { opener: "Reba" },
+    })
+  );
+});
+
+test("picks: non-owner non-admin cannot edit another user's pick", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "picks", "2026-04-23_bob"), {
+      userId: "bob",
+      showDate: "2026-04-23",
+      picks: { opener: "Tweezer" },
+    });
+  });
+  const db = signedInAs("alice");
+  await assertFails(
+    updateDoc(doc(db, "picks", "2026-04-23_bob"), {
+      picks: { opener: "Hijacked" },
+    })
+  );
+});
+
+test("picks: owner cannot hand off ownership via overwrite", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "picks", "2026-04-23_alice"), {
+      userId: "alice",
+      showDate: "2026-04-23",
+      picks: {},
+    });
+  });
+  const db = signedInAs("alice");
+  await assertFails(
+    setDoc(doc(db, "picks", "2026-04-23_alice"), {
+      userId: "bob",
+      showDate: "2026-04-23",
+      picks: {},
+    })
+  );
+});
+
+test("picks: admin claim holder may repair any pick", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "picks", "2026-04-23_bob"), {
+      userId: "bob",
+      showDate: "2026-04-23",
+      picks: {},
+    });
+  });
+  const db = signedInAs("mod", { admin: true });
+  await assertSucceeds(
+    updateDoc(doc(db, "picks", "2026-04-23_bob"), { score: 10 })
+  );
+});
+
+test("picks: non-owner non-admin cannot delete another user's pick", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "picks", "2026-04-23_bob"), {
+      userId: "bob",
+      showDate: "2026-04-23",
+      picks: {},
+    });
+  });
+  const db = signedInAs("alice");
+  await assertFails(deleteDoc(doc(db, "picks", "2026-04-23_bob")));
+});
+
+// ─── official_setlists/{showDate} ────────────────────────────────────────────
+
+test("official_setlists: signed-in user may read", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "official_setlists", "2026-04-23"), {
+      showDate: "2026-04-23",
+      status: "COMPLETED",
+    });
+  });
+  const db = signedInAs("alice");
+  await assertSucceeds(getDoc(doc(db, "official_setlists", "2026-04-23")));
+});
+
+test("official_setlists: non-admin cannot write", async () => {
+  const db = signedInAs("alice");
+  await assertFails(
+    setDoc(doc(db, "official_setlists", "2026-04-23"), {
+      showDate: "2026-04-23",
+      status: "COMPLETED",
+    })
+  );
+});
+
+test("official_setlists: admin claim holder may write", async () => {
+  const db = signedInAs("mod", { admin: true });
+  await assertSucceeds(
+    setDoc(doc(db, "official_setlists", "2026-04-23"), {
+      showDate: "2026-04-23",
+      status: "COMPLETED",
+    })
+  );
+});
+
+// ─── live_setlist_automation/{showDate} ──────────────────────────────────────
+
+test("live_setlist_automation: non-admin cannot read", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "live_setlist_automation", "2026-04-23"), {
+      enabled: true,
+    });
+  });
+  const db = signedInAs("alice");
+  await assertFails(
+    getDoc(doc(db, "live_setlist_automation", "2026-04-23"))
+  );
+});
+
+test("live_setlist_automation: admin claim holder may read", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "live_setlist_automation", "2026-04-23"), {
+      enabled: true,
+    });
+  });
+  const db = signedInAs("mod", { admin: true });
+  await assertSucceeds(
+    getDoc(doc(db, "live_setlist_automation", "2026-04-23"))
+  );
+});
+
+test("live_setlist_automation: client writes always rejected (even admin)", async () => {
+  const db = signedInAs("mod", { admin: true });
+  await assertFails(
+    setDoc(doc(db, "live_setlist_automation", "2026-04-23"), {
+      enabled: false,
+    })
+  );
+});
+
+// ─── rollup_audit/{showDate} ─────────────────────────────────────────────────
+
+test("rollup_audit: non-admin cannot read", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "rollup_audit", "2026-04-23"), {
+      processedPicks: 5,
+    });
+  });
+  const db = signedInAs("alice");
+  await assertFails(getDoc(doc(db, "rollup_audit", "2026-04-23")));
+});
+
+test("rollup_audit: admin claim holder may read", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "rollup_audit", "2026-04-23"), {
+      processedPicks: 5,
+    });
+  });
+  const db = signedInAs("mod", { admin: true });
+  await assertSucceeds(getDoc(doc(db, "rollup_audit", "2026-04-23")));
+});
+
+test("rollup_audit: client writes always rejected (even admin)", async () => {
+  const db = signedInAs("mod", { admin: true });
+  await assertFails(
+    setDoc(doc(db, "rollup_audit", "2026-04-23"), { processedPicks: 1 })
+  );
+});
+
+// ─── cross-collection: a pool member profiles query (standings-style) ────────
+
+test("users: signed-in user may query profiles (standings/pool lookup)", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "users", "alice"), { handle: "alice" });
+    await setDoc(doc(adminDb, "users", "bob"), { handle: "bob" });
+  });
+  const db = signedInAs("alice");
+  const snap = await assertSucceeds(
+    getDocs(query(collection(db, "users")))
+  );
+  assert.ok(snap && snap.size >= 2);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-router-dom": "^6.20.0"
       },
       "devDependencies": {
+        "@firebase/rules-unit-testing": "^3.0.4",
         "@vitejs/plugin-react": "^4.0.0",
         "autoprefixer": "^10.4.14",
         "eslint": "^9.39.4",
@@ -1345,6 +1346,23 @@
       "integrity": "sha512-0BC4+Ud7y2aPTyhXJTMTFfrGGLqdYXrUB9sJVAB8NiqJswDTc4/2qrE/yfUbnQJhbSi6ZaTTBKyG3n1nplssaA==",
       "license": "Apache-2.0"
     },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-3.0.4.tgz",
+      "integrity": "sha512-FxDc5rnTtt266PTs3dOkf4ZDq+P223TrFWXka/yG6gSFy3Es/iKwWh3bX9pROobHgbbrAd7she9+687yOC2z+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node-fetch": "2.6.4",
+        "node-fetch": "2.6.7"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      },
+      "peerDependencies": {
+        "firebase": "^10.0.0"
+      }
+    },
     "node_modules/@firebase/storage": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.2.tgz",
@@ -2150,6 +2168,17 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
+      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -2528,6 +2557,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
@@ -2892,6 +2928,19 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -3077,6 +3126,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/didyoumean": {
@@ -3844,6 +3903,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
+      "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -4963,6 +5039,29 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -5063,6 +5162,27 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.36",
@@ -6597,6 +6717,13 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -8007,6 +8134,13 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -8028,6 +8162,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "diagnose:phishnet": "node scripts/diagnose-phishnet-local.mjs",
     "print:phishnet-tour-clusters": "node scripts/print-phishnet-tour-clusters.mjs",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:rules": "firebase emulators:exec --only firestore --project setlist-pickem-rules-test \"node --test firestore.rules.test.cjs\""
   },
   "dependencies": {
     "@tanstack/react-query": "^5.0.0",
@@ -30,6 +31,7 @@
     "react-router-dom": "^6.20.0"
   },
   "devDependencies": {
+    "@firebase/rules-unit-testing": "^3.0.4",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.14",
     "eslint": "^9.39.4",


### PR DESCRIPTION
[SKIP-PRD]

Follow-up to PR #206 (merged). Automates 10 of 13 QA rows from `ADMIN_CLAIMS_RUNBOOK.md` §8 and turns the existing vitest + functions test suites into merge-gating CI steps. Zero runtime dollar cost (Firestore emulator is local; CI minutes are on GHA free tier).

## What's new

### Rules test suite (`firestore.rules.test.cjs`, 27 cases)
Uses `@firebase/rules-unit-testing@^3.0.4` (firebase v10 peer line; the v5 release requires v12). Covers:

- `users` — owner create/update/delete, cross-user rejection, admin claim override, anon rejection, peer-lookup reads.
- `picks` — owner create with matching `userId`, cross-user create rejection, owner update preserving `userId`, ownership-handoff rejection on overwrite, admin repair, non-owner edit/delete rejection.
- `official_setlists` — auth'd reads, non-admin write rejection, admin write allowed.
- `live_setlist_automation` — non-admin read rejected, admin read allowed, client writes rejected even for admin (server-only).
- `rollup_audit` — non-admin read rejected, admin read allowed, client writes rejected even for admin.
- Cross-collection sanity — signed-in users can query the `users` collection (standings / pool lookup parity).

### Wiring
- `firebase.json` — added `emulators.firestore` (port 8080) + UI disabled + single-project mode.
- Root `package.json` — `test:rules` script wraps `node --test firestore.rules.test.cjs` in `firebase emulators:exec --only firestore`. File is `.cjs` because root is ESM.
- `docs/ADMIN_CLAIMS_RUNBOOK.md` §8 — each row now annotated *(auto)* vs **manual** so the runbook reflects CI coverage.

### CI matrix (`.github/workflows/ci.yml`)
- Pre-existing `verify` job now also runs `npm test` (21 vitest cases).
- New `functions` job runs `cd functions && npm test` (78 node:test cases).
- New `rules` job provisions Temurin JDK 17 via `actions/setup-java@v4`, installs `firebase-tools@13` into `$RUNNER_TEMP`, runs `test:rules` against a throwaway emulator project.

Net: ~100 tests gate PRs. Before this change, CI ran only lint + dashboard guardrails.

## Verification

- `npx vitest run` → 21/21 pass.
- `cd functions && npm test` → 78/78 pass.
- `npm run lint` / `verify:dashboard-meta` / `verify:dashboard-ui` / `npm run build` → clean.
- `node --check firestore.rules.test.cjs` → OK; test runner discovers all 27 cases (fail with `ECONNREFUSED` without an emulator — expected).
- `npm run test:rules` not executed on authoring machine (no local JDK). CI provisions Java via `setup-java@v4` on every run.

## Non-technical reviewer notes

This PR doesn't change any app behavior. It only adds automated tests that re-verify PR #206's tightened Firestore rules on every future commit, plus wires existing-but-non-gating tests into CI.

If CI fails on this branch at the new `rules` step, that's the emulator tests themselves hitting a bug in PR #206's rules — we'd want to fix that in a follow-on rather than disable the tests.

## Follow-ups (not in this PR)
- Install Java locally (`brew install --cask temurin@17`) so developers can run `npm run test:rules` pre-push.
- Clean up `src/shared/lib/migrations/runPoolMigration.js` (dead code that would fail under PR B rules).

Addresses the QA automation discussion on #139.

Made with [Cursor](https://cursor.com)