### PR TITLE
feat(standings): overall winner of the night banner

### DIFF
--- a/src/features/pools/ui/PoolHubLeaderboard.jsx
+++ b/src/features/pools/ui/PoolHubLeaderboard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+
+import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
 
 export default function PoolHubLeaderboard({ members }) {
   return (
@@ -28,12 +29,11 @@ export default function PoolHubLeaderboard({ members }) {
                   <span className="w-8 shrink-0 font-black tabular-nums text-content-secondary/90">
                     {rank}
                   </span>
-                  <Link
-                    to={`/user/${m.id}`}
-                    className="min-w-0 truncate font-bold text-brand-primary hover:text-brand-primary-strong hover:underline"
-                  >
-                    {handle}
-                  </Link>
+                  <PlayerHandleLink
+                    userId={m.id}
+                    handle={handle}
+                    className="min-w-0 truncate"
+                  />
                 </div>
                 <div className="flex items-center gap-3 sm:gap-4 shrink-0">
                   <div className="flex flex-col items-center">

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -15,3 +15,5 @@ export {
 export { default as StandingsBannerWaitingSetlist } from './ui/StandingsBannerWaitingSetlist';
 export { default as StandingsFilterTabs } from './ui/StandingsFilterTabs';
 export { default as StandingsScopeIntro } from './ui/StandingsScopeIntro';
+export { default as StandingsWinnerOfTheNightBanner } from './ui/StandingsWinnerOfTheNightBanner';
+export { useShowWinnerOfTheNight } from './model/useShowWinnerOfTheNight';

--- a/src/features/scoring/model/useShowWinnerOfTheNight.js
+++ b/src/features/scoring/model/useShowWinnerOfTheNight.js
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+
+import {
+  pickCountsTowardSeason,
+  reduceShowWinners,
+} from '../../../shared/utils/showAggregation';
+
+/**
+ * Pure computation behind {@link useShowWinnerOfTheNight}, exported for unit
+ * tests and any non-React caller that needs the same shape (e.g. the Tour
+ * standings reducer in #219).
+ *
+ * @param {Array<{ isGraded?: boolean, score?: number, picks?: unknown } & Record<string, unknown>>} picks
+ * @returns {{
+ *   max: number | null,
+ *   winners: Array<Record<string, unknown>>,
+ *   eligiblePlayers: number,
+ *   beats: number,
+ * }}
+ */
+export function computeShowWinnerOfTheNight(picks) {
+  const list = Array.isArray(picks) ? picks : [];
+  const eligible = list.filter(pickCountsTowardSeason);
+  const { max, winners } = reduceShowWinners(eligible);
+  const eligiblePlayers = eligible.length;
+  const beats = Math.max(0, eligiblePlayers - winners.length);
+  return { max, winners, eligiblePlayers, beats };
+}
+
+/**
+ * Overall winner(s) of the night for the Standings "winner of the night"
+ * banner (#218). Shares the same "global max per show, ties share,
+ * `max === 0 → skip`" rule as Profile `Wins` (#217) and Tour standings
+ * (#219).
+ *
+ * Expects the full, un-filtered list of picks for a single show — the banner
+ * is explicitly non-pool-scoped (pool-level winners live in pool details).
+ * Only picks with `isGraded === true` and at least one non-empty slot are
+ * eligible, so the banner naturally stays hidden during live scoring until
+ * the CF rollup runs.
+ *
+ * `eligiblePlayers` is the count of graded non-empty picks for the show, and
+ * `beats = eligiblePlayers - winners.length` drives the "beat N players"
+ * subcopy.
+ *
+ * @param {Array<{ uid?: string, userId?: string, handle?: string, score?: number, isGraded?: boolean, picks?: unknown } & Record<string, unknown>>} picks
+ */
+export function useShowWinnerOfTheNight(picks) {
+  return useMemo(() => computeShowWinnerOfTheNight(picks), [picks]);
+}

--- a/src/features/scoring/model/useShowWinnerOfTheNight.test.js
+++ b/src/features/scoring/model/useShowWinnerOfTheNight.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeShowWinnerOfTheNight } from './useShowWinnerOfTheNight';
+
+const graded = (score, extra = {}) => ({
+  isGraded: true,
+  picks: { s1: 'Tweezer' },
+  score,
+  ...extra,
+});
+
+describe('computeShowWinnerOfTheNight', () => {
+  it('returns the zero-winner shape when nobody is eligible', () => {
+    const result = computeShowWinnerOfTheNight([
+      { isGraded: false, picks: { s1: 'Tweezer' }, score: 50, uid: 'a' },
+      { isGraded: true, picks: {}, score: 20, uid: 'b' },
+    ]);
+    expect(result).toEqual({
+      max: null,
+      winners: [],
+      eligiblePlayers: 0,
+      beats: 0,
+    });
+  });
+
+  it('credits nobody when max is 0', () => {
+    const result = computeShowWinnerOfTheNight([
+      graded(0, { uid: 'a' }),
+      graded(0, { uid: 'b' }),
+    ]);
+    expect(result.max).toBe(null);
+    expect(result.winners).toEqual([]);
+    expect(result.eligiblePlayers).toBe(2);
+    expect(result.beats).toBe(2);
+  });
+
+  it('identifies a lone winner and computes beats', () => {
+    const a = graded(30, { uid: 'a' });
+    const b = graded(72, { uid: 'b' });
+    const c = graded(25, { uid: 'c' });
+    const result = computeShowWinnerOfTheNight([a, b, c]);
+    expect(result.max).toBe(72);
+    expect(result.winners).toEqual([b]);
+    expect(result.eligiblePlayers).toBe(3);
+    expect(result.beats).toBe(2);
+  });
+
+  it('lists every tied winner and reports beats relative to the tie size', () => {
+    const rows = [
+      graded(72, { uid: 'a' }),
+      graded(50, { uid: 'b' }),
+      graded(72, { uid: 'c' }),
+      graded(30, { uid: 'd' }),
+    ];
+    const result = computeShowWinnerOfTheNight(rows);
+    expect(result.max).toBe(72);
+    expect(result.winners.map((r) => r.uid)).toEqual(['a', 'c']);
+    expect(result.eligiblePlayers).toBe(4);
+    expect(result.beats).toBe(2);
+  });
+
+  it('tolerates missing / null input', () => {
+    expect(computeShowWinnerOfTheNight(null)).toEqual({
+      max: null,
+      winners: [],
+      eligiblePlayers: 0,
+      beats: 0,
+    });
+    expect(computeShowWinnerOfTheNight(undefined)).toEqual({
+      max: null,
+      winners: [],
+      eligiblePlayers: 0,
+      beats: 0,
+    });
+  });
+});

--- a/src/features/scoring/ui/LeaderboardRow.jsx
+++ b/src/features/scoring/ui/LeaderboardRow.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
 import { calculateTotalScore } from '../../../shared/utils/scoring';
 import ScoreBreakdownGrid from './ScoreBreakdownGrid';
 
@@ -52,17 +52,11 @@ export default function LeaderboardRow({
           <div className="w-10 h-10 shrink-0 bg-gradient-to-tr from-brand-accent-blue to-brand-primary rounded-full flex items-center justify-center font-bold text-lg shadow-inner text-brand-bg-deep">
             👤
           </div>
-          {playerUserId ? (
-            <Link
-              to={`/user/${playerUserId}`}
-              onClick={(e) => e.stopPropagation()}
-              className="font-bold text-base tracking-tight text-brand-primary hover:text-brand-primary-strong hover:underline decoration-brand-primary/70 underline-offset-2"
-            >
-              {p.handle || 'Anonymous'}
-            </Link>
-          ) : (
-            <span className="font-bold text-white text-base tracking-tight">{p.handle || 'Anonymous'}</span>
-          )}
+          <PlayerHandleLink
+            userId={playerUserId}
+            handle={p.handle}
+            className="text-base"
+          />
         </div>
 
         <div className="flex items-center gap-4">

--- a/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
+++ b/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
@@ -1,0 +1,67 @@
+import React, { Fragment } from 'react';
+
+import { tonightsWinnerHeading } from '../../../shared/config/dashboardVocabulary';
+import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
+
+/**
+ * "Overall winner of the night" callout for `/dashboard/standings` (#218).
+ *
+ * Renders nothing when there are no eligible winners, so the page can mount
+ * this unconditionally and let the feature decide visibility.
+ *
+ * Ties: every winner is listed as its own `/user/:uid` link, joined with
+ * commas — same link treatment as Pool hub leaderboard / show standings rows
+ * (#222).
+ *
+ * @param {{
+ *   winners: Array<{
+ *     uid?: string,
+ *     userId?: string,
+ *     handle?: string,
+ *     score?: number,
+ *   } & Record<string, unknown>>,
+ *   max: number | null,
+ *   beats?: number,
+ * }} props
+ */
+export default function StandingsWinnerOfTheNightBanner({ winners, max, beats = 0 }) {
+  if (!Array.isArray(winners) || winners.length === 0 || max == null) {
+    return null;
+  }
+
+  const heading = tonightsWinnerHeading(winners.length);
+  const handlesLabel = winners.map((w) => w.handle || 'Anonymous').join(', ');
+
+  return (
+    <section
+      role="status"
+      aria-label={`${heading}: ${handlesLabel} — ${max} points`}
+      className="mx-0.5 mb-4 rounded-xl border border-amber-500/40 bg-gradient-to-br from-amber-500/[0.12] via-amber-500/[0.06] to-brand-primary/[0.08] px-4 py-3 shadow-inset-glass"
+    >
+      <p className="text-[10px] font-black uppercase tracking-widest text-amber-300">
+        {heading}
+      </p>
+      <p className="mt-1 text-sm font-bold text-slate-100">
+        {winners.map((w, idx) => {
+          const playerUserId = w.userId || w.uid;
+          const handle = w.handle || 'Anonymous';
+          const separator = idx === 0 ? null : ', ';
+          return (
+            <Fragment key={playerUserId || `${handle}-${idx}`}>
+              {separator}
+              <PlayerHandleLink userId={playerUserId} handle={handle} />
+            </Fragment>
+          );
+        })}
+        {' — '}
+        <span className="tabular-nums text-white">{max}</span>
+        <span className="font-semibold text-content-secondary"> pts</span>
+        {beats > 0 ? (
+          <span className="ml-2 text-xs font-semibold text-content-secondary">
+            (beat {beats} {beats === 1 ? 'player' : 'players'})
+          </span>
+        ) : null}
+      </p>
+    </section>
+  );
+}

--- a/src/pages/standings/StandingsPage.jsx
+++ b/src/pages/standings/StandingsPage.jsx
@@ -9,7 +9,9 @@ import {
   StandingsBannerWaitingSetlist,
   StandingsFilterTabs,
   StandingsScopeIntro,
+  StandingsWinnerOfTheNightBanner,
   useDisplayedPicks,
+  useShowWinnerOfTheNight,
   useStandings,
   useStandingsLeaderboardView,
   useScoringRulesModal,
@@ -43,6 +45,12 @@ export default function StandingsPage({ selectedDate }) {
   const { openScoringRules } = useScoringRulesModal();
 
   useStandingsLeaderboardView(selectedDate, loading, showDates);
+
+  const winnerOfTheNight = useShowWinnerOfTheNight(picks);
+  const showWinnerBanner =
+    activeFilter === 'global' &&
+    Boolean(actualSetlist) &&
+    winnerOfTheNight.winners.length > 0;
 
   const showLabel = useMemo(() => {
     const show = showDates.find((s) => s.date === selectedDate);
@@ -99,6 +107,14 @@ export default function StandingsPage({ selectedDate }) {
         filterOptions={filterOptions}
         onTabChange={setActiveFilter}
       />
+
+      {showWinnerBanner ? (
+        <StandingsWinnerOfTheNightBanner
+          winners={winnerOfTheNight.winners}
+          max={winnerOfTheNight.max}
+          beats={winnerOfTheNight.beats}
+        />
+      ) : null}
 
       {!actualSetlist && picks.length > 0 ? <StandingsBannerWaitingSetlist /> : null}
 

--- a/src/shared/ui/PlayerHandleLink.jsx
+++ b/src/shared/ui/PlayerHandleLink.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+/**
+ * Deep-link a player handle to their public profile at `/user/:uid` (#222).
+ *
+ * Single source of truth for the "brand-primary hover underline" handle link
+ * pattern used by Pool hub leaderboard, Show standings rows, Tour standings
+ * rows, and the Standings "winner of the night" banner so they stay visually
+ * consistent.
+ *
+ * Falls back to a plain `<span>` when no `userId` is available (legacy
+ * records), preserving styling parity minus the hover affordance.
+ *
+ * The link intentionally calls `stopPropagation` on click so it can be
+ * embedded inside row-level click targets (e.g. expandable Show standings
+ * rows) without toggling the row. Callers that render the link outside of a
+ * row container can ignore that behavior — it's a no-op for them.
+ *
+ * @param {{
+ *   userId?: string | null,
+ *   handle?: string | null,
+ *   className?: string,
+ *   ariaLabel?: string,
+ * }} props
+ */
+export default function PlayerHandleLink({
+  userId,
+  handle,
+  className = '',
+  ariaLabel,
+}) {
+  const safeHandle = (handle || '').trim() || 'Anonymous';
+  const baseClass =
+    'font-bold tracking-tight text-brand-primary hover:text-brand-primary-strong hover:underline decoration-brand-primary/70 underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand rounded-sm';
+  const combined = className ? `${baseClass} ${className}` : baseClass;
+
+  if (!userId) {
+    return <span className={combined}>{safeHandle}</span>;
+  }
+
+  return (
+    <Link
+      to={`/user/${userId}`}
+      onClick={(e) => e.stopPropagation()}
+      aria-label={ariaLabel || `View ${safeHandle}'s profile`}
+      className={combined}
+    >
+      {safeHandle}
+    </Link>
+  );
+}

--- a/src/shared/ui/index.js
+++ b/src/shared/ui/index.js
@@ -8,6 +8,7 @@ export { default as GhostPill } from './GhostPill';
 export { default as Input } from './Input';
 export { default as MetaChip } from './MetaChip';
 export { default as PageTitle } from './PageTitle';
+export { default as PlayerHandleLink } from './PlayerHandleLink';
 export { default as SongAutocomplete } from './SongAutocomplete';
 export { default as StatusBadge } from './StatusBadge';
 export { default as StatusBanner } from './StatusBanner';


### PR DESCRIPTION
## Summary

Adds the "Overall winner of the night" callout to \`/dashboard/standings\` so the global filter highlights who tied or beat the global high score once the setlist is in. Uses the shared aggregation rule from the foundation PR so the banner cannot drift from Profile \`Wins\` (#217) or the upcoming Tour standings (#219).

## What & why

- **New**: \`features/scoring/model/useShowWinnerOfTheNight\` — memoizes \`computeShowWinnerOfTheNight(picks)\` over \`reduceShowWinners\`. Exposes \`{ max, winners, eligiblePlayers, beats }\` so the banner can render the tie-aware handle list and the "(beat N players)" subcopy. Covered by \`useShowWinnerOfTheNight.test.js\` (tie, empty, \`max===0\` skip, \`beats\` subcopy).
- **New**: \`features/scoring/ui/StandingsWinnerOfTheNightBanner\` — accessible \`<section role="status">\` callout with the amber/brand gradient treatment. Heading is singular/plural via \`tonightsWinnerHeading(winnerCount)\`. Every tied winner renders as a \`PlayerHandleLink\` (from #222) so the banner routes ties to each player's \`/user/:uid\`.
- **Wired**: \`pages/standings/StandingsPage.jsx\` shows the banner only when the **global** filter is active, a graded setlist has posted, and \`winners.length > 0\` — pool-scoped views stay untouched, and the callout stays hidden during live CF scoring until the rollup runs.

Both the hook and the banner are exported through \`features/scoring/index.js\`.

> Stacked on #232 (foundation) and #233 (PlayerHandleLink). Base stays \`staging\`; GitHub will show the correct diff once earlier PRs merge.

Closes #218

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run verify:dashboard-meta\`
- [x] \`npx vitest run\` (56 passing, including the new hook tests)
- [ ] Manual: switch Standings to **global** on a graded show → banner renders with singular heading and beats subcopy
- [ ] Manual: force a tie in Firestore emulator → banner renders plural heading with every tied handle linking to \`/user/:uid\`
- [ ] Manual: switch to a pool filter → banner hidden
- [ ] Manual: switch to a show whose setlist hasn't posted → banner hidden (no \`actualSetlist\`)
- [ ] Manual: a show where nobody scored > 0 → banner hidden (\`max===0\` skip)


Made with [Cursor](https://cursor.com)