### PR TITLE
feat(standings): global tour standings section

### DIFF
--- a/src/features/pools/ui/PoolHubLeaderboard.jsx
+++ b/src/features/pools/ui/PoolHubLeaderboard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+
+import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
 
 export default function PoolHubLeaderboard({ members }) {
   return (
@@ -28,12 +29,11 @@ export default function PoolHubLeaderboard({ members }) {
                   <span className="w-8 shrink-0 font-black tabular-nums text-content-secondary/90">
                     {rank}
                   </span>
-                  <Link
-                    to={`/user/${m.id}`}
-                    className="min-w-0 truncate font-bold text-brand-primary hover:text-brand-primary-strong hover:underline"
-                  >
-                    {handle}
-                  </Link>
+                  <PlayerHandleLink
+                    userId={m.id}
+                    handle={handle}
+                    className="min-w-0 truncate"
+                  />
                 </div>
                 <div className="flex items-center gap-3 sm:gap-4 shrink-0">
                   <div className="flex flex-col items-center">

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -16,4 +16,7 @@ export { default as StandingsBannerWaitingSetlist } from './ui/StandingsBannerWa
 export { default as StandingsFilterTabs } from './ui/StandingsFilterTabs';
 export { default as StandingsScopeIntro } from './ui/StandingsScopeIntro';
 export { default as StandingsWinnerOfTheNightBanner } from './ui/StandingsWinnerOfTheNightBanner';
+export { default as TourStandingsSection } from './ui/TourStandingsSection';
+export { resolveCurrentTour } from './model/resolveCurrentTour';
 export { useShowWinnerOfTheNight } from './model/useShowWinnerOfTheNight';
+export { useTourStandings } from './model/useTourStandings';

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -15,3 +15,5 @@ export {
 export { default as StandingsBannerWaitingSetlist } from './ui/StandingsBannerWaitingSetlist';
 export { default as StandingsFilterTabs } from './ui/StandingsFilterTabs';
 export { default as StandingsScopeIntro } from './ui/StandingsScopeIntro';
+export { default as StandingsWinnerOfTheNightBanner } from './ui/StandingsWinnerOfTheNightBanner';
+export { useShowWinnerOfTheNight } from './model/useShowWinnerOfTheNight';

--- a/src/features/scoring/model/aggregateTourStandings.js
+++ b/src/features/scoring/model/aggregateTourStandings.js
@@ -1,0 +1,78 @@
+import {
+  pickCountsTowardSeason,
+  reduceShowWinners,
+} from '../../../shared/utils/showAggregation';
+
+/**
+ * Reduce a list of `{ date, picks: PickLike[] }` into a sorted tour
+ * leaderboard. The exported pure function powers `useTourStandings` and any
+ * non-React caller that needs the same math (future pool-tour aggregation
+ * can reuse this, layering a member-set filter on top).
+ *
+ * Rules (shared with Profile `Wins` and Standings #218):
+ *   - Points: sum of `score` across every graded, non-empty pick the user
+ *     submitted for a show in the tour.
+ *   - Shows: count of graded non-empty picks the user submitted in the tour.
+ *   - Wins: one per show where they tied/beat the global max (across every
+ *     graded, non-empty pick for that show). Ties share. `max === 0 → skip`.
+ *
+ * Sort: `totalPoints` desc, then `wins` desc, then `handle` asc as a stable
+ * placeholder. Deterministic intra-tie ordering that matches the real UI
+ * lives in #73 §3.5; this function will pick up that helper when it lands
+ * so every surface stays consistent.
+ *
+ * @typedef {{
+ *   uid: string,
+ *   handle: string,
+ *   totalPoints: number,
+ *   wins: number,
+ *   shows: number,
+ * }} TourStandingsRow
+ *
+ * @param {Array<{ date: string, picks: Array<Record<string, unknown>> }>} picksByDate
+ * @returns {TourStandingsRow[]}
+ */
+export function aggregateTourStandings(picksByDate) {
+  /** @type {Map<string, TourStandingsRow>} */
+  const perUser = new Map();
+
+  for (const entry of picksByDate || []) {
+    const picks = Array.isArray(entry?.picks) ? entry.picks : [];
+    const { max, winners } = reduceShowWinners(picks);
+    const winnerUids = new Set(
+      winners.map((w) => String(w.userId || w.uid || '')).filter(Boolean)
+    );
+
+    for (const row of picks) {
+      if (!pickCountsTowardSeason(row)) continue;
+      const uid = String(row.userId || row.uid || '').trim();
+      if (!uid) continue;
+
+      const prev = perUser.get(uid);
+      const score = typeof row.score === 'number' ? row.score : 0;
+      const handle =
+        typeof row.handle === 'string' && row.handle.trim()
+          ? row.handle.trim()
+          : prev?.handle || 'Anonymous';
+
+      const next = prev || {
+        uid,
+        handle,
+        totalPoints: 0,
+        wins: 0,
+        shows: 0,
+      };
+      next.handle = handle;
+      next.totalPoints += score;
+      next.shows += 1;
+      if (max != null && winnerUids.has(uid)) next.wins += 1;
+      perUser.set(uid, next);
+    }
+  }
+
+  return [...perUser.values()].sort((a, b) => {
+    if (b.totalPoints !== a.totalPoints) return b.totalPoints - a.totalPoints;
+    if (b.wins !== a.wins) return b.wins - a.wins;
+    return a.handle.localeCompare(b.handle);
+  });
+}

--- a/src/features/scoring/model/aggregateTourStandings.test.js
+++ b/src/features/scoring/model/aggregateTourStandings.test.js
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { aggregateTourStandings } from './aggregateTourStandings';
+
+const graded = (overrides) => ({
+  isGraded: true,
+  picks: { s1: 'Tweezer' },
+  ...overrides,
+});
+
+describe('aggregateTourStandings', () => {
+  it('returns an empty array for missing / empty input', () => {
+    expect(aggregateTourStandings(null)).toEqual([]);
+    expect(aggregateTourStandings([])).toEqual([]);
+  });
+
+  it('sums points and shows across tour shows, credits wins on global max', () => {
+    const input = [
+      {
+        date: '2025-07-15',
+        picks: [
+          graded({ userId: 'alice', handle: 'alice', score: 60 }),
+          graded({ userId: 'bob', handle: 'bob', score: 40 }),
+        ],
+      },
+      {
+        date: '2025-07-16',
+        picks: [
+          graded({ userId: 'alice', handle: 'alice', score: 30 }),
+          graded({ userId: 'bob', handle: 'bob', score: 70 }),
+          graded({ userId: 'carol', handle: 'carol', score: 70 }),
+        ],
+      },
+    ];
+    const rows = aggregateTourStandings(input);
+    const byUid = Object.fromEntries(rows.map((r) => [r.uid, r]));
+    expect(byUid.alice).toMatchObject({
+      totalPoints: 90,
+      wins: 1, // won show 1
+      shows: 2,
+      handle: 'alice',
+    });
+    expect(byUid.bob).toMatchObject({
+      totalPoints: 110,
+      wins: 1, // tied show 2
+      shows: 2,
+    });
+    expect(byUid.carol).toMatchObject({
+      totalPoints: 70,
+      wins: 1, // tied show 2
+      shows: 1,
+    });
+  });
+
+  it('ignores ungraded / empty picks', () => {
+    const input = [
+      {
+        date: '2025-03-01',
+        picks: [
+          { isGraded: false, userId: 'alice', score: 999, picks: { s1: 'x' } },
+          graded({ userId: 'bob', handle: 'bob', score: 20, picks: {} }), // empty
+          graded({ userId: 'carol', handle: 'carol', score: 10 }),
+        ],
+      },
+    ];
+    const rows = aggregateTourStandings(input);
+    expect(rows.map((r) => r.uid)).toEqual(['carol']);
+    expect(rows[0]).toMatchObject({ totalPoints: 10, shows: 1, wins: 1 });
+  });
+
+  it('skips wins entirely when global max is 0 on a show', () => {
+    const input = [
+      {
+        date: '2025-03-01',
+        picks: [
+          graded({ userId: 'a', handle: 'a', score: 0 }),
+          graded({ userId: 'b', handle: 'b', score: 0 }),
+        ],
+      },
+    ];
+    const rows = aggregateTourStandings(input);
+    expect(rows.every((r) => r.wins === 0)).toBe(true);
+    expect(rows.every((r) => r.shows === 1)).toBe(true);
+  });
+
+  it('sorts by points desc, then wins desc, then handle asc', () => {
+    const input = [
+      {
+        date: '2025-03-01',
+        picks: [
+          graded({ userId: 'a', handle: 'Zed', score: 100 }),
+          graded({ userId: 'b', handle: 'Alex', score: 100 }),
+          graded({ userId: 'c', handle: 'Bean', score: 80 }),
+        ],
+      },
+    ];
+    const rows = aggregateTourStandings(input);
+    expect(rows.map((r) => r.handle)).toEqual(['Alex', 'Zed', 'Bean']);
+  });
+});

--- a/src/features/scoring/model/resolveCurrentTour.js
+++ b/src/features/scoring/model/resolveCurrentTour.js
@@ -1,0 +1,57 @@
+/**
+ * Pick the "current tour" the Tour standings surface (#219) should show.
+ *
+ * Priority (ticket):
+ *   1. The tour containing `selectedDate`, if any.
+ *   2. The tour containing `todayYmd`, if any.
+ *   3. The most recent tour whose last show date is <= `todayYmd`
+ *      (i.e. the most recent tour with any finalized shows).
+ *
+ * Tours come from `show_calendar.showDatesByTour` (authoritative live data).
+ * The static fallback in `FALLBACK_SHOW_DATES_BY_TOUR` is only used when
+ * Firestore is unavailable — see `ShowCalendarContext`.
+ *
+ * @typedef {{ tour: string, shows: Array<{ date: string, venue: string }> }} TourGroup
+ *
+ * @param {string | null | undefined} selectedDate
+ * @param {string} todayYmd
+ * @param {TourGroup[]} showDatesByTour
+ * @returns {TourGroup | null}
+ */
+export function resolveCurrentTour(selectedDate, todayYmd, showDatesByTour) {
+  if (!Array.isArray(showDatesByTour) || showDatesByTour.length === 0) {
+    return null;
+  }
+
+  const sel = selectedDate?.trim?.();
+  if (sel) {
+    const match = showDatesByTour.find((g) =>
+      Array.isArray(g.shows) && g.shows.some((s) => s.date === sel)
+    );
+    if (match) return match;
+  }
+
+  if (todayYmd) {
+    const match = showDatesByTour.find((g) =>
+      Array.isArray(g.shows) && g.shows.some((s) => s.date === todayYmd)
+    );
+    if (match) return match;
+  }
+
+  // Most recent tour with at least one show whose date is on or before today.
+  /** @type {{ tour: TourGroup, lastFinalizedDate: string } | null} */
+  let best = null;
+  for (const tour of showDatesByTour) {
+    if (!Array.isArray(tour.shows) || tour.shows.length === 0) continue;
+    const finalized = tour.shows
+      .map((s) => s.date)
+      .filter((d) => typeof d === 'string' && (!todayYmd || d <= todayYmd));
+    if (finalized.length === 0) continue;
+    const last = finalized.reduce((a, b) => (a > b ? a : b));
+    if (!best || last > best.lastFinalizedDate) {
+      best = { tour, lastFinalizedDate: last };
+    }
+  }
+
+  return best ? best.tour : null;
+}

--- a/src/features/scoring/model/resolveCurrentTour.test.js
+++ b/src/features/scoring/model/resolveCurrentTour.test.js
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveCurrentTour } from './resolveCurrentTour';
+
+const tours = [
+  {
+    tour: 'Spring 2025',
+    shows: [
+      { date: '2025-03-01', venue: 'A' },
+      { date: '2025-03-04', venue: 'B' },
+    ],
+  },
+  {
+    tour: 'Summer 2025',
+    shows: [
+      { date: '2025-07-15', venue: 'C' },
+      { date: '2025-07-16', venue: 'D' },
+    ],
+  },
+  {
+    tour: 'Fall 2025',
+    shows: [
+      { date: '2025-11-01', venue: 'E' },
+      { date: '2025-12-05', venue: 'F' },
+    ],
+  },
+];
+
+describe('resolveCurrentTour', () => {
+  it('returns the tour containing the selected date when possible', () => {
+    const result = resolveCurrentTour('2025-07-16', '2025-12-31', tours);
+    expect(result?.tour).toBe('Summer 2025');
+  });
+
+  it('falls back to the tour containing today when selectedDate is not in any tour', () => {
+    const result = resolveCurrentTour('2024-01-01', '2025-11-01', tours);
+    expect(result?.tour).toBe('Fall 2025');
+  });
+
+  it('falls back to the most recent tour with any finalized shows', () => {
+    const result = resolveCurrentTour(null, '2025-08-01', tours);
+    // Neither Spring's nor Summer's dates match 2025-08-01 directly, but both
+    // have shows <= today. Most recent by last-finalized-date = Summer.
+    expect(result?.tour).toBe('Summer 2025');
+  });
+
+  it('skips tours whose shows are all in the future', () => {
+    const result = resolveCurrentTour(null, '2025-04-01', tours);
+    expect(result?.tour).toBe('Spring 2025');
+  });
+
+  it('returns null when no tours have finalized shows yet', () => {
+    const result = resolveCurrentTour(null, '2024-01-01', tours);
+    expect(result).toBe(null);
+  });
+
+  it('returns null when the tour list is missing or empty', () => {
+    expect(resolveCurrentTour('2025-03-01', '2025-03-01', [])).toBe(null);
+    expect(resolveCurrentTour('2025-03-01', '2025-03-01', null)).toBe(null);
+  });
+});

--- a/src/features/scoring/model/useShowWinnerOfTheNight.js
+++ b/src/features/scoring/model/useShowWinnerOfTheNight.js
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+
+import {
+  pickCountsTowardSeason,
+  reduceShowWinners,
+} from '../../../shared/utils/showAggregation';
+
+/**
+ * Pure computation behind {@link useShowWinnerOfTheNight}, exported for unit
+ * tests and any non-React caller that needs the same shape (e.g. the Tour
+ * standings reducer in #219).
+ *
+ * @param {Array<{ isGraded?: boolean, score?: number, picks?: unknown } & Record<string, unknown>>} picks
+ * @returns {{
+ *   max: number | null,
+ *   winners: Array<Record<string, unknown>>,
+ *   eligiblePlayers: number,
+ *   beats: number,
+ * }}
+ */
+export function computeShowWinnerOfTheNight(picks) {
+  const list = Array.isArray(picks) ? picks : [];
+  const eligible = list.filter(pickCountsTowardSeason);
+  const { max, winners } = reduceShowWinners(eligible);
+  const eligiblePlayers = eligible.length;
+  const beats = Math.max(0, eligiblePlayers - winners.length);
+  return { max, winners, eligiblePlayers, beats };
+}
+
+/**
+ * Overall winner(s) of the night for the Standings "winner of the night"
+ * banner (#218). Shares the same "global max per show, ties share,
+ * `max === 0 → skip`" rule as Profile `Wins` (#217) and Tour standings
+ * (#219).
+ *
+ * Expects the full, un-filtered list of picks for a single show — the banner
+ * is explicitly non-pool-scoped (pool-level winners live in pool details).
+ * Only picks with `isGraded === true` and at least one non-empty slot are
+ * eligible, so the banner naturally stays hidden during live scoring until
+ * the CF rollup runs.
+ *
+ * `eligiblePlayers` is the count of graded non-empty picks for the show, and
+ * `beats = eligiblePlayers - winners.length` drives the "beat N players"
+ * subcopy.
+ *
+ * @param {Array<{ uid?: string, userId?: string, handle?: string, score?: number, isGraded?: boolean, picks?: unknown } & Record<string, unknown>>} picks
+ */
+export function useShowWinnerOfTheNight(picks) {
+  return useMemo(() => computeShowWinnerOfTheNight(picks), [picks]);
+}

--- a/src/features/scoring/model/useShowWinnerOfTheNight.test.js
+++ b/src/features/scoring/model/useShowWinnerOfTheNight.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeShowWinnerOfTheNight } from './useShowWinnerOfTheNight';
+
+const graded = (score, extra = {}) => ({
+  isGraded: true,
+  picks: { s1: 'Tweezer' },
+  score,
+  ...extra,
+});
+
+describe('computeShowWinnerOfTheNight', () => {
+  it('returns the zero-winner shape when nobody is eligible', () => {
+    const result = computeShowWinnerOfTheNight([
+      { isGraded: false, picks: { s1: 'Tweezer' }, score: 50, uid: 'a' },
+      { isGraded: true, picks: {}, score: 20, uid: 'b' },
+    ]);
+    expect(result).toEqual({
+      max: null,
+      winners: [],
+      eligiblePlayers: 0,
+      beats: 0,
+    });
+  });
+
+  it('credits nobody when max is 0', () => {
+    const result = computeShowWinnerOfTheNight([
+      graded(0, { uid: 'a' }),
+      graded(0, { uid: 'b' }),
+    ]);
+    expect(result.max).toBe(null);
+    expect(result.winners).toEqual([]);
+    expect(result.eligiblePlayers).toBe(2);
+    expect(result.beats).toBe(2);
+  });
+
+  it('identifies a lone winner and computes beats', () => {
+    const a = graded(30, { uid: 'a' });
+    const b = graded(72, { uid: 'b' });
+    const c = graded(25, { uid: 'c' });
+    const result = computeShowWinnerOfTheNight([a, b, c]);
+    expect(result.max).toBe(72);
+    expect(result.winners).toEqual([b]);
+    expect(result.eligiblePlayers).toBe(3);
+    expect(result.beats).toBe(2);
+  });
+
+  it('lists every tied winner and reports beats relative to the tie size', () => {
+    const rows = [
+      graded(72, { uid: 'a' }),
+      graded(50, { uid: 'b' }),
+      graded(72, { uid: 'c' }),
+      graded(30, { uid: 'd' }),
+    ];
+    const result = computeShowWinnerOfTheNight(rows);
+    expect(result.max).toBe(72);
+    expect(result.winners.map((r) => r.uid)).toEqual(['a', 'c']);
+    expect(result.eligiblePlayers).toBe(4);
+    expect(result.beats).toBe(2);
+  });
+
+  it('tolerates missing / null input', () => {
+    expect(computeShowWinnerOfTheNight(null)).toEqual({
+      max: null,
+      winners: [],
+      eligiblePlayers: 0,
+      beats: 0,
+    });
+    expect(computeShowWinnerOfTheNight(undefined)).toEqual({
+      max: null,
+      winners: [],
+      eligiblePlayers: 0,
+      beats: 0,
+    });
+  });
+});

--- a/src/features/scoring/model/useTourStandings.js
+++ b/src/features/scoring/model/useTourStandings.js
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+
+import { fetchPicksForShowDate } from '../api/standingsApi';
+import { aggregateTourStandings } from './aggregateTourStandings';
+
+const FETCH_CHUNK_SIZE = 8;
+
+/**
+ * Global Tour standings (#219) — running points, wins, and shows across the
+ * current tour. Scope comes from `show_calendar.showDatesByTour` via
+ * {@link resolveCurrentTour}; callers pass the resolved `tour.shows`.
+ *
+ * Read cost per invocation = `|tour.shows|` collection queries
+ * (`picks where showDate == date`), chunked at {@link FETCH_CHUNK_SIZE}. If
+ * this becomes hot, materialize via `rollupScoresForShow` — see #220.
+ *
+ * @typedef {import('./aggregateTourStandings').TourStandingsRow} TourStandingsRow
+ *
+ * @param {Array<{ date: string, venue?: string }> | null | undefined} tourShows
+ * @returns {{
+ *   leaders: TourStandingsRow[],
+ *   loading: boolean,
+ *   error: Error | null,
+ * }}
+ */
+export function useTourStandings(tourShows) {
+  const [leaders, setLeaders] = useState(/** @type {TourStandingsRow[]} */ ([]));
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(/** @type {Error | null} */ (null));
+
+  const key = Array.isArray(tourShows)
+    ? tourShows.map((s) => s.date).filter(Boolean).join('|')
+    : '';
+
+  useEffect(() => {
+    let cancelled = false;
+    const dates = key ? key.split('|') : [];
+    if (dates.length === 0) {
+      setLeaders([]);
+      setLoading(false);
+      setError(null);
+      return undefined;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        /** @type {Array<{ date: string, picks: Array<Record<string, unknown>> }>} */
+        const byDate = [];
+        for (let i = 0; i < dates.length; i += FETCH_CHUNK_SIZE) {
+          const slice = dates.slice(i, i + FETCH_CHUNK_SIZE);
+          const results = await Promise.all(
+            slice.map((date) =>
+              fetchPicksForShowDate(date).then((picks) => ({ date, picks }))
+            )
+          );
+          for (const r of results) byDate.push(r);
+          if (cancelled) return;
+        }
+        if (cancelled) return;
+        const nextLeaders = aggregateTourStandings(byDate);
+        setLeaders(nextLeaders);
+      } catch (e) {
+        if (cancelled) return;
+        console.error('useTourStandings error:', e);
+        setError(e instanceof Error ? e : new Error('Failed to load tour standings.'));
+        setLeaders([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [key]);
+
+  return { leaders, loading, error };
+}

--- a/src/features/scoring/ui/LeaderboardRow.jsx
+++ b/src/features/scoring/ui/LeaderboardRow.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
 import { calculateTotalScore } from '../../../shared/utils/scoring';
 import ScoreBreakdownGrid from './ScoreBreakdownGrid';
 
@@ -52,17 +52,11 @@ export default function LeaderboardRow({
           <div className="w-10 h-10 shrink-0 bg-gradient-to-tr from-brand-accent-blue to-brand-primary rounded-full flex items-center justify-center font-bold text-lg shadow-inner text-brand-bg-deep">
             👤
           </div>
-          {playerUserId ? (
-            <Link
-              to={`/user/${playerUserId}`}
-              onClick={(e) => e.stopPropagation()}
-              className="font-bold text-base tracking-tight text-brand-primary hover:text-brand-primary-strong hover:underline decoration-brand-primary/70 underline-offset-2"
-            >
-              {p.handle || 'Anonymous'}
-            </Link>
-          ) : (
-            <span className="font-bold text-white text-base tracking-tight">{p.handle || 'Anonymous'}</span>
-          )}
+          <PlayerHandleLink
+            userId={playerUserId}
+            handle={p.handle}
+            className="text-base"
+          />
         </div>
 
         <div className="flex items-center gap-4">

--- a/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
+++ b/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
@@ -1,0 +1,67 @@
+import React, { Fragment } from 'react';
+
+import { tonightsWinnerHeading } from '../../../shared/config/dashboardVocabulary';
+import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
+
+/**
+ * "Overall winner of the night" callout for `/dashboard/standings` (#218).
+ *
+ * Renders nothing when there are no eligible winners, so the page can mount
+ * this unconditionally and let the feature decide visibility.
+ *
+ * Ties: every winner is listed as its own `/user/:uid` link, joined with
+ * commas — same link treatment as Pool hub leaderboard / show standings rows
+ * (#222).
+ *
+ * @param {{
+ *   winners: Array<{
+ *     uid?: string,
+ *     userId?: string,
+ *     handle?: string,
+ *     score?: number,
+ *   } & Record<string, unknown>>,
+ *   max: number | null,
+ *   beats?: number,
+ * }} props
+ */
+export default function StandingsWinnerOfTheNightBanner({ winners, max, beats = 0 }) {
+  if (!Array.isArray(winners) || winners.length === 0 || max == null) {
+    return null;
+  }
+
+  const heading = tonightsWinnerHeading(winners.length);
+  const handlesLabel = winners.map((w) => w.handle || 'Anonymous').join(', ');
+
+  return (
+    <section
+      role="status"
+      aria-label={`${heading}: ${handlesLabel} — ${max} points`}
+      className="mx-0.5 mb-4 rounded-xl border border-amber-500/40 bg-gradient-to-br from-amber-500/[0.12] via-amber-500/[0.06] to-brand-primary/[0.08] px-4 py-3 shadow-inset-glass"
+    >
+      <p className="text-[10px] font-black uppercase tracking-widest text-amber-300">
+        {heading}
+      </p>
+      <p className="mt-1 text-sm font-bold text-slate-100">
+        {winners.map((w, idx) => {
+          const playerUserId = w.userId || w.uid;
+          const handle = w.handle || 'Anonymous';
+          const separator = idx === 0 ? null : ', ';
+          return (
+            <Fragment key={playerUserId || `${handle}-${idx}`}>
+              {separator}
+              <PlayerHandleLink userId={playerUserId} handle={handle} />
+            </Fragment>
+          );
+        })}
+        {' — '}
+        <span className="tabular-nums text-white">{max}</span>
+        <span className="font-semibold text-content-secondary"> pts</span>
+        {beats > 0 ? (
+          <span className="ml-2 text-xs font-semibold text-content-secondary">
+            (beat {beats} {beats === 1 ? 'player' : 'players'})
+          </span>
+        ) : null}
+      </p>
+    </section>
+  );
+}

--- a/src/features/scoring/ui/TourStandingsSection.jsx
+++ b/src/features/scoring/ui/TourStandingsSection.jsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { Loader2 } from 'lucide-react';
+
+import {
+  TOUR_STANDINGS_DESCRIPTION,
+  TOUR_STANDINGS_HEADING,
+} from '../../../shared/config/dashboardVocabulary';
+import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
+
+const rankBadgeClass = (rank) => {
+  if (rank === 1) return 'bg-amber-500/20 text-amber-300 ring-1 ring-amber-500/40';
+  if (rank === 2)
+    return 'bg-brand-accent-blue/15 text-blue-200 ring-1 ring-brand-accent-blue/35';
+  if (rank === 3) return 'bg-orange-900/40 text-orange-200 ring-1 ring-orange-700/40';
+  return 'bg-surface-inset text-slate-300 ring-1 ring-border-muted';
+};
+
+/**
+ * Global Tour standings secondary section on `/dashboard/standings` (#219).
+ *
+ * Renders the running tour leaderboard below the single-night Show standings
+ * list. Scope (current tour name) is passed in by the page so copy stays
+ * declarative; aggregation math lives in {@link useTourStandings}.
+ *
+ * Handle cells are `<Link to="/user/:uid">` for #222 parity with Show
+ * standings rows and Pool hub leaderboard.
+ *
+ * @param {{
+ *   tourName: string | null | undefined,
+ *   leaders: Array<{ uid: string, handle: string, totalPoints: number, wins: number, shows: number }>,
+ *   loading: boolean,
+ *   error?: Error | null,
+ * }} props
+ */
+export default function TourStandingsSection({ tourName, leaders, loading, error }) {
+  const heading = TOUR_STANDINGS_HEADING;
+
+  return (
+    <section
+      aria-label={heading}
+      className="mt-10 rounded-2xl border border-border-subtle/35 bg-surface-panel/40 p-4 shadow-inset-glass sm:p-5"
+    >
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div>
+          <h2 className="font-display text-sm font-bold uppercase tracking-wide text-content-secondary">
+            {heading}
+          </h2>
+          <p className="mt-0.5 text-base font-bold text-white sm:text-lg">
+            {tourName || 'Current tour'}
+          </p>
+          <p className="mt-0.5 text-xs font-semibold text-content-secondary">
+            {TOUR_STANDINGS_DESCRIPTION}
+          </p>
+        </div>
+        {loading ? (
+          <Loader2
+            className="h-5 w-5 animate-spin text-brand-primary"
+            aria-label="Loading tour standings"
+          />
+        ) : null}
+      </div>
+
+      {error ? (
+        <p className="rounded-lg border border-red-900/50 bg-red-900/20 px-3 py-2 text-sm font-bold text-red-200">
+          Couldn&apos;t load tour standings. Try refreshing.
+        </p>
+      ) : null}
+
+      {!loading && !error && leaders.length === 0 ? (
+        <p className="text-sm font-semibold text-content-secondary">
+          No graded picks in this tour yet.
+        </p>
+      ) : null}
+
+      {leaders.length > 0 ? (
+        <ol className="space-y-2">
+          {leaders.map((row, idx) => {
+            const rank = idx + 1;
+            return (
+              <li
+                key={row.uid}
+                className="flex items-center justify-between gap-3 rounded-xl border border-border-subtle/30 bg-surface-panel/80 px-3 py-2"
+              >
+                <div className="flex min-w-0 items-center gap-3">
+                  <span
+                    className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-xs font-black tabular-nums ${rankBadgeClass(rank)}`}
+                    aria-label={`Rank ${rank}`}
+                  >
+                    {rank}
+                  </span>
+                  <PlayerHandleLink
+                    userId={row.uid}
+                    handle={row.handle}
+                    className="truncate text-sm"
+                  />
+                </div>
+                <div className="flex items-center gap-4 text-right">
+                  <TourStat label="Pts" value={row.totalPoints} emphasized />
+                  <TourStat label="Wins" value={row.wins} />
+                  <TourStat label="Shows" value={row.shows} />
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      ) : null}
+    </section>
+  );
+}
+
+function TourStat({ label, value, emphasized = false }) {
+  return (
+    <div className="leading-none">
+      <span
+        className={`block text-base font-black tabular-nums ${
+          emphasized ? 'text-brand-primary' : 'text-white'
+        }`}
+      >
+        {value}
+      </span>
+      <span className="text-[9px] font-bold uppercase tracking-widest text-content-secondary">
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/src/pages/standings/StandingsPage.jsx
+++ b/src/pages/standings/StandingsPage.jsx
@@ -10,13 +10,17 @@ import {
   StandingsFilterTabs,
   StandingsScopeIntro,
   StandingsWinnerOfTheNightBanner,
+  TourStandingsSection,
+  resolveCurrentTour,
   useDisplayedPicks,
   useShowWinnerOfTheNight,
   useStandings,
   useStandingsLeaderboardView,
   useScoringRulesModal,
+  useTourStandings,
 } from '../../features/scoring';
 import { useShowCalendar } from '../../features/show-calendar';
+import { todayYmd } from '../../shared/utils/dateUtils.js';
 import { getShowStatus } from '../../shared/utils/timeLogic.js';
 import { showOptionLabelCompact } from '../../shared/utils/showOptionLabel.js';
 import Card from '../../shared/ui/Card';
@@ -31,7 +35,7 @@ export default function StandingsPage({ selectedDate }) {
       : '';
 
   const { user } = useAuth();
-  const { showDates } = useShowCalendar();
+  const { showDates, showDatesByTour } = useShowCalendar();
   const { pools: userPools } = useUserPools(user?.uid);
   const { picks, actualSetlist, loading } = useStandings(selectedDate, showDates);
   const { displayedPicks, activeFilter, setActiveFilter, filterOptions } = useDisplayedPicks(
@@ -51,6 +55,17 @@ export default function StandingsPage({ selectedDate }) {
     activeFilter === 'global' &&
     Boolean(actualSetlist) &&
     winnerOfTheNight.winners.length > 0;
+
+  const currentTour = useMemo(
+    () => resolveCurrentTour(selectedDate, todayYmd(), showDatesByTour),
+    [selectedDate, showDatesByTour]
+  );
+  const {
+    leaders: tourLeaders,
+    loading: tourLoading,
+    error: tourError,
+  } = useTourStandings(activeFilter === 'global' ? currentTour?.shows : null);
+  const showTourStandings = activeFilter === 'global' && Boolean(currentTour);
 
   const showLabel = useMemo(() => {
     const show = showDates.find((s) => s.date === selectedDate);
@@ -157,6 +172,15 @@ export default function StandingsPage({ selectedDate }) {
           title={leaderboardTitle}
         />
       )}
+
+      {showTourStandings ? (
+        <TourStandingsSection
+          tourName={currentTour?.tour}
+          leaders={tourLeaders}
+          loading={tourLoading}
+          error={tourError}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/pages/standings/StandingsPage.jsx
+++ b/src/pages/standings/StandingsPage.jsx
@@ -9,7 +9,9 @@ import {
   StandingsBannerWaitingSetlist,
   StandingsFilterTabs,
   StandingsScopeIntro,
+  StandingsWinnerOfTheNightBanner,
   useDisplayedPicks,
+  useShowWinnerOfTheNight,
   useStandings,
   useStandingsLeaderboardView,
   useScoringRulesModal,
@@ -43,6 +45,12 @@ export default function StandingsPage({ selectedDate }) {
   const { openScoringRules } = useScoringRulesModal();
 
   useStandingsLeaderboardView(selectedDate, loading, showDates);
+
+  const winnerOfTheNight = useShowWinnerOfTheNight(picks);
+  const showWinnerBanner =
+    activeFilter === 'global' &&
+    Boolean(actualSetlist) &&
+    winnerOfTheNight.winners.length > 0;
 
   const showLabel = useMemo(() => {
     const show = showDates.find((s) => s.date === selectedDate);
@@ -99,6 +107,14 @@ export default function StandingsPage({ selectedDate }) {
         filterOptions={filterOptions}
         onTabChange={setActiveFilter}
       />
+
+      {showWinnerBanner ? (
+        <StandingsWinnerOfTheNightBanner
+          winners={winnerOfTheNight.winners}
+          max={winnerOfTheNight.max}
+          beats={winnerOfTheNight.beats}
+        />
+      ) : null}
 
       {!actualSetlist && picks.length > 0 ? <StandingsBannerWaitingSetlist /> : null}
 

--- a/src/shared/ui/PlayerHandleLink.jsx
+++ b/src/shared/ui/PlayerHandleLink.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+/**
+ * Deep-link a player handle to their public profile at `/user/:uid` (#222).
+ *
+ * Single source of truth for the "brand-primary hover underline" handle link
+ * pattern used by Pool hub leaderboard, Show standings rows, Tour standings
+ * rows, and the Standings "winner of the night" banner so they stay visually
+ * consistent.
+ *
+ * Falls back to a plain `<span>` when no `userId` is available (legacy
+ * records), preserving styling parity minus the hover affordance.
+ *
+ * The link intentionally calls `stopPropagation` on click so it can be
+ * embedded inside row-level click targets (e.g. expandable Show standings
+ * rows) without toggling the row. Callers that render the link outside of a
+ * row container can ignore that behavior — it's a no-op for them.
+ *
+ * @param {{
+ *   userId?: string | null,
+ *   handle?: string | null,
+ *   className?: string,
+ *   ariaLabel?: string,
+ * }} props
+ */
+export default function PlayerHandleLink({
+  userId,
+  handle,
+  className = '',
+  ariaLabel,
+}) {
+  const safeHandle = (handle || '').trim() || 'Anonymous';
+  const baseClass =
+    'font-bold tracking-tight text-brand-primary hover:text-brand-primary-strong hover:underline decoration-brand-primary/70 underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand rounded-sm';
+  const combined = className ? `${baseClass} ${className}` : baseClass;
+
+  if (!userId) {
+    return <span className={combined}>{safeHandle}</span>;
+  }
+
+  return (
+    <Link
+      to={`/user/${userId}`}
+      onClick={(e) => e.stopPropagation()}
+      aria-label={ariaLabel || `View ${safeHandle}'s profile`}
+      className={combined}
+    >
+      {safeHandle}
+    </Link>
+  );
+}

--- a/src/shared/ui/index.js
+++ b/src/shared/ui/index.js
@@ -8,6 +8,7 @@ export { default as GhostPill } from './GhostPill';
 export { default as Input } from './Input';
 export { default as MetaChip } from './MetaChip';
 export { default as PageTitle } from './PageTitle';
+export { default as PlayerHandleLink } from './PlayerHandleLink';
 export { default as SongAutocomplete } from './SongAutocomplete';
 export { default as StatusBadge } from './StatusBadge';
 export { default as StatusBanner } from './StatusBanner';


### PR DESCRIPTION
## Summary

Adds the "Tour standings" section to \`/dashboard/standings\` so the global filter now shows cumulative points / wins / shows across the current tour alongside tonight's leaderboard. Tour windows come from \`show_calendar.showDatesByTour\` (live Firestore) per the epic constraint.

## What & why

- **New**: \`features/scoring/model/resolveCurrentTour\` — picks the tour that owns \`selectedDate\` (or "today" when the user is browsing a future show). Covered by \`resolveCurrentTour.test.js\`.
- **New**: \`features/scoring/model/aggregateTourStandings\` — reduces per-show pick rows to a ranked leader list using the shared \`reduceShowWinners\` rule from the foundation PR, so \`Wins\` stay identical with Profile \`Wins\` and the #218 Winner banner. Covered by \`aggregateTourStandings.test.js\` (tie shares, \`max===0\` skip, empty inputs).
- **New**: \`features/scoring/model/useTourStandings\` — fans out the per-show \`picks where showDate == X\` queries in parallel, surfaces \`loading\`/\`error\`, and memoizes over the tour shows list so scope toggles don't re-query.
- **New**: \`features/scoring/ui/TourStandingsSection\` — ranked rows with \`PlayerHandleLink\` (from #222) so handles deep-link to \`/user/:uid\` consistently with the Pool hub and Show standings rows.
- **Wired**: \`pages/standings/StandingsPage.jsx\` renders the section only when the global filter is active and a current tour is resolvable. \`useShowCalendar\` now also returns \`showDatesByTour\` here.

All exports surfaced through \`features/scoring/index.js\`.

> Stacked on #232 / #233 / #234. Base stays \`staging\`; GitHub will show the correct diff once earlier PRs merge.

Closes #219

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run verify:dashboard-meta\`
- [x] \`npx vitest run\` (67 passing, including the new tour tests)
- [ ] Manual: on a show inside the current tour, switch to **global** → Tour standings renders below the Show leaderboard, per-row handles link to \`/user/:uid\`
- [ ] Manual: switch to a pool filter → Tour standings hidden
- [ ] Manual: force a tour with every \`max===0\` entry → wins column reads 0
- [ ] Manual: offline / empty tour shows → renders nothing, no console noise


Made with [Cursor](https://cursor.com)