### PR TITLE
refactor(backfill): share backfillBustouts core between callable and script

### DIFF
--- a/functions/backfillBustoutsCore.js
+++ b/functions/backfillBustoutsCore.js
@@ -1,0 +1,231 @@
+/**
+ * Core backfill logic for per-show `bustouts` snapshots (#214).
+ *
+ * This is the single source of truth used by both:
+ *   - the deployed callable `backfillBustoutsForShows` (functions/index.js),
+ *     which wraps this with an admin-claim auth gate + HttpsError reporting.
+ *   - the admin ops script (functions/scripts/backfillBustouts.js), which
+ *     calls it directly under Application Default Credentials so it can run
+ *     locally without minting a Firebase Auth ID token.
+ *
+ * Keeping the module Firebase-SDK-only (no firebase-functions imports) means
+ * the script doesn't pay the cost of loading the callable runtime just to
+ * reach this code path.
+ */
+
+const {
+  deriveBustoutsFromRows,
+  fetchPhishnetSetlistForDate,
+  normalizeSetlistRows,
+  BUSTOUT_MIN_GAP: AUTOMATION_BUSTOUT_MIN_GAP,
+} = require("./phishnetLiveSetlistAutomation");
+const {
+  calculateTotalScore,
+  actualSetlistFromOfficialDoc,
+} = require("./scoringCore");
+
+/** Firestore batch write limit (same invariant as `adminRollupApi.js` / `profileApi.js`). */
+const MAX_FIRESTORE_BATCH_WRITES = 500;
+
+const SHOW_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** @param {unknown} showDate */
+function normalizeShowDate(showDate) {
+  if (typeof showDate !== "string" || !SHOW_DATE_RE.test(showDate.trim())) {
+    throw new Error(`showDate must be a YYYY-MM-DD string (got: ${showDate})`);
+  }
+  return showDate.trim();
+}
+
+/**
+ * @param {import("firebase-admin").firestore.Firestore} db
+ * @returns {Promise<string[]>}
+ */
+async function scanShowsMissingBustouts(db) {
+  const snap = await db.collection("official_setlists").get();
+  /** @type {string[]} */
+  const out = [];
+  for (const d of snap.docs) {
+    const data = d.data() || {};
+    if (!Array.isArray(data.bustouts)) out.push(d.id);
+  }
+  out.sort();
+  return out;
+}
+
+/**
+ * Resolve target show dates from caller input.
+ *
+ * @param {object} args
+ * @param {import("firebase-admin").firestore.Firestore} args.db
+ * @param {string[]} [args.showDates]
+ * @param {"missing"} [args.mode]
+ * @returns {Promise<string[]>}
+ */
+async function resolveTargetShowDates({ db, showDates, mode }) {
+  if (Array.isArray(showDates) && showDates.length > 0) {
+    return showDates.map((d) => normalizeShowDate(d));
+  }
+  if (mode === "missing") {
+    return scanShowsMissingBustouts(db);
+  }
+  throw new Error(
+    'Pass { showDates: ["YYYY-MM-DD", ...] } or { mode: "missing" }.'
+  );
+}
+
+/**
+ * Re-fetch Phish.net rows for `showDate`, write a fresh `bustouts` snapshot
+ * onto `official_setlists/{showDate}`, recompute every pick's score, and
+ * reconcile `users.totalPoints` by score delta for picks already marked
+ * `isGraded: true`.
+ *
+ * Idempotent: re-running with unchanged Phish.net data produces the same
+ * snapshot and zero score deltas.
+ *
+ * @param {object} args
+ * @param {import("firebase-admin").firestore.Firestore} args.db
+ * @param {typeof import("firebase-admin")} args.admin
+ * @param {{warn?: Function, info?: Function}} [args.logger]
+ * @param {string} args.phishnetApiKey
+ * @param {string[]} [args.showDates]
+ * @param {"missing"} [args.mode]
+ * @param {string} [args.updatedBy] - audit tag written to `updatedBy`.
+ * @returns {Promise<{ results: Array<Record<string, unknown>>, minGap: number }>}
+ */
+async function runBackfill({
+  db,
+  admin,
+  logger = console,
+  phishnetApiKey,
+  showDates,
+  mode,
+  updatedBy = "backfill-bustouts",
+}) {
+  if (!db) throw new Error("runBackfill: `db` is required.");
+  if (!admin) throw new Error("runBackfill: `admin` is required.");
+  if (!phishnetApiKey || !String(phishnetApiKey).trim()) {
+    throw new Error(
+      "runBackfill: `phishnetApiKey` is required (Phish.net API key not configured)."
+    );
+  }
+
+  const targets = await resolveTargetShowDates({ db, showDates, mode });
+  const apiKey = String(phishnetApiKey).trim();
+  const results = [];
+
+  for (const showDate of targets) {
+    const setlistRef = db.collection("official_setlists").doc(showDate);
+    const setlistSnap = await setlistRef.get();
+    if (!setlistSnap.exists) {
+      results.push({ showDate, skipped: "no-setlist-doc" });
+      continue;
+    }
+
+    // 1) Re-fetch Phish.net rows and derive bustouts.
+    let bustouts;
+    try {
+      const payload = await fetchPhishnetSetlistForDate(showDate, apiKey);
+      const rows = normalizeSetlistRows(payload);
+      bustouts = deriveBustoutsFromRows(rows);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      logger.warn?.("backfillBustoutsForShows fetch failed", { showDate, msg });
+      results.push({ showDate, skipped: "phishnet-fetch-failed", error: msg });
+      continue;
+    }
+
+    // 2) Write merge + capture prior bustouts for idempotency / logging.
+    const prior = setlistSnap.data() || {};
+    const priorBustouts = Array.isArray(prior.bustouts) ? prior.bustouts : null;
+    await setlistRef.set(
+      {
+        bustouts,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        updatedBy,
+      },
+      { merge: true }
+    );
+
+    // 3) Recompute live scores from the *post-write* doc so the snapshot
+    // we just wrote is what scoring sees. Also reconcile graded picks'
+    // contribution to `users.totalPoints` by score diff — mirrors the
+    // rollup pathway so we don't leave stale totals behind.
+    const freshSnap = await setlistRef.get();
+    const freshDoc = freshSnap.data() || {};
+    const actualSetlist = actualSetlistFromOfficialDoc(freshDoc);
+
+    const picksSnap = await db
+      .collection("picks")
+      .where("showDate", "==", showDate)
+      .get();
+
+    let batch = db.batch();
+    let opCount = 0;
+    let updatedPicks = 0;
+    let reconciledGradedPicks = 0;
+
+    for (const pickDoc of picksSnap.docs) {
+      if (opCount + 2 > MAX_FIRESTORE_BATCH_WRITES) {
+        await batch.commit();
+        batch = db.batch();
+        opCount = 0;
+      }
+      const pickData = pickDoc.data() || {};
+      const newScore = calculateTotalScore(pickData.picks || {}, actualSetlist);
+      const oldScore = Number.isFinite(pickData.score)
+        ? Number(pickData.score)
+        : 0;
+      const scoreDelta = newScore - oldScore;
+
+      const pickUpdate = { score: newScore };
+      if (pickData.isGraded !== true) {
+        pickUpdate.gradedAt = admin.firestore.FieldValue.delete();
+      }
+      batch.update(pickDoc.ref, pickUpdate);
+      opCount += 1;
+      updatedPicks += 1;
+
+      // Only reconcile user totals when this pick was already graded —
+      // otherwise the rollup flow owns first-grade accounting.
+      if (pickData.isGraded === true && scoreDelta !== 0 && pickData.userId) {
+        batch.set(
+          db.collection("users").doc(pickData.userId),
+          {
+            totalPoints: admin.firestore.FieldValue.increment(scoreDelta),
+          },
+          { merge: true }
+        );
+        opCount += 1;
+        reconciledGradedPicks += 1;
+      }
+    }
+
+    if (opCount > 0) {
+      await batch.commit();
+    }
+
+    results.push({
+      showDate,
+      bustoutCount: bustouts.length,
+      priorBustoutCount: priorBustouts ? priorBustouts.length : null,
+      updatedPicks,
+      reconciledGradedPicks,
+    });
+  }
+
+  logger.info?.("backfillBustoutsForShows complete", {
+    minGap: AUTOMATION_BUSTOUT_MIN_GAP,
+    results,
+  });
+
+  return { results, minGap: AUTOMATION_BUSTOUT_MIN_GAP };
+}
+
+module.exports = {
+  runBackfill,
+  resolveTargetShowDates,
+  scanShowsMissingBustouts,
+  normalizeShowDate,
+  MAX_FIRESTORE_BATCH_WRITES,
+};

