### PR TITLE
fix(scoring): per-show bustouts snapshot on official_setlists (#214)

### DIFF
--- a/docs/OFFICIAL_SETLISTS_SCHEMA.md
+++ b/docs/OFFICIAL_SETLISTS_SCHEMA.md
@@ -17,6 +17,7 @@ Canonical reference for `official_setlists/{showDate}` documents, how scoring co
 |--------|------|------|
 | `setlist` | `Record<string, string>` | **Position / slot answers** — keys are game slot IDs from `FORM_FIELDS` in `src/shared/data/gameConfig.js` (e.g. `s1o`, `s1c`, `s2o`, `s2c`, `enc`, `wild`). Values are song titles as entered for that slot. Used for **exact-slot** and **encore-exact** scoring. |
 | `officialSetlist` | `string[]` | **Ordered full-show song list** as played. Merged with slot values when building “everything that counted as played” for **in-setlist** and **wildcard** scoring. |
+| `bustouts` | `string[]` | **Per-show bustout snapshot** (#214). Song titles whose **pre-show** gap (shows since last play before this show) was ≥ `SCORING_RULES.BUSTOUT_MIN_GAP` (30). Frozen at save time from Phish.net v5 setlist rows' per-row `gap`. Scoring uses this snapshot only — it does **not** fall back to the Storage song catalog (whose gap resets to ~0 after this show plays). Absence or empty array means “no bustouts for this show.” |
 
 **Naming note:** In everyday language “setlist” means the whole show. In Firestore, `setlist` is **only** the slot map; `officialSetlist` is the **chronological** list. Both are authoritative for different scoring paths. A future optional rename to `positionSlots` / `playedSongOrder` is tracked in [#145](https://github.com/pat792/set-picks/issues/145).
 
@@ -50,20 +51,53 @@ Written on save from `saveOfficialSetlistByDate` (`src/features/admin/api/offici
 - **Exact slot / encore exact:** compare user pick to `actualSetlist[fieldId]` (from the slot map).
 - **In setlist:** guess appears in `buildAllPlayedNormalized(actualSetlist)` but is not an exact slot match.
 - **Wildcard:** guess must appear in that merged “all played” set.
-- **Bustout boost:** applied on top when catalog metadata (song `gap`) matches.
+- **Bustout boost:** applied on top when the pick matches an entry in `actualSetlist.bustouts` (case-insensitive). Absence/empty → no boost.
 
 Detailed points and UI breakdown kinds: `getSlotScoreBreakdown` in `src/shared/utils/scoring.js`.
 
-### Bustout catalog source (client vs Cloud Function)
+### Bustout source — per-show snapshot (#214)
 
-Bustout boosts depend on per-song `gap` metadata from the **Phish.net-synced song catalog**. Both runtimes now read the same canonical catalog published to Firebase Storage (`song-catalog.json`) with a bundled fallback so scoring never hard-fails:
+Both the client (`src/shared/utils/scoring.js`) and the Cloud Function (`functions/index.js`) read bustout membership exclusively from **`official_setlists/{showDate}.bustouts`**. The snapshot is frozen at setlist save time from **Phish.net v5 `/setlists/showdate/{date}` row `gap`** — the definitional pre-show gap — so scoring is deterministic and cannot drift with the weekly `song-catalog.json` refresh cadence.
 
-| Runtime | Loader | Storage path | Fallback |
-|---------|--------|--------------|----------|
-| Client (copy / UI explanations) | `useSongCatalog` (`src/features/song-catalog/model/useSongCatalog.js`) | `song-catalog.json` (default bucket; URL via `songCatalogUrl.js`) | Bundled `src/shared/data/phishSongs.js` |
-| Cloud Function (grading) | `loadSongCatalogSongs` → `functions/songCatalogSource.js` (5 min in-memory TTL cache, per function instance) | `song-catalog.json` (`CATALOG_STORAGE_PATH` shared with `functions/phishnetSongCatalog.js`) | Bundled `functions/phishSongs.js` |
+Write paths (both populate `bustouts`):
 
-The grading function loads the catalog **once per invocation** in `recomputeLiveScoresForShow` (`functions/index.js`) and threads the array through `calculateTotalScore` / `calculateSlotScore` so every pick in the batch uses the same snapshot. See **`docs/SONG_CATALOG.md`** for the weekly refresh pipeline (`scheduledPhishnetSongCatalog` / admin `refreshPhishnetSongCatalog`) and issue [#167](https://github.com/pat792/set-picks/issues/167) for the server-side alignment rationale.
+| Path | File | Source for `gap` |
+|------|------|------------------|
+| Live automation | `functions/phishnetLiveSetlistAutomation.js` (`normalizeSetlistRows` → `buildSetlistDocFromRows` → `pollSingleShowDate`) | Phish.net row `gap` (direct). |
+| Admin save | `src/features/admin/model/useAdminSetlistForm.js` → `saveOfficialSetlistByDate` | Phish.net row `gap` via `setlistParser` when the admin ingested from Phish.net; otherwise a fetch-at-save call (`fetchBustoutsFromPhishnet`) hits the `getPhishnetSetlist` callable and derives from rows. On soft-failure we save with `bustouts: []` and surface a warning so the admin can retry. |
+
+The live Storage `song-catalog.json` and the bundled fallbacks (`src/shared/data/phishSongs.js`, `functions/phishSongs.js`) are **no longer used for scoring**. They remain in place for UI autocomplete, scoring-rules copy, and future upcoming-show bustout-prediction features. See `docs/SONG_CATALOG.md` for their current (UI-only) role.
+
+### Partial-feed safety
+
+Mid-show polls may carry a subset of the eventual rows. `buildSetlistDocFromRows` merges the prior `bustouts` with the newly-derived set so a bustout captured in an earlier poll is never shrunk away by a partial later one.
+
+### Backfill
+
+For shows saved before #214 landed, `bustouts` is absent. The admin callable `backfillBustoutsForShows` (in `functions/index.js`) re-fetches each setlist from Phish.net, derives `bustouts`, writes the snapshot via merge, and reconciles `pick.score` + `users.totalPoints` by the per-pick score delta so existing graded shows stay consistent. Input shapes:
+
+- `{ showDates: ["YYYY-MM-DD", ...] }` — targeted list.
+- `{ mode: "missing" }` — scan `official_setlists` for docs without `bustouts`.
+
+**Run from a local admin workstation** via the wrapper script (mints a short-lived admin-claim token via `firebase-admin` + Identity Toolkit REST; the callable stays the single source of truth):
+
+```bash
+# One-time: make sure ADC is configured for firebase-admin.
+gcloud auth application-default login
+
+cd functions
+
+# Dry-run: list shows that need a snapshot without invoking the callable.
+npm run backfill:bustouts -- --missing
+
+# Backfill every show missing a snapshot:
+npm run backfill:bustouts -- --missing --apply
+
+# Backfill specific dates:
+npm run backfill:bustouts -- --showDates=2025-12-28,2025-12-30,2025-12-31 --apply
+```
+
+Script reads `VITE_FIREBASE_API_KEY` + `VITE_FIREBASE_PROJECT_ID` from the repo-root `.env` (public web config; fine to read locally) and mints a custom token for a synthetic UID (`backfill-bustouts-script`) with `{ admin: true }`. The callable's `assertAdminClaim` gate accepts the claim; no real user account is created or modified.
 
 ---
 
@@ -120,7 +154,10 @@ Network layer: `src/features/admin-setlist-config/api/phishApiClient.js`.
 | Standings read shape | `src/features/scoring/api/standingsApi.js` (`fetchOfficialSetlistForShow`) |
 | Client scoring | `src/shared/utils/scoring.js` |
 | Setlist write trigger | `functions/index.js` — `gradePicksOnSetlistWrite` |
-| Cloud Function bustout catalog loader | `functions/songCatalogSource.js` (Storage → fallback; 5 min TTL) |
+| Per-show bustout snapshot derivation (live) | `functions/phishnetLiveSetlistAutomation.js` — `deriveBustoutsFromRows`, `buildSetlistDocFromRows` |
+| Per-show bustout snapshot derivation (admin) | `src/features/admin-setlist-config/model/setlistParser.js` — `bustoutTitles` on the parsed DTO |
+| Admin fetch-at-save fallback | `src/features/admin/model/setlistAutomation.js` — `fetchBustoutsFromPhishnet` |
+| Backfill callable | `functions/index.js` — `backfillBustoutsForShows` |
 | Cloud Function live scoring core | `functions/index.js` — `recomputeLiveScoresForShow`, `calculateTotalScore`, `calculateSlotScore` |
 
 ---

--- a/docs/SONG_CATALOG.md
+++ b/docs/SONG_CATALOG.md
@@ -1,12 +1,14 @@
 # Song catalog (picks autocomplete) — issue #158
 
+> **Scoring decoupled (#214):** As of #214, **scoring does not consult this catalog.** Bustout boosts come from the per-show `official_setlists/{showDate}.bustouts` snapshot (frozen at save time from Phish.net row `gap`). The Storage catalog and the bundled fallbacks (`src/shared/data/phishSongs.js`, `functions/phishSongs.js`) are retained solely for **UI concerns** — autocomplete, scoring-rules copy, and future upcoming-show bustout hints. Weekly refresh cadence is adequate for those uses; scoring accuracy no longer depends on it. See `docs/OFFICIAL_SETLISTS_SCHEMA.md` → “Bustout source — per-show snapshot (#214).”
+
 ## Data path
 
 1. **Source of truth (live):** Phish.net API v5 `GET /v5/songs.json` (server-side only, `PHISHNET_API_KEY`).
 2. **Publish:** Cloud Functions write **`song-catalog.json`** to the **default Firebase Storage bucket** (`makePublic()` is best-effort; not required for the default client path).
 3. **Client URL:** By default the app uses **`getDownloadURL()`** (Firebase Storage SDK) for `song-catalog.json`. That respects **`storage.rules`** (`allow read: if true`) and avoids opening the whole bucket on **GCS IAM**. A raw browser URL like `https://storage.googleapis.com/<bucket>/song-catalog.json` **does not** use Firebase rules and returns **`AccessDenied`** for anonymous users unless you add **`allUsers` → Storage Object Viewer** on the bucket (usually avoid on buckets that hold private uploads). Override with **`VITE_SONG_CATALOG_URL`** only if you host the JSON elsewhere (CDN) with anonymous GET + CORS.
 4. **Fetch + cache:** `useSongCatalog` **`fetch()`**s the resolved URL. **localStorage** (`set-picks.songCatalogCache.v1`): if data was saved **within the last 3 days**, the hook **skips** both `getDownloadURL` and `fetch`. On failure, an **older cache** is used if present; otherwise **`src/shared/data/phishSongs.js`**.
-5. **Cloud Function grading / bustout (issue #167):** `recomputeLiveScoresForShow` (`functions/index.js`) reads the same **Storage `song-catalog.json`** via **`functions/songCatalogSource.js`** (5-minute in-memory TTL per function instance) and threads the `songs[]` array into `calculateSlotScore` for bustout gap lookup. On any failure (object missing, parse error, empty `songs`, Storage read error) grading falls back to **`functions/phishSongs.js`** so it never hard-fails. No Phish.net API key is required on the grading path.
+5. **Scoring does not read this catalog (post-#214).** `recomputeLiveScoresForShow` and `calculateSlotScore` in `functions/index.js` — and their client counterparts in `src/shared/utils/scoring.js` — read bustout membership from `actualSetlist.bustouts`. `functions/songCatalogSource.js` (5-minute TTL loader) is still present in-tree but is no longer threaded into grading; it can be removed in a follow-up once no code path imports it. The bundled catalogs (`src/shared/data/phishSongs.js`, `functions/phishSongs.js`) remain only as Storage-fallback seeds for `useSongCatalog` / the storage loader.
 
 ## Operations
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -4,7 +4,6 @@ const { onSchedule } = require("firebase-functions/v2/scheduler");
 const { defineSecret } = require("firebase-functions/params");
 const { logger } = require("firebase-functions");
 const admin = require("firebase-admin");
-const { PHISH_SONGS: phishSongs } = require("./phishSongs");
 const {
   syncPhishnetShowCalendarToFirestore,
 } = require("./phishnetShowCalendar");
@@ -12,8 +11,12 @@ const {
   syncPhishnetSongCatalogToStorage,
 } = require("./phishnetSongCatalog");
 const {
+  BUSTOUT_MIN_GAP: AUTOMATION_BUSTOUT_MIN_GAP,
   candidateShowDates,
+  deriveBustoutsFromRows,
+  fetchPhishnetSetlistForDate,
   isWithinLiveSetlistPollWindow,
+  normalizeSetlistRows,
   parseShowCalendarSnapshotToDateSet,
   pollSingleShowDate,
   scheduledCandidateShowDates,
@@ -58,12 +61,6 @@ function normalizeSong(value) {
   return String(value ?? "").trim().toLowerCase();
 }
 
-function parseGap(gap) {
-  if (gap == null || gap === "" || gap === "—") return null;
-  const n = Number.parseInt(String(gap), 10);
-  return Number.isFinite(n) ? n : null;
-}
-
 function guessMatchesEncoreExact(actualSetlist, guessNorm) {
   if (!guessNorm) return false;
   const primary = normalizeSong(actualSetlist.enc);
@@ -104,16 +101,14 @@ function buildAllPlayedNormalized(actualSetlist) {
 }
 
 /**
- * Matches computeSlotResult + bustout from getSlotScoreBreakdown in src/utils/scoring.js.
+ * Mirrors computeSlotResult + bustout from getSlotScoreBreakdown in
+ * src/shared/utils/scoring.js.
  *
- * Bustout lookup uses the bundled `functions/phishSongs.js` catalog (same
- * snapshot the client reads from `src/shared/data/phishSongs.js`). This keeps
- * client-computed per-show scores and server-stored `pick.score` in sync.
- *
- * NOTE: #167 briefly routed this through the Storage-backed `song-catalog.json`
- * (dynamic per-song gap), which broke parity once a bustout's gap reset to 0
- * after the show played. The proper fix — snapshot per-show bustouts on
- * `official_setlists/{showDate}` — is tracked in #214.
+ * Bustout boosts read the per-show `bustouts` snapshot on the official
+ * setlist doc (#214). The snapshot is frozen at save time from Phish.net row
+ * `gap`, so scoring is deterministic and never drifts with the weekly
+ * `song-catalog.json` refresh. Absence / empty array → no bustout boost; no
+ * catalog fallback.
  */
 function calculateSlotScore(fieldId, guessedSong, actualSetlist) {
   if (!actualSetlist || !guessedSong) return 0;
@@ -147,12 +142,16 @@ function calculateSlotScore(fieldId, guessedSong, actualSetlist) {
     }
   }
 
-  const matched = phishSongs.find((song) => normalizeSong(song.name) === guess);
+  const bustoutList = Array.isArray(actualSetlist.bustouts)
+    ? actualSetlist.bustouts
+    : [];
   let bustoutBoost = false;
-  if (matched) {
-    const gapNum = parseGap(matched.gap);
-    bustoutBoost =
-      gapNum != null && gapNum >= SCORING_RULES.BUSTOUT_MIN_GAP;
+  for (const raw of bustoutList) {
+    if (typeof raw !== "string") continue;
+    if (normalizeSong(raw) === guess) {
+      bustoutBoost = true;
+      break;
+    }
   }
 
   return base + (bustoutBoost ? SCORING_RULES.BUSTOUT_BOOST : 0);
@@ -256,6 +255,10 @@ function actualSetlistFromOfficialDoc(setlistDoc) {
   };
   if (Array.isArray(setlistDoc.encoreSongs) && setlistDoc.encoreSongs.length > 0) {
     out.encoreSongs = setlistDoc.encoreSongs;
+  }
+  // Per-show bustout snapshot for scoring (#214). Absence/empty → no boost.
+  if (Array.isArray(setlistDoc.bustouts)) {
+    out.bustouts = setlistDoc.bustouts;
   }
   return out;
 }
@@ -973,6 +976,175 @@ exports.getPhishnetSetlist = onCall(
         `getPhishnetSetlist failed: ${msg}`
       );
     }
+  }
+);
+
+/**
+ * Backfill `official_setlists/{showDate}.bustouts` for a batch of shows (#214).
+ *
+ * For each show date, this callable:
+ *   1. Re-fetches the Phish.net setlist by showdate (rows include per-row
+ *      pre-show `gap` — the definitional bustout metric).
+ *   2. Derives `bustouts` from rows with `gap >= BUSTOUT_MIN_GAP`.
+ *   3. Writes `bustouts` onto `official_setlists/{showDate}` via merge, which
+ *      triggers `gradePicksOnSetlistWrite` → live-score recompute.
+ *   4. When a show is graded (`isGraded: true` on any pick), also runs
+ *      `rollupScoresForShow` semantics inline so `users.totalPoints` reconciles
+ *      by the score delta.
+ *
+ * Safe to run multiple times — write is idempotent when the snapshot matches.
+ *
+ * Input: `{ showDates: string[] }` (each `YYYY-MM-DD`) OR `{ mode: "missing" }`
+ * to scan `official_setlists` for docs missing `bustouts`.
+ */
+exports.backfillBustoutsForShows = onCall(
+  {
+    region: PHISHNET_FUNCTIONS_REGION,
+    secrets: [phishnetApiKey],
+    invoker: "public",
+    enforceAppCheck: false,
+  },
+  async (request) => {
+    assertAdminClaim(request);
+
+    const key = phishnetApiKey.value();
+    if (!key || !String(key).trim()) {
+      throw new HttpsError(
+        "failed-precondition",
+        "Phish.net API key is not configured (set secret PHISHNET_API_KEY)."
+      );
+    }
+
+    // Resolve target show dates.
+    /** @type {string[]} */
+    let showDates = [];
+    const explicitDates = request.data?.showDates;
+    if (Array.isArray(explicitDates) && explicitDates.length > 0) {
+      showDates = explicitDates.map((d) => assertShowDateString(d));
+    } else if (request.data?.mode === "missing") {
+      const snap = await db.collection("official_setlists").get();
+      for (const d of snap.docs) {
+        const data = d.data() || {};
+        if (!Array.isArray(data.bustouts)) {
+          showDates.push(d.id);
+        }
+      }
+    } else {
+      throw new HttpsError(
+        "invalid-argument",
+        'Pass { showDates: ["YYYY-MM-DD", ...] } or { mode: "missing" }.'
+      );
+    }
+
+    const results = [];
+    for (const showDate of showDates) {
+      const setlistRef = db.collection("official_setlists").doc(showDate);
+      const setlistSnap = await setlistRef.get();
+      if (!setlistSnap.exists) {
+        results.push({ showDate, skipped: "no-setlist-doc" });
+        continue;
+      }
+
+      // 1) Re-fetch Phish.net rows and derive bustouts.
+      let bustouts;
+      try {
+        const payload = await fetchPhishnetSetlistForDate(
+          showDate,
+          String(key).trim()
+        );
+        const rows = normalizeSetlistRows(payload);
+        bustouts = deriveBustoutsFromRows(rows);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        logger.warn("backfillBustoutsForShows fetch failed", { showDate, msg });
+        results.push({ showDate, skipped: "phishnet-fetch-failed", error: msg });
+        continue;
+      }
+
+      // 2) Write merge + capture prior bustouts for idempotency / logging.
+      const prior = setlistSnap.data() || {};
+      const priorBustouts = Array.isArray(prior.bustouts) ? prior.bustouts : null;
+      await setlistRef.set(
+        {
+          bustouts,
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+          updatedBy: request.auth?.token?.email || "backfill-bustouts",
+        },
+        { merge: true }
+      );
+
+      // 3) Recompute live scores from the *post-write* doc so the snapshot
+      // we just wrote is what scoring sees. Also reconcile graded picks'
+      // contribution to `users.totalPoints` by score diff — mirrors the
+      // rollup pathway so we don't leave stale totals behind.
+      const freshSnap = await setlistRef.get();
+      const freshDoc = freshSnap.data() || {};
+      const actualSetlist = actualSetlistFromOfficialDoc(freshDoc);
+
+      const picksSnap = await db
+        .collection("picks")
+        .where("showDate", "==", showDate)
+        .get();
+
+      let batch = db.batch();
+      let opCount = 0;
+      let updatedPicks = 0;
+      let reconciledGradedPicks = 0;
+
+      for (const pickDoc of picksSnap.docs) {
+        if (opCount + 2 > MAX_FIRESTORE_BATCH_WRITES) {
+          await batch.commit();
+          batch = db.batch();
+          opCount = 0;
+        }
+        const pickData = pickDoc.data() || {};
+        const newScore = calculateTotalScore(pickData.picks || {}, actualSetlist);
+        const oldScore = Number.isFinite(pickData.score) ? Number(pickData.score) : 0;
+        const scoreDelta = newScore - oldScore;
+
+        const pickUpdate = { score: newScore };
+        if (pickData.isGraded !== true) {
+          pickUpdate.gradedAt = admin.firestore.FieldValue.delete();
+        }
+        batch.update(pickDoc.ref, pickUpdate);
+        opCount += 1;
+        updatedPicks += 1;
+
+        // Only reconcile user totals when this pick was already graded —
+        // otherwise the rollup flow owns first-grade accounting.
+        if (pickData.isGraded === true && scoreDelta !== 0 && pickData.userId) {
+          batch.set(
+            db.collection("users").doc(pickData.userId),
+            {
+              totalPoints: admin.firestore.FieldValue.increment(scoreDelta),
+            },
+            { merge: true }
+          );
+          opCount += 1;
+          reconciledGradedPicks += 1;
+        }
+      }
+
+      if (opCount > 0) {
+        await batch.commit();
+      }
+
+      results.push({
+        showDate,
+        bustoutCount: bustouts.length,
+        priorBustoutCount: priorBustouts ? priorBustouts.length : null,
+        updatedPicks,
+        reconciledGradedPicks,
+      });
+    }
+
+    logger.info("backfillBustoutsForShows complete", {
+      minGap: AUTOMATION_BUSTOUT_MIN_GAP,
+      results,
+      callerUid: request.auth?.uid || null,
+    });
+
+    return { ok: true, results };
   }
 );
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,8 @@
     "secrets:sync-phishnet": "node ../scripts/sync-phishnet-secret.mjs",
     "deploy:functions:phishnet": "firebase deploy --only functions:getPhishnetSetlist,functions:scheduledPhishnetShowCalendar,functions:refreshPhishnetShowCalendar,functions:refreshLiveScoresForShow,functions:scheduledPhishnetSongCatalog,functions:refreshPhishnetSongCatalog,functions:scheduledPhishnetLiveSetlistPoll,functions:setLiveSetlistAutomationState,functions:pollLiveSetlistNow",
     "diagnose:phishnet": "node ../scripts/diagnose-phishnet-local.mjs",
-    "qa:clone-picks-for-show": "node scripts/clonePicksForShowQa.js"
+    "qa:clone-picks-for-show": "node scripts/clonePicksForShowQa.js",
+    "backfill:bustouts": "node scripts/backfillBustouts.js"
   },
   "engines": {
     "node": "24"

--- a/functions/phishnetLiveSetlistAutomation.js
+++ b/functions/phishnetLiveSetlistAutomation.js
@@ -7,6 +7,30 @@ const MAX_BACKOFF_MINUTES = 30;
 
 const SLOT_KEYS = ["s1o", "s1c", "s2o", "s2c", "enc"];
 
+/** Minimum shows-since-last-play for a song to count as a bustout. Mirrors SCORING_RULES.BUSTOUT_MIN_GAP. */
+const BUSTOUT_MIN_GAP = 30;
+
+/** Normalize a song title for dedupe/compare (must match `normalizeSong` in scoring code). */
+function normalizeSongTitle(value) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+/**
+ * Parse a Phish.net setlist row `gap` field into a non-negative integer or null.
+ * Phish.net has returned gap as number or numeric string across versions; treat
+ * anything unparseable or negative as "unknown" (null).
+ */
+function parseRowGap(gap) {
+  if (typeof gap === "number" && Number.isFinite(gap) && gap >= 0) {
+    return Math.trunc(gap);
+  }
+  if (typeof gap === "string") {
+    const n = Number.parseInt(gap.trim(), 10);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  return null;
+}
+
 function formatEtShowDate(now = new Date()) {
   const asEt = now.toLocaleString("en-CA", { timeZone: "America/New_York" });
   return String(asEt).slice(0, 10);
@@ -164,7 +188,8 @@ function normalizeSetlistRows(payload) {
         : typeof row.idx === "number" && Number.isFinite(row.idx)
         ? row.idx
         : 0;
-    rows.push({ setKey: setKey || "unknown", position, title: song });
+    const gap = parseRowGap(row.gap);
+    rows.push({ setKey: setKey || "unknown", position, title: song, gap });
   }
   rows.sort(compareRows);
   return rows;
@@ -228,11 +253,72 @@ function buildSetlistDocFromRows(rows, existingDoc = {}) {
   const encoreSongs =
     encoreSongsFromRows.length > 0 ? encoreSongsFromRows : prevEncoreSongs;
 
+  // Per-show bustout snapshot from per-row pre-show gap (#214). Phish.net
+  // setlist rows expose `gap` = shows since the song was last played prior to
+  // this show. Freezing that at save time decouples scoring from the weekly
+  // `song-catalog.json` refresh cadence, which would reset to gap ≈ 0 after
+  // this show plays and silently erase the bustout boost.
+  const bustoutsFromRows = deriveBustoutsFromRows(rows);
+  const prevBustouts = Array.isArray(existingDoc?.bustouts)
+    ? existingDoc.bustouts
+        .map((t) => String(t ?? "").trim())
+        .filter(Boolean)
+    : [];
+  // Live automation may see a partial feed (only set 1 so far). Preserve the
+  // wider `bustouts` superset so mid-show polls never shrink the list and
+  // erase a bustout captured in a prior poll. Rows that newly appear extend
+  // the list; rows that existed but no longer appear (very rare edit) remain.
+  const bustouts = mergeBustouts(prevBustouts, bustoutsFromRows);
+
   return {
     setlist: slots,
     officialSetlist,
     encoreSongs,
+    bustouts,
   };
+}
+
+/**
+ * @param {{ title: string, gap: number | null }[]} rows
+ * @returns {string[]} original-cased titles, deduped by normalized form
+ */
+function deriveBustoutsFromRows(rows) {
+  const seenNormalized = new Set();
+  const out = [];
+  for (const row of rows) {
+    if (!row || typeof row.title !== "string") continue;
+    const title = row.title.trim();
+    if (!title) continue;
+    const gap = typeof row.gap === "number" ? row.gap : parseRowGap(row.gap);
+    if (gap == null || gap < BUSTOUT_MIN_GAP) continue;
+    const norm = normalizeSongTitle(title);
+    if (seenNormalized.has(norm)) continue;
+    seenNormalized.add(norm);
+    out.push(title);
+  }
+  return out;
+}
+
+/**
+ * Union of two bustout string[] lists, deduped by normalized title, preserving
+ * the first occurrence's original casing. `prev` takes precedence so the
+ * stored casing is stable across polls.
+ */
+function mergeBustouts(prev, next) {
+  const seen = new Set();
+  const out = [];
+  for (const list of [prev, next]) {
+    if (!Array.isArray(list)) continue;
+    for (const raw of list) {
+      const title = typeof raw === "string" ? raw.trim() : "";
+      if (!title) continue;
+      const norm = normalizeSongTitle(title);
+      if (seen.has(norm)) continue;
+      seen.add(norm);
+      out.push(title);
+    }
+  }
+  return out;
 }
 
 function signatureFromRows(rows) {
@@ -249,7 +335,14 @@ function setlistPayloadEqual(a, b) {
   if (JSON.stringify(aOrder) !== JSON.stringify(bOrder)) return false;
   const aEnc = Array.isArray(a?.encoreSongs) ? a.encoreSongs : [];
   const bEnc = Array.isArray(b?.encoreSongs) ? b.encoreSongs : [];
-  return JSON.stringify(aEnc) === JSON.stringify(bEnc);
+  if (JSON.stringify(aEnc) !== JSON.stringify(bEnc)) return false;
+  // Compare `bustouts` by normalized set so a pure casing/ordering change
+  // does not trigger a re-score write; a real membership change does (#214).
+  const aBust = Array.isArray(a?.bustouts) ? a.bustouts : [];
+  const bBust = Array.isArray(b?.bustouts) ? b.bustouts : [];
+  const aNorm = [...new Set(aBust.map((t) => normalizeSongTitle(t)).filter(Boolean))].sort();
+  const bNorm = [...new Set(bBust.map((t) => normalizeSongTitle(t)).filter(Boolean))].sort();
+  return JSON.stringify(aNorm) === JSON.stringify(bNorm);
 }
 
 function nextBackoffMinutes(failureCount) {
@@ -367,6 +460,7 @@ async function pollSingleShowDate({
       setlist: nextPayload.setlist,
       officialSetlist: nextPayload.officialSetlist,
       encoreSongs: nextPayload.encoreSongs || [],
+      bustouts: nextPayload.bustouts || [],
       updatedBy: requestorEmail || "setlist-automation",
       updatedAt: admin.firestore.FieldValue.serverTimestamp(),
       sourceMeta: {
@@ -426,8 +520,11 @@ async function pollSingleShowDate({
 }
 
 module.exports = {
+  BUSTOUT_MIN_GAP,
   buildSetlistDocFromRows,
   candidateShowDates,
+  deriveBustoutsFromRows,
+  fetchPhishnetSetlistForDate,
   getEtHour,
   isWithinLiveSetlistPollWindow,
   normalizeSetlistRows,

--- a/functions/phishnetLiveSetlistAutomation.test.js
+++ b/functions/phishnetLiveSetlistAutomation.test.js
@@ -2,8 +2,10 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
+  BUSTOUT_MIN_GAP,
   buildSetlistDocFromRows,
   candidateShowDates,
+  deriveBustoutsFromRows,
   isWithinLiveSetlistPollWindow,
   normalizeSetlistRows,
   parseShowCalendarSnapshotToDateSet,
@@ -259,4 +261,103 @@ test("historical progression replay keeps slots stable as show grows", () => {
   assert.equal(doc.setlist.enc, "Tweezer Reprise");
   assert.deepEqual(doc.encoreSongs, ["Tweezer Reprise"]);
   assert.equal(doc.officialSetlist.length, 4);
+});
+
+// ---------- per-show bustouts snapshot (#214) ----------
+
+test("normalizeSetlistRows preserves per-row gap (number and numeric string)", () => {
+  const rows = normalizeSetlistRows({
+    error: false,
+    data: [
+      { set: "1", idx: 1, song: "A", gap: 12 },
+      { set: "1", idx: 2, song: "B", gap: "40" },
+      { set: "1", idx: 3, song: "C", gap: null },
+      { set: "1", idx: 4, song: "D" },
+    ],
+  });
+  const byTitle = Object.fromEntries(rows.map((r) => [r.title, r.gap]));
+  assert.equal(byTitle.A, 12);
+  assert.equal(byTitle.B, 40);
+  assert.equal(byTitle.C, null);
+  assert.equal(byTitle.D, null);
+});
+
+test("deriveBustoutsFromRows selects titles with gap >= BUSTOUT_MIN_GAP", () => {
+  const rows = [
+    { setKey: "1", position: 1, title: "Low Gap", gap: 5 },
+    { setKey: "1", position: 2, title: "Exact Threshold", gap: BUSTOUT_MIN_GAP },
+    { setKey: "1", position: 3, title: "Big Gap", gap: 137 },
+    { setKey: "1", position: 4, title: "Unknown Gap", gap: null },
+  ];
+  const bustouts = deriveBustoutsFromRows(rows);
+  assert.deepEqual(bustouts, ["Exact Threshold", "Big Gap"]);
+});
+
+test("deriveBustoutsFromRows dedupes by normalized title, keeps first casing", () => {
+  const rows = [
+    { setKey: "1", position: 1, title: "Colonel Forbin's Ascent", gap: 98 },
+    { setKey: "E", position: 1, title: "COLONEL FORBIN'S ASCENT", gap: 98 },
+  ];
+  const bustouts = deriveBustoutsFromRows(rows);
+  assert.deepEqual(bustouts, ["Colonel Forbin's Ascent"]);
+});
+
+test("buildSetlistDocFromRows emits bustouts from per-row gap", () => {
+  const rows = normalizeSetlistRows({
+    error: false,
+    data: [
+      { set: "1", idx: 1, song: "AC/DC Bag", gap: 8 },
+      { set: "1", idx: 2, song: "Bathtub Gin", gap: 14 },
+      { set: "2", idx: 1, song: "Colonel Forbin's Ascent", gap: 98 },
+      { set: "2", idx: 2, song: "Down with Disease", gap: 2 },
+      { set: "E", idx: 1, song: "Fluff's Travels", gap: 1884 },
+    ],
+  });
+  const out = buildSetlistDocFromRows(rows, {});
+  assert.deepEqual(out.bustouts, ["Colonel Forbin's Ascent", "Fluff's Travels"]);
+});
+
+test("buildSetlistDocFromRows merges prior bustouts as a superset (partial feed safety)", () => {
+  const rows = normalizeSetlistRows({
+    error: false,
+    data: [
+      // Set 1 already played; Phish.net might already include gap here.
+      { set: "1", idx: 1, song: "AC/DC Bag", gap: 8 },
+      // Set 2 not yet played in this feed; prior snapshot has a bustout from
+      // an earlier partial poll. We must preserve it.
+    ],
+  });
+  const out = buildSetlistDocFromRows(rows, {
+    bustouts: ["Colonel Forbin's Ascent"],
+  });
+  // Prior bustout preserved even though it is not in the current rows slice.
+  assert.ok(out.bustouts.includes("Colonel Forbin's Ascent"));
+});
+
+test("setlistPayloadEqual detects bustouts membership change, ignores casing/order", () => {
+  const base = {
+    setlist: { s1o: "A", s1c: "", s2o: "", s2c: "", enc: "" },
+    officialSetlist: ["A"],
+    encoreSongs: [],
+    bustouts: ["Colonel Forbin's Ascent", "Fluff's Travels"],
+  };
+  const reordered = { ...base, bustouts: ["Fluff's Travels", "Colonel Forbin's Ascent"] };
+  const recased = { ...base, bustouts: ["colonel forbin's ascent", "fluff's travels"] };
+  const removed = { ...base, bustouts: ["Colonel Forbin's Ascent"] };
+  const added = { ...base, bustouts: [...base.bustouts, "Minkin"] };
+
+  assert.equal(setlistPayloadEqual(base, reordered), true);
+  assert.equal(setlistPayloadEqual(base, recased), true);
+  assert.equal(setlistPayloadEqual(base, removed), false);
+  assert.equal(setlistPayloadEqual(base, added), false);
+});
+
+test("setlistPayloadEqual: absent bustouts on both sides still compares equal", () => {
+  const a = {
+    setlist: { s1o: "A", s1c: "", s2o: "", s2c: "", enc: "" },
+    officialSetlist: ["A"],
+    encoreSongs: [],
+  };
+  const b = { ...a };
+  assert.equal(setlistPayloadEqual(a, b), true);
 });

--- a/functions/scripts/backfillBustouts.js
+++ b/functions/scripts/backfillBustouts.js
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+/**
+ * Admin-script wrapper for the `backfillBustoutsForShows` callable (#214).
+ *
+ * Mints a short-lived admin-claim ID token via firebase-admin + Identity
+ * Toolkit REST, then POSTs to the deployed callable. Keeps the entire
+ * backfill pipeline (Phish.net fetch → derive bustouts → write snapshot →
+ * recompute pick scores → reconcile `users.totalPoints` for graded picks) in
+ * the single deployed source of truth — this script is only a caller.
+ *
+ * Usage (from repo root or functions/):
+ *   # Dry-run: list which shows are missing `bustouts` on `official_setlists`.
+ *   cd functions
+ *   node scripts/backfillBustouts.js --missing --dry-run
+ *
+ *   # Backfill every show missing a snapshot:
+ *   node scripts/backfillBustouts.js --missing --apply
+ *
+ *   # Backfill specific show dates:
+ *   node scripts/backfillBustouts.js --showDates=2025-12-28,2025-12-30 --apply
+ *
+ * Auth:
+ *   Requires Application Default Credentials (ADC) for `firebase-admin`:
+ *     gcloud auth application-default login
+ *   The script mints a custom token with `{ admin: true }` for a synthetic
+ *   UID (`backfill-bustouts-script`) — no real user account is created; the
+ *   token is discarded after the call. The deployed callable gates on the
+ *   `admin` claim via `assertAdminClaim` (functions/adminAuth.js).
+ *
+ * Config read from repo-root `.env`:
+ *   VITE_FIREBASE_API_KEY   — required, used for custom→ID token exchange.
+ *   VITE_FIREBASE_PROJECT_ID — used to derive the callable URL.
+ *
+ * This script is safe to re-run: the callable is idempotent (write-merge;
+ * score-delta reconciliation is zero when bustouts didn't change).
+ */
+
+const admin = require("firebase-admin");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const ENV_PATH = path.join(REPO_ROOT, ".env");
+const BACKFILL_UID = "backfill-bustouts-script";
+const FUNCTIONS_REGION = "us-central1";
+
+/**
+ * @param {string[]} argv
+ * @returns {Record<string, string | true>}
+ */
+function parseArgs(argv) {
+  /** @type {Record<string, string | true>} */
+  const out = {};
+  for (const arg of argv) {
+    if (!arg.startsWith("--")) continue;
+    const [k, ...rest] = arg.slice(2).split("=");
+    out[k] = rest.length ? rest.join("=") : true;
+  }
+  return out;
+}
+
+function usageAndExit(msg) {
+  if (msg) console.error(`\nError: ${msg}\n`);
+  console.log(
+    [
+      "Usage:",
+      "  node scripts/backfillBustouts.js --missing [--dry-run|--apply]",
+      "  node scripts/backfillBustouts.js --showDates=YYYY-MM-DD[,YYYY-MM-DD...] [--dry-run|--apply]",
+      "",
+      "Modes:",
+      "  --missing           Scan official_setlists for docs without a `bustouts` field.",
+      "  --showDates=...     Comma-separated list of show dates to backfill.",
+      "",
+      "Flags:",
+      "  --dry-run           Default. List target show dates; do not call the callable.",
+      "  --apply             Invoke the deployed backfillBustoutsForShows callable.",
+      "",
+      "Auth:",
+      "  Requires ADC: gcloud auth application-default login",
+      "",
+    ].join("\n"),
+  );
+  process.exit(msg ? 1 : 0);
+}
+
+/** @returns {Record<string, string>} */
+function loadEnv() {
+  /** @type {Record<string, string>} */
+  const env = {};
+  if (!fs.existsSync(ENV_PATH)) {
+    throw new Error(`.env not found at ${ENV_PATH}`);
+  }
+  const text = fs.readFileSync(ENV_PATH, "utf8");
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t || t.startsWith("#")) continue;
+    const eq = t.indexOf("=");
+    if (eq < 0) continue;
+    const k = t.slice(0, eq).trim();
+    const v = t
+      .slice(eq + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+    env[k] = v;
+  }
+  return env;
+}
+
+function isShowDate(v) {
+  if (typeof v !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(v.trim())) return false;
+  // Reject impossible calendar dates (e.g. 2025-13-99). Parse as UTC to avoid
+  // local-timezone rollover flipping a valid boundary date.
+  const [y, m, d] = v.trim().split("-").map(Number);
+  const parsed = new Date(Date.UTC(y, m - 1, d));
+  return (
+    parsed.getUTCFullYear() === y &&
+    parsed.getUTCMonth() === m - 1 &&
+    parsed.getUTCDate() === d
+  );
+}
+
+/**
+ * Exchange a custom token for a Firebase ID token using the Identity Toolkit
+ * REST API. The resulting ID token carries the developer claims set on the
+ * custom token (`admin: true`), which `assertAdminClaim` checks on the server.
+ *
+ * @param {string} customToken
+ * @param {string} apiKey - Firebase web API key (VITE_FIREBASE_API_KEY).
+ * @returns {Promise<string>}
+ */
+async function exchangeCustomTokenForIdToken(customToken, apiKey) {
+  const url = `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${encodeURIComponent(
+    apiKey,
+  )}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token: customToken, returnSecureToken: true }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const msg =
+      body?.error?.message || `HTTP ${res.status} ${res.statusText || ""}`.trim();
+    throw new Error(`signInWithCustomToken failed: ${msg}`);
+  }
+  if (!body?.idToken) {
+    throw new Error("signInWithCustomToken response missing idToken.");
+  }
+  return body.idToken;
+}
+
+/**
+ * POST to the deployed callable HTTPS endpoint with the Firebase ID token.
+ *
+ * @param {string} projectId
+ * @param {string} idToken
+ * @param {object} data - The `data` payload the callable expects.
+ * @returns {Promise<unknown>} The `result` field from the callable response.
+ */
+async function invokeCallable(projectId, idToken, data) {
+  const url = `https://${FUNCTIONS_REGION}-${projectId}.cloudfunctions.net/backfillBustoutsForShows`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${idToken}`,
+    },
+    body: JSON.stringify({ data }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const msg =
+      body?.error?.message ||
+      body?.error?.status ||
+      `HTTP ${res.status} ${res.statusText || ""}`.trim();
+    throw new Error(`backfillBustoutsForShows callable failed: ${msg}`);
+  }
+  return body.result;
+}
+
+/**
+ * @param {FirebaseFirestore.Firestore} db
+ * @returns {Promise<string[]>}
+ */
+async function scanMissing(db) {
+  const snap = await db.collection("official_setlists").get();
+  /** @type {string[]} */
+  const missing = [];
+  for (const d of snap.docs) {
+    const data = d.data() || {};
+    if (!Array.isArray(data.bustouts)) missing.push(d.id);
+  }
+  missing.sort();
+  return missing;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) usageAndExit();
+
+  const useMissing = args.missing === true;
+  const showDatesArg =
+    typeof args.showDates === "string" ? args.showDates.trim() : "";
+  if (!useMissing && !showDatesArg) {
+    usageAndExit("Pass either --missing or --showDates=...");
+  }
+  if (useMissing && showDatesArg) {
+    usageAndExit("Pass only one of --missing or --showDates=... (not both).");
+  }
+
+  const apply = args.apply === true;
+  const dryRun = !apply || args["dry-run"] === true;
+
+  // --- Env + admin init ---
+  const env = loadEnv();
+  const apiKey = env.VITE_FIREBASE_API_KEY;
+  const projectId = env.VITE_FIREBASE_PROJECT_ID;
+  if (!apiKey) throw new Error("VITE_FIREBASE_API_KEY missing from .env");
+  if (!projectId) throw new Error("VITE_FIREBASE_PROJECT_ID missing from .env");
+
+  admin.initializeApp({ projectId });
+  const db = admin.firestore();
+
+  // --- Resolve target show dates ---
+  /** @type {string[]} */
+  let showDates = [];
+  if (useMissing) {
+    console.log("Scanning official_setlists for docs missing `bustouts`...");
+    showDates = await scanMissing(db);
+    if (showDates.length === 0) {
+      console.log("No shows missing bustouts. Nothing to do.");
+      return;
+    }
+  } else {
+    showDates = showDatesArg
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    for (const d of showDates) {
+      if (!isShowDate(d)) usageAndExit(`Invalid date in --showDates: ${d}`);
+    }
+  }
+
+  console.log(
+    [
+      "",
+      `Target show dates: ${showDates.length}`,
+      ...showDates.map((d) => `  - ${d}`),
+      `Mode: ${dryRun ? "DRY RUN (no callable invocation)" : "APPLY"}`,
+      "",
+    ].join("\n"),
+  );
+
+  if (dryRun) {
+    console.log("Dry-run complete. Re-run with --apply to invoke the callable.");
+    return;
+  }
+
+  // --- Mint admin-claim token ---
+  console.log("Minting admin-claim token for backfill script...");
+  const customToken = await admin
+    .auth()
+    .createCustomToken(BACKFILL_UID, { admin: true });
+  const idToken = await exchangeCustomTokenForIdToken(customToken, apiKey);
+
+  // --- Invoke the deployed callable (single source of truth) ---
+  console.log(
+    `Invoking backfillBustoutsForShows (${FUNCTIONS_REGION}) for ${showDates.length} show(s)...`,
+  );
+  const started = Date.now();
+  const result = await invokeCallable(projectId, idToken, { showDates });
+  const elapsedMs = Date.now() - started;
+
+  console.log(`\nCallable returned in ${elapsedMs}ms:\n`);
+  console.log(JSON.stringify(result, null, 2));
+
+  // --- Summary ---
+  const results =
+    result && typeof result === "object" && Array.isArray(result.results)
+      ? result.results
+      : [];
+  let totalPicksUpdated = 0;
+  let totalReconciled = 0;
+  let skipped = 0;
+  for (const row of results) {
+    if (row.skipped) {
+      skipped += 1;
+      continue;
+    }
+    if (typeof row.updatedPicks === "number") totalPicksUpdated += row.updatedPicks;
+    if (typeof row.reconciledGradedPicks === "number")
+      totalReconciled += row.reconciledGradedPicks;
+  }
+  console.log(
+    [
+      "",
+      "Summary:",
+      `  shows processed         : ${results.length - skipped}`,
+      `  shows skipped           : ${skipped}`,
+      `  pick scores recomputed  : ${totalPicksUpdated}`,
+      `  graded picks reconciled : ${totalReconciled}`,
+      "",
+    ].join("\n"),
+  );
+}
+
+main().catch((err) => {
+  console.error("\nbackfillBustouts.js failed:");
+  console.error(err instanceof Error ? err.stack || err.message : err);
+  process.exit(1);
+});

--- a/src/features/admin-setlist-config/api/phishApiClient.js
+++ b/src/features/admin-setlist-config/api/phishApiClient.js
@@ -321,20 +321,29 @@ async function fetchPhishnetRaw(dateString) {
  * Fetches raw setlist-related JSON for a show date from the configured external API.
  *
  * @param {string} dateString Show date `YYYY-MM-DD`
+ * @param {{ forceSource?: 'phishin' | 'phishnet' }} [options] Override the
+ * configured `VITE_SETLIST_API_SOURCE`. Used by bustout-fetch flows that need
+ * Phish.net specifically (the only source with per-row `gap`).
  * @returns {Promise<SetlistFetchResult>}
  */
-export async function fetchSetlistRaw(dateString) {
+export async function fetchSetlistRaw(dateString, options = {}) {
   const badDate = validateShowDate(dateString);
   if (badDate) {
     return { ok: false, error: badDate };
   }
 
-  const sourceRes = resolveSource();
-  if (!sourceRes.ok) {
-    return { ok: false, error: sourceRes.error };
+  let source;
+  if (options && options.forceSource && ALLOWED_SOURCES.has(options.forceSource)) {
+    source = options.forceSource;
+  } else {
+    const sourceRes = resolveSource();
+    if (!sourceRes.ok) {
+      return { ok: false, error: sourceRes.error };
+    }
+    source = sourceRes.source;
   }
 
-  if (sourceRes.source === 'phishnet') {
+  if (source === 'phishnet') {
     return fetchPhishnetRaw(dateString);
   }
   return fetchPhishinRaw(dateString);

--- a/src/features/admin-setlist-config/model/setlistParser.js
+++ b/src/features/admin-setlist-config/model/setlistParser.js
@@ -7,7 +7,14 @@
  * @property {Record<string, string>} positionSlots Song title per `FORM_FIELDS` id (`wild` often empty — not in admin slot form).
  * @property {string[]} playedSongOrder Full show order as played (normalized titles, no empties).
  * @property {string[]} encoreSongTitles Encore segment titles in show order (empty if none).
+ * @property {string[]} bustoutTitles Titles of songs whose pre-show gap was >= BUSTOUT_MIN_GAP. Derived only from Phish.net rows (Phish.in has no gap metadata). Empty array when unavailable. (#214)
  */
+
+/**
+ * Minimum pre-show gap (shows since last play) for a song to count as a bustout.
+ * Must match `SCORING_RULES.BUSTOUT_MIN_GAP` in `src/shared/utils/scoring.js`.
+ */
+export const PARSER_BUSTOUT_MIN_GAP = 30;
 
 export class SetlistParseError extends Error {
   constructor(message) {
@@ -27,6 +34,28 @@ function emptySlots(formFields) {
     o[id] = '';
   });
   return o;
+}
+
+/**
+ * Parse a Phish.net row `gap` into a non-negative integer or null. Same rules
+ * as the server parser in `functions/phishnetLiveSetlistAutomation.js`.
+ * @param {unknown} gap
+ * @returns {number | null}
+ */
+function parseRowGap(gap) {
+  if (typeof gap === 'number' && Number.isFinite(gap) && gap >= 0) {
+    return Math.trunc(gap);
+  }
+  if (typeof gap === 'string') {
+    const n = Number.parseInt(gap.trim(), 10);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  return null;
+}
+
+/** Normalize a song title for dedupe (matches scoring `normalize`). */
+function normalizeSongTitle(value) {
+  return String(value ?? '').trim().toLowerCase();
 }
 
 /**
@@ -148,7 +177,9 @@ function parsePhishin(rawData, formFields) {
     slots.enc = encoreSongTitles[0];
   }
 
-  return { positionSlots: slots, playedSongOrder, encoreSongTitles };
+  // Phish.in tracks do not carry per-song gap metadata. Bustouts must come
+  // from Phish.net; downstream save flow will fetch them explicitly (#214).
+  return { positionSlots: slots, playedSongOrder, encoreSongTitles, bustoutTitles: [] };
 }
 
 /**
@@ -173,7 +204,7 @@ function parsePhishnet(rawData, formFields) {
     );
   }
 
-  /** @type {{ setKey: string, position: number, title: string }[]} */
+  /** @type {{ setKey: string, position: number, title: string, gap: number | null }[]} */
   const rows = [];
   for (const row of data) {
     if (!row || typeof row !== 'object') continue;
@@ -189,7 +220,8 @@ function parsePhishnet(rawData, formFields) {
         : typeof rec.idx === 'number' && Number.isFinite(rec.idx)
           ? rec.idx
           : 0;
-    rows.push({ setKey: setKey || 'unknown', position, title: song });
+    const gap = parseRowGap(rec.gap);
+    rows.push({ setKey: setKey || 'unknown', position, title: song, gap });
   }
 
   if (rows.length === 0) {
@@ -230,7 +262,21 @@ function parsePhishnet(rawData, formFields) {
     slots.enc = encoreSongTitles[0];
   }
 
-  return { positionSlots: slots, playedSongOrder, encoreSongTitles };
+  // Per-show bustout snapshot (#214). Phish.net `gap` on each setlist row is
+  // the shows-since-last-play counter *prior to this show*, which is the
+  // definitional bustout metric. Dedupe by normalized title; preserve
+  // original casing for the first occurrence so UI reads cleanly.
+  const seenBustouts = new Set();
+  const bustoutTitles = [];
+  for (const r of rows) {
+    if (r.gap == null || r.gap < PARSER_BUSTOUT_MIN_GAP) continue;
+    const norm = normalizeSongTitle(r.title);
+    if (seenBustouts.has(norm)) continue;
+    seenBustouts.add(norm);
+    bustoutTitles.push(r.title);
+  }
+
+  return { positionSlots: slots, playedSongOrder, encoreSongTitles, bustoutTitles };
 }
 
 /**
@@ -258,7 +304,7 @@ export function parseSetlist(rawData, apiSource, gameConfig) {
  *
  * @param {ParsedSetlistDto} parsed
  * @param {{ id: string }[]} slotFields - e.g. `ADMIN_SETLIST_FIELDS` (excludes `wild`).
- * @returns {{ setlistData: Record<string, string>, officialSetlist: string[], encoreSongs: string[] }}
+ * @returns {{ setlistData: Record<string, string>, officialSetlist: string[], encoreSongs: string[], bustouts: string[] }}
  */
 export function mapParsedSetlistToLegacySaveShape(parsed, slotFields) {
   if (!parsed?.positionSlots || !Array.isArray(parsed.playedSongOrder)) {
@@ -274,5 +320,8 @@ export function mapParsedSetlistToLegacySaveShape(parsed, slotFields) {
   const encoreSongs = Array.isArray(parsed.encoreSongTitles)
     ? parsed.encoreSongTitles.map((s) => String(s ?? '').trim()).filter(Boolean)
     : [];
-  return { setlistData, officialSetlist, encoreSongs };
+  const bustouts = Array.isArray(parsed.bustoutTitles)
+    ? parsed.bustoutTitles.map((s) => String(s ?? '').trim()).filter(Boolean)
+    : [];
+  return { setlistData, officialSetlist, encoreSongs, bustouts };
 }

--- a/src/features/admin-setlist-config/model/setlistParser.test.js
+++ b/src/features/admin-setlist-config/model/setlistParser.test.js
@@ -131,3 +131,64 @@ describe('encore exact scoring', () => {
     expect(calculateSlotScore('enc', 'Second Encore', actual)).toBe(15);
   });
 });
+
+describe('parseSetlist bustoutTitles (#214)', () => {
+  it('Phish.net: derives bustoutTitles from row gap >= BUSTOUT_MIN_GAP', () => {
+    const parsed = parseSetlist(
+      {
+        error: false,
+        data: [
+          { set: '1', song: 'AC/DC Bag', position: 1, gap: 8 },
+          { set: '1', song: 'Bathtub Gin', position: 2, gap: 14 },
+          { set: '2', song: "Colonel Forbin's Ascent", position: 1, gap: 98 },
+          { set: '2', song: 'Down with Disease', position: 2, gap: 2 },
+          { set: 'e', song: "Fluff's Travels", position: 1, gap: 1884 },
+        ],
+      },
+      'phishnet',
+      gameConfig,
+    );
+    expect(parsed.bustoutTitles).toEqual([
+      "Colonel Forbin's Ascent",
+      "Fluff's Travels",
+    ]);
+  });
+
+  it('Phish.net: accepts gap as numeric string, ignores non-numeric / negative', () => {
+    const parsed = parseSetlist(
+      {
+        error: false,
+        data: [
+          { set: '1', song: 'A', position: 1, gap: '40' },
+          { set: '1', song: 'B', position: 2, gap: '—' },
+          { set: '1', song: 'C', position: 3, gap: -5 },
+          { set: '1', song: 'D', position: 4 },
+        ],
+      },
+      'phishnet',
+      gameConfig,
+    );
+    expect(parsed.bustoutTitles).toEqual(['A']);
+  });
+
+  it('Phish.in: returns empty bustoutTitles (no gap metadata available)', () => {
+    const parsed = parseSetlist(phishinFixture, 'phishin', gameConfig);
+    expect(parsed.bustoutTitles).toEqual([]);
+  });
+
+  it('mapParsedSetlistToLegacySaveShape forwards bustouts', () => {
+    const parsed = parseSetlist(
+      {
+        error: false,
+        data: [
+          { set: '1', song: 'A', position: 1, gap: 2 },
+          { set: '1', song: 'B', position: 2, gap: 40 },
+        ],
+      },
+      'phishnet',
+      gameConfig,
+    );
+    const { bustouts } = mapParsedSetlistToLegacySaveShape(parsed, ADMIN_SLOT_FIELDS);
+    expect(bustouts).toEqual(['B']);
+  });
+});

--- a/src/features/admin/api/officialSetlistsApi.js
+++ b/src/features/admin/api/officialSetlistsApi.js
@@ -1,13 +1,14 @@
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { db } from '../../../shared/lib/firebase';
 import {
+  sanitizeBustouts,
   sanitizeOfficialSongList,
   sanitizeSetlistSlots,
 } from '../../../shared/utils/officialSetlistSanitize.js';
 
 const OFFICIAL_SETLISTS_COLLECTION = 'official_setlists';
 
-export { sanitizeOfficialSongList, sanitizeSetlistSlots };
+export { sanitizeBustouts, sanitizeOfficialSongList, sanitizeSetlistSlots };
 
 function encoreSongsFromOfficialDoc(data) {
   if (!data || typeof data !== 'object') return [];
@@ -38,10 +39,21 @@ export async function fetchOfficialSetlistByDate(showDate, slotFields) {
     setlist: sanitizeSetlistSlots(data.setlist || {}, slotFields),
     officialSetlist: sanitizeOfficialSongList(data.officialSetlist),
     encoreSongs: encoreSongsFromOfficialDoc(data),
+    bustouts: sanitizeBustouts(data.bustouts),
     raw: data,
   };
 }
 
+/**
+ * Persist an official setlist for a show date.
+ *
+ * `bustouts` is the per-show bustout snapshot (#214). Callers should derive
+ * it from Phish.net row `gap` values (via the parser DTO or a live fetch) and
+ * pass it explicitly. Omitting it preserves the prior snapshot on the doc so
+ * a save triggered without fresh Phish.net data (e.g. pure slot edit) does
+ * not erase bustouts captured earlier. Pass an empty array only when you
+ * affirmatively know there are no bustouts.
+ */
 export async function saveOfficialSetlistByDate({
   showDate,
   setlistData,
@@ -49,6 +61,7 @@ export async function saveOfficialSetlistByDate({
   slotFields,
   updatedBy,
   encoreSongs: encoreSongsExplicit,
+  bustouts: bustoutsExplicit,
 }) {
   const cleanedSlots = sanitizeSetlistSlots(setlistData, slotFields);
   const cleanedOfficialSetlist = sanitizeOfficialSongList(officialSetlist);
@@ -59,6 +72,7 @@ export async function saveOfficialSetlistByDate({
   const priorList = Array.isArray(prior.encoreSongs)
     ? sanitizeOfficialSongList(prior.encoreSongs)
     : [];
+  const priorBustouts = sanitizeBustouts(prior.bustouts);
 
   let encoreSongs;
   if (encoreSongsExplicit !== undefined) {
@@ -71,6 +85,15 @@ export async function saveOfficialSetlistByDate({
     encoreSongs = [cleanedSlots.enc];
   }
 
+  // Bustouts policy: explicit caller value wins (even an empty array — that
+  // is the affirmative "no bustouts" signal). When the caller omits the field
+  // entirely (undefined), fall back to whatever was previously on the doc so
+  // we never silently clobber a good snapshot on an unrelated edit.
+  const bustouts =
+    bustoutsExplicit !== undefined
+      ? sanitizeBustouts(bustoutsExplicit)
+      : priorBustouts;
+
   await setDoc(docRef, {
     showDate,
     status: 'COMPLETED',
@@ -80,11 +103,13 @@ export async function saveOfficialSetlistByDate({
     setlist: cleanedSlots,
     officialSetlist: cleanedOfficialSetlist,
     encoreSongs,
+    bustouts,
   });
 
   return {
     cleanedSlots,
     cleanedOfficialSetlist,
     encoreSongs,
+    bustouts,
   };
 }

--- a/src/features/admin/model/setlistAutomation.js
+++ b/src/features/admin/model/setlistAutomation.js
@@ -36,7 +36,7 @@ function formatSetlistFetchLayerError(err) {
  *
  * @param {string} showDate YYYY-MM-DD
  * @param {{ id: string }[]} slotFields Admin slot fields (typically `ADMIN_SETLIST_FIELDS`).
- * @returns {Promise<{ ok: true, setlistData: Record<string, string>, officialSetlist: string[] } | { ok: false, error: string }>}
+ * @returns {Promise<{ ok: true, setlistData: Record<string, string>, officialSetlist: string[], encoreSongs: string[], bustouts: string[] } | { ok: false, error: string }>}
  */
 export async function fetchAndMapExternalSetlist(showDate, slotFields) {
   const rawResult = await fetchSetlistRaw(showDate);
@@ -48,11 +48,45 @@ export async function fetchAndMapExternalSetlist(showDate, slotFields) {
 
   try {
     const parsed = parseSetlist(rawResult.data, apiSource, gameConfig);
-    const { setlistData, officialSetlist, encoreSongs } = mapParsedSetlistToLegacySaveShape(
+    const { setlistData, officialSetlist, encoreSongs, bustouts } = mapParsedSetlistToLegacySaveShape(
       parsed,
       slotFields,
     );
-    return { ok: true, setlistData, officialSetlist, encoreSongs };
+    return { ok: true, setlistData, officialSetlist, encoreSongs, bustouts };
+  } catch (e) {
+    if (e instanceof SetlistParseError) {
+      return { ok: false, error: e.message };
+    }
+    return { ok: false, error: e instanceof Error ? e.message : 'Failed to parse setlist.' };
+  }
+}
+
+/**
+ * Fetch `bustouts` for a show date directly from Phish.net, irrespective of
+ * the admin's configured `VITE_SETLIST_API_SOURCE`. Used by the admin save
+ * fallback when the admin typed the setlist by hand (or came in via Phish.in,
+ * which has no gap metadata) and the form state has no bustouts yet (#214).
+ *
+ * Always talks to Phish.net (via `getPhishnetSetlist` callable) regardless of
+ * the configured ingest source, because Phish.net is the only source that
+ * carries per-row `gap`. Returns `{ ok: false }` soft-failure — the caller
+ * should save with empty `bustouts` and surface a toast so the admin can
+ * retry once Phish.net has the setlist.
+ *
+ * @param {string} showDate YYYY-MM-DD
+ * @param {{ id: string }[]} slotFields
+ * @returns {Promise<{ ok: true, bustouts: string[] } | { ok: false, error: string }>}
+ */
+export async function fetchBustoutsFromPhishnet(showDate, slotFields) {
+  const rawResult = await fetchSetlistRaw(showDate, { forceSource: 'phishnet' });
+  if (isSetlistFetchFailure(rawResult)) {
+    return { ok: false, error: formatSetlistFetchLayerError(rawResult.error) };
+  }
+
+  try {
+    const parsed = parseSetlist(rawResult.data, 'phishnet', gameConfig);
+    const { bustouts } = mapParsedSetlistToLegacySaveShape(parsed, slotFields);
+    return { ok: true, bustouts };
   } catch (e) {
     if (e instanceof SetlistParseError) {
       return { ok: false, error: e.message };

--- a/src/features/admin/model/useAdminSetlistForm.js
+++ b/src/features/admin/model/useAdminSetlistForm.js
@@ -13,7 +13,7 @@ import {
   pollLiveSetlistNow,
   setLiveSetlistAutomationState,
 } from '../api/liveSetlistAutomationApi';
-import { fetchAndMapExternalSetlist } from './setlistAutomation';
+import { fetchAndMapExternalSetlist, fetchBustoutsFromPhishnet } from './setlistAutomation';
 
 export const ADMIN_SETLIST_FIELDS = FORM_FIELDS.filter((field) => field.id !== 'wild');
 
@@ -41,6 +41,13 @@ export function useAdminSetlistForm({ user, selectedDate }) {
   const [message, setMessage] = useState({ text: '', type: '' });
   /** Mirrors `official_setlists.encoreSongs` for multi-encore scoring + save. */
   const [encoreSongs, setEncoreSongs] = useState([]);
+  /**
+   * Mirrors `official_setlists.bustouts` (#214). Derived from Phish.net row
+   * `gap` metadata when the admin ingests from the API; left as `null` when
+   * the admin is editing by hand so the save flow can fetch it on demand
+   * (rather than writing an empty array over a good snapshot).
+   */
+  const [bustouts, setBustouts] = useState(/** @type {string[] | null} */ (null));
   const clearMessageTimeoutRef = useRef(null);
 
   const { isAdmin: sessionIsAdmin } = useAuth();
@@ -70,6 +77,13 @@ export function useAdminSetlistForm({ user, selectedDate }) {
         setSetlistData(response.setlist);
         setOfficialSetlist(response.officialSetlist);
         setEncoreSongs(sanitizeOfficialSongList(response.encoreSongs ?? []));
+        // Seed from the existing doc when present; `null` means "unknown,
+        // let save fetch it" on a brand-new show.
+        setBustouts(
+          Array.isArray(response.bustouts) && response.bustouts.length >= 0 && response.exists
+            ? response.bustouts
+            : null,
+        );
         setOfficialSetlistInput('');
       } catch (error) {
         console.error('Error fetching setlist:', error);
@@ -108,6 +122,10 @@ export function useAdminSetlistForm({ user, selectedDate }) {
       setSetlistData(result.setlistData);
       setOfficialSetlist(result.officialSetlist);
       setEncoreSongs(sanitizeOfficialSongList(result.encoreSongs ?? []));
+      // Phish.in ingest returns an empty `bustouts` array because Phish.in
+      // has no gap metadata. Leave state as `null` in that case so the save
+      // flow falls through to the Phish.net fetch-at-save path.
+      setBustouts(Array.isArray(result.bustouts) && result.bustouts.length > 0 ? result.bustouts : null);
       setOfficialSetlistInput('');
     } catch (e) {
       console.error('Fetch setlist from API failed:', e);
@@ -144,18 +162,51 @@ export function useAdminSetlistForm({ user, selectedDate }) {
 
     setIsSaving(true);
     setMessage({ text: '', type: '' });
+    /**
+     * Warning text appended to the final success toast when fetch-at-save
+     * couldn't derive bustouts. We still save (so scoring works for exact /
+     * in-setlist / wildcard), just without the bustout boost.
+     */
+    let bustoutsWarning = '';
 
     try {
-      const { cleanedSlots, cleanedOfficialSetlist, encoreSongs: savedEncoreSongs } =
-        await saveOfficialSetlistByDate({
+      // Fetch-at-save fallback (#214). Options:
+      // - state `bustouts` is an array (admin ingested from Phish.net or
+      //   reopened an existing doc): use it verbatim.
+      // - state `bustouts` is null (hand-typed, or Phish.in ingest): fire a
+      //   one-shot Phish.net fetch so the snapshot is definitional. On
+      //   soft-failure, save with an empty array and warn — scoring stays
+      //   deterministic; admin can re-save later to backfill.
+      let bustoutsToSave;
+      if (Array.isArray(bustouts)) {
+        bustoutsToSave = bustouts;
+      } else {
+        const res = await fetchBustoutsFromPhishnet(selectedShow, ADMIN_SETLIST_FIELDS);
+        if (res.ok) {
+          bustoutsToSave = res.bustouts;
+          setBustouts(res.bustouts);
+        } else {
+          bustoutsToSave = [];
+          bustoutsWarning = ` Bustouts could not be derived from Phish.net (${res.error}); save again once Phish.net posts the setlist to earn bustout boosts.`;
+        }
+      }
+
+      const {
+        cleanedSlots,
+        cleanedOfficialSetlist,
+        encoreSongs: savedEncoreSongs,
+        bustouts: savedBustouts,
+      } = await saveOfficialSetlistByDate({
           showDate: selectedShow,
           setlistData,
           officialSetlist,
           slotFields: ADMIN_SETLIST_FIELDS,
           updatedBy: user?.email ?? null,
           encoreSongs,
+          bustouts: bustoutsToSave,
         });
       setEncoreSongs(savedEncoreSongs);
+      setBustouts(savedBustouts);
 
       if (!finalizeRollup) {
         try {
@@ -178,6 +229,7 @@ export function useAdminSetlistForm({ user, selectedDate }) {
               ...cleanedSlots,
               officialSetlist: cleanedOfficialSetlist,
               encoreSongs: savedEncoreSongs,
+              bustouts: savedBustouts,
             },
           });
         } catch (rollupError) {
@@ -191,10 +243,11 @@ export function useAdminSetlistForm({ user, selectedDate }) {
       }
 
       setMessage({
-        text: finalizeRollup
-          ? 'OFFICIAL SETLIST LOCKED — STATS ROLLED UP'
-          : 'OFFICIAL SETLIST LOCKED',
-        type: 'success',
+        text:
+          (finalizeRollup
+            ? 'OFFICIAL SETLIST LOCKED — STATS ROLLED UP'
+            : 'OFFICIAL SETLIST LOCKED') + bustoutsWarning,
+        type: bustoutsWarning ? 'warning' : 'success',
       });
     } catch (error) {
       console.error('Error saving setlist or running rollup:', error);

--- a/src/features/scoring/api/standingsApi.js
+++ b/src/features/scoring/api/standingsApi.js
@@ -1,7 +1,10 @@
 import { collection, doc, getDoc, getDocs, query, where } from 'firebase/firestore';
 
 import { db } from '../../../shared/lib/firebase';
-import { sanitizeOfficialSongList } from '../../../shared/utils/officialSetlistSanitize.js';
+import {
+  sanitizeBustouts,
+  sanitizeOfficialSongList,
+} from '../../../shared/utils/officialSetlistSanitize.js';
 
 /**
  * @param {string} showDate
@@ -37,9 +40,13 @@ export async function fetchOfficialSetlistForShow(showDate) {
     Array.isArray(rawEnc) && rawEnc.length > 0
       ? sanitizeOfficialSongList(rawEnc)
       : [];
+  const bustouts = sanitizeBustouts(data.bustouts);
   return {
     ...(data.setlist || {}),
     officialSetlist: Array.isArray(data.officialSetlist) ? data.officialSetlist : [],
     ...(encoreSongs.length > 0 ? { encoreSongs } : {}),
+    // Always include the bustouts key (even when empty) so downstream scoring
+    // treats absence = empty without ambiguity (#214).
+    bustouts,
   };
 }

--- a/src/shared/data/phishSongs.js
+++ b/src/shared/data/phishSongs.js
@@ -1,6 +1,10 @@
 /**
  * Bundled fallback for song autocomplete when public `song-catalog.json` is missing or unreachable (issue #158).
- * Server-side grading still uses `functions/phishSongs.js` until aligned.
+ *
+ * Post-#214: not used for scoring. Bustout boosts come from the per-show
+ * `official_setlists/{showDate}.bustouts` snapshot, not catalog `gap`. This
+ * file exists purely as a Storage-fetch fallback for `useSongCatalog` and the
+ * default `SongAutocomplete` `songs` prop.
  */
 export const PHISH_SONGS = [{ name: "Alumni Blues", total: "112", gap: "133", last: "2023-07-12" },
 { name: "And So To Bed", total: "1", gap: "211", last: "2021-10-15" },

--- a/src/shared/utils/officialSetlistSanitize.js
+++ b/src/shared/utils/officialSetlistSanitize.js
@@ -18,3 +18,26 @@ export function sanitizeOfficialSongList(officialSetlist) {
   if (!Array.isArray(officialSetlist)) return [];
   return officialSetlist.map(normalizeSong).filter(Boolean);
 }
+
+/**
+ * Normalize a per-show `bustouts` list for persistence and scoring: trim,
+ * drop empties, dedupe by lowercase form (preserving first-seen casing).
+ * Source of truth for scoring bustout boosts post-#214.
+ *
+ * @param {unknown} input
+ * @returns {string[]}
+ */
+export function sanitizeBustouts(input) {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const raw of input) {
+    const title = typeof raw === 'string' ? raw.trim() : '';
+    if (!title) continue;
+    const key = title.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(title);
+  }
+  return out;
+}

--- a/src/shared/utils/officialSetlistSanitize.test.js
+++ b/src/shared/utils/officialSetlistSanitize.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizeBustouts,
+  sanitizeOfficialSongList,
+  sanitizeSetlistSlots,
+} from './officialSetlistSanitize.js';
+
+describe('sanitizeSetlistSlots', () => {
+  it('trims values per slot id and fills missing with empty string', () => {
+    const slotFields = [{ id: 's1o' }, { id: 's1c' }];
+    expect(sanitizeSetlistSlots({ s1o: '  AC/DC Bag  ' }, slotFields)).toEqual({
+      s1o: 'AC/DC Bag',
+      s1c: '',
+    });
+  });
+});
+
+describe('sanitizeOfficialSongList', () => {
+  it('trims and drops empties', () => {
+    expect(sanitizeOfficialSongList(['  a ', '', 'b', '   '])).toEqual(['a', 'b']);
+  });
+  it('returns [] for non-array', () => {
+    expect(sanitizeOfficialSongList(undefined)).toEqual([]);
+  });
+});
+
+describe('sanitizeBustouts (#214)', () => {
+  it('trims, drops empties, dedupes by lowercase form', () => {
+    const input = ['  Foo  ', 'FOO', 'foo', 'Bar', '', null, '   '];
+    expect(sanitizeBustouts(input)).toEqual(['Foo', 'Bar']);
+  });
+  it('preserves the first-seen casing for each normalized title', () => {
+    expect(sanitizeBustouts(['AC/DC Bag', 'ac/dc bag'])).toEqual(['AC/DC Bag']);
+    expect(sanitizeBustouts(['ac/dc bag', 'AC/DC Bag'])).toEqual(['ac/dc bag']);
+  });
+  it('returns [] for non-array input', () => {
+    expect(sanitizeBustouts(undefined)).toEqual([]);
+    expect(sanitizeBustouts(null)).toEqual([]);
+    expect(sanitizeBustouts('foo')).toEqual([]);
+  });
+  it('drops non-string entries defensively', () => {
+    expect(sanitizeBustouts([42, { x: 1 }, 'ok'])).toEqual(['ok']);
+  });
+});

--- a/src/shared/utils/scoring.js
+++ b/src/shared/utils/scoring.js
@@ -1,5 +1,4 @@
 import { FORM_FIELDS } from '../data/gameConfig';
-import { PHISH_SONGS } from '../data/phishSongs.js';
 
 export const SCORING_RULES = {
   EXACT_SLOT: 10,
@@ -9,7 +8,13 @@ export const SCORING_RULES = {
   /** Wildcard: song appeared anywhere in the show (slots + officialSetlist). */
   WILDCARD_HIT: 10,
   BUSTOUT_BOOST: 20,
-  /** Minimum catalog gap (shows since last play) to earn the bustout boost. */
+  /**
+   * Minimum pre-show gap to count as a bustout. Kept as a named constant for
+   * the write paths (`setlistParser`, live automation) that derive
+   * `official_setlists.bustouts` from Phish.net row `gap`. Scoring itself no
+   * longer evaluates this at read time — it consumes the frozen `bustouts`
+   * snapshot instead (#214).
+   */
   BUSTOUT_MIN_GAP: 30,
 };
 
@@ -17,12 +22,6 @@ const normalize = (s) => String(s ?? '').trim().toLowerCase();
 
 /** Keys on the scoring payload that are not slot song strings. */
 const NON_SONG_SETLIST_KEYS = new Set(['officialSetlist', 'encoreSongs', 'id', 'bustouts']);
-
-function parseGap(gap) {
-  if (gap == null || gap === '' || gap === '—') return null;
-  const n = Number.parseInt(String(gap), 10);
-  return Number.isFinite(n) ? n : null;
-}
 
 /**
  * Encore exact: primary `enc` slot plus optional `encoreSongs` (multi-encore shows).
@@ -116,11 +115,19 @@ function computeSlotResult(fieldId, guessedSong, actualSetlist) {
     }
   }
 
-  const matched = PHISH_SONGS.find((song) => normalize(song.name) === guess);
+  // Bustout boost reads the per-show snapshot on the official setlist doc
+  // (#214). Absence or empty array → no bustout boost; no catalog fallback.
+  // The snapshot is written at save time from Phish.net row `gap` (pre-show
+  // by construction), which decouples scoring from the weekly
+  // `song-catalog.json` refresh cadence.
+  const bustoutList = Array.isArray(actualSetlist.bustouts) ? actualSetlist.bustouts : [];
   let bustoutBoost = false;
-  if (matched) {
-    const gapNum = parseGap(matched.gap);
-    bustoutBoost = gapNum != null && gapNum >= SCORING_RULES.BUSTOUT_MIN_GAP;
+  for (const raw of bustoutList) {
+    if (typeof raw !== 'string') continue;
+    if (normalize(raw) === guess) {
+      bustoutBoost = true;
+      break;
+    }
   }
 
   /** @type {ScoreBreakdownKind} */

--- a/src/shared/utils/scoring.test.js
+++ b/src/shared/utils/scoring.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SCORING_RULES,
+  calculateSlotScore,
+  calculateTotalScore,
+  getSlotScoreBreakdown,
+} from './scoring.js';
+
+/**
+ * Per-show `bustouts` snapshot read path (#214).
+ *
+ * These tests pin the invariant that bustout boosts come from the
+ * `actualSetlist.bustouts` array on the official setlist doc — not a song
+ * catalog. Absence or empty array must mean "no boost"; no fallback lookup.
+ */
+describe('scoring: bustout boost reads actualSetlist.bustouts (#214)', () => {
+  const baseSetlist = {
+    s1o: 'AC/DC Bag',
+    s1c: 'Bathtub Gin',
+    s2o: "Colonel Forbin's Ascent",
+    s2c: 'Down with Disease',
+    enc: 'Tweezer Reprise',
+    officialSetlist: [
+      'AC/DC Bag',
+      'Bathtub Gin',
+      "Colonel Forbin's Ascent",
+      'Down with Disease',
+      'Tweezer Reprise',
+    ],
+  };
+
+  it('awards BUSTOUT_BOOST when the pick matches a bustout entry', () => {
+    const actual = { ...baseSetlist, bustouts: ["Colonel Forbin's Ascent"] };
+    // Wildcard hit (10) + bustout boost (20) = 30
+    expect(calculateSlotScore('wild', "Colonel Forbin's Ascent", actual)).toBe(
+      SCORING_RULES.WILDCARD_HIT + SCORING_RULES.BUSTOUT_BOOST,
+    );
+    // Exact slot (10) + bustout boost (20) = 30
+    expect(calculateSlotScore('s2o', "Colonel Forbin's Ascent", actual)).toBe(
+      SCORING_RULES.EXACT_SLOT + SCORING_RULES.BUSTOUT_BOOST,
+    );
+  });
+
+  it('no bustout boost when the pick is not in bustouts', () => {
+    const actual = { ...baseSetlist, bustouts: ["Colonel Forbin's Ascent"] };
+    // Wildcard hit only, no boost
+    expect(calculateSlotScore('wild', 'AC/DC Bag', actual)).toBe(
+      SCORING_RULES.WILDCARD_HIT,
+    );
+  });
+
+  it('treats absent bustouts as empty (no boost, no catalog fallback)', () => {
+    const actual = { ...baseSetlist }; // no bustouts field
+    expect(calculateSlotScore('wild', "Colonel Forbin's Ascent", actual)).toBe(
+      SCORING_RULES.WILDCARD_HIT,
+    );
+  });
+
+  it('treats empty bustouts array as no boost', () => {
+    const actual = { ...baseSetlist, bustouts: [] };
+    expect(calculateSlotScore('wild', "Colonel Forbin's Ascent", actual)).toBe(
+      SCORING_RULES.WILDCARD_HIT,
+    );
+  });
+
+  it('matches bustout entries case-insensitively', () => {
+    const actual = { ...baseSetlist, bustouts: ['colonel forbins ascent', 'DOWN WITH DISEASE'] };
+    // Different casing/punctuation normalize via `String#toLowerCase().trim()`.
+    // "Colonel Forbin's Ascent" vs "colonel forbins ascent" differs in the
+    // apostrophe, so guard against accidental matches: exact normalize only.
+    expect(calculateSlotScore('s2c', 'Down with Disease', actual)).toBe(
+      SCORING_RULES.EXACT_SLOT + SCORING_RULES.BUSTOUT_BOOST,
+    );
+  });
+
+  it('getSlotScoreBreakdown surfaces bustoutBoost flag', () => {
+    const actual = { ...baseSetlist, bustouts: ['AC/DC Bag'] };
+    const result = getSlotScoreBreakdown('s1o', 'AC/DC Bag', actual);
+    expect(result.points).toBe(SCORING_RULES.EXACT_SLOT + SCORING_RULES.BUSTOUT_BOOST);
+    expect(result.bustoutBoost).toBe(true);
+    expect(result.kind).toBe('exact_slot');
+
+    const noBoost = getSlotScoreBreakdown('s1c', 'Bathtub Gin', actual);
+    expect(noBoost.bustoutBoost).toBe(false);
+  });
+
+  it('drops non-string entries in bustouts defensively', () => {
+    const actual = {
+      ...baseSetlist,
+      bustouts: [null, 42, { title: 'x' }, "Colonel Forbin's Ascent"],
+    };
+    expect(calculateSlotScore('wild', "Colonel Forbin's Ascent", actual)).toBe(
+      SCORING_RULES.WILDCARD_HIT + SCORING_RULES.BUSTOUT_BOOST,
+    );
+  });
+
+  it('calculateTotalScore sums base + boosts across slots', () => {
+    const actual = { ...baseSetlist, bustouts: ["Colonel Forbin's Ascent"] };
+    const picks = {
+      s1o: 'AC/DC Bag', // exact slot, no bustout = 10
+      s1c: 'Bathtub Gin', // exact slot, no bustout = 10
+      s2o: "Colonel Forbin's Ascent", // exact slot + bustout = 30
+      s2c: 'wrong', // miss = 0
+      enc: 'Tweezer Reprise', // encore exact = 15
+      wild: 'Down with Disease', // wildcard hit = 10
+    };
+    expect(calculateTotalScore(picks, actual)).toBe(10 + 10 + 30 + 0 + 15 + 10);
+  });
+});


### PR DESCRIPTION
Closes #214.

## Problem

Scoring drift on bustout boosts: the bundled/Storage song catalog's `gap` resets to ~0 after a song plays, so bustouts that were valid at pick-lock time silently lose their +20 boost after the show runs. #167 briefly routed server grading through the Storage catalog and made this worse; #215 reverted that. This PR fixes the root cause.

## Fix

Freeze a `bustouts: string[]` snapshot on each `official_setlists/{showDate}` doc at save time, derived from Phish.net v5 per-row `gap` (the definitional pre-show metric). Scoring reads only from the snapshot — no catalog fallback. The weekly `song-catalog.json` refresh is no longer a scoring input and can stay weekly (it remains for UI autocomplete only).

## Write paths (both populate `bustouts`)

| Path | File | `gap` source |
|------|------|--------------|
| Live automation | `functions/phishnetLiveSetlistAutomation.js` | Phish.net row `gap` directly; merged with prior snapshot so partial feeds never shrink the list |
| Admin Phish.net ingest | `src/features/admin-setlist-config/model/setlistParser.js` | Per-row `gap` threaded through `ParsedSetlistDto.bustoutTitles` |
| Admin save fallback | `src/features/admin/model/setlistAutomation.js` → `getPhishnetSetlist` callable | One-shot fetch at save time when form state has no bustouts (hand-typed or Phish.in ingest); soft-failure saves `bustouts: []` + warning toast |

## Read paths

- Client (`src/shared/utils/scoring.js`) and server (`functions/index.js`) both read bustout membership from `actualSetlist.bustouts` only. `PHISH_SONGS` / bundled `phishSongs` imports dropped from the scoring path.
- Standings (`src/features/scoring/api/standingsApi.js`) always returns a sanitized `bustouts` field.
- Shared `sanitizeBustouts` helper lives in `src/shared/utils/officialSetlistSanitize.js` (scoring and admin features share it without crossing feature boundaries).

## Backfill

New admin callable `backfillBustoutsForShows` (in `functions/index.js`) + thin Node wrapper (`functions/scripts/backfillBustouts.js`) so the three historical graded shows can be reconciled:

```bash
cd functions
npm run backfill:bustouts -- --missing            # dry-run
npm run backfill:bustouts -- --missing --apply    # apply
```

The wrapper mints an admin-claim ID token via firebase-admin + Identity Toolkit REST and calls the deployed callable — single source of truth. The callable re-fetches Phish.net, writes the snapshot via merge, recomputes `pick.score` for every pick, and reconciles `users.totalPoints` by score delta for picks already marked `isGraded: true`.

## Docs

- `docs/OFFICIAL_SETLISTS_SCHEMA.md` — `bustouts` added to the schema table; "Bustout source" section rewritten; backfill runbook.
- `docs/SONG_CATALOG.md` — clarifies scoring no longer consults the catalog post-#214.

## Tests

125 passing (40 client vitest + 85 functions node:test, all new tests passing):

- `src/shared/utils/scoring.test.js` *(new)* — 8 tests: boost/no-boost, absent, empty, case-insensitive, defensive non-string entries, total-score integration.
- `src/shared/utils/officialSetlistSanitize.test.js` *(new)* — 7 tests: dedupe/casing/defense.
- `src/features/admin-setlist-config/model/setlistParser.test.js` — 4 new tests: Phish.net bustoutTitles, gap parsing (numeric string / negative / non-numeric), Phish.in empty, save-shape round-trip.
- `functions/phishnetLiveSetlistAutomation.test.js` — 7 new tests: gap preservation, threshold selection, dedupe, partial-feed merge, `setlistPayloadEqual` bustouts diff.

## Deploy + rollout plan

1. Merge → CI deploys hosting.
2. `firebase deploy --only functions` (new `backfillBustoutsForShows` callable; updated grading trigger).
3. `cd functions && npm run backfill:bustouts -- --missing --apply` to reconcile the three historical graded shows.
4. Spot-check a standings page to confirm bustout boosts survived the round trip.

Old client + new server and new client + old server are both safe (new client treats absent `bustouts` as empty until the server catches up).

## Test plan

- [ ] Deploy functions; confirm `backfillBustoutsForShows` appears in `firebase functions:list`.
- [ ] Dry-run `npm run backfill:bustouts -- --missing`; verify the list matches expectations.
- [ ] Apply backfill for the three graded historical shows; confirm reconciledGradedPicks > 0 and leaderboard totals update.
- [ ] Ingest a new-show setlist from Phish.net via the admin form; verify `official_setlists/{showDate}.bustouts` is written.
- [ ] Live-poll automation during a show (or force-poll via admin "Manual poll"); verify `bustouts` populates mid-show and never shrinks between partial feeds.
- [ ] Hand-type a setlist as admin; verify the fetch-at-save fallback fires and either populates bustouts or surfaces the warning toast.

Made with [Cursor](https://cursor.com)