### PR TITLE
ux(standings): active-show CTA, pinned self row, primary pill toggle

### DIFF
--- a/scripts/verify-theme-contract.mjs
+++ b/scripts/verify-theme-contract.mjs
@@ -21,6 +21,7 @@ const TARGETS = [
   'src/features/scoring/ui/ScoreBreakdownGrid.jsx',
   'src/features/scoring/ui/ScoringRulesContent.jsx',
   'src/features/scoring/ui/ScoringRulesModal.jsx',
+  'src/features/scoring/ui/StandingsActiveShowCard.jsx',
   'src/features/scoring/ui/StandingsPoolPicker.jsx',
   'src/features/scoring/ui/StandingsViewToggle.jsx',
 ];

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -17,6 +17,7 @@ export {
   ScoringRulesModalProvider,
   useScoringRulesModal,
 } from './ui/ScoringRulesModalProvider';
+export { default as StandingsActiveShowCard } from './ui/StandingsActiveShowCard';
 export { default as StandingsBannerWaitingSetlist } from './ui/StandingsBannerWaitingSetlist';
 export { default as StandingsPoolPicker } from './ui/StandingsPoolPicker';
 export { default as StandingsViewToggle } from './ui/StandingsViewToggle';

--- a/src/features/scoring/model/useLeaderboard.js
+++ b/src/features/scoring/model/useLeaderboard.js
@@ -2,7 +2,33 @@ import { useMemo, useState } from 'react';
 import { FORM_FIELDS } from '../../../shared/data/gameConfig';
 import { calculateTotalScore } from '../../../shared/utils/scoring';
 
