### PR TITLE
feat(setlist-automation): auto-finalize & rollup

### DIFF
--- a/docs/OFFICIAL_SETLISTS_SCHEMA.md
+++ b/docs/OFFICIAL_SETLISTS_SCHEMA.md
@@ -53,6 +53,32 @@ State used for (2) lives on `live_setlist_automation/{showDate}` and is written 
 
 Long-set safeguard is inherent — `buildSetlistDocFromRows` re-derives `s1c` from rows every poll and does not preserve closers across writes, so an unusually long set 1 that plays another song after timing fires resets `lastSet1ChangeAt` and `s1c` rewrites to the new last song on the next poll where timing re-fires (or when set 2 starts, whichever first).
 
+### Auto-finalize and rollup (#266)
+
+The scheduled poller (`scheduledPhishnetLiveSetlistPoll`) finalizes a show and rolls up points automatically when either:
+
+1. **Encore idle:** `encoreSongs.length ≥ 1` **and** no new song has been appended to the setlist for ≥ **25 min** (`AUTO_FINALIZE_IDLE_MS`), **or**
+2. **Safety cap:** ≥ **4h 30m** (`SHOW_SAFETY_CAP_MS`) has elapsed since the first observed row **and** set 2 has ≥ 1 song — covers rare Phish.net encore-posting delays.
+
+The poller invokes the shared `runRollupForShow` core in `functions/rollupCore.js` (same code path as the manual `rollupScoresForShow` callable), stamps `autoFinalizedAt` + `autoFinalizeTrigger` on `live_setlist_automation/{showDate}` once the rollup succeeds, and tags the `rollup_audit/{showDate}` record with `trigger: "auto"`.
+
+Additional automation-doc state used by auto-finalize:
+
+| Field | Role |
+|-------|------|
+| `lastRowsChangedAt` | Timestamp of the most recent poll where the full-rows signature changed. Drives the idle calculation. |
+| `autoFinalizedAt` | Stamped when auto-finalize first runs rollup. Prevents double-firing. |
+| `autoFinalizeTrigger` | `"encore-idle"` or `"safety-cap"` — which rule fired. |
+
+**Reconciliation path:** if Phish.net edits a setlist after auto-finalize has fired (rare but possible within the ~3.5h post-encore poll window), the next changed-rows poll re-invokes `runRollupForShow` with `trigger: "auto-reconcile"`. The per-pick math in `computePerPickRollup` is delta-based, so `users.totalPoints` / `showsPlayed` / `wins` reconcile correctly rather than double-incrementing.
+
+**Manual override / pre-emption:** the admin "Finalize & Rollup Points" button (`rollupScoresForShow` callable, `trigger: "manual"`) keeps full control:
+
+- Clicking it before the 25-min idle pre-empts auto-finalize — the `rollup_audit` record exists, and on the next poll the automation sees no new row changes and leaves totals alone.
+- Clicking it after auto-finalize to correct a bad setlist runs the same delta-based rollup and reconciles totals identically to the `auto-reconcile` path.
+
+Admin "Poll Now" (`pollLiveSetlistNow`) does **not** inject the rollup core — auto-finalize is a no-op on that path by design so admins retain full control over finalize timing when they're actively monitoring a show.
+
 ---
 
 ## How scoring uses `setlist` + `officialSetlist`

--- a/functions/index.js
+++ b/functions/index.js
@@ -32,11 +32,7 @@ const {
   actualSetlistFromOfficialDoc,
 } = require("./scoringCore");
 const { runBackfill } = require("./backfillBustoutsCore");
-const {
-  computeGlobalMaxScore,
-  computePerPickRollup,
-  resolveTourKeyForDate,
-} = require("./rollupSeasonAggregates");
+const { runRollupForShow } = require("./rollupCore");
 
 const phishnetApiKey = defineSecret("PHISHNET_API_KEY");
 
