### PR TITLE
feat(shared): PlayerHandleLink component + wire existing surfaces

### DIFF
--- a/docs/DASHBOARD_IA.md
+++ b/docs/DASHBOARD_IA.md
@@ -42,8 +42,12 @@ Rationale: **Entity-first** detail view without a second full-width display titl
 | **Admin** | Tab label for `/dashboard/admin` (`NAV_LABEL_ADMIN`); context + desktop H1 stay **War Room** (meta string in `dashboardPageMeta.js`). |
 | **Standings** | Tab, context bar, and desktop H1 for `/dashboard/standings` (`NAV_LABEL_STANDINGS`) — aligned so the shell does not repeat two headings. |
 | **Show standings** | Ordered points for **one show date** only (Standings screen); use this phrase in glossary, help, and cross-links where the “one night” nuance matters. |
-| **Season totals** | Cumulative points / wins / shows in a pool (**pool details** screen). |
-| **Pool details** | Screen for one pool: roster, invites, game status, archive links, season totals (`NAV_LABEL_POOL_DETAILS`). |
+| **All-time standings** | Cumulative points / wins / shows across **every** finalized show (all tours). Canonical name on pool details (`POOL_ALL_TIME_STANDINGS_HEADING`) and optional global companion on Standings. Replaces legacy **Season totals**. See #148. |
+| **Tour standings** | Cumulative points / wins / shows scoped to the **current tour** via `show_calendar.showDatesByTour` (`TOUR_STANDINGS_HEADING`). Global on Standings (#219), pool-scoped on pool details (#148). |
+| **Season totals** | Legacy alias of **All-time standings** on pool details; retained as a `@deprecated` re-export while the pool-side migration (#148) lands. Avoid in new copy. |
+| **Tonight's winner / winners** | Standings "Overall winner of the night" banner (#218). Singular on a clean win, plural on ties — `tonightsWinnerHeading(winnerCount)` picks automatically. |
+| **Wins** | For any scope (one show, a tour, all-time), the count of shows where a player ties/beats the global high score across every graded non-empty pick (`max === 0 → skip`). Same rule on Profile, Standings, Tour standings, and pool surfaces; implemented once in `src/shared/utils/showAggregation.js::reduceShowWinners`. |
+| **Pool details** | Screen for one pool: roster, invites, game status, archive links, All-time and Tour standings (`NAV_LABEL_POOL_DETAILS`). |
 
 ### User-visible string ownership (support / engineering)
 

--- a/src/features/pools/api/poolFirestore.js
+++ b/src/features/pools/api/poolFirestore.js
@@ -1,21 +1,13 @@
 import { doc, getDoc, updateDoc } from 'firebase/firestore';
 
 import { db } from '../../../shared/lib/firebase';
+import { pickCountsTowardSeason } from '../../../shared/utils/showAggregation';
 
 /** @type {number} */
 export const POOL_NAME_MAX_LENGTH = 80;
 
 function pickDocId(showDate, userId) {
   return `${showDate}_${userId}`;
-}
-
-function hasNonEmptyPicksObject(picks) {
-  if (picks == null || typeof picks !== 'object' || Array.isArray(picks)) {
-    return false;
-  }
-  return Object.values(picks).some(
-    (v) => v != null && String(v).trim() !== ''
-  );
 }
 
 /**
@@ -30,15 +22,6 @@ export function pickDataCountsForPool(pickData, poolId) {
     return pools.some((p) => p && p.id === poolId);
   }
   return true;
-}
-
-/**
- * Pool season totals / wins: finalized (rollup) only, with submitted picks.
- * Do not use gradedAt — live CF scoring must not imply season eligibility.
- */
-function pickCountsTowardPoolSeasonTotals(pickData) {
-  if (pickData.isGraded !== true) return false;
-  return hasNonEmptyPicksObject(pickData.picks);
 }
 
 export async function updatePoolNameApi(poolId, newName) {
@@ -105,7 +88,7 @@ export async function computePoolSeasonTotalsByUser(poolId, memberIds, showDates
       if (!snap.exists()) continue;
       const data = snap.data();
       if (!pickDataCountsForPool(data, pid)) continue;
-      if (!pickCountsTowardPoolSeasonTotals(data)) continue;
+      if (!pickCountsTowardSeason(data)) continue;
       const score = typeof data.score === 'number' ? data.score : 0;
       const row = totals.get(userId);
       if (row) {

--- a/src/features/pools/ui/PoolHubLeaderboard.jsx
+++ b/src/features/pools/ui/PoolHubLeaderboard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+
+import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
 
 export default function PoolHubLeaderboard({ members }) {
   return (
@@ -28,12 +29,11 @@ export default function PoolHubLeaderboard({ members }) {
                   <span className="w-8 shrink-0 font-black tabular-nums text-content-secondary/90">
                     {rank}
                   </span>
-                  <Link
-                    to={`/user/${m.id}`}
-                    className="min-w-0 truncate font-bold text-brand-primary hover:text-brand-primary-strong hover:underline"
-                  >
-                    {handle}
-                  </Link>
+                  <PlayerHandleLink
+                    userId={m.id}
+                    handle={handle}
+                    className="min-w-0 truncate"
+                  />
                 </div>
                 <div className="flex items-center gap-3 sm:gap-4 shrink-0">
                   <div className="flex flex-col items-center">

--- a/src/features/profile/api/profileSeasonStats.js
+++ b/src/features/profile/api/profileSeasonStats.js
@@ -1,13 +1,8 @@
-import {
-  collection,
-  doc,
-  getDoc,
-  getDocs,
-  query,
-  where,
-} from 'firebase/firestore';
+import { doc, getDoc } from 'firebase/firestore';
 
 import { db } from '../../../shared/lib/firebase';
+import { pickCountsTowardSeason } from '../../../shared/utils/showAggregation';
+import { fetchGlobalMaxScoreForShow } from '../../scoring';
 
 /**
  * @typedef {Object} UserSeasonStats
@@ -24,53 +19,15 @@ export const EMPTY_USER_SEASON_STATS = Object.freeze({
   wins: 0,
 });
 
-function hasNonEmptyPicksObject(picks) {
-  if (picks == null || typeof picks !== 'object' || Array.isArray(picks)) {
-    return false;
-  }
-  return Object.values(picks).some(
-    (v) => v != null && String(v).trim() !== ''
-  );
-}
-
-function pickCountsTowardSeason(pickData) {
-  if (!pickData || pickData.isGraded !== true) return false;
-  return hasNonEmptyPicksObject(pickData.picks);
-}
-
-/**
- * Global max score among every graded, non-empty pick submitted for a single
- * show date. Returns `null` if nobody played the show. Mirrors the
- * "skip when max === 0" guard used by pool season totals so a night where
- * every player whiffed doesn't credit a tied "win" to everyone.
- *
- * @param {string} showDate
- * @returns {Promise<number | null>}
- */
-async function fetchGlobalMaxScoreForShow(showDate) {
-  const date = showDate?.trim?.();
-  if (!date) return null;
-  const snap = await getDocs(
-    query(collection(db, 'picks'), where('showDate', '==', date))
-  );
-  let max = null;
-  snap.forEach((docSnap) => {
-    const data = docSnap.data() || {};
-    if (!pickCountsTowardSeason(data)) return;
-    const score = typeof data.score === 'number' ? data.score : 0;
-    if (max === null || score > max) max = score;
-  });
-  if (max === null || max <= 0) return null;
-  return max;
-}
-
 /**
  * Season stats for a single user computed live from `picks`:
  *   - `totalPoints` / `shows` — sum of the user's own graded picks (picks
  *     aren't double-counted when they belong to multiple pools).
  *   - `wins` — shows won overall (global high score across every graded,
  *     non-empty pick for that show), not pool-scoped wins. Ties share the
- *     win, matching the per-pool leaderboard's tie rule.
+ *     win, matching the per-pool leaderboard's tie rule and the shared
+ *     `reduceShowWinners` rule used by Standings (#218) and Tour standings
+ *     (#219).
  *
  * @param {string | undefined} uid
  * @param {Array<{ date: string }>} showDates
@@ -112,7 +69,9 @@ export async function computeUserSeasonStats(uid, showDates) {
   }
 
   // Overall wins: count each show once where this user tied/beat the global
-  // high score. Parallelize across shows the user actually played.
+  // high score. Parallelize across shows the user actually played. The
+  // global-max fetch lives in `features/scoring` so the Standings "winner of
+  // the night" surface (#218) uses identical math.
   let wins = 0;
   const winChunkSize = 10;
   for (let i = 0; i < userGradedPicks.length; i += winChunkSize) {

--- a/src/features/scoring/api/globalShowAggregation.js
+++ b/src/features/scoring/api/globalShowAggregation.js
@@ -1,0 +1,49 @@
+import { collection, getDocs, query, where } from 'firebase/firestore';
+
+import { db } from '../../../shared/lib/firebase';
+import { reduceShowWinners } from '../../../shared/utils/showAggregation';
+
+/**
+ * Overall winner(s) for a single show across **all** players (not pool-scoped).
+ *
+ * Fetches every graded, non-empty pick for `showDate` and applies the shared
+ * "global max per show, ties share, max===0 → skip" rule so the Standings
+ * "winner of the night" banner (#218), Tour standings (#219), and Profile
+ * `Wins` (#217) all agree.
+ *
+ * @param {string} showDate  YYYY-MM-DD, as stored on `picks.showDate`.
+ * @returns {Promise<{
+ *   max: number | null,
+ *   winners: Array<{
+ *     id: string,
+ *     uid?: string,
+ *     userId?: string,
+ *     handle?: string,
+ *     score: number,
+ *   } & Record<string, unknown>>,
+ * }>}
+ *   `max === null` signals "no winner" (no eligible picks, or top score 0).
+ */
+export async function fetchGlobalShowWinners(showDate) {
+  const date = showDate?.trim?.();
+  if (!date) return { max: null, winners: [] };
+
+  const snap = await getDocs(
+    query(collection(db, 'picks'), where('showDate', '==', date))
+  );
+  const rows = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+  return reduceShowWinners(rows);
+}
+
+/**
+ * Convenience: just the global max score (or `null`). Used by cumulative
+ * aggregators (Profile `Wins`, Tour standings `Wins`) where we only need the
+ * threshold, not the winner identities.
+ *
+ * @param {string} showDate
+ * @returns {Promise<number | null>}
+ */
+export async function fetchGlobalMaxScoreForShow(showDate) {
+  const { max } = await fetchGlobalShowWinners(showDate);
+  return max;
+}

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -1,3 +1,7 @@
+export {
+  fetchGlobalMaxScoreForShow,
+  fetchGlobalShowWinners,
+} from './api/globalShowAggregation';
 export { default as Leaderboard } from './ui/Leaderboard';
 export { useDisplayedPicks } from './model/useDisplayedPicks';
 export { useStandings } from './model/useStandings';

--- a/src/features/scoring/ui/LeaderboardRow.jsx
+++ b/src/features/scoring/ui/LeaderboardRow.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
 import { calculateTotalScore } from '../../../shared/utils/scoring';
 import ScoreBreakdownGrid from './ScoreBreakdownGrid';
 
@@ -52,17 +52,11 @@ export default function LeaderboardRow({
           <div className="w-10 h-10 shrink-0 bg-gradient-to-tr from-brand-accent-blue to-brand-primary rounded-full flex items-center justify-center font-bold text-lg shadow-inner text-brand-bg-deep">
             👤
           </div>
-          {playerUserId ? (
-            <Link
-              to={`/user/${playerUserId}`}
-              onClick={(e) => e.stopPropagation()}
-              className="font-bold text-base tracking-tight text-brand-primary hover:text-brand-primary-strong hover:underline decoration-brand-primary/70 underline-offset-2"
-            >
-              {p.handle || 'Anonymous'}
-            </Link>
-          ) : (
-            <span className="font-bold text-white text-base tracking-tight">{p.handle || 'Anonymous'}</span>
-          )}
+          <PlayerHandleLink
+            userId={playerUserId}
+            handle={p.handle}
+            className="text-base"
+          />
         </div>
 
         <div className="flex items-center gap-4">

--- a/src/shared/config/dashboardVocabulary.js
+++ b/src/shared/config/dashboardVocabulary.js
@@ -4,8 +4,14 @@
  * - **Standings** — Short nav label (`/dashboard/standings`). Same screen as “show standings”
  *   for the date selected in the header.
  * - **Show standings** — Ordered points for one show date only (everyone or one pool).
- * - **Season totals** — Running points, wins, and shows played in a pool across all graded nights
- *   (on pool details — not the same as a single night’s show standings).
+ * - **All-time standings** — Cumulative leaderboard across every finalized show (all tours).
+ *   Canonical name replacing legacy “Season totals” on pool details and optional global
+ *   companion on Standings. See #148.
+ * - **Tour standings** — Cumulative leaderboard scoped to the current tour via
+ *   `show_calendar.showDatesByTour` (global surface on Standings; pool-scoped on pool details).
+ *   See #148 / #219.
+ * - **Season totals** — Legacy alias for All-time standings on pool details; kept during the
+ *   transition and re-exported through {@link POOL_ALL_TIME_STANDINGS_HEADING}.
  *
  * - **Pool details** — Player-facing name for `/dashboard/pool/:id` (roster, invites, season totals).
  *   Internal code may still use “Pool Hub”; user-facing strings should say Pool details.
@@ -43,8 +49,57 @@ export const SHOW_STANDINGS_PHRASE = 'Show standings';
 /** Desktop H1 for `/dashboard/standings` matches {@link NAV_LABEL_STANDINGS} (nav + context bar). */
 export const SHOW_STANDINGS_EYEBROW = SHOW_STANDINGS_PHRASE;
 
-export const SEASON_TOTALS_HEADING = 'Season totals';
-export const SEASON_TOTALS_DESCRIPTION =
-  'Running totals in this pool — points, wins, and shows played across every graded night (not just tonight).';
+/**
+ * Cumulative "across every finalized show" leaderboard heading. Canonical
+ * name; retires **Season totals** in net-new copy. See #148.
+ */
+export const ALL_TIME_STANDINGS_HEADING = 'All-time standings';
+export const ALL_TIME_STANDINGS_DESCRIPTION =
+  'Running totals across every graded show — points, wins, and shows played (not just tonight).';
+
+/** Pool-scoped alias of {@link ALL_TIME_STANDINGS_HEADING} for pool details. */
+export const POOL_ALL_TIME_STANDINGS_HEADING = ALL_TIME_STANDINGS_HEADING;
+export const POOL_ALL_TIME_STANDINGS_DESCRIPTION =
+  'Running totals in this pool — points, wins, and shows played across every graded show.';
+
+/**
+ * Tour-scoped cumulative leaderboard heading. Scope comes from
+ * `show_calendar.showDatesByTour` at runtime. See #148 / #219.
+ */
+export const TOUR_STANDINGS_HEADING = 'Tour standings';
+export const TOUR_STANDINGS_DESCRIPTION =
+  'Running totals for the current tour — points, wins, and shows played across every graded show in this tour.';
+
+/** Pool-scoped alias of {@link TOUR_STANDINGS_HEADING} for pool details. */
+export const POOL_TOUR_STANDINGS_HEADING = TOUR_STANDINGS_HEADING;
+export const POOL_TOUR_STANDINGS_DESCRIPTION =
+  'Running totals in this pool for the current tour — points, wins, and shows played across every graded show in this tour.';
+
+/**
+ * Legacy alias retained so existing call sites don't churn while we migrate
+ * pool details to **All-time standings** (#148). New code should prefer the
+ * `*_ALL_TIME_STANDINGS_*` names above.
+ * @deprecated Use {@link POOL_ALL_TIME_STANDINGS_HEADING}.
+ */
+export const SEASON_TOTALS_HEADING = POOL_ALL_TIME_STANDINGS_HEADING;
+/** @deprecated Use {@link POOL_ALL_TIME_STANDINGS_DESCRIPTION}. */
+export const SEASON_TOTALS_DESCRIPTION = POOL_ALL_TIME_STANDINGS_DESCRIPTION;
 
 export const LEADING_THIS_SHOW = 'Leading this show';
+
+/**
+ * Copy for the Standings "overall winner of the night" banner (#218). Ties
+ * render the plural heading; winners are a comma-separated list.
+ */
+export const TONIGHTS_WINNER_SINGULAR = "Tonight's winner";
+export const TONIGHTS_WINNERS_PLURAL = "Tonight's winners";
+
+/**
+ * Pick the correct singular/plural heading for the winner(s) of the night.
+ *
+ * @param {number} winnerCount
+ * @returns {string}
+ */
+export function tonightsWinnerHeading(winnerCount) {
+  return winnerCount > 1 ? TONIGHTS_WINNERS_PLURAL : TONIGHTS_WINNER_SINGULAR;
+}

--- a/src/shared/ui/PlayerHandleLink.jsx
+++ b/src/shared/ui/PlayerHandleLink.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+/**
+ * Deep-link a player handle to their public profile at `/user/:uid` (#222).
+ *
+ * Single source of truth for the "brand-primary hover underline" handle link
+ * pattern used by Pool hub leaderboard, Show standings rows, Tour standings
+ * rows, and the Standings "winner of the night" banner so they stay visually
+ * consistent.
+ *
+ * Falls back to a plain `<span>` when no `userId` is available (legacy
+ * records), preserving styling parity minus the hover affordance.
+ *
+ * The link intentionally calls `stopPropagation` on click so it can be
+ * embedded inside row-level click targets (e.g. expandable Show standings
+ * rows) without toggling the row. Callers that render the link outside of a
+ * row container can ignore that behavior — it's a no-op for them.
+ *
+ * @param {{
+ *   userId?: string | null,
+ *   handle?: string | null,
+ *   className?: string,
+ *   ariaLabel?: string,
+ * }} props
+ */
+export default function PlayerHandleLink({
+  userId,
+  handle,
+  className = '',
+  ariaLabel,
+}) {
+  const safeHandle = (handle || '').trim() || 'Anonymous';
+  const baseClass =
+    'font-bold tracking-tight text-brand-primary hover:text-brand-primary-strong hover:underline decoration-brand-primary/70 underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand rounded-sm';
+  const combined = className ? `${baseClass} ${className}` : baseClass;
+
+  if (!userId) {
+    return <span className={combined}>{safeHandle}</span>;
+  }
+
+  return (
+    <Link
+      to={`/user/${userId}`}
+      onClick={(e) => e.stopPropagation()}
+      aria-label={ariaLabel || `View ${safeHandle}'s profile`}
+      className={combined}
+    >
+      {safeHandle}
+    </Link>
+  );
+}

--- a/src/shared/ui/index.js
+++ b/src/shared/ui/index.js
@@ -8,6 +8,7 @@ export { default as GhostPill } from './GhostPill';
 export { default as Input } from './Input';
 export { default as MetaChip } from './MetaChip';
 export { default as PageTitle } from './PageTitle';
+export { default as PlayerHandleLink } from './PlayerHandleLink';
 export { default as SongAutocomplete } from './SongAutocomplete';
 export { default as StatusBadge } from './StatusBadge';
 export { default as StatusBanner } from './StatusBanner';

--- a/src/shared/utils/showAggregation.js
+++ b/src/shared/utils/showAggregation.js
@@ -1,0 +1,96 @@
+/**
+ * Pure, Firestore-agnostic primitives for the "overall winner of the night"
+ * aggregation rule that the profile, standings, and pool surfaces all share.
+ *
+ * The rule — single source of truth for every cumulative leaderboard:
+ *
+ *   For a given show, consider every graded, non-empty pick. Let `max` be the
+ *   maximum `score` across those picks. If `max` is null or `0`, nobody is
+ *   credited a win that night. Otherwise, every pick whose `score === max`
+ *   shares the win (ties share).
+ *
+ * Keeping the rule in one place means Profile `Wins` (shipped in #217),
+ * Standings "Overall winner of the night" (#218), global Tour standings
+ * (#219), and Pool details All-time / Tour standings (#148) can't drift
+ * apart.
+ *
+ * Core scoring is frozen (see `src/shared/utils/scoring.js` and
+ * `functions/index.js::calculateSlotScore`). This module only aggregates
+ * already-computed per-pick scores.
+ */
+
+/**
+ * A pick row as stored in Firestore `picks/{showDate}_{uid}` (or any
+ * normalized superset). Extra fields are passed through untouched by the
+ * aggregation helpers.
+ *
+ * @typedef {Object} PickLike
+ * @property {unknown} [picks]     Map of slot → song string.
+ * @property {boolean} [isGraded]  Finalize/rollup flag; required for season credit.
+ * @property {number} [score]      Computed total score (per-night).
+ */
+
+/**
+ * Whether a `picks` map has at least one non-empty song string.
+ *
+ * @param {unknown} picks
+ * @returns {boolean}
+ */
+export function hasNonEmptyPicksObject(picks) {
+  if (picks == null || typeof picks !== 'object' || Array.isArray(picks)) {
+    return false;
+  }
+  return Object.values(picks).some(
+    (v) => v != null && String(v).trim() !== ''
+  );
+}
+
+/**
+ * Whether a pick document is eligible to count toward any season-style
+ * aggregate (totals, wins, shows). Requires finalize/rollup (`isGraded`) and
+ * at least one non-empty pick.
+ *
+ * Intentionally does NOT check pool membership — pool-scoped callers layer
+ * their own membership filter on top (see `pickDataCountsForPool`).
+ *
+ * @param {PickLike | null | undefined} pickData
+ * @returns {boolean}
+ */
+export function pickCountsTowardSeason(pickData) {
+  if (!pickData || pickData.isGraded !== true) return false;
+  return hasNonEmptyPicksObject(pickData.picks);
+}
+
+/**
+ * Reduce a list of pick rows (one show, any scope — global or pool-scoped)
+ * down to the "overall winner(s) of the night" shape.
+ *
+ * Callers are expected to pre-filter to the rows they care about (e.g. all
+ * picks from `picks where showDate == X`, or just pool members' picks).
+ * This function applies the shared eligibility rule and tie logic.
+ *
+ * @template {PickLike} T
+ * @param {Iterable<T>} pickList
+ * @returns {{ max: number | null, winners: T[] }}
+ *   `max` is `null` when nobody is eligible or when the top score is `0`
+ *   (nobody is credited a win). `winners` is the subset tied at `max`, in
+ *   the same order they appeared in `pickList`.
+ */
+export function reduceShowWinners(pickList) {
+  let max = null;
+  /** @type {T[]} */
+  const eligible = [];
+  for (const row of pickList) {
+    if (!pickCountsTowardSeason(row)) continue;
+    eligible.push(row);
+    const score = typeof row.score === 'number' ? row.score : 0;
+    if (max === null || score > max) max = score;
+  }
+  if (max === null || max <= 0) {
+    return { max: null, winners: [] };
+  }
+  const winners = eligible.filter(
+    (row) => (typeof row.score === 'number' ? row.score : 0) === max
+  );
+  return { max, winners };
+}

--- a/src/shared/utils/showAggregation.test.js
+++ b/src/shared/utils/showAggregation.test.js
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  hasNonEmptyPicksObject,
+  pickCountsTowardSeason,
+  reduceShowWinners,
+} from './showAggregation';
+
+describe('hasNonEmptyPicksObject', () => {
+  it('rejects non-objects and arrays', () => {
+    expect(hasNonEmptyPicksObject(null)).toBe(false);
+    expect(hasNonEmptyPicksObject(undefined)).toBe(false);
+    expect(hasNonEmptyPicksObject('set1')).toBe(false);
+    expect(hasNonEmptyPicksObject(['set1'])).toBe(false);
+  });
+
+  it('treats blank / missing values as empty', () => {
+    expect(hasNonEmptyPicksObject({})).toBe(false);
+    expect(hasNonEmptyPicksObject({ s1: '', s2: null, s3: '   ' })).toBe(false);
+  });
+
+  it('is non-empty as soon as any slot has a song', () => {
+    expect(hasNonEmptyPicksObject({ s1: '', s2: 'Tweezer' })).toBe(true);
+  });
+});
+
+describe('pickCountsTowardSeason', () => {
+  it('requires isGraded === true', () => {
+    expect(
+      pickCountsTowardSeason({ isGraded: false, picks: { s1: 'Tweezer' } })
+    ).toBe(false);
+    expect(
+      pickCountsTowardSeason({ picks: { s1: 'Tweezer' } })
+    ).toBe(false);
+  });
+
+  it('requires at least one non-empty pick', () => {
+    expect(
+      pickCountsTowardSeason({ isGraded: true, picks: { s1: '' } })
+    ).toBe(false);
+    expect(
+      pickCountsTowardSeason({ isGraded: true, picks: { s1: 'Tweezer' } })
+    ).toBe(true);
+  });
+
+  it('handles null / undefined inputs', () => {
+    expect(pickCountsTowardSeason(null)).toBe(false);
+    expect(pickCountsTowardSeason(undefined)).toBe(false);
+  });
+});
+
+describe('reduceShowWinners', () => {
+  const graded = (score, extra = {}) => ({
+    isGraded: true,
+    picks: { s1: 'Tweezer' },
+    score,
+    ...extra,
+  });
+
+  it('returns null max when nobody is eligible', () => {
+    const result = reduceShowWinners([
+      { isGraded: false, picks: { s1: 'Tweezer' }, score: 50 },
+      { isGraded: true, picks: {}, score: 20 },
+    ]);
+    expect(result).toEqual({ max: null, winners: [] });
+  });
+
+  it('credits nobody when max score is 0', () => {
+    const result = reduceShowWinners([graded(0, { uid: 'a' }), graded(0, { uid: 'b' })]);
+    expect(result).toEqual({ max: null, winners: [] });
+  });
+
+  it('returns a single winner when no tie exists', () => {
+    const a = graded(30, { uid: 'a' });
+    const b = graded(40, { uid: 'b' });
+    const c = graded(20, { uid: 'c' });
+    const result = reduceShowWinners([a, b, c]);
+    expect(result.max).toBe(40);
+    expect(result.winners).toEqual([b]);
+  });
+
+  it('returns all tied rows at the top score', () => {
+    const a = graded(72, { uid: 'a' });
+    const b = graded(30, { uid: 'b' });
+    const c = graded(72, { uid: 'c' });
+    const result = reduceShowWinners([a, b, c]);
+    expect(result.max).toBe(72);
+    expect(result.winners).toEqual([a, c]);
+  });
+
+  it('treats missing score as 0', () => {
+    const a = { isGraded: true, picks: { s1: 'Tweezer' }, uid: 'a' };
+    const b = graded(5, { uid: 'b' });
+    const result = reduceShowWinners([a, b]);
+    expect(result.max).toBe(5);
+    expect(result.winners.map((r) => r.uid)).toEqual(['b']);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the shared \`PlayerHandleLink\` component so every handle in the app routes to \`/user/:uid\` with consistent brand-primary hover + focus-ring styling, and wires it into the two existing handle surfaces (Pool hub leaderboard and Show standings rows). Subsequent epic PRs (#218, #219) consume the same component.

## What & why

- **New**: \`src/shared/ui/PlayerHandleLink.jsx\` exported from \`shared/ui/index.js\`. Single source of truth for the "brand-primary hover underline" pattern. Falls back to a \`<span>\` when no \`userId\` is available (legacy records) so styling parity is preserved minus the hover affordance. Calls \`stopPropagation\` on click so it can sit inside expandable row click targets without toggling them.
- **Wired**: \`features/pools/ui/PoolHubLeaderboard\` and \`features/scoring/ui/LeaderboardRow\` both drop their inline \`<Link>\` + Tailwind class strings in favor of the shared component. Identical visuals, one copy of the hover / focus / anonymous-fallback rules.

This is sequenced **before** #218 / #219 in the epic so the new winner banner and tour standings rows can consume the shared component natively instead of introducing inline class strings that would need refactoring later.

> Stacked on #232 (foundation). Base stays \`staging\`; GitHub will show the correct diff once #232 merges.

Closes #222

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run verify:dashboard-meta\`
- [x] \`npx vitest run\` (51 passing)
- [ ] Manual: click a handle on Pool hub leaderboard → lands on \`/user/:uid\`
- [ ] Manual: click a handle on Show standings row → lands on \`/user/:uid\`, parent row does not expand/collapse
- [ ] Manual: anonymous / missing-uid handle renders as plain text


Made with [Cursor](https://cursor.com)