### PR TITLE
feat(pools): backfill pick pool snapshot on create and join

### DIFF
--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -63,7 +63,7 @@ export default function DashboardLayout() {
   const [searchParams] = useSearchParams();
   const { user, isAdmin } = useAuth();
   const { showDates, showDatesByTour } = useShowCalendar();
-  usePendingPoolJoin();
+  usePendingPoolJoin(showDates);
   
   const scrollDirection = useScrollDirection(); 
 

--- a/src/features/picks/api/picksApi.js
+++ b/src/features/picks/api/picksApi.js
@@ -1,4 +1,5 @@
 import {
+  arrayUnion,
   collection,
   doc,
   getDoc,
@@ -6,6 +7,7 @@ import {
   query,
   setDoc,
   where,
+  writeBatch,
 } from 'firebase/firestore';
 
 import { db } from '../../../shared/lib/firebase';
@@ -87,6 +89,77 @@ export async function fetchPoolsSnapshotForPick(userId) {
     id: poolDoc.id,
     name: poolDoc.data().name,
   }));
+}
+
+const BACKFILL_READ_CHUNK = 40;
+const BACKFILL_BATCH_MAX = 400;
+
+/**
+ * Normalize calendar entries to `YYYY-MM-DD` strings.
+ * @param {Array<string | { date?: string }> | null | undefined} showDates
+ * @returns {string[]}
+ */
+function normalizeCalendarDates(showDates) {
+  if (!Array.isArray(showDates)) return [];
+  return showDates
+    .map((s) =>
+      typeof s === 'string' ? s.trim() : String(s?.date ?? '').trim()
+    )
+    .filter(Boolean);
+}
+
+/**
+ * After creating or joining a pool, merge `{ id, name }` into `pools` on every
+ * existing pick doc for this user across the season calendar. Idempotent via
+ * {@link arrayUnion}. Picks saved before the pool existed otherwise stay
+ * invisible to `pickDataCountsForPool` / pool standings.
+ *
+ * Failures are swallowed by callers (pool membership still succeeds); this
+ * only repairs snapshot alignment.
+ *
+ * @param {string} userId
+ * @param {{ id: string, name?: string }} pool
+ * @param {Array<string | { date?: string }> | null | undefined} showDates
+ */
+export async function arrayUnionPoolOntoUserPickDocs(userId, pool, showDates) {
+  const uid = userId?.trim();
+  const pid = pool?.id?.trim();
+  if (!uid || !pid) return;
+
+  const dates = normalizeCalendarDates(showDates);
+  if (dates.length === 0) return;
+
+  const poolEntry = { id: pid, name: pool.name?.trim() ?? '' };
+
+  for (let i = 0; i < dates.length; i += BACKFILL_READ_CHUNK) {
+    const chunkDates = dates.slice(i, i + BACKFILL_READ_CHUNK);
+    const snaps = await Promise.all(
+      chunkDates.map((d) =>
+        getDoc(doc(db, 'picks', getPickDocumentId(d, uid)))
+      )
+    );
+
+    let batch = writeBatch(db);
+    let pending = 0;
+
+    const flush = async () => {
+      if (pending === 0) return;
+      await batch.commit();
+      batch = writeBatch(db);
+      pending = 0;
+    };
+
+    for (let j = 0; j < snaps.length; j += 1) {
+      if (!snaps[j].exists()) continue;
+      const ref = doc(db, 'picks', getPickDocumentId(chunkDates[j], uid));
+      batch.update(ref, { pools: arrayUnion(poolEntry) });
+      pending += 1;
+      if (pending >= BACKFILL_BATCH_MAX) {
+        await flush();
+      }
+    }
+    await flush();
+  }
 }
 
 /**

--- a/src/features/picks/index.js
+++ b/src/features/picks/index.js
@@ -1,3 +1,4 @@
+export { arrayUnionPoolOntoUserPickDocs } from './api/picksApi';
 export { default as PastShowLockBanner } from './ui/PastShowLockBanner';
 export { default as TooEarlyBanner } from './ui/TooEarlyBanner';
 export { default as PicksFieldsForm } from './ui/PicksFieldsForm';

--- a/src/features/pool-invite/api/joinPool.js
+++ b/src/features/pool-invite/api/joinPool.js
@@ -2,12 +2,12 @@ import { joinPool as joinPoolFromPools } from '../../pools';
 
 /**
  * Join via invite code for the deep-link flow.
- * @param {{ userId: string, inviteCode: string }} params
+ * @param {{ userId: string, inviteCode: string, showDates?: Array<string | { date?: string }> }} params
  * @returns {Promise<'joined' | 'already-member' | 'invalid-code' | 'pool-full'>}
  */
