### PR TITLE
ci(rules): bump firebase-tools to 15 + JDK 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,13 +71,13 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: Install dependencies
         run: npm ci
 
       - name: Install Firebase CLI
-        run: npm install --no-save --prefix "$RUNNER_TEMP" firebase-tools@13
+        run: npm install --no-save --prefix "$RUNNER_TEMP" firebase-tools@15
 
       - name: Firestore rules emulator tests
         run: "$RUNNER_TEMP/node_modules/.bin/firebase emulators:exec --only firestore --project setlist-pickem-rules-test 'node --test firestore.rules.test.cjs'"


### PR DESCRIPTION
## Summary
- Bump the rules-emulator CI job from \`firebase-tools@13\` + JDK 17 to \`firebase-tools@15\` (current latest major) + JDK 21.
- \`firebase-tools@15\` dropped support for JDK < 21; aligning so we stop running a major behind and stay supported.

## Rule-test coverage
Unchanged — same 27 cases in \`firestore.rules.test.cjs\`, same emulator config, same assertions. This PR is purely a runtime bump.

## Test plan
- [x] CI \`rules\` job passes on the new combo (firebase-tools@15 + JDK 21).
- [x] CI \`verify\` and \`functions\` jobs unchanged.

## Local impact (heads up)
Anyone running \`npm run test:rules\` locally now needs JDK 21 installed (the global \`firebase-tools@15\` also requires it). On macOS: \`brew install --cask temurin@21\`, then open a new terminal. JDK 17-only installs can still run the tests via \`npx firebase-tools@13 emulators:exec …\` but CI is the source of truth.

## References
- Follow-up to #207 (rules emulator CI matrix)
- Not required for any open sprint ticket; housekeeping on CI freshness.

Made with [Cursor](https://cursor.com)