### PR TITLE
chore(gitignore): ignore .env.* variants and emulator logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,14 @@
 node_modules
 .env
+.env.*
+!.env.example
 .DS_Store
 dist
 .cursor/debug-2b48e0.log
 mcp.json
+firestore-debug.log
+firebase-debug.log
+*.log
 
 # Local credentials (GCP service accounts, etc.). Prefer ~/… or secrets/ and never commit.
 secrets/


### PR DESCRIPTION
## Summary
- Ignore \`.env.*\` so per-project Firebase Functions env files (e.g. \`functions/.env.set-picks\` carrying \`SUPER_ADMIN_UIDS\` per \`docs/ADMIN_CLAIMS_RUNBOOK.md\` §2a) can't be committed accidentally. \`.env.example\` is explicitly allowlisted so sample configs stay trackable.
- Ignore \`firestore-debug.log\`, \`firebase-debug.log\`, and \`*.log\` so local \`npm run test:rules\` emulator runs stop leaving noise in \`git status\`.

## Motivation
Follow-up hygiene after the #139 PR B rollout: we started using the \`functions/.env.<project>\` pattern for admin env vars, and the current gitignore only covered bare \`.env\`. Closing that loophole before it bites.

## Test plan
- [x] \`git check-ignore functions/.env.set-picks\` → ignored ✓
- [x] No source / behavior changes; CI \`verify\`, \`functions\`, and \`rules\` jobs should all stay green.

Made with [Cursor](https://cursor.com)