-export async function joinPoolByInviteCode({ userId, inviteCode }) {
+export async function joinPoolByInviteCode({ userId, inviteCode, showDates }) {
   try {
-    await joinPoolFromPools({ userId, inviteCode });
+    await joinPoolFromPools({ userId, inviteCode, showDates });
     return 'joined';
   } catch (err) {
     if (err?.code === 'invalid-invite-code') return 'invalid-code';

--- a/src/features/pool-invite/model/usePendingPoolJoin.js
+++ b/src/features/pool-invite/model/usePendingPoolJoin.js
@@ -14,7 +14,10 @@ import { POOL_INVITE_STORAGE_KEY } from '../config';
 /** Prevents duplicate join attempts when React Strict Mode double-invokes effects. */
 let pendingJoinKeyInFlight = null;
 
-export function usePendingPoolJoin() {
+/**
+ * @param {Array<string | { date?: string }>} showDates Season calendar dates for pick-doc pool snapshot backfill after join.
+ */
+export function usePendingPoolJoin(showDates = []) {
   const { userId } = useAuthSession();
   const navigate = useNavigate();
 
@@ -35,6 +38,7 @@ export function usePendingPoolJoin() {
         const outcome = await joinPoolByInviteCode({
           userId,
           inviteCode: code,
+          showDates,
         });
 
         if (outcome === 'joined') {
@@ -63,5 +67,5 @@ export function usePendingPoolJoin() {
         pendingJoinKeyInFlight = null;
       }
     })();
-  }, [userId, navigate]);
+  }, [userId, navigate, showDates]);
 }

