### PR TITLE
perf(build): vendor/firebase manualChunks + Vercel cache headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,52 @@
       "source": "/(.*)",
       "destination": "/index.html"
     }
+  ],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/index.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/robots.txt",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        }
+      ]
+    },
+    {
+      "source": "/sitemap.xml",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        }
+      ]
+    }
   ]
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,50 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Group third-party modules into stable, cacheable chunks. Returning `undefined`
+// for anything outside `node_modules` preserves Vite's automatic per-route
+// splitting introduced in #240 — do NOT bundle app code here.
+function manualChunks(id) {
+  const normalized = id.replace(/\\/g, '/');
+  if (!normalized.includes('/node_modules/')) return undefined;
+
+  // Firebase ships as `firebase/<subpath>` wrappers that re-export from
+  // `@firebase/<subpath>` internals. Match both so all Firebase code lands
+  // in a firebase-* chunk (keeps #242's lazy-init story stable).
+  const fbMatch = normalized.match(
+    /\/node_modules\/(?:@firebase|firebase)\/([^/]+)/
+  );
+  if (fbMatch) {
+    const sub = fbMatch[1];
+    if (sub.startsWith('app-check')) return 'firebase-appcheck';
+    if (sub.startsWith('storage')) return 'firebase-storage';
+    return 'firebase-core';
+  }
+
+  // Path-segment match supports scoped packages (@tanstack/react-query).
+  const pkgMatch = normalized.match(/\/node_modules\/((?:@[^/]+\/)?[^/]+)/);
+  if (!pkgMatch) return undefined;
+  const pkg = pkgMatch[1];
+
+  if (pkg === '@tanstack/react-query') return 'vendor-react-query';
+  if (pkg === 'lucide-react') return 'vendor-icons';
+
+  // Exact-name set avoids the `react` naively matching `react-query` /
+  // `react-helmet-async` / `react-ga4` classes of bug.
+  const reactPkgs = new Set([
+    'react',
+    'react-dom',
+    'react-router',
+    'react-router-dom',
+    'react-helmet-async',
+    'react-ga4',
+    'scheduler',
+  ]);
+  if (reactPkgs.has(pkg)) return 'vendor-react';
+
+  return undefined;
+}
+
 export default defineConfig({
   base: '/',
   plugins: [react()],
@@ -15,6 +59,13 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks,
+      },
     },
   },
 });


### PR DESCRIPTION
Closes #241. Part of perf epic #239.

## Summary

- `vite.config.js`: adds `build.rollupOptions.output.manualChunks` (function form) that groups third-party modules into stable vendor/firebase chunks. Returns `undefined` for anything under `src/`, preserving #240's per-route splitting.
- `vercel.json`: adds `headers` array — `/assets/*` gets `public, max-age=31536000, immutable`; `/`, `/index.html` get `no-stale` headers; `/robots.txt`, `/sitemap.xml` get a 1-hour cache. Existing SPA rewrite is unchanged.

The `@tanstack/react-query` bundle path isn't wired in yet (no imports in `src/`); the `vendor-react-query` chunk name is reserved and stable for when #243 starts using it.

## Implementation notes

- `manualChunks` uses exact-match package sets and POSIX path normalization to avoid the well-known trap where `'react'` naively matches `'react-query'` / `'react-helmet-async'` / `'react-ga4'`.
- Firebase regex matches both the user-facing `firebase/<subpath>` wrappers and their `@firebase/<subpath>` internals, so everything Firebase lands in a `firebase-*` chunk. Shared Firebase utilities (`@firebase/util`, `@firebase/component`, etc.) go into `firebase-core` — they stay side-loaded with the auth + firestore path that every user needs, and they don't have to be re-fetched when #242 flips app-check / storage to dynamic imports.

## Before/after chunk sizes