-export function useLeaderboard(poolPicks = [], actualSetlist = null) {
+/**
+ * Pull the signed-in user's row to rank 1 pre-grade (#255). Once
+ * `actualSetlist` arrives, scores drive ordering and the row falls into
+ * its natural rank. Non-mutating; leaves relative order of the rest.
+ *
+ * @template {{ userId?: string, uid?: string }} T
+ * @param {T[]} rows
+ * @param {string | null | undefined} selfUserId
+ * @returns {T[]}
+ */
+export function pinSelfToTop(rows, selfUserId) {
+  if (!selfUserId || !Array.isArray(rows) || rows.length === 0) return rows;
+  const idx = rows.findIndex((row) => (row?.userId || row?.uid) === selfUserId);
+  if (idx <= 0) return rows;
+  const next = rows.slice();
+  const [self] = next.splice(idx, 1);
+  next.unshift(self);
+  return next;
+}
+
+/**
+ * @param {Array<Record<string, unknown>>} poolPicks
+ * @param {unknown[] | null} actualSetlist
+ * @param {{ selfUserId?: string | null }} [options]
+ */
+export function useLeaderboard(poolPicks = [], actualSetlist = null, options = {}) {
+  const { selfUserId = null } = options;
   const [expandedUser, setExpandedUser] = useState(null);
 
   const getPickPayload = (pickEntry) => {
@@ -18,12 +44,18 @@ export function useLeaderboard(poolPicks = [], actualSetlist = null) {
   };
 
   const sortedPicks = useMemo(() => {
-    return [...poolPicks].sort((a, b) => {
+    const byScore = [...poolPicks].sort((a, b) => {
       const scoreA = calculateTotalScore(getPickPayload(a), actualSetlist);
       const scoreB = calculateTotalScore(getPickPayload(b), actualSetlist);
       return scoreB - scoreA;
     });
-  }, [poolPicks, actualSetlist]);
+    // Pre-grade: pin self to the top so the user can see their locked-in
+    // picks at a glance while waiting for the setlist to finalize.
+    if (!actualSetlist && selfUserId) {
+      return pinSelfToTop(byScore, selfUserId);
+    }
+    return byScore;
+  }, [poolPicks, actualSetlist, selfUserId]);
 
   const toggleUserExpansion = (userId) => {
     setExpandedUser((prev) => (prev === userId ? null : userId));

--- a/src/features/scoring/model/useLeaderboard.test.js
+++ b/src/features/scoring/model/useLeaderboard.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+
+import { pinSelfToTop } from './useLeaderboard';
+
+describe('pinSelfToTop', () => {
+  it('returns rows unchanged when selfUserId is falsy', () => {
+    const rows = [{ userId: 'a' }, { userId: 'b' }];
+    expect(pinSelfToTop(rows, null)).toBe(rows);
+    expect(pinSelfToTop(rows, undefined)).toBe(rows);
+    expect(pinSelfToTop(rows, '')).toBe(rows);
+  });
+
+  it('returns rows unchanged when the row set is empty or malformed', () => {
+    expect(pinSelfToTop([], 'me')).toEqual([]);
+    expect(pinSelfToTop(null, 'me')).toBeNull();
+    expect(pinSelfToTop(undefined, 'me')).toBeUndefined();
+  });
+
+  it('returns the same array reference when self is not present', () => {
+    const rows = [{ userId: 'a' }, { userId: 'b' }];
+    expect(pinSelfToTop(rows, 'me')).toBe(rows);
+  });
+
+  it('returns the same array reference when self is already rank 1', () => {
+    const rows = [{ userId: 'me' }, { userId: 'a' }, { userId: 'b' }];
+    expect(pinSelfToTop(rows, 'me')).toBe(rows);
+  });
+
+  it('moves self to index 0 and preserves the relative order of the rest', () => {
+    const rows = [
+      { userId: 'a' },
+      { userId: 'b' },
+      { userId: 'me' },
+      { userId: 'c' },
+    ];
+    const result = pinSelfToTop(rows, 'me');
+    expect(result).not.toBe(rows);
+    expect(result.map((r) => r.userId)).toEqual(['me', 'a', 'b', 'c']);
+  });
+
+  it('matches on either `userId` or legacy `uid`', () => {
+    const rows = [
+      { uid: 'a' },
+      { uid: 'b' },
+      { uid: 'me' },
+    ];
+    expect(pinSelfToTop(rows, 'me').map((r) => r.uid)).toEqual(['me', 'a', 'b']);
+
+    const rows2 = [{ userId: 'a' }, { uid: 'me' }, { userId: 'b' }];
+    expect(pinSelfToTop(rows2, 'me').map((r) => r.userId || r.uid)).toEqual([
+      'me',
+      'a',
+      'b',
+    ]);
+  });
+});

--- a/src/features/scoring/ui/Leaderboard.jsx
+++ b/src/features/scoring/ui/Leaderboard.jsx
@@ -2,10 +2,17 @@ import React from 'react';
 import { useLeaderboard } from '../model/useLeaderboard';
 import LeaderboardList from './LeaderboardList';
 
-const Leaderboard = ({ poolPicks = [], actualSetlist = null, title, headerEnd = null }) => {
+const Leaderboard = ({
+  poolPicks = [],
+  actualSetlist = null,
+  title,
+  headerEnd = null,
+  selfUserId = null,
+}) => {
   const { sortedPicks, getPickPayload, expandedUser, toggleUserExpansion } = useLeaderboard(
     poolPicks,
-    actualSetlist
+    actualSetlist,
+    { selfUserId }
   );
 
   return (
@@ -17,6 +24,7 @@ const Leaderboard = ({ poolPicks = [], actualSetlist = null, title, headerEnd = 
       getPickPayload={getPickPayload}
       title={title}
       headerEnd={headerEnd}
+      selfUserId={selfUserId}
     />
   );
 };

--- a/src/features/scoring/ui/LeaderboardList.jsx
+++ b/src/features/scoring/ui/LeaderboardList.jsx
@@ -17,6 +17,7 @@ export default function LeaderboardList({
   getPickPayload,
   title = 'Everyone',
   headerEnd = null,
+  selfUserId = null,
 }) {
   if (sortedPicks.length === 0) {
     return (
@@ -81,12 +82,18 @@ export default function LeaderboardList({
         const userPicks = getPickPayload(p);
         const isExpanded = expandedUser === uniqueId;
         const rank = index + 1;
+        const isSelf = Boolean(selfUserId) && (p.userId || p.uid) === selfUserId;
+        // Pre-grade, the self row is pinned to rank 1 by `useLeaderboard`;
+        // skip the natural rank badge so users don't misread "1" as a
+        // scoring result before the setlist lands.
+        const displayRank = isSelf && !actualSetlist ? null : rank;
 
         return (
           <LeaderboardRow
             key={uniqueId}
-            rank={rank}
+            rank={displayRank}
             isLeaderRow={showLeaderCallout && uniqueId === leaderId}
+            isSelf={isSelf}
             p={p}
             actualSetlist={actualSetlist}
             isExpanded={isExpanded}

--- a/src/features/scoring/ui/LeaderboardRow.jsx
+++ b/src/features/scoring/ui/LeaderboardRow.jsx
@@ -14,6 +14,7 @@ const rankBadgeClass = (rank) => {
 export default function LeaderboardRow({
   rank,
   isLeaderRow = false,
+  isSelf = false,
   p,
   actualSetlist,
   isExpanded,
@@ -24,11 +25,17 @@ export default function LeaderboardRow({
   const playerUserId = p.userId || p.uid;
   const score = calculateTotalScore(userPicks, actualSetlist);
 
+  // Self gets a stronger brand ring so users can locate themselves at
+  // a glance — doubly useful pre-grade when the row is pinned to rank 1.
+  const borderTone = isSelf
+    ? 'border-brand-primary/55 ring-1 ring-brand-primary/35'
+    : isLeaderRow
+    ? 'border-border-venue/55 ring-1 ring-brand-primary/15'
+    : 'border-border-subtle/35';
+
   return (
     <div
-      className={`bg-surface-panel rounded-2xl border overflow-hidden shadow-inset-glass transition-all ${
-        isLeaderRow ? 'border-border-venue/55 ring-1 ring-brand-primary/15' : 'border-border-subtle/35'
-      }`}
+      className={`bg-surface-panel rounded-2xl border overflow-hidden shadow-inset-glass transition-all ${borderTone}`}
     >
       <div
         role="button"
@@ -43,20 +50,39 @@ export default function LeaderboardRow({
         className="w-full flex items-center justify-between p-5 hover:bg-surface-panel-strong/80 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand rounded-t-2xl"
       >
         <div className="flex items-center gap-3 text-left min-w-0">
-          <div
-            className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-sm font-black tabular-nums ${rankBadgeClass(rank)}`}
-            aria-label={`Rank ${rank}`}
-          >
-            {rank}
-          </div>
+          {rank != null ? (
+            <div
+              className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-sm font-black tabular-nums ${rankBadgeClass(rank)}`}
+              aria-label={`Rank ${rank}`}
+            >
+              {rank}
+            </div>
+          ) : (
+            <div
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-[9px] font-black uppercase tracking-widest bg-brand-primary/15 text-brand-primary ring-1 ring-brand-primary/40"
+              aria-label="Pinned — you"
+            >
+              You
+            </div>
+          )}
           <div className="w-10 h-10 shrink-0 bg-gradient-to-tr from-brand-accent-blue to-brand-primary rounded-full flex items-center justify-center font-bold text-lg shadow-inner text-brand-bg-deep">
             👤
           </div>
-          <PlayerHandleLink
-            userId={playerUserId}
-            handle={p.handle}
-            className="text-base"
-          />
+          <div className="flex items-center gap-2 min-w-0">
+            <PlayerHandleLink
+              userId={playerUserId}
+              handle={p.handle}
+              className="text-base"
+            />
+            {isSelf && rank != null ? (
+              <span
+                className="inline-flex items-center rounded-full bg-brand-primary/15 px-2 py-0.5 text-[9px] font-black uppercase tracking-widest text-brand-primary ring-1 ring-brand-primary/40"
+                aria-label="You"
+              >
+                You
+              </span>
+            ) : null}
+          </div>
         </div>
 
         <div className="flex items-center gap-4">

--- a/src/features/scoring/ui/StandingsActiveShowCard.jsx
+++ b/src/features/scoring/ui/StandingsActiveShowCard.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ListMusic, Loader2, Pencil } from 'lucide-react';
+
+import Button from '../../../shared/ui/Button';
+import Card from '../../../shared/ui/Card';
+
+/**
+ * "Tonight's show / make picks" surface for the Standings page Show view
+ * (#255). Mirrors `PoolHubActiveShow`'s pre-lock branches — "Make picks"
+ * when not secured, "You're in / edit until showtime" when secured — but
+ * intentionally omits the `isLocked` / "View show standings" branch
+ * because this card only renders while the pick window is open; once the
+ * show locks, the leaderboard itself is the primary surface and this
+ * card is hidden by the page.
+ *
+ * Routes to `/dashboard` (Picks tab) so users land on the editable form.
+ *
+ * @param {Object} props
+ * @param {string} props.showLabel — venue + date for the selected show
+ * @param {boolean} props.isShowToday — selectedDate === today
+ * @param {boolean} props.isSecured — user has submitted non-empty picks
+ * @param {boolean} [props.picksStatusLoading] — avoids flashing "no picks" before Firestore resolves
+ */
+export default function StandingsActiveShowCard({
+  showLabel,
+  isShowToday,
+  isSecured,
+  picksStatusLoading = false,
+}) {
+  const navigate = useNavigate();
+
+  let eyebrow;
+  let bodyLine;
+
+  if (picksStatusLoading) {
+    eyebrow = isShowToday ? "TONIGHT'S SHOW" : 'NOW PICKING FOR';
+    bodyLine = 'Checking your picks for this show…';
+  } else if (!isSecured) {
+    eyebrow = isShowToday ? "TONIGHT'S SHOW" : 'NOW PICKING FOR';
+    bodyLine = isShowToday
+      ? "You haven't locked in picks for tonight's show yet."
+      : "You haven't locked in picks for this upcoming show yet.";
+  } else {
+    eyebrow = isShowToday ? "TONIGHT'S SHOW" : 'PICKS SECURED';
+    bodyLine = isShowToday
+      ? "You're in for tonight — you can still edit on the Picks tab until showtime."
+      : "You're in for this show — you can still edit on the Picks tab until showtime.";
+  }
+
+  return (
+    <Card as="section" variant="venue" padding="sm" className="md:p-6">
+      <div className="flex flex-col gap-3 md:gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          <p className="text-[10px] font-black uppercase tracking-widest text-brand-primary">
+            {eyebrow}
+          </p>
+          {showLabel ? (
+            <p className="font-display text-lg font-bold leading-snug text-white md:text-xl">
+              <span className="text-brand-primary">{showLabel}</span>
+            </p>
+          ) : null}
+          {picksStatusLoading ? (
+            <p className="flex items-center gap-2 text-sm font-bold text-content-secondary">
+              <Loader2
+                className="h-4 w-4 shrink-0 animate-spin text-content-secondary"
+                aria-hidden
+              />
+              {bodyLine}
+            </p>
+          ) : (
+            <p className="text-sm font-bold text-content-secondary">{bodyLine}</p>
+          )}
+        </div>
+
+        <div className="flex shrink-0 flex-col gap-2 sm:items-end">
+          {picksStatusLoading ? (
+            <div
+              className="flex h-11 w-full min-w-[12rem] items-center justify-center rounded-xl border border-border-subtle bg-surface-field sm:w-auto"
+              aria-busy="true"
+              aria-label="Loading picks status"
+            >
+              <Loader2 className="h-5 w-5 animate-spin text-content-secondary" />
+            </div>
+          ) : !isSecured ? (
+            <Button
+              type="button"
+              variant="primary"
+              size="md"
+              className="w-full min-w-[12rem] sm:w-auto uppercase tracking-widest"
+              onClick={() => navigate('/dashboard')}
+            >
+              <ListMusic className="mr-2 h-5 w-5 shrink-0" aria-hidden />
+              Make picks
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              variant="secondary"
+              size="md"
+              className="w-full min-w-[12rem] sm:w-auto uppercase tracking-widest"
+              onClick={() => navigate('/dashboard')}
+            >
+              <Pencil className="mr-2 h-5 w-5 shrink-0" aria-hidden />
+              View / Edit picks
+            </Button>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/features/scoring/ui/StandingsViewToggle.jsx
+++ b/src/features/scoring/ui/StandingsViewToggle.jsx
@@ -1,18 +1,33 @@
 import React from 'react';
 import { CalendarDays, ListOrdered, Users } from 'lucide-react';
 
-import FilterPill from '../../../shared/ui/FilterPill';
-
 const OPTIONS = [
   { id: 'show', label: 'Show', Icon: ListOrdered },
   { id: 'tour', label: 'Tour', Icon: CalendarDays },
   { id: 'pools', label: 'Pools', Icon: Users },
 ];
 
+const baseClass =
+  'shrink-0 inline-flex items-center gap-1.5 rounded-full border px-4 py-1.5 text-sm font-semibold tracking-tight transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg';
+
+/**
+ * Active state mirrors `Button variant="primary"` (teal fill, dark text,
+ * brand glow) — the user-facing contract for primary CTAs across the
+ * app — so the IA toggle reads as "pick one of these", not a passive
+ * filter. Kept inline rather than extending `FilterPill` so the neutral
+ * pool sub-selector pills can retain the subdued `FilterPill` style and
+ * preserve visual hierarchy.
+ */
+const selectedClass =
+  'border-transparent bg-brand-primary text-brand-bg-deep shadow-glow-brand hover:shadow-glow-brand-lg';
+
+const unselectedClass =
+  'border-border-venue/70 bg-surface-panel text-slate-300 hover:border-border-venue-strong hover:bg-surface-panel-strong hover:text-white';
+
 /**
  * Primary IA toggle for `/dashboard/standings` (#255) — three-way pick
  * between show-scoped standings, tour-scoped cumulative standings, and
- * pool-scoped show standings. Renders as the first in-page element so
+ * pool-scoped show standings. Renders as the first in-page content so
  * users can orient before any data is shown.
  *
  * State + URL sync lives in {@link useStandingsView}; this is the
@@ -39,19 +54,21 @@ export default function StandingsViewToggle({ view, onChange, className = '' }) 
       {OPTIONS.map(({ id, label, Icon }) => {
         const selected = view === id;
         return (
-          <FilterPill
+          <button
             key={id}
+            type="button"
             role="tab"
             aria-selected={selected}
-            selected={selected}
             onClick={() => onChange(id)}
-            className="min-w-[5.5rem] justify-center"
+            className={[
+              baseClass,
+              selected ? selectedClass : unselectedClass,
+              'min-w-[5.5rem] justify-center',
+            ].join(' ')}
           >
-            <span className="inline-flex items-center gap-1.5">
-              <Icon className="h-4 w-4 shrink-0" aria-hidden />
-              {label}
-            </span>
-          </FilterPill>
+            <Icon className="h-4 w-4 shrink-0" aria-hidden />
+            {label}
+          </button>
         );
       })}
     </div>

--- a/src/pages/standings/StandingsPage.jsx
+++ b/src/pages/standings/StandingsPage.jsx
@@ -3,9 +3,11 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { Inbox, Loader2, Music, Scale } from 'lucide-react';
 
 import { useAuth } from '../../features/auth';
+import { useNextShowPicksStatus } from '../../features/picks';
 import { useUserPools } from '../../features/pools';
 import {
   Leaderboard,
+  StandingsActiveShowCard,
   StandingsBannerWaitingSetlist,
   StandingsPoolPicker,
   StandingsViewToggle,
@@ -56,6 +58,15 @@ export default function StandingsPage({ selectedDate }) {
   const showStatus = getShowStatus(selectedDate, showDates);
   const { openScoringRules } = useScoringRulesModal();
 
+  // Only fetch pick-status for the "Now picking" active-show card — NEXT is
+  // the only status where users can still enter picks (see timeLogic.js).
+  // For PAST / LIVE, picks are already in `picks` and no extra read is
+  // needed; for FUTURE (a listed show beyond NEXT), picks aren't yet open.
+  const picksStatusTarget =
+    view === 'show' && showStatus === 'NEXT' ? selectedDate : undefined;
+  const { hasSubmittedPicksForNextShow, loading: picksStatusLoading } =
+    useNextShowPicksStatus(picksStatusTarget);
+
   useStandingsLeaderboardView(selectedDate, loading, showDates);
 
   const winnerOfTheNight = useShowWinnerOfTheNight(picks);
@@ -89,11 +100,14 @@ export default function StandingsPage({ selectedDate }) {
       ? activePoolName || 'This pool'
       : 'Everyone';
 
+  const isShowToday = selectedDate === todayYmd();
+
   return (
     <div className="w-full">
-      <StandingsViewToggle view={view} onChange={setView} />
-
-      <div className="mb-3 flex items-center justify-end">
+      {/* Scoring rules: sits above the primary IA toggle per #255 — "top-right,
+          below the 2nd header" (layout H1) — so it reads as utility chrome,
+          not competition with the three-way view switch. */}
+      <div className="mb-2 flex items-center justify-end">
         <button
           type="button"
           onClick={openScoringRules}
@@ -103,6 +117,8 @@ export default function StandingsPage({ selectedDate }) {
           Scoring rules
         </button>
       </div>
+
+      <StandingsViewToggle view={view} onChange={setView} />
 
       {view === 'tour' ? (
         <TourView
@@ -126,6 +142,7 @@ export default function StandingsPage({ selectedDate }) {
           loading={loading}
           showStatus={showStatus}
           showLabel={showLabel}
+          isShowToday={isShowToday}
           picks={picks}
           actualSetlist={actualSetlist}
           displayedPicks={displayedPicks}
@@ -133,6 +150,9 @@ export default function StandingsPage({ selectedDate }) {
           showWinnerBanner={showWinnerBanner}
           winnerOfTheNight={winnerOfTheNight}
           activePoolName={activePoolName}
+          selfUserId={user?.uid || null}
+          isSecured={hasSubmittedPicksForNextShow}
+          picksStatusLoading={picksStatusLoading}
         />
       )}
     </div>
@@ -172,6 +192,7 @@ function ShowOrPoolView({
   loading,
   showStatus,
   showLabel,
+  isShowToday,
   picks,
   actualSetlist,
   displayedPicks,
@@ -179,8 +200,12 @@ function ShowOrPoolView({
   showWinnerBanner,
   winnerOfTheNight,
   activePoolName,
+  selfUserId,
+  isSecured,
+  picksStatusLoading,
 }) {
   const isPoolsView = view === 'pools';
+  const isShowView = view === 'show';
 
   if (isPoolsView && !poolId) {
     return (
@@ -210,7 +235,43 @@ function ShowOrPoolView({
     );
   }
 
+  // Show view (#255): when the selected date is the next pickable show
+  // (NEXT — see timeLogic.js), surface the actionable "tonight's show"
+  // CTA as the primary affordance and render the leaderboard beneath
+  // it. The CTA stays pinned at the top until showtime regardless of
+  // pick status — "Make picks" when not secured, the "edit until
+  // showtime" message when already secured (copy mirrors
+  // PoolHubActiveShow). Self row is pinned at rank 1 pre-grade.
+  if (isShowView && showStatus === 'NEXT') {
+    return (
+      <>
+        <StandingsActiveShowCard
+          showLabel={showLabel}
+          isShowToday={Boolean(isShowToday)}
+          isSecured={Boolean(isSecured)}
+          picksStatusLoading={Boolean(picksStatusLoading)}
+        />
+        {displayedPicks.length > 0 ? (
+          <div className="mt-6">
+            {!actualSetlist && picks.length > 0 ? (
+              <StandingsBannerWaitingSetlist />
+            ) : null}
+            <Leaderboard
+              poolPicks={displayedPicks}
+              actualSetlist={actualSetlist}
+              title={leaderboardTitle}
+              selfUserId={selfUserId}
+            />
+          </div>
+        ) : null}
+      </>
+    );
+  }
+
   if (showStatus === 'FUTURE') {
+    // FUTURE = a listed show beyond the next pickable one; picks aren't
+    // open yet, so we keep the neutral "results aren't up yet" copy on
+    // both Show and Pools views.
     return (
       <>
         {isPoolsView ? (
@@ -315,6 +376,7 @@ function ShowOrPoolView({
           poolPicks={displayedPicks}
           actualSetlist={actualSetlist}
           title={leaderboardTitle}
+          selfUserId={selfUserId}
         />
       )}
     </>


### PR DESCRIPTION
Closes #257

## Summary

Cosmetic follow-ups to the #255 standings pill toggle:

- **Primary-color pill toggle.** The top `[Show | Tour | Pools]` switch now uses teal fill + dark text + brand glow (matches `Button variant="primary"`), reading as the primary IA control. Pool sub-selector pills stay muted to keep hierarchy.
- **Scoring rules repositioned.** Moved above the pill toggle, top-right, below the layout "Standings" H1 — the view switch is now the first primary affordance.
- **"Tonight's show" CTA on Show view.** New `StandingsActiveShowCard` renders when `showStatus === 'NEXT'`:
  - not secured → primary **Make picks** button → `/dashboard`
  - secured → secondary **View / Edit picks** + "edit until showtime" copy (mirrors `PoolHubActiveShow`)
  - leaderboard still renders beneath the card once any pick exists
- **Self row pinned pre-grade.** `useLeaderboard` exports a new `pinSelfToTop` pure helper that moves the signed-in user's row to rank 1 while `actualSetlist === null`. Natural score-sorted order resumes once the setlist lands. `LeaderboardRow` surfaces a "You" pill so the user can locate themselves at a glance.
- **Read gate.** `useNextShowPicksStatus` only fires for `showStatus === 'NEXT'` — no extra Firestore reads on PAST / LIVE / FUTURE.

No Firestore rules, schema, or telemetry changes — UI-only.

## Files

- New: `src/features/scoring/ui/StandingsActiveShowCard.jsx`, `src/features/scoring/model/useLeaderboard.test.js`
- Modified: `StandingsViewToggle.jsx`, `StandingsPage.jsx`, `useLeaderboard.js`, `Leaderboard.jsx`, `LeaderboardList.jsx`, `LeaderboardRow.jsx`, `features/scoring/index.js`, `scripts/verify-theme-contract.mjs`

## Local verification

- `npm run lint` — clean
- `npx vitest run` — **118/118** (includes 6 new `pinSelfToTop` tests)
- `npm run verify:dashboard-meta` — 11/11 OK
- `npm run verify:dashboard-ui` — OK
- `npm run verify:theme-contract` — 12/12 OK
- `npm run build` — `StandingsPage` chunk = **28.40 kB / 8.59 kB gzip** (+0.4 kB gzip vs the post-#255 baseline; still below pre-#255 size)

## Test plan (preview)

Run each on the Vercel preview URL once it's up:

- [ ] `/dashboard/standings?view=show` as a user **without** picks for today → `StandingsActiveShowCard` with "Make picks" primary button shows; leaderboard below shows others who've locked in (or empty state if none).
- [ ] Click **Make picks** → routes to `/dashboard` (Picks tab).
- [ ] Same URL, as a user **with** picks locked in → card shows "You're in — edit until showtime" with **View / Edit picks** secondary button; leaderboard below shows user's row pinned at rank 1 with a "You" pill, `-` scores pre-grade.
- [ ] After a show grades (setlist present) → self row falls into natural rank; "You" chip persists next to the handle.
- [ ] `?view=pools` → pool sub-picker pills still use the muted `FilterPill` style; scoring-rules link still top-right.
- [ ] `?view=tour` → unchanged.
- [ ] FUTURE date (beyond today) → "Results aren't up yet" card (CTA correctly suppressed; picks aren't open for that date).
- [ ] Scoring-rules link opens the modal; keyboard/focus-ring still works on the pill toggle.


Made with [Cursor](https://cursor.com)