### PR TITLE
feat(pools): add inline "how pools work" help on pools page

### DIFF
--- a/src/features/pools/index.js
+++ b/src/features/pools/index.js
@@ -20,4 +20,5 @@ export { default as PoolHubSeasonTotalsSection } from './ui/PoolHubStandingsSect
 export { default as PoolHubStandingsSection } from './ui/PoolHubStandingsSection';
 export { default as PoolHubShowArchive } from './ui/PoolHubShowArchive';
 export { default as PoolJoinCreateCard } from './ui/PoolJoinCreateCard';
+export { default as PoolsHowItWorksMenu } from './ui/PoolsHowItWorksMenu';
 export { default as UserPoolsSection } from './ui/UserPoolsSection';

--- a/src/features/pools/ui/PoolsHowItWorksMenu.jsx
+++ b/src/features/pools/ui/PoolsHowItWorksMenu.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { ChevronDown } from 'lucide-react';
+
+import DashboardRowPill from '../../../shared/ui/DashboardRowPill';
+
+/**
+ * Native disclosure: top row is the action bar (leading + “How pools work”);
+ * open content expands in normal flow below—no overlay or floating layer.
+ *
+ * @param {{ leading: React.ReactNode }} props
+ */
+export default function PoolsHowItWorksMenu({ leading }) {
+  return (
+    <details className="group w-full">
+      <summary className="flex w-full cursor-pointer list-none items-start justify-between gap-2 [&::-webkit-details-marker]:hidden">
+        <div className="min-w-0 shrink">{leading}</div>
+        <DashboardRowPill
+          as="span"
+          tone="muted"
+          className="shrink-0 uppercase tracking-widest"
+        >
+          How pools work
+          <ChevronDown
+            className="h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-180"
+            aria-hidden
+          />
+        </DashboardRowPill>
+      </summary>
+      <div className="mt-2 rounded-xl border border-border-subtle bg-surface-glass px-3 py-3 shadow-inset-glass">
+        <div className="space-y-3 text-sm font-medium leading-relaxed text-content-secondary">
+          <p>
+            A pool is a private group with one shared hub: active show, members,
+            and pool-only standings.
+          </p>
+          <ul className="list-disc space-y-2 pl-4 marker:text-content-secondary/70">
+            <li>
+              <span className="text-white/90">Join</span>—full member access to that
+              pool. Any member can invite others; use{' '}
+              <span className="text-white/90">Invite Friends</span> on the pool card.
+            </li>
+            <li>
+              <span className="text-white/90">Create</span>—we give you a shareable
+              invite link (text/social) and a 5-character code. Buddy next to you at
+              the show? The code is often fastest—you choose.
+            </li>
+            <li>
+              <span className="text-white/90">Invite Friends</span>—share the invite
+              link via Messages, social, email, and the like, or we copy it for you.
+              Same link your people use to join.
+            </li>
+          </ul>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/src/pages/pools/PoolsPage.jsx
+++ b/src/pages/pools/PoolsPage.jsx
@@ -5,6 +5,7 @@ import { Users } from 'lucide-react';
 import { useNextShowPicksStatus } from '../../features/picks';
 import {
   PoolJoinCreateCard,
+  PoolsHowItWorksMenu,
   UserPoolsSection,
   useUserPools,
 } from '../../features/pools';
@@ -33,12 +34,14 @@ export default function Pools({ user }) {
   return (
     <div className="w-full space-y-8 pb-6 md:pb-12">
       <DashboardActionRow>
-        <div className="flex w-full justify-start">
-          <DashboardRowPill as={Link} to="/dashboard" tone="accent">
-            <Users className="h-3.5 w-3.5 shrink-0 sm:h-4 sm:w-4" aria-hidden />
-            Go to Picks
-          </DashboardRowPill>
-        </div>
+        <PoolsHowItWorksMenu
+          leading={
+            <DashboardRowPill as={Link} to="/dashboard" tone="accent">
+              <Users className="h-3.5 w-3.5 shrink-0 sm:h-4 sm:w-4" aria-hidden />
+              Go to Picks
+            </DashboardRowPill>
+          }
+        />
       </DashboardActionRow>
 
       <UserPoolsSection


### PR DESCRIPTION
Native details disclosure in the pools action row with copy for join, create, and Invite Friends behavior.

Made-with: Cursor