### PR TITLE
feat(splash): polish landing copy, scoring modal, and auth modal UX

### DIFF
--- a/public/favicon/site.webmanifest
+++ b/public/favicon/site.webmanifest
@@ -3,13 +3,13 @@
   "short_name": "Pick 'Em",
   "icons": [
     {
-      "src": "/web-app-manifest-192x192.png",
+      "src": "/favicon/web-app-manifest-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "/web-app-manifest-512x512.png",
+      "src": "/favicon/web-app-manifest-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"

--- a/src/features/auth/ui/SplashAuthModalShell.jsx
+++ b/src/features/auth/ui/SplashAuthModalShell.jsx
@@ -2,7 +2,15 @@ import React from 'react';
 
 import Button from '../../../shared/ui/Button';
 
-export default function SplashAuthModalShell({ isOpen, onClose, title, handleGoogle, busy, children }) {
+export default function SplashAuthModalShell({
+  isOpen,
+  onClose,
+  title,
+  handleGoogle,
+  busy,
+  googleFootnote,
+  children,
+}) {
   if (!isOpen) return null;
 
   return (
@@ -35,15 +43,21 @@ export default function SplashAuthModalShell({ isOpen, onClose, title, handleGoo
           type="button"
           onClick={handleGoogle}
           disabled={busy}
-          className="w-full bg-white text-slate-900 py-3.5 rounded-xl gap-3 hover:bg-slate-100 transition-colors mb-6"
+          className="w-full bg-white text-slate-900 py-3.5 rounded-xl gap-3 shadow-[0_8px_24px_-12px_rgba(255,255,255,0.35)] ring-1 ring-white/20 transition-all duration-200 hover:-translate-y-0.5 hover:bg-slate-50 hover:shadow-[0_12px_28px_-12px_rgba(255,255,255,0.45)]"
         >
           <img src="https://www.google.com/favicon.ico" alt="" className="w-5 h-5" />
           Continue with Google
         </Button>
 
-        <div className="flex items-center gap-3 mb-6">
+        {googleFootnote ? (
+          <p className="mt-3 text-center text-xs font-semibold leading-relaxed text-slate-300">
+            {googleFootnote}
+          </p>
+        ) : null}
+
+        <div className="mt-8 flex items-center gap-3 mb-6">
           <div className="h-px flex-1 bg-border-muted" />
-          <span className="text-xs font-bold uppercase text-slate-500">or email</span>
+          <span className="text-xs font-bold uppercase text-slate-500">or</span>
           <div className="h-px flex-1 bg-border-muted" />
         </div>
 

--- a/src/features/auth/ui/SplashSignInModal.jsx
+++ b/src/features/auth/ui/SplashSignInModal.jsx
@@ -141,7 +141,7 @@ export default function SplashSignInModal({ isOpen, onClose }) {
           </div>
           {error ? <StatusBanner type="error" message={error} /> : null}
           <Button
-            variant="primary"
+            variant="secondary"
             type="submit"
             disabled={busy}
             className="w-full py-3.5 rounded-xl uppercase tracking-widest"

--- a/src/features/auth/ui/SplashSignUpModal.jsx
+++ b/src/features/auth/ui/SplashSignUpModal.jsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef } from 'react';
+import React from 'react';
 
 import Button from '../../../shared/ui/Button';
 import Input from '../../../shared/ui/Input';
@@ -7,7 +7,6 @@ import SplashAuthModalShell from './SplashAuthModalShell';
 import { useSplashSignUp } from '../model/useSplashSignUp';
 
 export default function SplashSignUpModal({ isOpen, onClose }) {
-  const emailInputRef = useRef(null);
   const {
     email,
     setEmail,
@@ -22,11 +21,6 @@ export default function SplashSignUpModal({ isOpen, onClose }) {
     handleEmailSignUp,
   } = useSplashSignUp(isOpen, onClose);
 
-  useLayoutEffect(() => {
-    if (!isOpen) return;
-    emailInputRef.current?.focus({ preventScroll: true });
-  }, [isOpen]);
-
   return (
     <SplashAuthModalShell
       isOpen={isOpen}
@@ -34,6 +28,7 @@ export default function SplashSignUpModal({ isOpen, onClose }) {
       title="Create account"
       handleGoogle={handleGoogle}
       busy={busy}
+      googleFootnote="You'll set your handle on the next page. Your personal info will never be shared with users."
     >
         <form onSubmit={handleEmailSignUp} className="space-y-4 text-left">
           <div>
@@ -41,7 +36,6 @@ export default function SplashSignUpModal({ isOpen, onClose }) {
               Email
             </label>
             <Input
-              ref={emailInputRef}
               id="su-email"
               type="email"
               name="email"
@@ -85,7 +79,7 @@ export default function SplashSignUpModal({ isOpen, onClose }) {
           </div>
           {error ? <StatusBanner type="error" message={error} /> : null}
           <Button
-            variant="primary"
+            variant="secondary"
             type="submit"
             disabled={busy}
             className="w-full py-3.5 rounded-xl uppercase tracking-widest"
@@ -93,9 +87,6 @@ export default function SplashSignUpModal({ isOpen, onClose }) {
             {busy ? 'Creating…' : 'Create account'}
           </Button>
         </form>
-        <p className="text-xs text-slate-500 mt-4 text-center">
-          After you sign up, you&apos;ll set your handle on the next screen—same as Google sign-in.
-        </p>
     </SplashAuthModalShell>
   );
 }

--- a/src/features/landing/ui/SplashAboutSection.jsx
+++ b/src/features/landing/ui/SplashAboutSection.jsx
@@ -16,12 +16,12 @@ export default function SplashAboutSection({
       className="relative z-10 w-full bg-transparent py-20 md:py-24 lg:py-32"
     >
       <div className="w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-16 items-start">
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-4 lg:gap-16 items-start">
           <div className="lg:col-span-5 lg:sticky lg:top-32">
             <h2
               ref={headingRef}
               tabIndex={-1}
-              className="font-display text-[6.5vw] sm:text-4xl md:text-5xl lg:text-6xl font-bold italic text-transparent bg-clip-text bg-gradient-to-r from-red-500 to-blue-500 mb-8 outline-none focus-visible:ring-2 focus-visible:ring-teal-400 rounded-md leading-tight whitespace-nowrap sm:whitespace-normal"
+              className="font-display text-[6.5vw] sm:text-4xl md:text-5xl lg:text-6xl font-bold italic text-transparent bg-clip-text bg-gradient-to-r from-red-500 to-blue-500 mb-2 lg:mb-8 outline-none focus-visible:ring-2 focus-visible:ring-teal-400 rounded-md leading-tight whitespace-nowrap sm:whitespace-normal"
             >
               About Setlist Pick &apos;Em
             </h2>

--- a/src/features/landing/ui/SplashHeroSection.jsx
+++ b/src/features/landing/ui/SplashHeroSection.jsx
@@ -12,15 +12,23 @@ export default function SplashHeroSection({ onHowItWorksClick, onPlayNowClick, o
           aria-label={"Setlist Pick 'Em"}
         >
           <SplashHeroWordmark />
+          <span className="sr-only">
+            Setlist Pick &apos;Em &mdash; the free live setlist prediction game for Phish fans
+          </span>
         </h1>
 
         <div className="mx-auto mt-6 max-w-2xl shrink-0 sm:-mt-0.5 md:-mt-1">
           <p className="mb-3 text-lg font-bold tracking-wide text-teal-400 drop-shadow-[0_0_12px_rgba(45,212,191,0.5)] sm:mb-2 md:text-xl">
-            The ultimate live music prediction game. Launching on Phish Tour.
+            Predict the setlist. Win the night. 
+            Now live on Phish Tour.
           </p>
 
           <p className="text-base font-normal leading-relaxed text-slate-300 sm:leading-snug md:text-lg md:leading-relaxed">
-            Join a global community of fans who live for the next song. Challenge your tour family, lock in your predictions, and share the thrill of calling a legendary show before the lights even go down.
+            Make picks for tonight's show, watch scores update as songs are played, and compete with your tour crew for the top spot.
+          </p>
+
+          <p className="mt-4 text-base font-normal leading-relaxed text-slate-300 sm:leading-snug md:text-lg md:leading-relaxed">
+            What started as a game on paper 25 years ago is now a fully automated, live setlist game for friends to play at the show and on couch tour. Invite your friends, track stats, and make every show count.
           </p>
         </div>
 

--- a/src/features/landing/ui/SplashHowItWorksSection.jsx
+++ b/src/features/landing/ui/SplashHowItWorksSection.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
+import { ArrowRight } from 'lucide-react';
+
+import { useScoringRulesModal } from '../../scoring';
 import Button from '../../../shared/ui/Button';
 
 export default function SplashHowItWorksSection({ sectionRef, headingRef, onCreateAccountClick }) {
+  const { openScoringRules } = useScoringRulesModal();
+
   return (
     <section
       ref={sectionRef}
@@ -13,7 +18,7 @@ export default function SplashHowItWorksSection({ sectionRef, headingRef, onCrea
           tabIndex={-1}
           className="mb-12 rounded-md text-center font-display text-display-lg font-bold text-slate-900 outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue md:text-display-lg-lg"
         >
-          How It Works
+          Game Format
         </h2>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 lg:gap-8">
@@ -23,8 +28,16 @@ export default function SplashHowItWorksSection({ sectionRef, headingRef, onCrea
             </div>
             <h3 className="font-bold text-xl text-slate-900 mb-3">Lock It In</h3>
             <p className="text-slate-600 leading-relaxed">
-              Predict openers, closers, the encore, and a wildcard before the lights go down.
+              Pick openers, closers, encore and wildcard before showtime. Earn points for correct picks, higher points for exact slot picks, plus a Bustout Boost™ for calling longshots.
             </p>
+            <button
+              type="button"
+              onClick={openScoringRules}
+              className="mt-4 inline-flex items-center gap-1 rounded-md text-sm font-bold text-emerald-700 underline underline-offset-4 decoration-emerald-300 transition-colors hover:text-emerald-800 hover:decoration-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue"
+            >
+              Learn how scoring works
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </button>
           </div>
 
           <div className="rounded-2xl bg-white p-6 md:p-8 shadow-xl shadow-slate-200/50 ring-1 ring-slate-100 flex flex-col items-center text-center md:items-start md:text-left transition-transform hover:-translate-y-1 hover:shadow-2xl hover:shadow-slate-200/60 duration-300">
@@ -33,8 +46,7 @@ export default function SplashHowItWorksSection({ sectionRef, headingRef, onCrea
             </div>
             <h3 className="font-bold text-xl text-slate-900 mb-3">Watch It Unfold</h3>
             <p className="text-slate-600 leading-relaxed">
-              Setlist and scores will be updated in real-time. Final official scoring will be
-              confirmed at show&apos;s end.
+              Live scores and standings update in real-time as songs are played. See your picks and everyone else's light up the leaderboard.
             </p>
           </div>
 
@@ -44,8 +56,7 @@ export default function SplashHowItWorksSection({ sectionRef, headingRef, onCrea
             </div>
             <h3 className="font-bold text-xl text-slate-900 mb-3">Claim the Crown</h3>
             <p className="text-slate-600 leading-relaxed">
-              Play in the global pool or join private pools with your crew.
-            </p>
+              Challenge friends in private pools and compete in global standings with everyone playing that night. See all-time stats in private pools to compete across tours and years.          </p>
           </div>
         </div>
 

--- a/src/features/landing/ui/SplashPageShell.jsx
+++ b/src/features/landing/ui/SplashPageShell.jsx
@@ -55,6 +55,24 @@ export default function SplashPageShell({
           />
         </main>
 
+        <footer className="relative z-10 border-t border-slate-800/60 bg-transparent px-4 py-6 text-center text-xs font-medium leading-relaxed text-slate-500 sm:px-6 lg:px-8">
+          <p>
+            &copy; {new Date().getFullYear()} Road2 Media, LLC. All rights reserved.
+          </p>
+          <p className="mt-1">
+            Song and setlist data provided by{' '}
+            <a
+              href="https://phish.net"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400"
+            >
+              The Mockingbird Foundation / Phish.Net
+            </a>
+            .
+          </p>
+        </footer>
+
         {children}
       </div>
     </>

--- a/src/features/scoring/ui/ScoringRulesContent.jsx
+++ b/src/features/scoring/ui/ScoringRulesContent.jsx
@@ -20,38 +20,14 @@ export default function ScoringRulesContent() {
         id="scoring-rules-heading"
         className="font-display text-display-md font-bold uppercase tracking-tight text-white mb-2"
       >
-        Scoring rules
+        How Scoring Works
       </h1>
       <p className="mb-6 text-sm font-bold leading-relaxed text-content-secondary">
-        As songs are played, scoring updates live. Each pick is scored per slot; your total for that
-        night feeds the show standings (Standings tab) for the date you picked.
+        Picks earn points based on where they land in the setlist. Live scoring feeds nightly
+        standings.
       </p>
 
       <ul className="space-y-5">
-        <li className="flex gap-4">
-          <span className="shrink-0 w-12 h-12 rounded-xl bg-brand-primary/15 border border-brand-primary/30 flex items-center justify-center font-black text-brand-primary text-lg tabular-nums">
-            {EXACT_SLOT}
-          </span>
-          <div>
-            <h2 className="font-bold text-white text-sm uppercase tracking-widest mb-1">Exact slot</h2>
-            <p className="text-sm font-bold leading-relaxed text-content-secondary">
-              Your song matches that slot on the official setlist (Set 1 opener/closer, Set 2 opener/closer).
-            </p>
-          </div>
-        </li>
-
-        <li className="flex gap-4">
-          <span className="shrink-0 w-12 h-12 rounded-xl bg-brand-primary/12 border border-brand-primary/25 flex items-center justify-center font-black text-brand-primary text-lg tabular-nums">
-            {ENCORE_EXACT}
-          </span>
-          <div>
-            <h2 className="font-bold text-white text-sm uppercase tracking-widest mb-1">Exact encore</h2>
-            <p className="text-sm font-bold leading-relaxed text-content-secondary">
-              Encore pick only: your song matches the official encore slot.
-            </p>
-          </div>
-        </li>
-
         <li className="flex gap-4">
           <span className="shrink-0 w-12 h-12 rounded-xl bg-blue-500/15 border border-blue-500/30 flex items-center justify-center font-black text-blue-400 text-lg tabular-nums">
             {IN_SETLIST}
@@ -59,7 +35,21 @@ export default function ScoringRulesContent() {
           <div>
             <h2 className="font-bold text-white text-sm uppercase tracking-widest mb-1">In setlist</h2>
             <p className="text-sm font-bold leading-relaxed text-content-secondary">
-              The song was played, but not in the slot you picked.
+              Your pick got played, just not in the slot you called. Partial credit for nailing
+              the song.
+            </p>
+          </div>
+        </li>
+
+        <li className="flex gap-4">
+          <span className="shrink-0 w-12 h-12 rounded-xl bg-brand-primary/15 border border-brand-primary/30 flex items-center justify-center font-black text-brand-primary text-lg tabular-nums">
+            {EXACT_SLOT}
+          </span>
+          <div>
+            <h2 className="font-bold text-white text-sm uppercase tracking-widest mb-1">Exact slot</h2>
+            <p className="text-sm font-bold leading-relaxed text-content-secondary">
+              Your pick lands on the exact slot you chose &mdash; Set 1 opener or closer,
+              or Set 2 opener or closer.
             </p>
           </div>
         </li>
@@ -71,8 +61,20 @@ export default function ScoringRulesContent() {
           <div>
             <h2 className="font-bold text-white text-sm uppercase tracking-widest mb-1">Wildcard</h2>
             <p className="text-sm font-bold leading-relaxed text-content-secondary">
-              For the wildcard pick only: if your song was played anywhere in the show (full setlist), you earn{' '}
-              {WILDCARD_HIT} points. Wrong song scores 0.
+              If your Wildcard pick is played anywhere in the setlist, you score {WILDCARD_HIT} points.
+            </p>
+          </div>
+        </li>
+
+        <li className="flex gap-4">
+          <span className="shrink-0 w-12 h-12 rounded-xl bg-brand-primary/12 border border-brand-primary/25 flex items-center justify-center font-black text-brand-primary text-lg tabular-nums">
+            {ENCORE_EXACT}
+          </span>
+          <div>
+            <h2 className="font-bold text-white text-sm uppercase tracking-widest mb-1">Encore</h2>
+            <p className="text-sm font-bold leading-relaxed text-content-secondary">
+              Your pick is played during the encore. Worth a little more because the encore is
+              the toughest call.
             </p>
           </div>
         </li>
@@ -82,20 +84,32 @@ export default function ScoringRulesContent() {
             +{BUSTOUT_BOOST}
           </span>
           <div>
-            <h2 className="font-bold text-white text-sm uppercase tracking-widest mb-1">Bustout boost</h2>
+            <h2 className="font-bold text-white text-sm uppercase tracking-widest mb-1">Bustout Boost™</h2>
             <p className="text-sm font-bold leading-relaxed text-content-secondary">
-              If your pick earns exact-slot, in-setlist, or wildcard points and the song’s gap in our catalog is{' '}
-              <span className="text-slate-300">{BUSTOUT_MIN_GAP} shows or more</span> since it was last played,
-              you get an extra <span className="text-slate-300">{BUSTOUT_BOOST} points</span> for that slot. Songs
-              not in the catalog only get the base points.
+              Correct picks on songs with a{' '}
+              <span className="text-slate-300">{BUSTOUT_MIN_GAP}+ show gap</span> earn a bonus{' '}
+              <span className="text-slate-300">{BUSTOUT_BOOST} points</span> on top of base points &mdash;
+              rewarding strategic picks over heavy rotation.
+              <a
+                href="#scoring-rules-footnote"
+                aria-describedby="scoring-rules-footnote"
+                className="ml-0.5 align-super text-[0.65rem] text-amber-400 no-underline hover:text-amber-300"
+              >
+                *
+              </a>
             </p>
           </div>
         </li>
       </ul>
 
-      <p className="mt-8 border-t border-border-subtle/30 pt-6 text-xs font-bold leading-relaxed text-content-secondary/90">
-        Missed picks score 0. Maximum per slot is {ENCORE_EXACT + BUSTOUT_BOOST} (encore exact plus bustout) or{' '}
-        {EXACT_SLOT + BUSTOUT_BOOST} / {WILDCARD_HIT + BUSTOUT_BOOST} for other slots when bustout applies.
+      <p
+        id="scoring-rules-footnote"
+        className="mt-6 scroll-mt-4 border-t border-border-subtle/30 pt-4 text-xs font-bold leading-snug text-content-secondary/90"
+      >
+        <span className="mr-1 text-amber-400">*</span>
+        Max per slot (if pick earns Bustout Boost): {IN_SETLIST + BUSTOUT_BOOST} in setlist &middot;{' '}
+        {EXACT_SLOT + BUSTOUT_BOOST} exact slot &middot; {WILDCARD_HIT + BUSTOUT_BOOST} wildcard &middot;{' '}
+        {ENCORE_EXACT + BUSTOUT_BOOST} encore.
       </p>
     </div>
   );

--- a/src/pages/landing/SplashPage.jsx
+++ b/src/pages/landing/SplashPage.jsx
@@ -6,6 +6,7 @@ import {
   SplashPageShell,
   useScrollToSectionFocus,
 } from '../../features/landing';
+import { ScoringRulesModalProvider } from '../../features/scoring';
 import { POOL_INVITE_STORAGE_KEY } from '../../shared/config/poolInvite';
 import { getLocalStorageItem } from '../../shared/lib/local-storage';
 import { showSuccessToast } from '../../shared/ui/toast';
@@ -57,7 +58,7 @@ export default function Splash() {
   }, [openSignInModal]);
 
   return (
-    <>
+    <ScoringRulesModalProvider>
       <SplashPageShell
         howItWorksSectionRef={howItWorksSectionRef}
         howItWorksHeadingRef={howItWorksHeadingRef}
@@ -73,6 +74,6 @@ export default function Splash() {
         onOpenSignInModal={openSignInModal}
       />
       <SplashAuthModals authModal={authModal} closeModal={closeModal} />
-    </>
+    </ScoringRulesModalProvider>
   );
 }


### PR DESCRIPTION
## Summary

Splash-page copy/UX pass focused on (a) making the scoring rules modal genuinely helpful, (b) biasing the auth flow toward Google sign-in to cut email-flow abandons, and (c) tightening the landing hero + About spacing. Also fixes the site.webmanifest icon paths and adds an `sr-only` H1 string for SEO/AI-search pickup.

### Highlights

- **Scoring rules modal is now the canonical "Learn how scoring works" surface on splash.** Wrapped splash in the existing `ScoringRulesModalProvider` (gives us the `?scoringRules=1` deep link on the public route for free) and added an inline "Learn how scoring works →" link inside the Lock It In card on the How It Works section.
- **Rewrote all scoring copy** for clarity and density — renamed to "How Scoring Works", reordered rules ascending by base points, tightened Bustout Boost to a single sentence with an amber asterisk linking to a max-per-slot footnote. Verbiage stays in sync with `SCORING_RULES` constants (no hardcoded numbers).
- **Hero copy**: added a product-history second paragraph and an `sr-only` span in the H1 ("Setlist Pick 'Em — the free live setlist prediction game for Phish fans") so Googlebot and LLM crawlers see entity keywords the wordmark SVG can't convey.
- **Auth modal hierarchy**: elevated the Google button with a soft glow + hover lift + white ring; simplified divider copy to `or`; dropped email autofocus on sign-up; downgraded email submit to `secondary` variant; moved the reassurance microcopy directly beneath Google ("You'll set your handle on the next page. Your personal info will never be shared with users.") via a new `googleFootnote` slot on the modal shell.
- **About section**: tightened the mobile gap between the gradient heading and the body paragraphs (`gap-10`→`gap-4`, heading `mb-8`→`mb-2 lg:mb-8`). Desktop unchanged.
- **Splash footer**: added copyright + Mockingbird Foundation / Phish.Net data attribution below the About section.
- **Favicon manifest bugfix**: `site.webmanifest` icon `src` paths now point to `/favicon/web-app-manifest-*.png` (were pointing to root). Fixes Android Add-to-Home-Screen icons. No SERP-favicon impact.

### Deferred

Remaining SEO/AI-search recommendations (meta description rewrite, FAQ JSON-LD, og:image + Twitter card, `llms.txt`, optional tagline tighten, static canonical) are tracked in #228 to keep this PR scoped.

### FSD notes

- Splash features import `ScoringRulesModalProvider` / `useScoringRulesModal` through the scoring feature's public `index.js` — cross-feature reuse via an explicit public entry point per the project `.cursorrules`.
- Intentional divergence from the "primary button" convention on the email submit buttons in both auth modals — documented here as a UX-driven styling choice, not a structural rule bypass.

## Test plan

- [ ] `npm run lint` clean.
- [ ] Load `/` unauthenticated:
  - [ ] Hero shows both paragraphs; wordmark visible; inspect DOM to confirm the `sr-only` span is present in the H1.
  - [ ] How It Works → click "Learn how scoring works" inside the Lock It In card → scoring modal opens.
  - [ ] Visit `/?scoringRules=1` directly → modal opens, query param is stripped from the URL.
  - [ ] Scoring modal: verify rules are In setlist → Exact slot → Wildcard → Encore → Bustout Boost; asterisk click scrolls to the footnote.
  - [ ] About section: confirm mobile spacing between heading and body is visibly tighter; desktop layout unchanged.
  - [ ] Footer: copyright line + Phish.Net link (new tab, rel=noopener) render.
- [ ] Auth modals:
  - [ ] Sign-up and sign-in: Google button has the white glow + lift on hover; divider reads "or"; email submit is teal-outlined (not filled).
  - [ ] Sign-up: reassurance microcopy renders directly under the Google button in `text-slate-300` + `font-semibold`.
  - [ ] Sign-up: focus does NOT land on email input when the modal opens.
- [ ] Favicon manifest: load `https://<preview>/favicon/site.webmanifest` in DevTools Application → Manifest tab and confirm icons resolve (no 404s).
- [ ] Mobile viewport (iOS Safari + Android Chrome): sanity check hero layout, modal max-height, About spacing.

## Related

- #228 — SEO & AI-search follow-up (meta description, FAQ schema, og:image, `llms.txt`)

Made with [Cursor](https://cursor.com)