### PR TITLE
feat(profile): live season stats with overall wins (points / wins / shows)

### DIFF
--- a/src/features/profile/api/profileSeasonStats.js
+++ b/src/features/profile/api/profileSeasonStats.js
@@ -1,0 +1,131 @@
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  where,
+} from 'firebase/firestore';
+
+import { db } from '../../../shared/lib/firebase';
+
+/**
+ * @typedef {Object} UserSeasonStats
+ * @property {number} totalPoints   Sum of graded pick scores (this user only).
+ * @property {number} shows         Number of finalized shows the user played.
+ * @property {number} wins          Shows this user won overall (global max
+ *                                  among every graded pick for that show).
+ */
+
+/** @type {UserSeasonStats} */
+export const EMPTY_USER_SEASON_STATS = Object.freeze({
+  totalPoints: 0,
+  shows: 0,
+  wins: 0,
+});
+
+function hasNonEmptyPicksObject(picks) {
+  if (picks == null || typeof picks !== 'object' || Array.isArray(picks)) {
+    return false;
+  }
+  return Object.values(picks).some(
+    (v) => v != null && String(v).trim() !== ''
+  );
+}
+
+function pickCountsTowardSeason(pickData) {
+  if (!pickData || pickData.isGraded !== true) return false;
+  return hasNonEmptyPicksObject(pickData.picks);
+}
+
+/**
+ * Global max score among every graded, non-empty pick submitted for a single
+ * show date. Returns `null` if nobody played the show. Mirrors the
+ * "skip when max === 0" guard used by pool season totals so a night where
+ * every player whiffed doesn't credit a tied "win" to everyone.
+ *
+ * @param {string} showDate
+ * @returns {Promise<number | null>}
+ */
+async function fetchGlobalMaxScoreForShow(showDate) {
+  const date = showDate?.trim?.();
+  if (!date) return null;
+  const snap = await getDocs(
+    query(collection(db, 'picks'), where('showDate', '==', date))
+  );
+  let max = null;
+  snap.forEach((docSnap) => {
+    const data = docSnap.data() || {};
+    if (!pickCountsTowardSeason(data)) return;
+    const score = typeof data.score === 'number' ? data.score : 0;
+    if (max === null || score > max) max = score;
+  });
+  if (max === null || max <= 0) return null;
+  return max;
+}
+
+/**
+ * Season stats for a single user computed live from `picks`:
+ *   - `totalPoints` / `shows` — sum of the user's own graded picks (picks
+ *     aren't double-counted when they belong to multiple pools).
+ *   - `wins` — shows won overall (global high score across every graded,
+ *     non-empty pick for that show), not pool-scoped wins. Ties share the
+ *     win, matching the per-pool leaderboard's tie rule.
+ *
+ * @param {string | undefined} uid
+ * @param {Array<{ date: string }>} showDates
+ * @returns {Promise<UserSeasonStats>}
+ */
+export async function computeUserSeasonStats(uid, showDates) {
+  const id = uid?.trim();
+  if (!id) return { ...EMPTY_USER_SEASON_STATS };
+  if (!Array.isArray(showDates) || showDates.length === 0) {
+    return { ...EMPTY_USER_SEASON_STATS };
+  }
+
+  const dates = showDates.map((s) => s.date).filter(Boolean);
+  const chunkSize = 24;
+
+  /** @type {Array<{ showDate: string, score: number }>} */
+  const userGradedPicks = [];
+
+  for (let i = 0; i < dates.length; i += chunkSize) {
+    const slice = dates.slice(i, i + chunkSize);
+    const snaps = await Promise.all(
+      slice.map((date) => getDoc(doc(db, 'picks', `${date}_${id}`)))
+    );
+    for (let j = 0; j < slice.length; j += 1) {
+      const snap = snaps[j];
+      if (!snap.exists()) continue;
+      const data = snap.data() || {};
+      if (!pickCountsTowardSeason(data)) continue;
+      const score = typeof data.score === 'number' ? data.score : 0;
+      userGradedPicks.push({ showDate: slice[j], score });
+    }
+  }
+
+  let totalPoints = 0;
+  let shows = 0;
+  for (const p of userGradedPicks) {
+    totalPoints += p.score;
+    shows += 1;
+  }
+
+  // Overall wins: count each show once where this user tied/beat the global
+  // high score. Parallelize across shows the user actually played.
+  let wins = 0;
+  const winChunkSize = 10;
+  for (let i = 0; i < userGradedPicks.length; i += winChunkSize) {
+    const slice = userGradedPicks.slice(i, i + winChunkSize);
+    const maxes = await Promise.all(
+      slice.map((p) => fetchGlobalMaxScoreForShow(p.showDate))
+    );
+    for (let j = 0; j < slice.length; j += 1) {
+      const max = maxes[j];
+      if (max === null) continue;
+      if (slice[j].score === max) wins += 1;
+    }
+  }
+
+  return { totalPoints, shows, wins };
+}

