### PR TITLE
staging → main: catalog freshness hotfix (#262)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1048,12 +1048,16 @@ exports.refreshPhishnetShowCalendar = onCall(
 );
 
 /**
- * Weekly sync: Phish.net v5 `songs.json` → Storage `song-catalog.json` (issue #158).
- * Sunday 7:00 America/New_York. Same secret as other Phish.net callables.
+ * Sync Phish.net v5 `songs.json` → Storage `song-catalog.json` every 6h
+ * (issue #158; freshness tightened in #261). Running at 00/06/12/18 ET keeps
+ * autocomplete `gap` + `last_played` aligned with tonight's show by the time
+ * users pick breakfast the next morning. Client-side localStorage TTL
+ * (`SONG_CATALOG_CACHE_MAX_AGE_MS`) is intentionally kept at 6h so the two
+ * freshness windows match. Same secret as other Phish.net callables.
  */
 exports.scheduledPhishnetSongCatalog = onSchedule(
   {
-    schedule: "0 7 * * 0",
+    schedule: "0 */6 * * *",
     timeZone: "America/New_York",
     region: PHISHNET_FUNCTIONS_REGION,
     secrets: [phishnetApiKey],

--- a/functions/phishnetSongCatalog.test.js
+++ b/functions/phishnetSongCatalog.test.js
@@ -28,3 +28,37 @@ test("normalizePhishnetSongRow maps v5 row", () => {
 test("normalizePhishnetSongRow returns null for empty song", () => {
   assert.equal(normalizePhishnetSongRow({ song: "  " }), null);
 });
+
+// Regression guard for #261: the displayed `Gap` and `Last` in
+// `SongAutocomplete` must always come from the same Phish.net row so they
+// cannot drift relative to each other. Worst-case staleness should move both
+// in lockstep (bounded by the cron window); mismatch between them in a single
+// snapshot would break the user-visible "gap = shows since last_played"
+// invariant the bustout UX relies on.
+test(
+  "normalizePhishnetSongRow reads gap and last_played from the same row",
+  () => {
+    const row = {
+      songid: 42,
+      song: "Ghost",
+      times_played: 300,
+      gap: 75,
+      last_played: "2023-12-31",
+    };
+    const out = normalizePhishnetSongRow(row);
+    assert.equal(out.gap, "75");
+    assert.equal(out.last, "2023-12-31");
+
+    const rowRecent = { ...row, gap: 0, last_played: "2025-07-15" };
+    const outRecent = normalizePhishnetSongRow(rowRecent);
+    assert.equal(outRecent.gap, "0");
+    assert.equal(outRecent.last, "2025-07-15");
+
+    // Missing either field falls back to the sentinel independently — never
+    // composes a value from a different row's data.
+    const rowPartial = { song: "Wilson", gap: 12 };
+    const outPartial = normalizePhishnetSongRow(rowPartial);
+    assert.equal(outPartial.gap, "12");
+    assert.equal(outPartial.last, "—");
+  }
+);

--- a/src/features/song-catalog/model/songCatalogConstants.js
+++ b/src/features/song-catalog/model/songCatalogConstants.js
@@ -1,5 +1,15 @@
 /** localStorage key for cached Phish.net-derived catalog JSON. */
 export const SONG_CATALOG_CACHE_KEY = 'set-picks.songCatalogCache.v1';
 
-/** Skip network if cache was written within this window (3 days). */
-export const SONG_CATALOG_CACHE_MAX_AGE_MS = 3 * 24 * 60 * 60 * 1000;
+/**
+ * Skip network if cache was written within this window (6 hours).
+ *
+ * Intentionally matches the server-side refresh cadence of
+ * `scheduledPhishnetSongCatalog` (every 6 hours ET — see functions/index.js).
+ * Keeping the two windows aligned means a user who reloads shortly after a
+ * cron run sees the fresh catalog, and worst-case user-visible drift is
+ * bounded by one cron window (~6h) rather than 3 days + cron window. This
+ * closes the reported mismatch where displayed `Gap` lagged days behind the
+ * most recent show date vs. the song's `last_played` (#261).
+ */
+export const SONG_CATALOG_CACHE_MAX_AGE_MS = 6 * 60 * 60 * 1000;


### PR DESCRIPTION
Promotes staging to main. Single change rolled up:

- #262 — fix(song-catalog): tighten refresh cadence to stop gap/last drift (Closes #261)

## Summary

- \`scheduledPhishnetSongCatalog\` cron \`0 7 * * 0\` → \`0 */6 * * *\` ET.
- \`SONG_CATALOG_CACHE_MAX_AGE_MS\` 3d → 6h.
- Regression test: \`normalizePhishnetSongRow\` reads \`gap\` and \`last_played\` from the same row.

Bustout scoring path untouched — \`official_setlists.bustouts\` is still snapshotted from per-row \`/v5/setlists\` gap at save time.

## Test plan

- [x] CI matrix green on #262 against staging (verify / functions / rules / Vercel)
- [ ] Firebase console shows every-6h cadence for \`scheduledPhishnetSongCatalog\` after prod deploy
- [ ] \`song-catalog.json\` \`updatedAt\` advances within 6h of the next show; spot-check a played song's \`gap: 0\` + \`last\` in autocomplete

Made with [Cursor](https://cursor.com)