Baseline (post-#240, pre-#241):

| Chunk | Size |
| --- | --- |
| `index-*.js` | **806.75 kB** (gzip 209.48 kB) |
| `useSongCatalog-*.js` | 71.45 kB |
| `AdminPage-*.js` | 36.63 kB |
| `StandingsPage-*.js` | 26.51 kB |
| `PoolHubPage-*.js` | 24.96 kB |
| `DashboardRoute-*.js` | 22.97 kB |
| `PoolsPage-*.js` | 8.30 kB |
| `PicksPage-*.js` | 7.18 kB |
| `useUserSeasonStats-*.js` | 6.67 kB |
| (others) | ≤ 5.47 kB each |

After #241:

| Chunk | Size | Note |
| --- | --- | --- |
| `firebase-core-*.js` | **473.56 kB** (gzip 110.27 kB) | new; auth + firestore + app + shared utils |
| `vendor-react-*.js` | **187.99 kB** (gzip 61.38 kB) | new; react + react-dom + router + helmet + ga4 + scheduler |
| `index-*.js` (main) | **96.00 kB** (gzip 27.23 kB) | **was 806.75 kB** — 88% smaller |
| `firebase-storage-*.js` | 25.73 kB | new; ready for #242 lazy-load |
| `firebase-appcheck-*.js` | 21.12 kB | new; ready for #242 lazy-init |
| `vendor-icons-*.js` | 16.21 kB | new; `lucide-react` |
| `useSongCatalog-*.js` | 71.53 kB | unchanged |
| `AdminPage-*.js` | 33.03 kB | slightly smaller (vendor code moved out) |
| `StandingsPage-*.js` | 25.21 kB | slightly smaller |
| `PoolHubPage-*.js` | 24.13 kB | slightly smaller |
| `DashboardRoute-*.js` | 21.04 kB | slightly smaller |
| `PoolsPage-*.js` | 7.98 kB | ~same |
| `PicksPage-*.js` | 6.58 kB | slightly smaller |
| `useUserSeasonStats-*.js` | 6.79 kB | ~same |

Total first-load bytes for `/dashboard/profile` (shell + profile route + vendors): ~797 kB uncompressed / ~208 kB gzip, broken into separately cacheable chunks. On subsequent deploys, only `index-*.js` + any changed route/feature chunks re-download — `vendor-react`, `firebase-*`, `vendor-icons` stay warm in the browser cache.

## Known inherited state

The Rollup circular-chunk warning for `useUserSeasonStats` (introduced by #240's lazy boundaries) still prints during `npm run build`:

> Export \`useUserSeasonStats\` of module \`src/features/profile/model/useUserSeasonStats.js\` was reexported through module \`src/features/profile/index.js\` while both modules are dependencies of each other and will end up in different chunks...

It's non-blocking. Resolving it structurally would require grouping `features/profile/**` into one chunk, which directly conflicts with this ticket's \"leave app code alone / don't bundle \`src/features/**\` into a vendor chunk\" guidance. Deferring to a follow-up; flagging here so it doesn't look like a regression introduced by this PR.

## Test plan

- [x] \`npm run lint\`
- [x] \`npm test\` — 71/71 pass
- [x] \`npm run verify:dashboard-meta\`
- [x] \`npm run verify:dashboard-ui\`
- [x] \`npm run build\` — emits all six expected vendor/firebase chunks
- [x] Vercel preview: devtools Network tab shows \`Cache-Control: public, max-age=31536000, immutable\` on a \`/assets/*.js\` response
- [x] Vercel preview: devtools Network tab shows \`Cache-Control: public, max-age=0, must-revalidate\` on \`/\` and \`/index.html\`
- [x] Lighthouse run on landing + \`/dashboard/profile\` no longer flags \"Use efficient cache lifetimes\" for static JS
- [ ] Cold-load \`/dashboard/profile\` fetches \`vendor-react-*.js\` + \`firebase-core-*.js\` alongside the main entry; hot-reload of a feature chunk does NOT re-download the vendor chunks

Made with [Cursor](https://cursor.com)