--- a/functions/index.js
+++ b/functions/index.js
@@ -11,12 +11,8 @@ const {
   syncPhishnetSongCatalogToStorage,
 } = require("./phishnetSongCatalog");
 const {
-  BUSTOUT_MIN_GAP: AUTOMATION_BUSTOUT_MIN_GAP,
   candidateShowDates,
-  deriveBustoutsFromRows,
-  fetchPhishnetSetlistForDate,
   isWithinLiveSetlistPollWindow,
-  normalizeSetlistRows,
   parseShowCalendarSnapshotToDateSet,
   pollSingleShowDate,
   scheduledCandidateShowDates,
@@ -31,141 +27,16 @@ const {
   findPoolPickActivity,
   parseShowCalendarDates,
 } = require("./poolDelete");
+const {
+  calculateTotalScore,
+  actualSetlistFromOfficialDoc,
+} = require("./scoringCore");
+const { runBackfill } = require("./backfillBustoutsCore");
 
 const phishnetApiKey = defineSecret("PHISHNET_API_KEY");
 
 admin.initializeApp();
 const db = admin.firestore();
-
-// Mirrors src/utils/scoring.js (keep in sync).
-const SCORING_RULES = {
-  EXACT_SLOT: 10,
-  ENCORE_EXACT: 15,
-  IN_SETLIST: 5,
-  WILDCARD_HIT: 10,
-  BUSTOUT_BOOST: 20,
-  BUSTOUT_MIN_GAP: 30,
-};
-
-const SCORE_FIELDS = ["s1o", "s1c", "s2o", "s2c", "enc", "wild"];
-
-/** Keys on the scoring payload that are not slot song strings. */
-const NON_SONG_SETLIST_KEYS = new Set([
-  "officialSetlist",
-  "encoreSongs",
-  "id",
-  "bustouts",
-]);
-
-function normalizeSong(value) {
-  return String(value ?? "").trim().toLowerCase();
-}
-
-function guessMatchesEncoreExact(actualSetlist, guessNorm) {
-  if (!guessNorm) return false;
-  const primary = normalizeSong(actualSetlist.enc);
-  if (primary === guessNorm) return true;
-  const list = actualSetlist.encoreSongs;
-  if (!Array.isArray(list)) return false;
-  return list.some((t) => normalizeSong(t) === guessNorm);
-}
-
-/**
- * Slot strings from the flat map plus ordered officialSetlist, normalized and deduped.
- * Same as buildAllPlayedNormalized in src/utils/scoring.js.
- * @param {Record<string, unknown>} actualSetlist
- * @returns {string[]}
- */
-function buildAllPlayedNormalized(actualSetlist) {
-  const fromSlots = [];
-  for (const [key, val] of Object.entries(actualSetlist || {})) {
-    if (NON_SONG_SETLIST_KEYS.has(key)) continue;
-    if (typeof val !== "string") continue;
-    const t = val.trim();
-    if (!t) continue;
-    fromSlots.push(normalizeSong(t));
-  }
-
-  const rawOfficial = actualSetlist.officialSetlist;
-  const fromOfficial = Array.isArray(rawOfficial)
-    ? rawOfficial
-        .map((s) =>
-          typeof s === "string" ? s.trim() : String(s ?? "").trim()
-        )
-        .filter(Boolean)
-        .map((s) => normalizeSong(s))
-    : [];
-
-  const combined = [...fromSlots, ...fromOfficial];
-  return [...new Set(combined)];
-}
-
-/**
- * Mirrors computeSlotResult + bustout from getSlotScoreBreakdown in
- * src/shared/utils/scoring.js.
- *
- * Bustout boosts read the per-show `bustouts` snapshot on the official
- * setlist doc (#214). The snapshot is frozen at save time from Phish.net row
- * `gap`, so scoring is deterministic and never drifts with the weekly
- * `song-catalog.json` refresh. Absence / empty array → no bustout boost; no
- * catalog fallback.
- */
-function calculateSlotScore(fieldId, guessedSong, actualSetlist) {
-  if (!actualSetlist || !guessedSong) return 0;
-
-  const guess = normalizeSong(guessedSong);
-  if (!guess) return 0;
-
-  const allPlayed = buildAllPlayedNormalized(actualSetlist);
-
-  let base = 0;
-  if (fieldId === "wild") {
-    if (allPlayed.includes(guess)) {
-      base = SCORING_RULES.WILDCARD_HIT;
-    } else {
-      return 0;
-    }
-  } else {
-    const exactNonEnc =
-      fieldId !== "enc" && normalizeSong(actualSetlist[fieldId]) === guess;
-    const exactEnc =
-      fieldId === "enc" && guessMatchesEncoreExact(actualSetlist, guess);
-    if (exactNonEnc || exactEnc) {
-      base =
-        fieldId === "enc"
-          ? SCORING_RULES.ENCORE_EXACT
-          : SCORING_RULES.EXACT_SLOT;
-    } else if (allPlayed.includes(guess)) {
-      base = SCORING_RULES.IN_SETLIST;
-    } else {
-      return 0;
-    }
-  }
-
-  const bustoutList = Array.isArray(actualSetlist.bustouts)
-    ? actualSetlist.bustouts
-    : [];
-  let bustoutBoost = false;
-  for (const raw of bustoutList) {
-    if (typeof raw !== "string") continue;
-    if (normalizeSong(raw) === guess) {
-      bustoutBoost = true;
-      break;
-    }
-  }
-
-  return base + (bustoutBoost ? SCORING_RULES.BUSTOUT_BOOST : 0);
-}
-
-function calculateTotalScore(userPicks, actualSetlist) {
-  if (!actualSetlist || !userPicks) return 0;
-  return SCORE_FIELDS.reduce((total, fieldId) => {
-    return (
-      total +
-      calculateSlotScore(fieldId, userPicks[fieldId], actualSetlist)
-    );
-  }, 0);
-}
 
 /**
  * Gate an admin-only callable on the `admin: true` custom claim (issue #139).
@@ -243,24 +114,6 @@ async function recomputeLiveScoresForShow(showDate, actualSetlistFromWrite = nul
     await batch.commit();
   }
   return { updatedPicks };
-}
-
-function actualSetlistFromOfficialDoc(setlistDoc) {
-  const setlistFlat = setlistDoc.setlist || {};
-  const out = {
-    ...setlistFlat,
-    officialSetlist: Array.isArray(setlistDoc.officialSetlist)
-      ? setlistDoc.officialSetlist
-      : [],
-  };
-  if (Array.isArray(setlistDoc.encoreSongs) && setlistDoc.encoreSongs.length > 0) {
-    out.encoreSongs = setlistDoc.encoreSongs;
-  }
-  // Per-show bustout snapshot for scoring (#214). Absence/empty → no boost.
-  if (Array.isArray(setlistDoc.bustouts)) {
-    out.bustouts = setlistDoc.bustouts;
-  }
-  return out;
 }
 
 exports.gradePicksOnSetlistWrite = onDocumentWritten(
@@ -1015,136 +868,39 @@ exports.backfillBustoutsForShows = onCall(
       );
     }
 
-    // Resolve target show dates.
-    /** @type {string[]} */
-    let showDates = [];
     const explicitDates = request.data?.showDates;
-    if (Array.isArray(explicitDates) && explicitDates.length > 0) {
-      showDates = explicitDates.map((d) => assertShowDateString(d));
-    } else if (request.data?.mode === "missing") {
-      const snap = await db.collection("official_setlists").get();
-      for (const d of snap.docs) {
-        const data = d.data() || {};
-        if (!Array.isArray(data.bustouts)) {
-          showDates.push(d.id);
-        }
-      }
-    } else {
+    const mode = request.data?.mode === "missing" ? "missing" : undefined;
+    if (
+      !(Array.isArray(explicitDates) && explicitDates.length > 0) &&
+      mode !== "missing"
+    ) {
       throw new HttpsError(
         "invalid-argument",
         'Pass { showDates: ["YYYY-MM-DD", ...] } or { mode: "missing" }.'
       );
     }
 
-    const results = [];
-    for (const showDate of showDates) {
-      const setlistRef = db.collection("official_setlists").doc(showDate);
-      const setlistSnap = await setlistRef.get();
-      if (!setlistSnap.exists) {
-        results.push({ showDate, skipped: "no-setlist-doc" });
-        continue;
-      }
-
-      // 1) Re-fetch Phish.net rows and derive bustouts.
-      let bustouts;
-      try {
-        const payload = await fetchPhishnetSetlistForDate(
-          showDate,
-          String(key).trim()
-        );
-        const rows = normalizeSetlistRows(payload);
-        bustouts = deriveBustoutsFromRows(rows);
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        logger.warn("backfillBustoutsForShows fetch failed", { showDate, msg });
-        results.push({ showDate, skipped: "phishnet-fetch-failed", error: msg });
-        continue;
-      }
-
-      // 2) Write merge + capture prior bustouts for idempotency / logging.
-      const prior = setlistSnap.data() || {};
-      const priorBustouts = Array.isArray(prior.bustouts) ? prior.bustouts : null;
-      await setlistRef.set(
-        {
-          bustouts,
-          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-          updatedBy: request.auth?.token?.email || "backfill-bustouts",
-        },
-        { merge: true }
-      );
-
-      // 3) Recompute live scores from the *post-write* doc so the snapshot
-      // we just wrote is what scoring sees. Also reconcile graded picks'
-      // contribution to `users.totalPoints` by score diff — mirrors the
-      // rollup pathway so we don't leave stale totals behind.
-      const freshSnap = await setlistRef.get();
-      const freshDoc = freshSnap.data() || {};
-      const actualSetlist = actualSetlistFromOfficialDoc(freshDoc);
-
-      const picksSnap = await db
-        .collection("picks")
-        .where("showDate", "==", showDate)
-        .get();
-
-      let batch = db.batch();
-      let opCount = 0;
-      let updatedPicks = 0;
-      let reconciledGradedPicks = 0;
-
-      for (const pickDoc of picksSnap.docs) {
-        if (opCount + 2 > MAX_FIRESTORE_BATCH_WRITES) {
-          await batch.commit();
-          batch = db.batch();
-          opCount = 0;
-        }
-        const pickData = pickDoc.data() || {};
-        const newScore = calculateTotalScore(pickData.picks || {}, actualSetlist);
-        const oldScore = Number.isFinite(pickData.score) ? Number(pickData.score) : 0;
-        const scoreDelta = newScore - oldScore;
-
-        const pickUpdate = { score: newScore };
-        if (pickData.isGraded !== true) {
-          pickUpdate.gradedAt = admin.firestore.FieldValue.delete();
-        }
-        batch.update(pickDoc.ref, pickUpdate);
-        opCount += 1;
-        updatedPicks += 1;
-
-        // Only reconcile user totals when this pick was already graded —
-        // otherwise the rollup flow owns first-grade accounting.
-        if (pickData.isGraded === true && scoreDelta !== 0 && pickData.userId) {
-          batch.set(
-            db.collection("users").doc(pickData.userId),
-            {
-              totalPoints: admin.firestore.FieldValue.increment(scoreDelta),
-            },
-            { merge: true }
-          );
-          opCount += 1;
-          reconciledGradedPicks += 1;
-        }
-      }
-
-      if (opCount > 0) {
-        await batch.commit();
-      }
-
-      results.push({
-        showDate,
-        bustoutCount: bustouts.length,
-        priorBustoutCount: priorBustouts ? priorBustouts.length : null,
-        updatedPicks,
-        reconciledGradedPicks,
+    try {
+      const { results } = await runBackfill({
+        db,
+        admin,
+        logger,
+        phishnetApiKey: key,
+        showDates: Array.isArray(explicitDates) ? explicitDates : undefined,
+        mode,
+        updatedBy: request.auth?.token?.email || "backfill-bustouts",
       });
+      logger.info("backfillBustoutsForShows callable complete", {
+        callerUid: request.auth?.uid || null,
+      });
+      return { ok: true, results };
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (/^showDate must be a YYYY-MM-DD/.test(msg)) {
+        throw new HttpsError("invalid-argument", msg);
+      }
+      throw e;
     }
-
-    logger.info("backfillBustoutsForShows complete", {
-      minGap: AUTOMATION_BUSTOUT_MIN_GAP,
-      results,
-      callerUid: request.auth?.uid || null,
-    });
-
-    return { ok: true, results };
   }
 );
 

--- a/functions/scoringCore.js
+++ b/functions/scoringCore.js
@@ -1,0 +1,150 @@
+/**
+ * Server-side scoring helpers extracted from `functions/index.js` so they can
+ * be shared with ops tooling (e.g. `scripts/backfillBustouts.js`) without
+ * pulling in the full Cloud Functions module graph.
+ *
+ * Mirrors `src/shared/utils/scoring.js` — keep the two in sync. The `bustouts`
+ * snapshot on `actualSetlist` is the only source of truth for bustout boosts
+ * (#214); absence/empty → no boost, no catalog fallback.
+ */
+
+const SCORING_RULES = {
+  EXACT_SLOT: 10,
+  ENCORE_EXACT: 15,
+  IN_SETLIST: 5,
+  WILDCARD_HIT: 10,
+  BUSTOUT_BOOST: 20,
+  BUSTOUT_MIN_GAP: 30,
+};
+
+const SCORE_FIELDS = ["s1o", "s1c", "s2o", "s2c", "enc", "wild"];
+
+const NON_SONG_SETLIST_KEYS = new Set([
+  "officialSetlist",
+  "encoreSongs",
+  "id",
+  "bustouts",
+]);
+
+function normalizeSong(value) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function guessMatchesEncoreExact(actualSetlist, guessNorm) {
+  if (!guessNorm) return false;
+  const primary = normalizeSong(actualSetlist.enc);
+  if (primary === guessNorm) return true;
+  const list = actualSetlist.encoreSongs;
+  if (!Array.isArray(list)) return false;
+  return list.some((t) => normalizeSong(t) === guessNorm);
+}
+
+function buildAllPlayedNormalized(actualSetlist) {
+  const fromSlots = [];
+  for (const [key, val] of Object.entries(actualSetlist || {})) {
+    if (NON_SONG_SETLIST_KEYS.has(key)) continue;
+    if (typeof val !== "string") continue;
+    const t = val.trim();
+    if (!t) continue;
+    fromSlots.push(normalizeSong(t));
+  }
+
+  const rawOfficial = actualSetlist.officialSetlist;
+  const fromOfficial = Array.isArray(rawOfficial)
+    ? rawOfficial
+        .map((s) =>
+          typeof s === "string" ? s.trim() : String(s ?? "").trim()
+        )
+        .filter(Boolean)
+        .map((s) => normalizeSong(s))
+    : [];
+
+  const combined = [...fromSlots, ...fromOfficial];
+  return [...new Set(combined)];
+}
+
+function calculateSlotScore(fieldId, guessedSong, actualSetlist) {
+  if (!actualSetlist || !guessedSong) return 0;
+
+  const guess = normalizeSong(guessedSong);
+  if (!guess) return 0;
+
+  const allPlayed = buildAllPlayedNormalized(actualSetlist);
+
+  let base = 0;
+  if (fieldId === "wild") {
+    if (allPlayed.includes(guess)) {
+      base = SCORING_RULES.WILDCARD_HIT;
+    } else {
+      return 0;
+    }
+  } else {
+    const exactNonEnc =
+      fieldId !== "enc" && normalizeSong(actualSetlist[fieldId]) === guess;
+    const exactEnc =
+      fieldId === "enc" && guessMatchesEncoreExact(actualSetlist, guess);
+    if (exactNonEnc || exactEnc) {
+      base =
+        fieldId === "enc"
+          ? SCORING_RULES.ENCORE_EXACT
+          : SCORING_RULES.EXACT_SLOT;
+    } else if (allPlayed.includes(guess)) {
+      base = SCORING_RULES.IN_SETLIST;
+    } else {
+      return 0;
+    }
+  }
+
+  const bustoutList = Array.isArray(actualSetlist.bustouts)
+    ? actualSetlist.bustouts
+    : [];
+  let bustoutBoost = false;
+  for (const raw of bustoutList) {
+    if (typeof raw !== "string") continue;
+    if (normalizeSong(raw) === guess) {
+      bustoutBoost = true;
+      break;
+    }
+  }
+
+  return base + (bustoutBoost ? SCORING_RULES.BUSTOUT_BOOST : 0);
+}
+
+function calculateTotalScore(userPicks, actualSetlist) {
+  if (!actualSetlist || !userPicks) return 0;
+  return SCORE_FIELDS.reduce((total, fieldId) => {
+    return (
+      total + calculateSlotScore(fieldId, userPicks[fieldId], actualSetlist)
+    );
+  }, 0);
+}
+
+function actualSetlistFromOfficialDoc(setlistDoc) {
+  const setlistFlat = setlistDoc.setlist || {};
+  const out = {
+    ...setlistFlat,
+    officialSetlist: Array.isArray(setlistDoc.officialSetlist)
+      ? setlistDoc.officialSetlist
+      : [],
+  };
+  if (Array.isArray(setlistDoc.encoreSongs) && setlistDoc.encoreSongs.length > 0) {
+    out.encoreSongs = setlistDoc.encoreSongs;
+  }
+  // Per-show bustout snapshot for scoring (#214). Absence/empty → no boost.
+  if (Array.isArray(setlistDoc.bustouts)) {
+    out.bustouts = setlistDoc.bustouts;
+  }
+  return out;
+}
+
+module.exports = {
+  SCORING_RULES,
+  SCORE_FIELDS,
+  NON_SONG_SETLIST_KEYS,
+  normalizeSong,
+  guessMatchesEncoreExact,
+  buildAllPlayedNormalized,
+  calculateSlotScore,
+  calculateTotalScore,
+  actualSetlistFromOfficialDoc,
+};

--- a/functions/scripts/backfillBustouts.js
+++ b/functions/scripts/backfillBustouts.js
@@ -1,17 +1,16 @@
 #!/usr/bin/env node
 /**
- * Admin-script wrapper for the `backfillBustoutsForShows` callable (#214).
+ * Admin-script for the #214 per-show `bustouts` snapshot backfill.
  *
- * Mints a short-lived admin-claim ID token via firebase-admin + Identity
- * Toolkit REST, then POSTs to the deployed callable. Keeps the entire
- * backfill pipeline (Phish.net fetch → derive bustouts → write snapshot →
- * recompute pick scores → reconcile `users.totalPoints` for graded picks) in
- * the single deployed source of truth — this script is only a caller.
+ * Runs the exact same pipeline as the deployed `backfillBustoutsForShows`
+ * callable by importing the shared core module (`functions/backfillBustoutsCore.js`).
+ * Does NOT call the deployed callable — so there is no Firebase Auth dance
+ * (no custom token, no Identity Toolkit round-trip, no referrer-restricted
+ * API key). The script uses Application Default Credentials directly.
  *
- * Usage (from repo root or functions/):
- *   # Dry-run: list which shows are missing `bustouts` on `official_setlists`.
- *   cd functions
- *   node scripts/backfillBustouts.js --missing --dry-run
+ * Usage (from `functions/`):
+ *   # Dry-run: list which shows are missing `bustouts`.
+ *   node scripts/backfillBustouts.js --missing
  *
  *   # Backfill every show missing a snapshot:
  *   node scripts/backfillBustouts.js --missing --apply
@@ -20,18 +19,22 @@
  *   node scripts/backfillBustouts.js --showDates=2025-12-28,2025-12-30 --apply
  *
  * Auth:
- *   Requires Application Default Credentials (ADC) for `firebase-admin`:
+ *   Requires Application Default Credentials for firebase-admin:
  *     gcloud auth application-default login
- *   The script mints a custom token with `{ admin: true }` for a synthetic
- *   UID (`backfill-bustouts-script`) — no real user account is created; the
- *   token is discarded after the call. The deployed callable gates on the
- *   `admin` claim via `assertAdminClaim` (functions/adminAuth.js).
+ *   Your ADC identity must have Firestore read/write on the project.
  *
- * Config read from repo-root `.env`:
- *   VITE_FIREBASE_API_KEY   — required, used for custom→ID token exchange.
- *   VITE_FIREBASE_PROJECT_ID — used to derive the callable URL.
+ * Phish.net key:
+ *   The core re-fetches Phish.net at runtime to re-derive bustouts from per-row
+ *   `gap`. Provide the key via `PHISHNET_API_KEY` env var — the same secret the
+ *   deployed function uses. Easiest pull:
+ *     PHISHNET_API_KEY="$(firebase functions:secrets:access PHISHNET_API_KEY \
+ *       --project=<project-id>)"
  *
- * This script is safe to re-run: the callable is idempotent (write-merge;
+ * Project id:
+ *   Read from repo-root `.env` (`VITE_FIREBASE_PROJECT_ID`) or the
+ *   `GOOGLE_CLOUD_PROJECT` env var.
+ *
+ * This script is safe to re-run: the core is idempotent (write-merge;
  * score-delta reconciliation is zero when bustouts didn't change).
  */
 
@@ -39,10 +42,10 @@ const admin = require("firebase-admin");
 const fs = require("node:fs");
 const path = require("node:path");
 
+const { runBackfill } = require("../backfillBustoutsCore");
+
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
 const ENV_PATH = path.join(REPO_ROOT, ".env");
-const BACKFILL_UID = "backfill-bustouts-script";
-const FUNCTIONS_REGION = "us-central1";
 
 /**
  * @param {string[]} argv
@@ -64,19 +67,23 @@ function usageAndExit(msg) {
   console.log(
     [
       "Usage:",
-      "  node scripts/backfillBustouts.js --missing [--dry-run|--apply]",
-      "  node scripts/backfillBustouts.js --showDates=YYYY-MM-DD[,YYYY-MM-DD...] [--dry-run|--apply]",
+      "  node scripts/backfillBustouts.js --missing [--apply]",
+      "  node scripts/backfillBustouts.js --showDates=YYYY-MM-DD[,YYYY-MM-DD...] [--apply]",
       "",
       "Modes:",
-      "  --missing           Scan official_setlists for docs without a `bustouts` field.",
+      "  --missing           Scan official_setlists for docs without `bustouts`.",
       "  --showDates=...     Comma-separated list of show dates to backfill.",
       "",
       "Flags:",
-      "  --dry-run           Default. List target show dates; do not call the callable.",
-      "  --apply             Invoke the deployed backfillBustoutsForShows callable.",
+      "  --dry-run           Default. List target show dates; no writes.",
+      "  --apply             Actually run the backfill pipeline.",
       "",
-      "Auth:",
-      "  Requires ADC: gcloud auth application-default login",
+      "Env:",
+      "  PHISHNET_API_KEY    Required for --apply. Pull via:",
+      "                        firebase functions:secrets:access PHISHNET_API_KEY",
+      "  GOOGLE_CLOUD_PROJECT  Optional override (falls back to .env VITE_FIREBASE_PROJECT_ID).",
+      "",
+      "Auth:  gcloud auth application-default login",
       "",
     ].join("\n"),
   );
@@ -87,9 +94,7 @@ function usageAndExit(msg) {
 function loadEnv() {
   /** @type {Record<string, string>} */
   const env = {};
-  if (!fs.existsSync(ENV_PATH)) {
-    throw new Error(`.env not found at ${ENV_PATH}`);
-  }
+  if (!fs.existsSync(ENV_PATH)) return env;
   const text = fs.readFileSync(ENV_PATH, "utf8");
   for (const line of text.split("\n")) {
     const t = line.trim();
@@ -108,8 +113,6 @@ function loadEnv() {
 
 function isShowDate(v) {
   if (typeof v !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(v.trim())) return false;
-  // Reject impossible calendar dates (e.g. 2025-13-99). Parse as UTC to avoid
-  // local-timezone rollover flipping a valid boundary date.
   const [y, m, d] = v.trim().split("-").map(Number);
   const parsed = new Date(Date.UTC(y, m - 1, d));
   return (
@@ -119,69 +122,6 @@ function isShowDate(v) {
   );
 }
 
-/**
- * Exchange a custom token for a Firebase ID token using the Identity Toolkit
- * REST API. The resulting ID token carries the developer claims set on the
- * custom token (`admin: true`), which `assertAdminClaim` checks on the server.
- *
- * @param {string} customToken
- * @param {string} apiKey - Firebase web API key (VITE_FIREBASE_API_KEY).
- * @returns {Promise<string>}
- */
-async function exchangeCustomTokenForIdToken(customToken, apiKey) {
-  const url = `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${encodeURIComponent(
-    apiKey,
-  )}`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ token: customToken, returnSecureToken: true }),
-  });
-  const body = await res.json().catch(() => ({}));
-  if (!res.ok) {
-    const msg =
-      body?.error?.message || `HTTP ${res.status} ${res.statusText || ""}`.trim();
-    throw new Error(`signInWithCustomToken failed: ${msg}`);
-  }
-  if (!body?.idToken) {
-    throw new Error("signInWithCustomToken response missing idToken.");
-  }
-  return body.idToken;
-}
-
-/**
- * POST to the deployed callable HTTPS endpoint with the Firebase ID token.
- *
- * @param {string} projectId
- * @param {string} idToken
- * @param {object} data - The `data` payload the callable expects.
- * @returns {Promise<unknown>} The `result` field from the callable response.
- */
-async function invokeCallable(projectId, idToken, data) {
-  const url = `https://${FUNCTIONS_REGION}-${projectId}.cloudfunctions.net/backfillBustoutsForShows`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${idToken}`,
-    },
-    body: JSON.stringify({ data }),
-  });
-  const body = await res.json().catch(() => ({}));
-  if (!res.ok) {
-    const msg =
-      body?.error?.message ||
-      body?.error?.status ||
-      `HTTP ${res.status} ${res.statusText || ""}`.trim();
-    throw new Error(`backfillBustoutsForShows callable failed: ${msg}`);
-  }
-  return body.result;
-}
-
-/**
- * @param {FirebaseFirestore.Firestore} db
- * @returns {Promise<string[]>}
- */
 async function scanMissing(db) {
   const snap = await db.collection("official_setlists").get();
   /** @type {string[]} */
@@ -211,17 +151,18 @@ async function main() {
   const apply = args.apply === true;
   const dryRun = !apply || args["dry-run"] === true;
 
-  // --- Env + admin init ---
-  const env = loadEnv();
-  const apiKey = env.VITE_FIREBASE_API_KEY;
-  const projectId = env.VITE_FIREBASE_PROJECT_ID;
-  if (!apiKey) throw new Error("VITE_FIREBASE_API_KEY missing from .env");
-  if (!projectId) throw new Error("VITE_FIREBASE_PROJECT_ID missing from .env");
+  const fileEnv = loadEnv();
+  const projectId =
+    process.env.GOOGLE_CLOUD_PROJECT || fileEnv.VITE_FIREBASE_PROJECT_ID;
+  if (!projectId) {
+    throw new Error(
+      "Project id missing: set GOOGLE_CLOUD_PROJECT or VITE_FIREBASE_PROJECT_ID in .env",
+    );
+  }
 
   admin.initializeApp({ projectId });
   const db = admin.firestore();
 
-  // --- Resolve target show dates ---
   /** @type {string[]} */
   let showDates = [];
   if (useMissing) {
@@ -246,39 +187,42 @@ async function main() {
       "",
       `Target show dates: ${showDates.length}`,
       ...showDates.map((d) => `  - ${d}`),
-      `Mode: ${dryRun ? "DRY RUN (no callable invocation)" : "APPLY"}`,
+      `Mode: ${dryRun ? "DRY RUN (no writes)" : "APPLY"}`,
+      `Project: ${projectId}`,
       "",
     ].join("\n"),
   );
 
   if (dryRun) {
-    console.log("Dry-run complete. Re-run with --apply to invoke the callable.");
+    console.log("Dry-run complete. Re-run with --apply to execute the backfill.");
     return;
   }
 
-  // --- Mint admin-claim token ---
-  console.log("Minting admin-claim token for backfill script...");
-  const customToken = await admin
-    .auth()
-    .createCustomToken(BACKFILL_UID, { admin: true });
-  const idToken = await exchangeCustomTokenForIdToken(customToken, apiKey);
+  const phishnetApiKey = process.env.PHISHNET_API_KEY;
+  if (!phishnetApiKey || !phishnetApiKey.trim()) {
+    throw new Error(
+      [
+        "PHISHNET_API_KEY env var is required for --apply. Pull it from Firebase secrets:",
+        `  firebase functions:secrets:access PHISHNET_API_KEY --project=${projectId}`,
+      ].join("\n"),
+    );
+  }
 
-  // --- Invoke the deployed callable (single source of truth) ---
-  console.log(
-    `Invoking backfillBustoutsForShows (${FUNCTIONS_REGION}) for ${showDates.length} show(s)...`,
-  );
+  console.log(`Running backfill against ${showDates.length} show(s)...`);
   const started = Date.now();
-  const result = await invokeCallable(projectId, idToken, { showDates });
+  const { results, minGap } = await runBackfill({
+    db,
+    admin,
+    logger: console,
+    phishnetApiKey,
+    showDates,
+    updatedBy: `backfill-script:${process.env.USER || "unknown"}`,
+  });
   const elapsedMs = Date.now() - started;
 
-  console.log(`\nCallable returned in ${elapsedMs}ms:\n`);
-  console.log(JSON.stringify(result, null, 2));
+  console.log(`\nCompleted in ${elapsedMs}ms (minGap=${minGap}):\n`);
+  console.log(JSON.stringify({ results }, null, 2));
 
-  // --- Summary ---
-  const results =
-    result && typeof result === "object" && Array.isArray(result.results)
-      ? result.results
-      : [];
   let totalPicksUpdated = 0;
   let totalReconciled = 0;
   let skipped = 0;


### PR DESCRIPTION
Follow-up to #224. No production behavior change — refactor only.

## Problem

The admin script `functions/scripts/backfillBustouts.js` landed as an HTTPS wrapper over the deployed `backfillBustoutsForShows` callable: it minted a custom token with `admin: true`, exchanged it for a Firebase Auth ID token via Identity Toolkit, and POSTed to the HTTPS endpoint. That means running it locally against prod requires the full Firebase Auth stack to cooperate.

In practice every auth layer gets in the way:

- `invalid_rapt` on ADC — needs `gcloud auth application-default login` reauth.
- `Failed to determine service account` — `createCustomToken` with user ADC can't sign locally; tries the GCE metadata server (not available locally).
- `Permission 'iam.serviceAccounts.signBlob' denied` — fixing the above by impersonating the Firebase SA requires granting `roles/iam.serviceAccountTokenCreator` to the operator's user and enabling `iamcredentials.googleapis.com`.
- `Requests from referer <empty> are blocked` — `signInWithCustomToken` uses a Firebase Web API key which has an HTTP-referrer allowlist for the browser app, rejecting server-side calls.

Each failure is a separate IAM / API-key chore. The round-trip was pure ceremony: the script already has admin-level Firestore access via ADC.

## Fix

Extract the callable's pipeline into a shared module so the callable and the script both import the same code path:

- `functions/backfillBustoutsCore.js` — exports `runBackfill({ db, admin, logger, phishnetApiKey, showDates, mode, updatedBy })`. Firebase-SDK-only; no `firebase-functions` imports so the script doesn't pay the callable-runtime cost.
- `functions/scoringCore.js` — scoring helpers (`calculateTotalScore`, `actualSetlistFromOfficialDoc`, etc.) that were inlined in `functions/index.js`. Mirrors `src/shared/utils/scoring.js` with the same sync obligation.
- `functions/index.js` — `backfillBustoutsForShows` shrinks to a ~25-line wrapper: `assertAdminClaim` → input validation → `runBackfill`. Other call sites continue to use `calculateTotalScore` / `actualSetlistFromOfficialDoc` via the new import.
- `functions/scripts/backfillBustouts.js` — rewritten. No `createCustomToken`, no `signInWithCustomToken`, no HTTPS fetch. Initializes `firebase-admin` under ADC and calls `runBackfill` directly.

Source-of-truth invariant the original PR established is preserved — the sharing just happens at module-import time instead of over HTTPS.

## Behavior parity

- Callable contract unchanged: same `{ showDates }` / `{ mode: "missing" }` input, same `{ ok, results }` return shape, same `assertAdminClaim` gate. Error mapping still surfaces `invalid-argument` for bad show dates.
- Grading / rollup semantics unchanged: post-write snapshot drives scoring; graded picks' `users.totalPoints` reconciled by score delta; ungraded picks are re-scored with `gradedAt` cleared.
- Idempotent: re-running with unchanged Phish.net data produces zero score deltas.
- Live poll / setlist-write / admin form paths in `functions/index.js` and `src/` are untouched.

## New local workflow

\`\`\`bash
gcloud auth application-default login   # once
cd functions
PHISHNET_API_KEY=\"\$(firebase functions:secrets:access PHISHNET_API_KEY --project=set-picks)\" \\
  npm run backfill:bustouts -- --showDates=YYYY-MM-DD --apply
\`\`\`

No SA impersonation, no `iamcredentials` API enablement, no Token Creator binding, no unrestricted admin API key.

## Tests

- `functions` `node --test` suite: 85/85 passing (unchanged — the refactor doesn't touch any tested surface, helpers are still invoked through the same public entry points).
- Client vitest: 40/40 passing.

## Verified against prod

Ran the new script against 2026-04-18 under ADC + `PHISHNET_API_KEY` env var:

- `official_setlists/2026-04-18.bustouts` written as a top-level `string[]`.
- `updatedBy: backfill-script:pat` on the doc.
- Pick scores for the show recomputed under the snapshot reader path.

## Test plan

- [ ] CI green (lint + tests).
- [ ] Deploy functions to a non-prod env; confirm `backfillBustoutsForShows` callable still returns a sensible shape for both `{ showDates: [...] }` and `{ mode: \"missing\" }` inputs.
- [ ] Sanity run `npm run backfill:bustouts -- --missing` (dry-run) locally and confirm no behavior change vs. pre-refactor dry-run.
- [ ] Spot-check one existing `official_setlists` doc post-run to confirm `bustouts` + `updatedBy` untouched when bustouts are already correct (idempotency).

Made with [Cursor](https://cursor.com)