### PR TITLE
perf(app): route-level code splitting with React.lazy + Suspense

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,15 +1,24 @@
-import React from 'react';
+import React, { lazy } from 'react';
 import { Routes, Route } from 'react-router-dom';
 
-import PasswordResetCompletePage from '../pages/auth/PasswordResetCompletePage';
-import PublicProfilePage from '../pages/profile/PublicProfilePage';
-
 import RootAppShell from './layout/RootAppShell';
-import DashboardRoute from './routes/DashboardRoute';
 import HomeRoute from './routes/HomeRoute';
-import SetupRoute from './routes/SetupRoute';
-import PoolInviteMissingCodePage from '../pages/pool-invite/PoolInviteMissingCodePage';
-import PoolInvitePage from '../pages/pool-invite/PoolInvitePage';
+
+// Keep `HomeRoute` eager: it's the public splash / SEO-facing surface, so it
+// must paint before any dynamic import resolves. Every other top-level route
+// is lazy-loaded so direct hits on e.g. `/dashboard/profile` don't pay the
+// full dashboard+admin+pools download on first paint. The shared Suspense
+// boundary lives in `RootAppShell` (one place → consistent fallback).
+const PasswordResetCompletePage = lazy(() =>
+  import('../pages/auth/PasswordResetCompletePage')
+);
+const PublicProfilePage = lazy(() => import('../pages/profile/PublicProfilePage'));
+const PoolInviteMissingCodePage = lazy(() =>
+  import('../pages/pool-invite/PoolInviteMissingCodePage')
+);
+const PoolInvitePage = lazy(() => import('../pages/pool-invite/PoolInvitePage'));
+const SetupRoute = lazy(() => import('./routes/SetupRoute'));
+const DashboardRoute = lazy(() => import('./routes/DashboardRoute'));
 
 function App() {
   return (

--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -1,20 +1,35 @@
-import React, { useState, useEffect } from 'react';
+import React, { Suspense, lazy, useState, useEffect } from 'react';
 import { Link, Navigate, useLocation, Routes, Route, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../../features/auth';
 import { usePendingPoolJoin } from '../../features/pool-invite';
 import { useShowCalendar } from '../../features/show-calendar';
 import { useScrollDirection } from '../../shared/hooks/useScrollDirection';
+import RouteSuspenseFallback from '../../shared/ui/RouteSuspenseFallback';
 
-import { ListMusic, Users, Medal, User as UserIcon, Settings } from 'lucide-react'; 
+import { ListMusic, Users, Medal, User as UserIcon, Settings } from 'lucide-react';
 
-import PicksPage from '../../pages/picks/PicksPage';
-import AdminPage from '../../pages/admin/AdminPage';
-import StandingsPage from '../../pages/standings/StandingsPage';
-import ProfilePage from '../../pages/profile/ProfilePage';
-import { AccountSecurity } from '../../features/profile';
-import PoolsPage from '../../pages/pools/PoolsPage';
-import PoolHubPage from '../../pages/pools/PoolHubPage';
+// Lazy-load each dashboard page so a direct hit on e.g. `/dashboard/profile`
+// doesn't pay the download cost for Admin / Pools / Standings / Picks /
+// PoolHub. Static imports here would defeat the route-level code splitting
+// at the top level (`App.jsx`), because they'd all collapse back into the
+// DashboardRoute chunk. The inner `<Suspense>` below reuses the shared
+// brand loading fallback.
+const PicksPage = lazy(() => import('../../pages/picks/PicksPage'));
+const AdminPage = lazy(() => import('../../pages/admin/AdminPage'));
+const StandingsPage = lazy(() => import('../../pages/standings/StandingsPage'));
+const ProfilePage = lazy(() => import('../../pages/profile/ProfilePage'));
+// `AccountSecurity` ships through the `profile` feature barrel — preserve
+// that public API by dynamic-importing the barrel and picking the named
+// export for `React.lazy`'s default-module contract.
+const AccountSecurity = lazy(() =>
+  import('../../features/profile').then((m) => ({ default: m.AccountSecurity }))
+);
+const PoolsPage = lazy(() => import('../../pages/pools/PoolsPage'));
+const PoolHubPage = lazy(() => import('../../pages/pools/PoolHubPage'));
 
+// `ScoringRulesModalProvider` must stay eager — it wraps the whole dashboard
+// and owns the modal portal state; lazy-loading it would Suspense-flash the
+// entire dashboard chrome.
 import { ScoringRulesModalProvider } from '../../features/scoring';
 import {
   NAV_LABEL_ADMIN,
@@ -219,20 +234,34 @@ export default function DashboardLayout() {
             <DashboardPageHeading title={meta.layoutDesktopHeading} tone={isWarRoomRoute ? 'warRoom' : 'default'} />
           )}
 
-          <Routes>
-            <Route index element={<PicksPage user={user} selectedDate={selectedDate} />} />
-            <Route path="picks" element={<PicksPage user={user} selectedDate={selectedDate} />} />
-            <Route
-              path="scoring"
-              element={<Navigate to="/dashboard?scoringRules=1" replace />}
-            />
-            <Route path="standings" element={<StandingsPage selectedDate={selectedDate} />} />
-            <Route path="admin" element={<AdminPage user={user} selectedDate={selectedDate} />} />
-            <Route path="profile" element={<ProfilePage user={user} />} />
-            <Route path="account-security" element={<AccountSecurity user={user} />} />
-            <Route path="pools" element={<PoolsPage user={user} />} />
-            <Route path="pool/:poolId" element={<PoolHubPage user={user} />} />
-          </Routes>
+          <Suspense fallback={<RouteSuspenseFallback />}>
+            <Routes>
+              <Route index element={<PicksPage user={user} selectedDate={selectedDate} />} />
+              <Route
+                path="picks"
+                element={<PicksPage user={user} selectedDate={selectedDate} />}
+              />
+              <Route
+                path="scoring"
+                element={<Navigate to="/dashboard?scoringRules=1" replace />}
+              />
+              <Route
+                path="standings"
+                element={<StandingsPage selectedDate={selectedDate} />}
+              />
+              <Route
+                path="admin"
+                element={<AdminPage user={user} selectedDate={selectedDate} />}
+              />
+              <Route path="profile" element={<ProfilePage user={user} />} />
+              <Route
+                path="account-security"
+                element={<AccountSecurity user={user} />}
+              />
+              <Route path="pools" element={<PoolsPage user={user} />} />
+              <Route path="pool/:poolId" element={<PoolHubPage user={user} />} />
+            </Routes>
+          </Suspense>
         </div>
       </main>
 

--- a/src/app/layout/RootAppShell.jsx
+++ b/src/app/layout/RootAppShell.jsx
@@ -1,11 +1,17 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 
 import AppBackground from '../../shared/ui/AppBackground';
+import RouteSuspenseFallback from '../../shared/ui/RouteSuspenseFallback';
 
 /**
  * Global chrome: ambient background + top-level route outlet with enter animation.
  * Keeps router hooks in the app layer; AppBackground stays a shared presentational primitive.
+ *
+ * The `<Suspense>` boundary here catches every top-level lazy route (dashboard,
+ * setup, public profile, pool-invite, etc.), so we only need one boundary at
+ * this level. Nested boundaries exist inside `DashboardLayout` for its child
+ * pages.
  */
 export default function RootAppShell() {
   const { pathname } = useLocation();
@@ -15,7 +21,9 @@ export default function RootAppShell() {
       <AppBackground />
       <div className="relative z-[1] min-h-screen">
         <div key={pathname} className="min-h-screen animate-page-enter">
-          <Outlet />
+          <Suspense fallback={<RouteSuspenseFallback />}>
+            <Outlet />
+          </Suspense>
         </div>
       </div>
     </>

--- a/src/shared/ui/RouteSuspenseFallback.jsx
+++ b/src/shared/ui/RouteSuspenseFallback.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Loader2 } from 'lucide-react';
+
+/**
+ * Shared fallback for `<Suspense>` boundaries that wrap lazy-loaded route
+ * chunks. Matches the brand loading treatment used by the Standings page /
+ * Pool Hub so transitions between eager and lazy routes feel identical.
+ *
+ * Rendered both at the top-level shell (`RootAppShell` → `<Outlet />`) and
+ * inside the dashboard sub-routes (`DashboardLayout` → `<Routes>`). Keep the
+ * copy neutral so it works for any route.
+ */
+export default function RouteSuspenseFallback({ label = 'Loading…' }) {
+  return (
+    <div
+      className="mt-20 flex flex-col items-center justify-center gap-3 font-bold text-brand-primary"
+      role="status"
+      aria-live="polite"
+    >
+      <Loader2 className="h-10 w-10 animate-spin" aria-hidden />
+      <p>{label}</p>
+    </div>
+  );
+}

--- a/src/shared/ui/index.js
+++ b/src/shared/ui/index.js
@@ -9,6 +9,7 @@ export { default as Input } from './Input';
 export { default as MetaChip } from './MetaChip';
 export { default as PageTitle } from './PageTitle';
 export { default as PlayerHandleLink } from './PlayerHandleLink';
+export { default as RouteSuspenseFallback } from './RouteSuspenseFallback';
 export { default as SongAutocomplete } from './SongAutocomplete';
 export { default as StatusBadge } from './StatusBadge';
 export { default as StatusBanner } from './StatusBanner';


### PR DESCRIPTION
Closes #240. Part of perf epic #239.

## Summary

- Every top-level route except the public splash (`HomeRoute`) is now `React.lazy`; `HomeRoute` stays eager for SEO / unauthenticated first paint.
- Every dashboard page (`PicksPage`, `PoolsPage`, `PoolHubPage`, `StandingsPage`, `ProfilePage`, `AccountSecurity`, `AdminPage`) is now `React.lazy`; `ScoringRulesModalProvider` stays static because it owns the modal portal state.
- New shared `RouteSuspenseFallback` reuses the `Loader2` + brand copy pattern already used by Standings / Pool Hub. Two `<Suspense>` boundaries total: one wrapping `<Outlet />` in `RootAppShell`, one wrapping the inner `<Routes>` in `DashboardLayout`.
- `AccountSecurity` still ships through the `features/profile` public barrel via the standard `import(...).then(m => ({ default: m.AccountSecurity }))` pattern so the feature boundary is unchanged.

## Build impact (`npm run build`)

Direct hits on `/dashboard/profile` no longer download the admin console, picks form, pools hub, or standings bundle on first paint. Per-route chunks:

| Route chunk | Size | Gzip |
| --- | --- | --- |
| PublicProfilePage | 1.82 kB | 0.86 kB |
| ProfilePage | 2.92 kB | 1.41 kB |
| SetupRoute | 3.44 kB | 1.51 kB |
| PasswordResetCompletePage | 5.47 kB | 2.10 kB |
| PicksPage | 7.18 kB | 2.99 kB |
| PoolsPage | 8.30 kB | 2.82 kB |
| DashboardRoute | 22.97 kB | 7.39 kB |
| PoolHubPage | 24.96 kB | 7.67 kB |
| StandingsPage | 26.51 kB | 8.47 kB |
| AdminPage | 36.63 kB | 11.24 kB |
| useSongCatalog (shared, Picks + Admin) | 71.45 kB | 18.97 kB |
| main (`index-*.js`, React + Firebase + shared) | 806.75 kB | 209.48 kB |

The 806 kB main chunk is the remaining target for #241 (Vite `manualChunks` + Vercel cache headers). This PR lands the structural splitting that #241 depends on.

## Known follow-up

Rollup emits a "re-exported through barrel ends up in different chunk" warning for `useUserSeasonStats` because `PublicProfilePage` and dashboard routes both reach the `features/profile` barrel across lazy boundaries. Deep-importing the symbols to silence the warning was blocked by the ESLint `no-restricted-imports` rule that requires page → feature imports to go through the public barrel. The warning is non-blocking (build succeeds, `vite preview` serves the SPA correctly) and is resolved structurally by the `manualChunks` grouping in #241.

## Test plan

- [x] `npm run lint`
- [x] `npm test` (71/71)
- [x] `npm run verify:dashboard-meta`
- [x] `npm run verify:dashboard-ui`
- [x] `npm run build` — per-route chunks listed above
- [x] `npm run preview` serves 200 on `/`, `/dashboard/profile`, `/user/*`
- [x] On the Vercel preview deploy, confirm in devtools Network that visiting `/dashboard/profile` only fetches the dashboard + profile chunks (not admin/pools/standings/picks)
- [x] Fresh Lighthouse run on `/dashboard/profile` (Slow 4G / Moto G Power) attached in review comment

## Related

- Epic: #239
- Next up: #241 (Vite `manualChunks` + Vercel cache headers) which splits the remaining 806 kB main chunk into long-cacheable vendor chunks.

Made with [Cursor](https://cursor.com)