@@ -189,228 +185,30 @@ exports.rollupScoresForShow = onCall(
   async (request) => {
     assertAdminClaim(request);
     const showDate = assertShowDateString(request.data?.showDate);
+    const callerUid = request.auth?.uid || null;
 
-    const setlistSnap = await db
-      .collection("official_setlists")
-      .doc(showDate)
-      .get();
-    if (!setlistSnap.exists) {
+    const result = await runRollupForShow({
+      db,
+      admin,
+      showDate,
+      callerUid,
+      trigger: "manual",
+      logger,
+    });
+    if (!result.setlistExists) {
       throw new HttpsError(
         "failed-precondition",
         `official_setlists/${showDate} does not exist. Save the setlist first.`
       );
     }
-    const setlistDoc = setlistSnap.data() || {};
-    const actualSetlist = actualSetlistFromOfficialDoc(setlistDoc);
-
-    const picksSnap = await db
-      .collection("picks")
-      .where("showDate", "==", showDate)
-      .get();
-
-    const callerUid = request.auth?.uid || null;
-
-    if (picksSnap.empty) {
-      await writeRollupAuditDoc({
-        showDate,
-        processedPicks: 0,
-        skippedPicks: 0,
-        totalPicks: 0,
-        callerUid,
-      });
-      logger.info("rollupScoresForShow", {
-        showDate,
-        processedPicks: 0,
-        skippedPicks: 0,
-        totalPicks: 0,
-        callerUid,
-      });
-      return {
-        ok: true,
-        processedPicks: 0,
-        skippedPicks: 0,
-        totalPicks: 0,
-      };
-    }
-
-    // Load the show calendar once so we can map `showDate` → `tourKey` for
-    // the `users.{uid}.seasonStats.{tourKey}` materialization (#244). If
-    // the calendar is stale (missing the date), the tour-scoped write is
-    // skipped and logged — global totals/wins still materialize.
-    const calendarSnap = await db
-      .collection("show_calendar")
-      .doc("snapshot")
-      .get();
-    const showDatesByTour = calendarSnap.exists
-      ? (calendarSnap.data() || {}).showDatesByTour
-      : null;
-    const tourKey = resolveTourKeyForDate(showDate, showDatesByTour);
-    if (!tourKey) {
-      logger.warn("rollupScoresForShow: tourKey missing for showDate", {
-        showDate,
-      });
-    }
-
-    // Pre-compute every pick's new score in one pass so we can derive the
-    // show's global max (for the wins pass) before issuing any writes.
-    // Mirrors `src/shared/utils/showAggregation.js::reduceShowWinners`: only
-    // graded, non-empty picks owned by an authenticated user are eligible;
-    // `max === 0` credits nobody.
-    /** @type {Map<string, number>} */
-    const newScoresById = new Map();
-    /** @type {Array<Record<string, unknown> & { id: string }>} */
-    const provisionalPicks = [];
-    for (const pickDoc of picksSnap.docs) {
-      const pickData = pickDoc.data() || {};
-      if (!pickData.userId) continue;
-      const userPicks = pickData.picks || {};
-      // Compute against the hypothetical "graded" view so the max reflects
-      // the post-commit state even for picks being graded for the first time.
-      newScoresById.set(
-        pickDoc.id,
-        calculateTotalScore(userPicks, actualSetlist)
-      );
-      provisionalPicks.push({ id: pickDoc.id, ...pickData, isGraded: true });
-    }
-    const newGlobalMax = computeGlobalMaxScore(provisionalPicks, newScoresById);
-
-    // Three writes per pick (picks doc + users doc + users doc #244 extras),
-    // but the users doc is merged into a single `set` — so the actual op
-    // count is still 2 per pick. The pick update now also carries
-    // `winCredited` so re-runs can diff cleanly against the prior state.
-    const OPS_PER_PICK = 2;
-    let batch = db.batch();
-    let opCount = 0;
-    let processedPicks = 0;
-    let skippedPicks = 0;
-
-    for (const pickDoc of picksSnap.docs) {
-      const pickData = pickDoc.data() || {};
-      if (!pickData.userId) {
-        skippedPicks += 1;
-        continue;
-      }
-      if (opCount + OPS_PER_PICK > MAX_FIRESTORE_BATCH_WRITES) {
-        await batch.commit();
-        batch = db.batch();
-        opCount = 0;
-      }
-      const newScore = newScoresById.get(pickDoc.id) || 0;
-      const plan = computePerPickRollup({
-        pickData,
-        newScore,
-        newGlobalMax,
-      });
-
-      const pickUpdate = {
-        score: newScore,
-        isGraded: true,
-        winCredited: plan.newIsWin,
-      };
-      if (plan.isFirstGrade) {
-        pickUpdate.gradedAt = admin.firestore.FieldValue.serverTimestamp();
-      }
-      batch.update(pickDoc.ref, pickUpdate);
-
-      const userUpdate = {
-        totalPoints: admin.firestore.FieldValue.increment(plan.scoreDiff),
-        showsPlayed: admin.firestore.FieldValue.increment(
-          plan.isFirstGrade ? 1 : 0
-        ),
-        wins: admin.firestore.FieldValue.increment(plan.winsDelta),
-        seasonStatsSnapshotAt: admin.firestore.FieldValue.serverTimestamp(),
-        seasonStatsThroughShow: showDate,
-      };
-      // `seasonStats.{tourKey}` mirrors the three global counters so
-      // tour-scoped surfaces (#219 Tour standings, Profile tour card) can
-      // read the user doc directly without re-filtering per-show picks.
-      if (tourKey) {
-        userUpdate.seasonStats = {
-          [tourKey]: {
-            totalPoints: admin.firestore.FieldValue.increment(plan.scoreDiff),
-            shows: admin.firestore.FieldValue.increment(
-              plan.isFirstGrade ? 1 : 0
-            ),
-            wins: admin.firestore.FieldValue.increment(plan.winsDelta),
-          },
-        };
-      }
-      batch.set(
-        db.collection("users").doc(pickData.userId),
-        userUpdate,
-        { merge: true }
-      );
-      opCount += OPS_PER_PICK;
-      processedPicks += 1;
-    }
-
-    if (opCount > 0) {
-      await batch.commit();
-    }
-
-    const totalPicks = picksSnap.size;
-    await writeRollupAuditDoc({
-      showDate,
-      processedPicks,
-      skippedPicks,
-      totalPicks,
-      callerUid,
-    });
-    logger.info("rollupScoresForShow", {
-      showDate,
-      processedPicks,
-      skippedPicks,
-      totalPicks,
-      callerUid,
-    });
-
     return {
       ok: true,
-      processedPicks,
-      skippedPicks,
-      totalPicks,
+      processedPicks: result.processedPicks,
+      skippedPicks: result.skippedPicks,
+      totalPicks: result.totalPicks,
     };
   }
 );
-
-/**
- * Writes an audit record to `rollup_audit/{showDate}` with the counts and
- * timestamp of the most recent `rollupScoresForShow` invocation. Standalone
- * top-level collection (not under `official_setlists`) so it never re-triggers
- * `gradePicksOnSetlistWrite`. PR B will add a rule that makes this collection
- * admin-read-only; Admin SDK writes bypass rules so this still works under
- * tightened policy. Soft-fails on error so a transient audit write failure
- * never loses a successful grading pass.
- */
-async function writeRollupAuditDoc({
-  showDate,
-  processedPicks,
-  skippedPicks,
-  totalPicks,
-  callerUid,
-}) {
-  try {
-    await db
-      .collection("rollup_audit")
-      .doc(showDate)
-      .set(
-        {
-          lastRolledUpAt: admin.firestore.FieldValue.serverTimestamp(),
-          processedPicks,
-          skippedPicks,
-          totalPicks,
-          callerUid: callerUid || null,
-        },
-        { merge: true }
-      );
-  } catch (e) {
-    const msg = e?.message || String(e);
-    logger.warn("rollupScoresForShow.auditWrite failed", {
-      showDate,
-      msg,
-    });
-  }
-}
 
 /**
  * Grant or revoke the `admin: true` Firebase custom claim on a target user.
@@ -697,6 +495,19 @@ exports.scheduledPhishnetLiveSetlistPoll = onSchedule(
         apiKey: String(key).trim(),
         logger,
         force: false,
+        // Inject rollup core so the poller can auto-finalize + rollup
+        // without going through the HTTPS callable path (#266). Only the
+        // scheduled path gets this: admin "Poll Now" keeps full manual
+        // control over finalize timing.
+        runRollup: ({ showDate: sd, trigger }) =>
+          runRollupForShow({
+            db,
+            admin,
+            showDate: sd,
+            callerUid: null,
+            trigger,
+            logger,
+          }),
       });
       results.push(result);
     }

--- a/functions/phishnetLiveSetlistAutomation.js
+++ b/functions/phishnetLiveSetlistAutomation.js
@@ -35,6 +35,56 @@ const BUSTOUT_MIN_GAP = 30;
 const MIN_SET1_ELAPSED_MS = 85 * 60_000;
 const SET1_IDLE_MS = 10 * 60_000;
 
+/**
+ * Auto-finalize thresholds (issue #266).
+ *
+ * - `AUTO_FINALIZE_IDLE_MS`: after an encore is reported, the show is
+ *   considered finished once no new song has been appended to the setlist
+ *   for this long. 25 min is well past the longest realistic encore
+ *   transition and still lands well inside the natural 3.5h post-encore
+ *   poll window.
+ * - `SHOW_SAFETY_CAP_MS`: hard cutoff from first observed row. Fires
+ *   finalize even without a detected encore as long as set 2 has at least
+ *   one song — protects against the rare Phish.net encore-posting delay.
+ */
+const AUTO_FINALIZE_IDLE_MS = 25 * 60_000;
+const SHOW_SAFETY_CAP_MS = 4.5 * 60 * 60_000;
+
+/**
+ * Pure decision function for the auto-finalize step — kept side-effect-free
+ * so it can be unit-tested directly without Firestore.
+ *
+ * @param {object} state
+ * @param {number} state.nowMs
+ * @param {number | null} state.firstRowObservedAtMs
+ * @param {number | null} state.lastRowsChangedAtMs
+ * @param {number} state.encoreSongsCount
+ * @param {number} state.set2Count
+ * @param {boolean} state.alreadyAutoFinalized — true if a prior poll stamped `autoFinalizedAt`.
+ * @returns {{ shouldFinalize: boolean, reason?: "encore-idle" | "safety-cap" }}
+ */
+function evaluateAutoFinalize(state) {
+  if (state.alreadyAutoFinalized) {
+    return { shouldFinalize: false };
+  }
+  if (!Number.isFinite(state.firstRowObservedAtMs)) {
+    return { shouldFinalize: false };
+  }
+  const idleSource = Number.isFinite(state.lastRowsChangedAtMs)
+    ? state.lastRowsChangedAtMs
+    : state.firstRowObservedAtMs;
+  const idleMs = state.nowMs - idleSource;
+  const elapsedMs = state.nowMs - state.firstRowObservedAtMs;
+
+  if (state.encoreSongsCount >= 1 && idleMs >= AUTO_FINALIZE_IDLE_MS) {
+    return { shouldFinalize: true, reason: "encore-idle" };
+  }
+  if (elapsedMs >= SHOW_SAFETY_CAP_MS && state.set2Count >= 1) {
+    return { shouldFinalize: true, reason: "safety-cap" };
+  }
+  return { shouldFinalize: false };
+}
+
 /** Normalize a song title for dedupe/compare (must match `normalizeSong` in scoring code). */
 function normalizeSongTitle(value) {
   return String(value ?? "").trim().toLowerCase();
@@ -450,6 +500,103 @@ async function fetchPhishnetSetlistForDate(showDate, apiKey) {
   return payload;
 }
 
+/**
+ * Side-effectful companion to `evaluateAutoFinalize`: when the pure check
+ * says "finalize now", invoke the injected rollup core and stamp
+ * `autoFinalizedAt` + `autoFinalizeTrigger` on the automation doc.
+ *
+ * Also handles the reconciliation case: when a show has already been
+ * auto-finalized and a new row-level change lands on a later poll (rare
+ * Phish.net post-show edit), re-run the rollup core with
+ * `trigger: "auto-reconcile"` so `users.totalPoints` reconciles against
+ * the new per-pick scores (delta-based math in `computePerPickRollup`).
+ *
+ * Returns a small summary object for logging. Never throws — rollup
+ * errors are logged and surfaced as `{ fired: false, error }` so a failing
+ * rollup does not break the surrounding poll.
+ */
+async function maybeAutoFinalize({
+  db: _db,
+  admin,
+  showDate,
+  automationRef,
+  runRollup,
+  logger,
+  nowMs,
+  firstRowObservedAtMs,
+  lastRowsChangedAtMs,
+  encoreSongsCount,
+  set2Count,
+  prevAutoFinalizedAtMs,
+  rowsChanged,
+}) {
+  if (!runRollup) {
+    return { fired: false, reason: "no-runner" };
+  }
+
+  const alreadyAutoFinalized = prevAutoFinalizedAtMs != null;
+
+  // Reconciliation: already finalized once, and Phish.net sent an edit
+  // (row-level change). Re-run rollup to reconcile users.totalPoints.
+  if (alreadyAutoFinalized && rowsChanged) {
+    try {
+      const result = await runRollup({
+        showDate,
+        trigger: "auto-reconcile",
+      });
+      return { fired: true, trigger: "auto-reconcile", result };
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      logger?.error?.("auto-finalize reconcile failed", { showDate, msg });
+      return { fired: false, trigger: "auto-reconcile", error: msg };
+    }
+  }
+
+  // Idempotency: already finalized, no new rows → nothing to do.
+  if (alreadyAutoFinalized) {
+    return { fired: false, reason: "already-finalized" };
+  }
+
+  const decision = evaluateAutoFinalize({
+    nowMs,
+    firstRowObservedAtMs,
+    lastRowsChangedAtMs,
+    encoreSongsCount,
+    set2Count,
+    alreadyAutoFinalized: false,
+  });
+  if (!decision.shouldFinalize) {
+    return { fired: false };
+  }
+
+  try {
+    const result = await runRollup({ showDate, trigger: "auto" });
+    // Stamp post-rollup so a rollup failure doesn't leave a misleading
+    // "already finalized" flag that would suppress future retries.
+    await automationRef.set(
+      {
+        autoFinalizedAt: admin.firestore.Timestamp.fromMillis(nowMs),
+        autoFinalizeTrigger: decision.reason,
+      },
+      { merge: true }
+    );
+    return {
+      fired: true,
+      trigger: "auto",
+      reason: decision.reason,
+      result,
+    };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logger?.error?.("auto-finalize run failed", {
+      showDate,
+      reason: decision.reason,
+      msg,
+    });
+    return { fired: false, trigger: "auto", error: msg };
+  }
+}
+
 async function pollSingleShowDate({
   db,
   admin,
@@ -458,6 +605,11 @@ async function pollSingleShowDate({
   logger,
   force = false,
   requestorEmail = null,
+  // Injected by `functions/index.js` so the poller can auto-finalize without
+  // going through the HTTPS callable path (#266). Left optional (null) so
+  // existing tests and any future caller that doesn't want auto-finalize
+  // keep working unchanged.
+  runRollup = null,
 }) {
   const started = Date.now();
   const automationRef = db.collection(LIVE_AUTOMATION_COLLECTION).doc(showDate);
@@ -551,10 +703,23 @@ async function pollSingleShowDate({
     };
     const nextPayload = buildSetlistDocFromRows(rows, prev, timingForBuild);
 
+    // Full-rows change detection (distinct from set-1 signature; used for
+    // #266 auto-finalize idle). A row-level change is any mismatch between
+    // the prior setlist-doc signature and the current one. On the very
+    // first poll (no prior signature), rows are considered changed.
+    const rowsChanged = prevSignature !== signature;
+    const prevLastRowsChangedAtMs = timestampToMs(automation.lastRowsChangedAt);
+    const lastRowsChangedAtMs = rowsChanged
+      ? nowMs
+      : prevLastRowsChangedAtMs != null
+      ? prevLastRowsChangedAtMs
+      : firstRowObservedAtMs;
+
     // Merge timing-state updates into every automation write below so the
     // next poll has monotonic anchors. Stamp `firstRowObservedAt` only on
     // first observation; update `lastSet1ChangeAt` + `set1TitleSignature`
-    // only when the set-1 title sequence actually changed.
+    // only when the set-1 title sequence actually changed; update
+    // `lastRowsChangedAt` whenever the full-rows signature changed.
     const timingStateUpdate = {
       ...(prevFirstRowObservedAtMs == null
         ? {
@@ -569,6 +734,37 @@ async function pollSingleShowDate({
             set1TitleSignature: currSet1Sig,
           }
         : {}),
+      ...(rowsChanged
+        ? {
+            lastRowsChangedAt: admin.firestore.Timestamp.fromMillis(nowMs),
+          }
+        : {}),
+    };
+
+    // Context for the #266 auto-finalize step (runs after either write
+    // branch below). Computed once to keep the two call sites consistent.
+    const prevAutoFinalizedAtMs = timestampToMs(automation.autoFinalizedAt);
+    const encoreSongsCount = Array.isArray(nextPayload.encoreSongs)
+      ? nextPayload.encoreSongs.length
+      : 0;
+    const set2Count = rows.reduce(
+      (n, r) => (r.setKey === "2" ? n + 1 : n),
+      0
+    );
+    const autoFinalizeContext = {
+      db,
+      admin,
+      showDate,
+      automationRef,
+      runRollup,
+      logger,
+      nowMs,
+      firstRowObservedAtMs,
+      lastRowsChangedAtMs,
+      encoreSongsCount,
+      set2Count,
+      prevAutoFinalizedAtMs,
+      rowsChanged,
     };
 
     // Use AND here (previously OR): once #264 timing can flip `s1c` without
@@ -590,7 +786,14 @@ async function pollSingleShowDate({
         },
         { merge: true }
       );
-      return { showDate, changed: false, updatedPicks: 0, reason: "unchanged" };
+      const autoFinalize = await maybeAutoFinalize(autoFinalizeContext);
+      return {
+        showDate,
+        changed: false,
+        updatedPicks: 0,
+        reason: "unchanged",
+        autoFinalize,
+      };
     }
 
     const setlistPayload = {
@@ -625,7 +828,14 @@ async function pollSingleShowDate({
     batch.set(setlistRef, setlistPayload, { merge: true });
     batch.set(automationRef, automationPayload, { merge: true });
     await batch.commit();
-    return { showDate, changed: true, updatedPicks: null, durationMs: Date.now() - started };
+    const autoFinalize = await maybeAutoFinalize(autoFinalizeContext);
+    return {
+      showDate,
+      changed: true,
+      updatedPicks: null,
+      durationMs: Date.now() - started,
+      autoFinalize,
+    };
   } catch (e) {
     const failureCount = Number(automation.failureCount || 0) + 1;
     const backoffMinutes = nextBackoffMinutes(failureCount);
@@ -661,12 +871,15 @@ async function pollSingleShowDate({
 }
 
 module.exports = {
+  AUTO_FINALIZE_IDLE_MS,
   BUSTOUT_MIN_GAP,
   MIN_SET1_ELAPSED_MS,
   SET1_IDLE_MS,
+  SHOW_SAFETY_CAP_MS,
   buildSetlistDocFromRows,
   candidateShowDates,
   deriveBustoutsFromRows,
+  evaluateAutoFinalize,
   fetchPhishnetSetlistForDate,
   getEtHour,
   isWithinLiveSetlistPollWindow,

--- a/functions/phishnetLiveSetlistAutomation.test.js
+++ b/functions/phishnetLiveSetlistAutomation.test.js
@@ -2,15 +2,19 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
+  AUTO_FINALIZE_IDLE_MS,
   BUSTOUT_MIN_GAP,
   MIN_SET1_ELAPSED_MS,
   SET1_IDLE_MS,
+  SHOW_SAFETY_CAP_MS,
   buildSetlistDocFromRows,
   candidateShowDates,
   deriveBustoutsFromRows,
+  evaluateAutoFinalize,
   isWithinLiveSetlistPollWindow,
   normalizeSetlistRows,
   parseShowCalendarSnapshotToDateSet,
+  pollSingleShowDate,
   randomScheduledPollDelayMs,
   scheduledCandidateShowDates,
   set1TitleSignatureFromRows,
@@ -519,4 +523,486 @@ test("buildSetlistDocFromRows: exact-threshold elapsed + idle fires (inclusive)"
     }
   );
   assert.equal(out.setlist.s1c, "Bathtub Gin");
+});
+
+// ---------- #266 auto-finalize ----------
+
+test("evaluateAutoFinalize: fires on encore + 25 min idle", () => {
+  const nowMs = 1_000_000_000_000;
+  const decision = evaluateAutoFinalize({
+    nowMs,
+    firstRowObservedAtMs: nowMs - (3 * 60 * 60_000), // 3h into show
+    lastRowsChangedAtMs: nowMs - AUTO_FINALIZE_IDLE_MS,
+    encoreSongsCount: 1,
+    set2Count: 6,
+    alreadyAutoFinalized: false,
+  });
+  assert.equal(decision.shouldFinalize, true);
+  assert.equal(decision.reason, "encore-idle");
+});
+
+test("evaluateAutoFinalize: encore but idle under threshold does not fire", () => {
+  const nowMs = 1_000_000_000_000;
+  const decision = evaluateAutoFinalize({
+    nowMs,
+    firstRowObservedAtMs: nowMs - (3 * 60 * 60_000),
+    lastRowsChangedAtMs: nowMs - (10 * 60_000),
+    encoreSongsCount: 1,
+    set2Count: 6,
+    alreadyAutoFinalized: false,
+  });
+  assert.equal(decision.shouldFinalize, false);
+});
+
+test("evaluateAutoFinalize: idle long but no encore does not fire (below safety cap)", () => {
+  const nowMs = 1_000_000_000_000;
+  const decision = evaluateAutoFinalize({
+    nowMs,
+    firstRowObservedAtMs: nowMs - (3 * 60 * 60_000),
+    lastRowsChangedAtMs: nowMs - (30 * 60_000),
+    encoreSongsCount: 0,
+    set2Count: 6,
+    alreadyAutoFinalized: false,
+  });
+  assert.equal(decision.shouldFinalize, false);
+});
+
+test("evaluateAutoFinalize: safety cap fires past 4h30m when set 2 has songs", () => {
+  const nowMs = 1_000_000_000_000;
+  const decision = evaluateAutoFinalize({
+    nowMs,
+    firstRowObservedAtMs: nowMs - SHOW_SAFETY_CAP_MS,
+    lastRowsChangedAtMs: nowMs - (5 * 60_000), // idle short — cap still fires
+    encoreSongsCount: 0,
+    set2Count: 1,
+    alreadyAutoFinalized: false,
+  });
+  assert.equal(decision.shouldFinalize, true);
+  assert.equal(decision.reason, "safety-cap");
+});
+
+test("evaluateAutoFinalize: safety cap does NOT fire if set 2 has no songs", () => {
+  const nowMs = 1_000_000_000_000;
+  const decision = evaluateAutoFinalize({
+    nowMs,
+    firstRowObservedAtMs: nowMs - SHOW_SAFETY_CAP_MS,
+    lastRowsChangedAtMs: nowMs - (60 * 60_000),
+    encoreSongsCount: 0,
+    set2Count: 0,
+    alreadyAutoFinalized: false,
+  });
+  assert.equal(decision.shouldFinalize, false);
+});
+
+test("evaluateAutoFinalize: skips when already auto-finalized", () => {
+  const nowMs = 1_000_000_000_000;
+  const decision = evaluateAutoFinalize({
+    nowMs,
+    firstRowObservedAtMs: nowMs - (3 * 60 * 60_000),
+    lastRowsChangedAtMs: nowMs - AUTO_FINALIZE_IDLE_MS,
+    encoreSongsCount: 1,
+    set2Count: 6,
+    alreadyAutoFinalized: true,
+  });
+  assert.equal(decision.shouldFinalize, false);
+});
+
+test("evaluateAutoFinalize: missing firstRowObservedAtMs → no fire", () => {
+  const nowMs = 1_000_000_000_000;
+  const decision = evaluateAutoFinalize({
+    nowMs,
+    firstRowObservedAtMs: null,
+    lastRowsChangedAtMs: nowMs - AUTO_FINALIZE_IDLE_MS,
+    encoreSongsCount: 1,
+    set2Count: 6,
+    alreadyAutoFinalized: false,
+  });
+  assert.equal(decision.shouldFinalize, false);
+});
+
+test("evaluateAutoFinalize: exact-threshold idle + encore fires (inclusive)", () => {
+  const nowMs = 1_000_000_000_000;
+  const decision = evaluateAutoFinalize({
+    nowMs,
+    firstRowObservedAtMs: nowMs - (3 * 60 * 60_000),
+    lastRowsChangedAtMs: nowMs - AUTO_FINALIZE_IDLE_MS,
+    encoreSongsCount: 1,
+    set2Count: 4,
+    alreadyAutoFinalized: false,
+  });
+  assert.equal(decision.shouldFinalize, true);
+});
+
+// ---------- #266 pollSingleShowDate integration with auto-finalize ----------
+
+/** Minimal Firestore/admin harness for `pollSingleShowDate` wiring tests. */
+function buildFakeFirestoreHarness(initialDocs = {}) {
+  /** @type {Map<string, Record<string, unknown>>} */
+  const docs = new Map(Object.entries(initialDocs));
+  /** @type {Array<{ path: string, data: Record<string, unknown>, merge: boolean }>} */
+  const writes = [];
+
+  function path(collection, id) {
+    return `${collection}/${id}`;
+  }
+
+  function makeRef(collection, id) {
+    const key = path(collection, id);
+    return {
+      path: key,
+      async get() {
+        const data = docs.get(key);
+        return {
+          exists: data !== undefined,
+          data: () => (data ? { ...data } : undefined),
+        };
+      },
+      async set(value, opts) {
+        const merge = Boolean(opts?.merge);
+        const prev = docs.get(key) || {};
+        const next = merge ? { ...prev, ...value } : { ...value };
+        docs.set(key, next);
+        writes.push({ path: key, data: { ...value }, merge });
+      },
+    };
+  }
+
+  const db = {
+    collection(name) {
+      return {
+        doc: (id) => makeRef(name, id),
+      };
+    },
+    batch() {
+      /** @type {Array<() => void>} */
+      const ops = [];
+      return {
+        set(ref, value, opts) {
+          ops.push(async () => {
+            await ref.set(value, opts);
+          });
+        },
+        async commit() {
+          for (const op of ops) {
+            await op();
+          }
+        },
+      };
+    },
+  };
+
+  const admin = {
+    firestore: {
+      Timestamp: {
+        fromMillis: (ms) => ({ _millis: ms, toMillis: () => ms }),
+        fromDate: (d) => ({
+          _millis: d.getTime(),
+          toMillis: () => d.getTime(),
+        }),
+      },
+      FieldValue: {
+        serverTimestamp: () => ({ _sentinel: "serverTimestamp" }),
+        delete: () => ({ _sentinel: "delete" }),
+        increment: (n) => ({ _sentinel: "increment", n }),
+      },
+    },
+  };
+
+  return { db, admin, docs, writes };
+}
+
+/** Build a Phish.net API JSON response envelope from a list of rows. */
+function phishnetResponseFromRows(rows) {
+  return { data: rows };
+}
+
+/** Minimal `fetch` stub mirroring what `fetchPhishnetSetlistForDate` consumes. */
+function makeFakeFetch(rows) {
+  const bodyText = JSON.stringify(phishnetResponseFromRows(rows));
+  return async () => ({
+    ok: true,
+    status: 200,
+    async text() {
+      return bodyText;
+    },
+  });
+}
+
+test("pollSingleShowDate: encore + idle triggers auto-finalize and stamps automation doc", async () => {
+  const showDate = "2026-07-03";
+  const nowMs = 1_000_000_000_000;
+  const firstRowMs = nowMs - 3 * 60 * 60_000; // 3h in
+  const lastRowsChangedMs = nowMs - AUTO_FINALIZE_IDLE_MS - 60_000; // idle past threshold
+
+  const signature = "pre-existing-signature"; // matches what the harness will produce
+  const rows = [
+    { set: "1", position: 1, song: "AC/DC Bag" },
+    { set: "1", position: 2, song: "Bathtub Gin" },
+    { set: "2", position: 1, song: "Tweezer" },
+    { set: "2", position: 2, song: "Simple" },
+    { set: "e", position: 1, song: "Loving Cup" },
+  ];
+  const normalized = normalizeSetlistRows({ data: rows });
+  const realSignature = signatureFromRows(normalized);
+
+  const initialSetlist = {
+    showDate,
+    status: "LIVE",
+    isScored: false,
+    setlist: { s1o: "AC/DC Bag", s2o: "Tweezer", enc: "Loving Cup" },
+    officialSetlist: { set1: [], set2: [], encore: [] },
+    encoreSongs: ["Loving Cup"],
+    sourceMeta: { signature: realSignature, songCount: rows.length },
+  };
+  const initialAutomation = {
+    showDate,
+    enabled: true,
+    firstRowObservedAt: { _millis: firstRowMs, toMillis: () => firstRowMs },
+    lastRowsChangedAt: {
+      _millis: lastRowsChangedMs,
+      toMillis: () => lastRowsChangedMs,
+    },
+  };
+
+  const harness = buildFakeFirestoreHarness({
+    [`official_setlists/${showDate}`]: initialSetlist,
+    [`live_setlist_automation/${showDate}`]: initialAutomation,
+  });
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = makeFakeFetch(rows);
+
+  let rollupCalled = null;
+  const runRollup = async ({ showDate: sd, trigger }) => {
+    rollupCalled = { showDate: sd, trigger };
+    return { processedPicks: 3, skippedPicks: 0, totalPicks: 3, setlistExists: true };
+  };
+
+  const originalNow = Date.now;
+  Date.now = () => nowMs;
+
+  try {
+    const result = await pollSingleShowDate({
+      db: harness.db,
+      admin: harness.admin,
+      showDate,
+      apiKey: "test-key",
+      logger: { info() {}, warn() {}, error() {} },
+      runRollup,
+    });
+
+    // Payload may differ from the prior doc (s1c/other built fields), so the
+    // write may take the "changed" branch even though the rows signature is
+    // identical. Auto-finalize should still fire because the prior
+    // `lastRowsChangedAt` anchor is preserved (rows signature unchanged).
+    assert.deepEqual(rollupCalled, { showDate, trigger: "auto" });
+
+    const autoStamp = harness.docs.get(`live_setlist_automation/${showDate}`);
+    assert.ok(
+      autoStamp?.autoFinalizedAt,
+      "automation doc should be stamped with autoFinalizedAt"
+    );
+    assert.equal(autoStamp.autoFinalizeTrigger, "encore-idle");
+    assert.equal(result.autoFinalize.fired, true);
+    assert.equal(result.autoFinalize.trigger, "auto");
+  } finally {
+    globalThis.fetch = originalFetch;
+    Date.now = originalNow;
+  }
+});
+
+test("pollSingleShowDate: idempotent — prior autoFinalizedAt + no row change = no rollup", async () => {
+  const showDate = "2026-07-03";
+  const nowMs = 1_000_000_000_000;
+  const firstRowMs = nowMs - 3 * 60 * 60_000;
+  const lastRowsChangedMs = nowMs - 30 * 60_000;
+  const autoFinalizedMs = nowMs - 5 * 60_000;
+
+  const rows = [
+    { set: "1", position: 1, song: "AC/DC Bag" },
+    { set: "2", position: 1, song: "Tweezer" },
+    { set: "e", position: 1, song: "Loving Cup" },
+  ];
+  const normalized = normalizeSetlistRows({ data: rows });
+  const realSignature = signatureFromRows(normalized);
+
+  const harness = buildFakeFirestoreHarness({
+    [`official_setlists/${showDate}`]: {
+      showDate,
+      sourceMeta: { signature: realSignature, songCount: rows.length },
+      encoreSongs: ["Loving Cup"],
+      setlist: { s1o: "AC/DC Bag", s2o: "Tweezer", enc: "Loving Cup" },
+      officialSetlist: { set1: [], set2: [], encore: [] },
+    },
+    [`live_setlist_automation/${showDate}`]: {
+      showDate,
+      enabled: true,
+      firstRowObservedAt: { _millis: firstRowMs, toMillis: () => firstRowMs },
+      lastRowsChangedAt: {
+        _millis: lastRowsChangedMs,
+        toMillis: () => lastRowsChangedMs,
+      },
+      autoFinalizedAt: {
+        _millis: autoFinalizedMs,
+        toMillis: () => autoFinalizedMs,
+      },
+      autoFinalizeTrigger: "encore-idle",
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = makeFakeFetch(rows);
+
+  let rollupCallCount = 0;
+  const runRollup = async () => {
+    rollupCallCount += 1;
+    return { processedPicks: 0, skippedPicks: 0, totalPicks: 0, setlistExists: true };
+  };
+
+  const originalNow = Date.now;
+  Date.now = () => nowMs;
+
+  try {
+    const result = await pollSingleShowDate({
+      db: harness.db,
+      admin: harness.admin,
+      showDate,
+      apiKey: "test-key",
+      logger: { info() {}, warn() {}, error() {} },
+      runRollup,
+    });
+
+    assert.equal(rollupCallCount, 0, "no rollup call expected on already-finalized no-change poll");
+    assert.equal(result.autoFinalize.fired, false);
+  } finally {
+    globalThis.fetch = originalFetch;
+    Date.now = originalNow;
+  }
+});
+
+test("pollSingleShowDate: post-finalize row change triggers auto-reconcile", async () => {
+  const showDate = "2026-07-03";
+  const nowMs = 1_000_000_000_000;
+  const firstRowMs = nowMs - 4 * 60 * 60_000;
+  const autoFinalizedMs = nowMs - 30 * 60_000;
+
+  const rows = [
+    { set: "1", position: 1, song: "AC/DC Bag" },
+    { set: "2", position: 1, song: "Tweezer" },
+    { set: "e", position: 1, song: "Loving Cup" },
+    { set: "e", position: 2, song: "Tweezer Reprise" },
+  ];
+
+  const harness = buildFakeFirestoreHarness({
+    [`official_setlists/${showDate}`]: {
+      showDate,
+      sourceMeta: { signature: "stale-signature", songCount: 3 },
+      encoreSongs: ["Loving Cup"],
+      setlist: { s1o: "AC/DC Bag", s2o: "Tweezer", enc: "Loving Cup" },
+      officialSetlist: { set1: [], set2: [], encore: [] },
+    },
+    [`live_setlist_automation/${showDate}`]: {
+      showDate,
+      enabled: true,
+      firstRowObservedAt: { _millis: firstRowMs, toMillis: () => firstRowMs },
+      autoFinalizedAt: {
+        _millis: autoFinalizedMs,
+        toMillis: () => autoFinalizedMs,
+      },
+      autoFinalizeTrigger: "encore-idle",
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = makeFakeFetch(rows);
+
+  let rollupCalled = null;
+  const runRollup = async ({ showDate: sd, trigger }) => {
+    rollupCalled = { showDate: sd, trigger };
+    return { processedPicks: 2, skippedPicks: 0, totalPicks: 2, setlistExists: true };
+  };
+
+  const originalNow = Date.now;
+  Date.now = () => nowMs;
+
+  try {
+    const result = await pollSingleShowDate({
+      db: harness.db,
+      admin: harness.admin,
+      showDate,
+      apiKey: "test-key",
+      logger: { info() {}, warn() {}, error() {} },
+      runRollup,
+    });
+
+    assert.equal(result.changed, true, "signature differs → changed branch");
+    assert.deepEqual(rollupCalled, { showDate, trigger: "auto-reconcile" });
+    assert.equal(result.autoFinalize.trigger, "auto-reconcile");
+  } finally {
+    globalThis.fetch = originalFetch;
+    Date.now = originalNow;
+  }
+});
+
+test("pollSingleShowDate: runRollup not injected → auto-finalize is a no-op", async () => {
+  const showDate = "2026-07-03";
+  const nowMs = 1_000_000_000_000;
+  const firstRowMs = nowMs - 3 * 60 * 60_000;
+  const lastRowsChangedMs = nowMs - AUTO_FINALIZE_IDLE_MS - 60_000;
+
+  const rows = [
+    { set: "1", position: 1, song: "AC/DC Bag" },
+    { set: "2", position: 1, song: "Tweezer" },
+    { set: "e", position: 1, song: "Loving Cup" },
+  ];
+  const normalized = normalizeSetlistRows({ data: rows });
+  const realSignature = signatureFromRows(normalized);
+
+  const harness = buildFakeFirestoreHarness({
+    [`official_setlists/${showDate}`]: {
+      showDate,
+      sourceMeta: { signature: realSignature, songCount: rows.length },
+      encoreSongs: ["Loving Cup"],
+      setlist: { s1o: "AC/DC Bag", s2o: "Tweezer", enc: "Loving Cup" },
+      officialSetlist: { set1: [], set2: [], encore: [] },
+    },
+    [`live_setlist_automation/${showDate}`]: {
+      showDate,
+      enabled: true,
+      firstRowObservedAt: { _millis: firstRowMs, toMillis: () => firstRowMs },
+      lastRowsChangedAt: {
+        _millis: lastRowsChangedMs,
+        toMillis: () => lastRowsChangedMs,
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = makeFakeFetch(rows);
+
+  const originalNow = Date.now;
+  Date.now = () => nowMs;
+
+  try {
+    const result = await pollSingleShowDate({
+      db: harness.db,
+      admin: harness.admin,
+      showDate,
+      apiKey: "test-key",
+      logger: { info() {}, warn() {}, error() {} },
+      // No runRollup — simulates the admin "Poll Now" path.
+    });
+
+    assert.equal(result.autoFinalize.fired, false);
+    assert.equal(result.autoFinalize.reason, "no-runner");
+    const autoStamp = harness.docs.get(`live_setlist_automation/${showDate}`);
+    assert.equal(
+      autoStamp.autoFinalizedAt,
+      undefined,
+      "no stamp should be written when runRollup absent"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    Date.now = originalNow;
+  }
 });

--- a/functions/rollupCore.js
+++ b/functions/rollupCore.js
@@ -1,0 +1,280 @@
+/**
+ * Rollup core (extracted from `rollupScoresForShow` callable in #266).
+ *
+ * Single source of truth for finalizing a show:
+ *   - Read `official_setlists/{showDate}` (authoritative snapshot).
+ *   - Recompute every matching pick's `score` via the same path as live
+ *     scoring (`calculateTotalScore`).
+ *   - Set `isGraded: true` (and `gradedAt` on first grade); increment
+ *     `users.totalPoints`, `showsPlayed`, `wins`, and `seasonStats.{tourKey}`
+ *     by the per-pick delta (`computePerPickRollup`).
+ *   - Write a `rollup_audit/{showDate}` record with the caller identity and
+ *     a `trigger` tag (`"manual"`, `"auto"`, or `"auto-reconcile"`).
+ *
+ * Callable wrapper (`functions/index.js::rollupScoresForShow`) passes
+ * `trigger: "manual"` and the admin UID. Scheduled poller passes
+ * `trigger: "auto"` (first finalize) or `"auto-reconcile"` (post-finalize
+ * re-run after a Phish.net edit) and `callerUid: null`.
+ *
+ * The per-pick math is delta-based so repeated invocations reconcile
+ * `users.totalPoints` rather than double-increment; this is why the same
+ * core is safe to invoke from both manual and automatic paths.
+ */
+
+const { calculateTotalScore, actualSetlistFromOfficialDoc } = require("./scoringCore");
+const {
+  computeGlobalMaxScore,
+  computePerPickRollup,
+  resolveTourKeyForDate,
+} = require("./rollupSeasonAggregates");
+
+/** Same invariant as `adminRollupApi.js` / `profileApi.js`. */
+const MAX_FIRESTORE_BATCH_WRITES = 500;
+
+/**
+ * @param {object} params
+ * @param {import("firebase-admin").firestore.Firestore} params.db
+ * @param {typeof import("firebase-admin")} params.admin
+ * @param {string} params.showDate YYYY-MM-DD.
+ * @param {string | null} [params.callerUid] Firebase UID of the caller (null for scheduler).
+ * @param {"manual" | "auto" | "auto-reconcile"} [params.trigger] Audit tag.
+ * @param {{ info?: Function, warn?: Function, error?: Function } | undefined} [params.logger]
+ * @returns {Promise<{ processedPicks: number, skippedPicks: number, totalPicks: number, setlistExists: boolean }>}
+ */
+async function runRollupForShow({
+  db,
+  admin,
+  showDate,
+  callerUid = null,
+  trigger = "manual",
+  logger = undefined,
+}) {
+  const setlistSnap = await db
+    .collection("official_setlists")
+    .doc(showDate)
+    .get();
+  if (!setlistSnap.exists) {
+    // Surfaced to the manual callable as `failed-precondition`; the auto
+    // path checks existence before invoking, so this branch is defensive.
+    return {
+      processedPicks: 0,
+      skippedPicks: 0,
+      totalPicks: 0,
+      setlistExists: false,
+    };
+  }
+  const setlistDoc = setlistSnap.data() || {};
+  const actualSetlist = actualSetlistFromOfficialDoc(setlistDoc);
+
+  const picksSnap = await db
+    .collection("picks")
+    .where("showDate", "==", showDate)
+    .get();
+
+  if (picksSnap.empty) {
+    await writeRollupAuditDoc({
+      db,
+      admin,
+      showDate,
+      processedPicks: 0,
+      skippedPicks: 0,
+      totalPicks: 0,
+      callerUid,
+      trigger,
+      logger,
+    });
+    logger?.info?.("runRollupForShow", {
+      showDate,
+      trigger,
+      processedPicks: 0,
+      skippedPicks: 0,
+      totalPicks: 0,
+      callerUid,
+    });
+    return {
+      processedPicks: 0,
+      skippedPicks: 0,
+      totalPicks: 0,
+      setlistExists: true,
+    };
+  }
+
+  // Load show calendar once for `showDate` → `tourKey` (#244). If the
+  // calendar is stale (missing the date), tour-scoped writes are skipped
+  // with a warn; global totals/wins still materialize.
+  const calendarSnap = await db.collection("show_calendar").doc("snapshot").get();
+  const showDatesByTour = calendarSnap.exists
+    ? (calendarSnap.data() || {}).showDatesByTour
+    : null;
+  const tourKey = resolveTourKeyForDate(showDate, showDatesByTour);
+  if (!tourKey) {
+    logger?.warn?.("runRollupForShow: tourKey missing for showDate", {
+      showDate,
+      trigger,
+    });
+  }
+
+  // Pre-compute every pick's new score to derive `newGlobalMax` before any
+  // write lands. Mirrors `src/shared/utils/showAggregation.js::reduceShowWinners`:
+  // only graded, non-empty picks owned by an authenticated user are eligible;
+  // `max === 0` credits nobody.
+  /** @type {Map<string, number>} */
+  const newScoresById = new Map();
+  const provisionalPicks = [];
+  for (const pickDoc of picksSnap.docs) {
+    const pickData = pickDoc.data() || {};
+    if (!pickData.userId) continue;
+    const userPicks = pickData.picks || {};
+    newScoresById.set(
+      pickDoc.id,
+      calculateTotalScore(userPicks, actualSetlist)
+    );
+    provisionalPicks.push({ id: pickDoc.id, ...pickData, isGraded: true });
+  }
+  const newGlobalMax = computeGlobalMaxScore(provisionalPicks, newScoresById);
+
+  // Two writes per pick (pick doc + user doc, merged) — 500-op batch limit.
+  const OPS_PER_PICK = 2;
+  let batch = db.batch();
+  let opCount = 0;
+  let processedPicks = 0;
+  let skippedPicks = 0;
+
+  for (const pickDoc of picksSnap.docs) {
+    const pickData = pickDoc.data() || {};
+    if (!pickData.userId) {
+      skippedPicks += 1;
+      continue;
+    }
+    if (opCount + OPS_PER_PICK > MAX_FIRESTORE_BATCH_WRITES) {
+      await batch.commit();
+      batch = db.batch();
+      opCount = 0;
+    }
+    const newScore = newScoresById.get(pickDoc.id) || 0;
+    const plan = computePerPickRollup({
+      pickData,
+      newScore,
+      newGlobalMax,
+    });
+
+    const pickUpdate = {
+      score: newScore,
+      isGraded: true,
+      winCredited: plan.newIsWin,
+    };
+    if (plan.isFirstGrade) {
+      pickUpdate.gradedAt = admin.firestore.FieldValue.serverTimestamp();
+    }
+    batch.update(pickDoc.ref, pickUpdate);
+
+    const userUpdate = {
+      totalPoints: admin.firestore.FieldValue.increment(plan.scoreDiff),
+      showsPlayed: admin.firestore.FieldValue.increment(
+        plan.isFirstGrade ? 1 : 0
+      ),
+      wins: admin.firestore.FieldValue.increment(plan.winsDelta),
+      seasonStatsSnapshotAt: admin.firestore.FieldValue.serverTimestamp(),
+      seasonStatsThroughShow: showDate,
+    };
+    if (tourKey) {
+      userUpdate.seasonStats = {
+        [tourKey]: {
+          totalPoints: admin.firestore.FieldValue.increment(plan.scoreDiff),
+          shows: admin.firestore.FieldValue.increment(
+            plan.isFirstGrade ? 1 : 0
+          ),
+          wins: admin.firestore.FieldValue.increment(plan.winsDelta),
+        },
+      };
+    }
+    batch.set(
+      db.collection("users").doc(pickData.userId),
+      userUpdate,
+      { merge: true }
+    );
+    opCount += OPS_PER_PICK;
+    processedPicks += 1;
+  }
+
+  if (opCount > 0) {
+    await batch.commit();
+  }
+
+  const totalPicks = picksSnap.size;
+  await writeRollupAuditDoc({
+    db,
+    admin,
+    showDate,
+    processedPicks,
+    skippedPicks,
+    totalPicks,
+    callerUid,
+    trigger,
+    logger,
+  });
+  logger?.info?.("runRollupForShow", {
+    showDate,
+    trigger,
+    processedPicks,
+    skippedPicks,
+    totalPicks,
+    callerUid,
+  });
+
+  return {
+    processedPicks,
+    skippedPicks,
+    totalPicks,
+    setlistExists: true,
+  };
+}
+
+/**
+ * Append-style audit write for every rollup invocation.
+ *
+ * Standalone top-level collection (not under `official_setlists`) so it never
+ * re-triggers `gradePicksOnSetlistWrite`. Soft-fails so a transient audit
+ * write failure never loses a successful grading pass.
+ */
+async function writeRollupAuditDoc({
+  db,
+  admin,
+  showDate,
+  processedPicks,
+  skippedPicks,
+  totalPicks,
+  callerUid,
+  trigger,
+  logger,
+}) {
+  try {
+    await db
+      .collection("rollup_audit")
+      .doc(showDate)
+      .set(
+        {
+          lastRolledUpAt: admin.firestore.FieldValue.serverTimestamp(),
+          processedPicks,
+          skippedPicks,
+          totalPicks,
+          callerUid: callerUid || null,
+          trigger: trigger || "manual",
+        },
+        { merge: true }
+      );
+  } catch (e) {
+    const msg = e?.message || String(e);
+    logger?.warn?.("runRollupForShow.auditWrite failed", {
+      showDate,
+      trigger,
+      msg,
+    });
+  }
+}
+
+module.exports = {
+  MAX_FIRESTORE_BATCH_WRITES,
+  runRollupForShow,
+  writeRollupAuditDoc,
+};


### PR DESCRIPTION
Closes #266

## Summary

Automate the last manual step in the setlist pipeline. The scheduled poller now runs the rollup core directly when a show reaches a confident \"done\" state, instead of waiting on an admin click.

**Triggers (either):**
- **encore-idle** — encore observed + no row-level change for ≥ 25 min (\`AUTO_FINALIZE_IDLE_MS\`)
- **safety-cap** — ≥ 4h 30m (\`SHOW_SAFETY_CAP_MS\`) since first observed row AND set 2 has ≥ 1 song (covers rare Phish.net encore-posting delays)

**Refactor:** rollup body lifted verbatim out of the \`rollupScoresForShow\` callable into \`functions/rollupCore.js::runRollupForShow\`. Manual callable becomes a thin wrapper (\`trigger: \"manual\"\`). Scheduled poll injects the same core (\`trigger: \"auto\"\`). Admin \"Poll Now\" (\`pollLiveSetlistNow\`) does **not** inject it — admins actively monitoring a show keep full control over finalize timing by design.

**Idempotency + reconciliation:**
- First trigger stamps \`autoFinalizedAt\` + \`autoFinalizeTrigger\` on \`live_setlist_automation/{showDate}\` post-rollup. Subsequent no-change polls skip.
- If Phish.net edits a setlist after auto-finalize has fired (rare but possible inside the ~3.5h post-encore poll window), the next changed-rows poll re-invokes rollup with \`trigger: \"auto-reconcile\"\`. Delta-based math in \`computePerPickRollup\` reconciles \`users.totalPoints/showsPlayed/wins\` rather than double-incrementing.

**Manual finalize still works unchanged:**
- Click early → pre-empts auto-finalize (rollup_audit exists; auto path skips).
- Click after auto-finalize to correct a bad setlist → delta reconciles identically to the auto-reconcile path.

**Observability:** \`rollup_audit/{showDate}\` gains a \`trigger\` field (\`\"manual\"\`/\`\"auto\"\`/\`\"auto-reconcile\"\`).

**New automation-doc state:**
| Field | Role |
|-------|------|
| \`lastRowsChangedAt\` | Drives idle calc; independent of PR #264's set-1-specific \`lastSet1ChangeAt\`. |
| \`autoFinalizedAt\` | Stamped post-rollup, gates future firings. |
| \`autoFinalizeTrigger\` | \`\"encore-idle\"\` or \`\"safety-cap\"\`. |

## Tests

Local matrix green:
- \`functions\`: 123 pass (+12 — 8 new pure \`evaluateAutoFinalize\` cases, 4 new integration tests)
- \`vitest\`: 118 pass (unchanged)
- \`lint\`, \`verify:dashboard-meta\`, \`verify:dashboard-ui\`, \`verify:theme-contract\`: green

Integration tests exercise \`pollSingleShowDate\` end-to-end against a minimal fake Firestore + \`fetch\` stub, covering:
1. Encore + idle triggers rollup with \`trigger: \"auto\"\` and stamps \`autoFinalizedAt\`.
2. Prior \`autoFinalizedAt\` + no row change → zero rollup calls.
3. Post-finalize row change → rollup called with \`trigger: \"auto-reconcile\"\`.
4. \`runRollup\` not injected (admin Poll Now path) → auto-finalize is a no-op.

## Test plan

- [ ] CI matrix green: \`verify\`, \`functions\`, \`rules\`, Vercel preview.
- [ ] Next time a show is live, confirm on the \`live_setlist_automation/{showDate}\` doc that \`lastRowsChangedAt\` ticks with every new song, \`autoFinalizedAt\` + \`autoFinalizeTrigger\` appear ~25 min after the encore settles, and \`rollup_audit/{showDate}.trigger\` is \`\"auto\"\`.
- [ ] Spot-check that manual \"Finalize & Rollup Points\" still works on a show that has NOT yet auto-finalized (should pre-empt) and on one that HAS (should reconcile).

## Related

- PR 1 of the setlist-automation pair: #265 (time-gated set 1 closer).
- Docs updated: \`docs/OFFICIAL_SETLISTS_SCHEMA.md\`.

Made with [Cursor](https://cursor.com)