--- a/src/features/pools/api/poolFirestore.js
+++ b/src/features/pools/api/poolFirestore.js
@@ -12,6 +12,19 @@ function pickDocId(showDate, userId) {
 
 /**
  * Whether a pick document should count toward this pool (snapshot or legacy).
+ *
+ * Pool standings, the active-show pool view, and the server-side pool
+ * delete path all gate inclusion on `pick.pools` (the snapshot of which
+ * pools the author belonged to at pick-save time). After pool **create**
+ * or **join**, `arrayUnionPoolOntoUserPickDocs` (picks API) merges the
+ * pool into that user's existing pick docs for the season calendar so
+ * pre-create / pre-join graded picks count for that pool.
+ *
+ * Legacy fallback: pick docs written before snapshots were introduced
+ * (no `pools` field, or `pools: []`) count for every pool the user is
+ * currently a member of — there is no other signal available for those
+ * rows.
+ *
  * @param {Record<string, unknown>} pickData
  * @param {string} poolId
  */
@@ -47,6 +60,18 @@ export async function updatePoolStatusApi(poolId, status) {
 }
 
 /**
+ * Compute pool-scoped totals (points, showsPlayed, wins) for each
+ * current member across the given show dates.
+ *
+ * Pool inclusion is gated by `pickDataCountsForPool`: a pick counts if
+ * the pool id appears in `pick.pools` (including after create/join
+ * backfill). This keeps pool leaderboards pool-specific rather than
+ * mirroring global standings.
+ *
+ * Wins follow the shared "overall winner of the night" rule restricted
+ * to picks that count for this pool: per show, max score across the
+ * pool's qualifying picks; ties share; `max === 0` credits no one.
+ *
  * @param {string} poolId
  * @param {string[]} memberIds
  * @param {{ date: string }[]} showDates

--- a/src/features/pools/api/poolsApi.js
+++ b/src/features/pools/api/poolsApi.js
@@ -8,6 +8,7 @@ import {
   writeBatch,
 } from 'firebase/firestore';
 
+import { arrayUnionPoolOntoUserPickDocs } from '../../picks';
 import { db } from '../../../shared/lib/firebase';
 
 function generateInviteCode() {
@@ -36,7 +37,10 @@ export async function fetchPools(userId) {
     .filter((p) => p.status !== 'archived');
 }
 
-export async function createPool({ userId, name }) {
+/**
+ * @param {{ userId: string, name: string, showDates?: Array<string | { date?: string }> }} params
+ */
+export async function createPool({ userId, name, showDates }) {
   const trimmedName = name?.trim();
   if (!userId || !trimmedName) {
     throw new Error('Missing required create pool fields.');
@@ -67,13 +71,26 @@ export async function createPool({ userId, name }) {
   );
   await batch.commit();
 
+  try {
+    await arrayUnionPoolOntoUserPickDocs(
+      userId,
+      { id: poolRef.id, name: trimmedName },
+      showDates
+    );
+  } catch (e) {
+    console.error('createPool: pick snapshot backfill failed:', e);
+  }
+
   return {
     id: poolRef.id,
     ...poolPayload,
   };
 }
 
-export async function joinPool({ userId, inviteCode }) {
+/**
+ * @param {{ userId: string, inviteCode: string, showDates?: Array<string | { date?: string }> }} params
+ */
+export async function joinPool({ userId, inviteCode, showDates }) {
   const normalizedCode = inviteCode?.trim().toUpperCase();
   if (!userId || !normalizedCode) {
     throw new Error('Missing required join pool fields.');
@@ -129,6 +146,22 @@ export async function joinPool({ userId, inviteCode }) {
     { merge: true }
   );
   await batch.commit();
+
+  try {
+    await arrayUnionPoolOntoUserPickDocs(
+      userId,
+      {
+        id: poolDoc.id,
+        name:
+          typeof poolData.name === 'string' && poolData.name.trim()
+            ? poolData.name.trim()
+            : '',
+      },
+      showDates
+    );
+  } catch (e) {
+    console.error('joinPool: pick snapshot backfill failed:', e);
+  }
 
   return {
     id: poolDoc.id,

--- a/src/features/pools/model/useUserPools.js
+++ b/src/features/pools/model/useUserPools.js
@@ -7,7 +7,12 @@ import {
 } from '../api/poolsApi';
 import { subscribeUserPoolsInvalidate } from './userPoolsRefreshBus';
 
-export default function useUserPools(userId) {
+/**
+ * @param {string | undefined} userId
+ * @param {{ showDates?: Array<string | { date?: string }> }} [options] Calendar dates used to backfill `pick.pools` after create/join.
+ */
+export default function useUserPools(userId, options = {}) {
+  const { showDates = [] } = options;
   const [pools, setPools] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -48,7 +53,7 @@ export default function useUserPools(userId) {
       setLoading(true);
       setError(null);
       try {
-        const createdPool = await createPoolApi({ userId, name });
+        const createdPool = await createPoolApi({ userId, name, showDates });
         setPools((prev) => [...prev, createdPool]);
         return createdPool;
       } catch (err) {
@@ -58,7 +63,7 @@ export default function useUserPools(userId) {
         setLoading(false);
       }
     },
-    [userId]
+    [userId, showDates]
   );
 
   const handleJoin = useCallback(
@@ -66,7 +71,7 @@ export default function useUserPools(userId) {
       setLoading(true);
       setError(null);
       try {
-        const joinedPool = await joinPoolApi({ userId, inviteCode });
+        const joinedPool = await joinPoolApi({ userId, inviteCode, showDates });
         setPools((prev) => {
           if (prev.some((pool) => pool.id === joinedPool.id)) return prev;
           return [...prev, joinedPool];
@@ -79,7 +84,7 @@ export default function useUserPools(userId) {
         setLoading(false);
       }
     },
-    [userId]
+    [userId, showDates]
   );
 
   return {

--- a/src/pages/pools/PoolsPage.jsx
+++ b/src/pages/pools/PoolsPage.jsx
@@ -17,7 +17,8 @@ import { getNextShow } from '../../shared/utils/timeLogic.js';
 export default function Pools({ user }) {
   const { showDates } = useShowCalendar();
   const { pools, loading, error, handleJoin, handleCreate } = useUserPools(
-    user?.uid
+    user?.uid,
+    { showDates }
   );
   const nextShowDate = getNextShow(showDates).date;
   const {


### PR DESCRIPTION
## Summary
Pool standings use `pick.pools` (snapshot at save time). Users who created or joined a pool after already saving picks had no pool id on those docs, so they showed zero shows in pool all-time/tour standings. After successful **createPool** or **joinPool**, we now merge `{ id, name }` into `pools` on every existing `picks/{date}_{uid}` doc for the season calendar via Firestore `arrayUnion` (chunked reads and batches). Invite-link joins receive the same treatment by passing `showDates` from `DashboardLayout` into `usePendingPoolJoin`. Backfill failures are logged only; pool membership still succeeds.

## Test plan
- [ ] `npm run lint` and `npx vitest run` (green locally before push)
- [ ] Create a new pool after submitting picks for a past show; confirm pool standings show non-zero shows for the creator without manual Firestore edits
- [ ] Join a pool via invite after having picks on calendar dates; confirm standings include those shows for the joiner
- [ ] Smoke: existing pool hub standings and pending-invite join flow still work

Made with [Cursor](https://cursor.com)