### PR TITLE
fix(scoring): revert #167 server bustout lookup to bundled catalog

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -18,7 +18,6 @@ const {
   pollSingleShowDate,
   scheduledCandidateShowDates,
 } = require("./phishnetLiveSetlistAutomation");
-const { loadSongCatalogSongs } = require("./songCatalogSource");
 const {
   parseSuperAdminUidsEnv,
   resolveAdminCallerRole,
@@ -107,11 +106,16 @@ function buildAllPlayedNormalized(actualSetlist) {
 /**
  * Matches computeSlotResult + bustout from getSlotScoreBreakdown in src/utils/scoring.js.
  *
- * `catalogSongs` is the normalized catalog (Storage `song-catalog.json` with
- * `functions/phishSongs.js` as fallback — see `loadSongCatalogSongs`). Passed
- * in (not imported) so it can be loaded once per grading invocation.
+ * Bustout lookup uses the bundled `functions/phishSongs.js` catalog (same
+ * snapshot the client reads from `src/shared/data/phishSongs.js`). This keeps
+ * client-computed per-show scores and server-stored `pick.score` in sync.
+ *
+ * NOTE: #167 briefly routed this through the Storage-backed `song-catalog.json`
+ * (dynamic per-song gap), which broke parity once a bustout's gap reset to 0
+ * after the show played. The proper fix — snapshot per-show bustouts on
+ * `official_setlists/{showDate}` — is tracked in #214.
  */
-function calculateSlotScore(fieldId, guessedSong, actualSetlist, catalogSongs) {
+function calculateSlotScore(fieldId, guessedSong, actualSetlist) {
   if (!actualSetlist || !guessedSong) return 0;
 
   const guess = normalizeSong(guessedSong);
@@ -143,8 +147,7 @@ function calculateSlotScore(fieldId, guessedSong, actualSetlist, catalogSongs) {
     }
   }
 
-  const songs = Array.isArray(catalogSongs) ? catalogSongs : phishSongs;
-  const matched = songs.find((song) => normalizeSong(song.name) === guess);
+  const matched = phishSongs.find((song) => normalizeSong(song.name) === guess);
   let bustoutBoost = false;
   if (matched) {
     const gapNum = parseGap(matched.gap);
@@ -155,12 +158,12 @@ function calculateSlotScore(fieldId, guessedSong, actualSetlist, catalogSongs) {
   return base + (bustoutBoost ? SCORING_RULES.BUSTOUT_BOOST : 0);
 }
 
-function calculateTotalScore(userPicks, actualSetlist, catalogSongs) {
+function calculateTotalScore(userPicks, actualSetlist) {
   if (!actualSetlist || !userPicks) return 0;
   return SCORE_FIELDS.reduce((total, fieldId) => {
     return (
       total +
-      calculateSlotScore(fieldId, userPicks[fieldId], actualSetlist, catalogSongs)
+      calculateSlotScore(fieldId, userPicks[fieldId], actualSetlist)
     );
   }, 0);
 }
@@ -213,11 +216,6 @@ async function recomputeLiveScoresForShow(showDate, actualSetlistFromWrite = nul
     return { updatedPicks: 0 };
   }
 
-  const catalogSongs = await loadSongCatalogSongs({
-    fallbackSongs: phishSongs,
-    logger,
-  });
-
   let batch = db.batch();
   let opCount = 0;
   let updatedPicks = 0;
@@ -230,7 +228,7 @@ async function recomputeLiveScoresForShow(showDate, actualSetlistFromWrite = nul
     }
     const pickData = pickDoc.data() || {};
     const userPicks = pickData.picks || {};
-    const score = calculateTotalScore(userPicks, setlistDoc, catalogSongs);
+    const score = calculateTotalScore(userPicks, setlistDoc);
 
     // Live scoring only: do not set gradedAt here (pool season uses isGraded from rollup).
     const update = { score };
@@ -374,11 +372,6 @@ exports.rollupScoresForShow = onCall(
       };
     }
 
-    const catalogSongs = await loadSongCatalogSongs({
-      fallbackSongs: phishSongs,
-      logger,
-    });
-
     // Two writes per pick (picks doc + users doc), same as client rollup.
     const OPS_PER_PICK = 2;
     let batch = db.batch();
@@ -398,7 +391,7 @@ exports.rollupScoresForShow = onCall(
         opCount = 0;
       }
       const userPicks = pickData.picks || {};
-      const newScore = calculateTotalScore(userPicks, actualSetlist, catalogSongs);
+      const newScore = calculateTotalScore(userPicks, actualSetlist);
       const oldScore = pickData.score || 0;
       const scoreDiff = newScore - oldScore;
       const isFirstGrade = pickData.isGraded !== true;


### PR DESCRIPTION
## Summary

Restores client/server parity for the +20 `BUSTOUT_BOOST`. #167 routed the server bustout lookup through Storage's `song-catalog.json`, whose per-song `gap` gets rewritten after a show plays — so any song that was a bustout at the show we're grading stops looking like one moments later. The client was still reading the bundled `src/shared/data/phishSongs.js` (stable pre-show gaps), so stored `pick.score` diverged from the per-show Standings the user sees.

**Observed prod bug (2026-04-21):** 4/18/2026 wildcard _"Colonel Forbin's Ascent"_ (bundled gap = 98) scored **35** server-side vs **55** client-side. Dragged one pool cumulative from 70 → 50 across three graded shows.

## What this PR changes

- `functions/index.js`
  - Drops the `catalogSongs` param from `calculateSlotScore` / `calculateTotalScore`.
  - Bustout lookup now uses module-level `phishSongs` (same snapshot the client reads).
  - Removes both `loadSongCatalogSongs(...)` calls in `recomputeLiveScoresForShow` and `rollupScoresForShow`.
  - Removes the unused `loadSongCatalogSongs` import.
  - Updates the JSDoc to call out the regression and link the follow-up.

Net diff: 1 file, +14 / −21.

## What this PR does NOT change

- `functions/songCatalogSource.js` and `songCatalogSource.test.js` — the Storage loader remains intact (still useful for UI / future bustout preview, and for the proper fix in #214).
- Client scoring (`src/shared/utils/scoring.js`) — already correct, reads bundled catalog.

## Why not the architectural fix now

Bustout is a `(song, show)` tuple property. Deriving it from any _current_ catalog (Storage or bundled) is intrinsically racy with future refreshes. The proper fix is to snapshot per-show bustouts on `official_setlists/{showDate}` at save/automation time and have scoring consult that snapshot. That's tracked in **#214** and scheduled as a follow-on to this PR. This PR just buys us back the pre-#167 invariant (bundled catalog stays stable, client and server agree) so user totals stop silently under-counting today.

## Verification

- `cd functions && npm test` → 78/78 ✔ (includes untouched `songCatalogSource.test.js`)
- `npm test` (client) → 21/21 ✔
- `npm run lint` → clean
- `node -e "require('./functions/index.js')"` → loads without errors

## Post-merge deploy checklist

- [ ] Merge to `staging`, fast-forward `main`.
- [ ] Deploy functions: `firebase deploy --only functions --project set-picks`.
- [ ] As admin: re-run **Finalize** + **rollup** for 4/16, 4/17, 4/18/2026.
- [ ] Verify `ArmenianMan` cumulative in _Lemonwheel Gang_ pool reads **70** (was 50).
- [ ] Spot-check 4/18 `pick.score` for the Colonel Forbin wildcard: `WILDCARD_HIT (10) + EXACT_SLOT (35) + BUSTOUT_BOOST (20) = 55` for the show.

## References

- Introduces regression: #167 / PR #189
- Follow-on architectural fix: #214

Made with [Cursor](https://cursor.com)