--- a/src/features/profile/index.js
+++ b/src/features/profile/index.js
@@ -4,3 +4,4 @@ export { default as ProfileEditForm } from './ui/ProfileEditForm';
 export { default as PublicProfileView } from './ui/PublicProfileView';
 export { usePublicProfile } from './model/usePublicProfile';
 export { useUserProfile } from './model/useUserProfile';
+export { useUserSeasonStats } from './model/useUserSeasonStats';

--- a/src/features/profile/model/useUserSeasonStats.js
+++ b/src/features/profile/model/useUserSeasonStats.js
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+
+import { useShowCalendar } from '../../show-calendar';
+import {
+  EMPTY_USER_SEASON_STATS,
+  computeUserSeasonStats,
+} from '../api/profileSeasonStats';
+
+/**
+ * Live-computed season totals for a user's public profile.
+ *
+ * - `totalPoints` / `shows` come from the user's own graded picks.
+ * - `wins` = shows won overall (global high score across every graded pick
+ *   for that show), not pool-scoped wins — a user who won 3 shows total is
+ *   credited 3, regardless of how many pools they're in.
+ *
+ * @param {string | undefined} uid
+ */
+export function useUserSeasonStats(uid) {
+  const { showDates, loading: showDatesLoading } = useShowCalendar();
+  const [stats, setStats] = useState({ ...EMPTY_USER_SEASON_STATS });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(/** @type {Error | null} */ (null));
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async () => {
+      if (!uid?.trim()) {
+        setStats({ ...EMPTY_USER_SEASON_STATS });
+        setLoading(false);
+        setError(null);
+        return;
+      }
+      if (showDatesLoading) return;
+
+      setLoading(true);
+      setError(null);
+      try {
+        const next = await computeUserSeasonStats(uid, showDates);
+        if (!cancelled) setStats(next);
+      } catch (e) {
+        console.error('useUserSeasonStats error:', e);
+        if (!cancelled) {
+          setStats({ ...EMPTY_USER_SEASON_STATS });
+          setError(e instanceof Error ? e : new Error('Failed to load stats.'));
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [uid, showDates, showDatesLoading]);
+
+  return { stats, loading, error };
+}

--- a/src/features/profile/ui/PublicProfileView.jsx
+++ b/src/features/profile/ui/PublicProfileView.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Loader2 } from 'lucide-react';
+
 import { formatMonthYear } from '../../../shared';
 import BackButton from '../../../shared/ui/BackButton';
 
@@ -7,10 +9,38 @@ function formatPlayingSince(createdAt) {
   return value || null;
 }
 
+function StatCell({ label, value, loading }) {
+  return (
+    <div className="rounded-2xl border border-border-subtle bg-surface-field p-4">
+      <p className="mb-1 text-[10px] font-black uppercase tracking-wider text-content-secondary">
+        {label}
+      </p>
+      {loading ? (
+        <Loader2
+          className="mx-auto h-5 w-5 animate-spin text-brand-primary"
+          aria-label={`Loading ${label.toLowerCase()}`}
+        />
+      ) : (
+        <p className="text-xl font-black tabular-nums text-brand-primary">
+          {value}
+        </p>
+      )}
+    </div>
+  );
+}
+
 /**
- * Read-only public profile: handle, favorite song, pools, and stats.
+ * Read-only public profile: handle, favorite song, pools, and season stats.
+ * Stats are the global cross-pool view (points from the user's own graded
+ * picks, overall shows won, and shows played) — `wins` counts each night
+ * once based on the global high score, not per-pool.
  */
-export default function PublicProfileView({ profile, userPools = [] }) {
+export default function PublicProfileView({
+  profile,
+  userPools = [],
+  stats,
+  statsLoading = false,
+}) {
   if (!profile) return null;
 
   const handle = profile.handle?.trim() || 'Anonymous';
@@ -21,8 +51,11 @@ export default function PublicProfileView({ profile, userPools = [] }) {
     profile.favoriteSong !== 'Unknown'
       ? profile.favoriteSong
       : null;
+
   const totalPoints =
-    typeof profile.totalPoints === 'number' ? profile.totalPoints : 0;
+    typeof stats?.totalPoints === 'number' ? stats.totalPoints : 0;
+  const wins = typeof stats?.wins === 'number' ? stats.wins : 0;
+  const shows = typeof stats?.shows === 'number' ? stats.shows : 0;
 
   return (
     <div className="min-h-screen bg-transparent text-white">
@@ -74,25 +107,18 @@ export default function PublicProfileView({ profile, userPools = [] }) {
             Stats
           </h2>
           <div className="grid grid-cols-3 gap-3 text-center">
-            <div className="rounded-2xl border border-border-subtle bg-surface-field p-4">
-              <p className="mb-1 text-[10px] font-black uppercase tracking-wider text-content-secondary">
-                Total points
-              </p>
-              <p className="text-xl font-black tabular-nums text-brand-primary">{totalPoints}</p>
-            </div>
-            <div className="rounded-2xl border border-border-subtle bg-surface-field p-4">
-              <p className="mb-1 text-[10px] font-black uppercase tracking-wider text-content-secondary">
-                Shows played
-              </p>
-              <p className="text-xl font-black tabular-nums text-content-secondary/90">TBD</p>
-            </div>
-            <div className="rounded-2xl border border-border-subtle bg-surface-field p-4">
-              <p className="mb-1 text-[10px] font-black uppercase tracking-wider text-content-secondary">
-                Direct hits
-              </p>
-              <p className="text-xl font-black tabular-nums text-content-secondary/90">TBD</p>
-            </div>
+            <StatCell
+              label="Total points"
+              value={totalPoints}
+              loading={statsLoading}
+            />
+            <StatCell label="Wins" value={wins} loading={statsLoading} />
+            <StatCell label="Shows" value={shows} loading={statsLoading} />
           </div>
+          <p className="mt-3 text-[11px] font-medium leading-relaxed text-content-secondary">
+            Running totals across every graded night. Wins count shows where
+            this player had the top score overall, not just in a single pool.
+          </p>
         </section>
       </div>
     </div>

--- a/src/pages/profile/PublicProfilePage.jsx
+++ b/src/pages/profile/PublicProfilePage.jsx
@@ -1,13 +1,21 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
-import { PublicProfileView, usePublicProfile } from '../../features/profile';
+import {
+  PublicProfileView,
+  usePublicProfile,
+  useUserSeasonStats,
+} from '../../features/profile';
+import { ShowCalendarProvider } from '../../features/show-calendar';
 import { AsyncStatus } from '../../shared';
 import BackButton from '../../shared/ui/BackButton';
 
-export default function PublicProfile() {
+function PublicProfileContent() {
   const { userId } = useParams();
   const { loading, error, profile, userPools } = usePublicProfile(userId);
+  const { stats, loading: statsLoading } = useUserSeasonStats(
+    profile ? userId : undefined
+  );
 
   if (loading || error === 'fetch') {
     return (
@@ -36,5 +44,22 @@ export default function PublicProfile() {
     );
   }
 
-  return <PublicProfileView profile={profile} userPools={userPools} />;
+  return (
+    <PublicProfileView
+      profile={profile}
+      userPools={userPools}
+      stats={stats}
+      statsLoading={statsLoading}
+    />
+  );
+}
+
+export default function PublicProfile() {
+  // Season stats need the show calendar; the public profile route lives
+  // outside the dashboard shell so we provide it locally.
+  return (
+    <ShowCalendarProvider>
+      <PublicProfileContent />
+    </ShowCalendarProvider>
+  );
 }


### PR DESCRIPTION
## Summary

- Public profile stats now render **Total points / Wins / Shows** (replacing the TBD "Shows played" and "Direct hits" placeholders) and are **computed live** from `picks` so they stay consistent regardless of whether the stored `users.totalPoints` / `users.showsPlayed` counters have been kept in sync.
- `totalPoints` / `shows` sum the user's own graded, non-empty picks (no double-counting when a pick belongs to multiple pools).
- `wins` counts shows won **overall** — the user ties/beats the global high score across every graded pick for that show → +1 win. Ties share the win, nights where everyone whiffed (max = 0) credit nobody. Winning the same show in multiple pools still counts as one win.
- The `/user/:userId` route gets its own `ShowCalendarProvider` since it lives outside the dashboard shell.

## Non-goals

- **No changes** to per-night scoring (`src/shared/utils/scoring.js`, `functions/index.js` `calculateSlotScore`).
- **No changes** to pool Season totals (`computePoolSeasonTotalsByUser`) — those remain pool-scoped wins by design.

## Files

- `src/features/profile/api/profileSeasonStats.js` (new)
- `src/features/profile/model/useUserSeasonStats.js` (new)
- `src/features/profile/index.js` (export new hook)
- `src/features/profile/ui/PublicProfileView.jsx` (new stats UI, `StatCell` helper, updated caption)
- `src/pages/profile/PublicProfilePage.jsx` (wraps content in `ShowCalendarProvider`, passes stats in)

## FSD / rules compliance

- All Firestore access stays in `features/profile/api/`; UI is presentational.
- Only one public-API addition (`useUserSeasonStats`) on the profile feature barrel.
- Reuses the same `picks` read pattern already allowed by `firestore.rules` (standings feature reads the collection the same way).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 21/21 pass
- [ ] Smoke: visit `/user/{uid}` for a user with graded picks in multiple pools → stats load, Wins = count of shows where they had the global high score, not double-counted per pool.
- [ ] Smoke: visit `/user/{uid}` for a user with no picks yet → three zeros, no errors.
- [ ] Confirm profile stats match the sum of that user's scores in the global Standings view across all graded nights.

## Follow-ups (separate tickets)

- Standings: "Overall winner of the night" surface (to be filed)
- Standings: "Overall tour leader" using `show_calendar.showDatesByTour` (to be filed)
- Read-cost observability for `computeUserSeasonStats` (to be filed)
- Pools tour-scoped vs all-time season totals — existing #148 (refresh pending)

Made with [Cursor](https://cursor.com)