### PR TITLE
feat(standings): clarify winner callouts and auto-select pools

### DIFF
--- a/docs/DASHBOARD_IA.md
+++ b/docs/DASHBOARD_IA.md
@@ -46,6 +46,7 @@ Rationale: **Entity-first** detail view without a second full-width display titl
 | **Tour standings** | Cumulative points / wins / shows scoped to the **current tour** via `show_calendar.showDatesByTour` (`TOUR_STANDINGS_HEADING`). Global on Standings (#219), pool-scoped on pool details (#148). |
 | **Season totals** | Legacy alias of **All-time standings** on pool details; retained as a `@deprecated` re-export while the pool-side migration (#148) lands. Avoid in new copy. |
 | **Tonight's winner / winners** | Standings "Overall winner of the night" banner (#218). Singular on a clean win, plural on ties — `tonightsWinnerHeading(winnerCount)` picks automatically. |
+| **Last show's winner / winners** | Standings callout for the prior tour night when the selected show is next or live; same global win rule as tonight — `lastShowWinnerHeading(winnerCount)`. |
 | **Wins** | For any scope (one show, a tour, all-time), the count of shows where a player ties/beats the global high score across every graded non-empty pick (`max === 0 → skip`). Same rule on Profile, Standings, Tour standings, and pool surfaces; implemented once in `src/shared/utils/showAggregation.js::reduceShowWinners`. |
 | **Pool details** | Screen for one pool: roster, invites, game status, archive links, All-time and Tour standings (`NAV_LABEL_POOL_DETAILS`). |
 

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -25,4 +25,5 @@ export { default as StandingsWinnerOfTheNightBanner } from './ui/StandingsWinner
 export { default as TourStandingsSection } from './ui/TourStandingsSection';
 export { resolveCurrentTour } from './model/resolveCurrentTour';
 export { useShowWinnerOfTheNight } from './model/useShowWinnerOfTheNight';
+export { usePreviousShowNightWinner } from './model/usePreviousShowNightWinner';
 export { useTourStandings } from './model/useTourStandings';

--- a/src/features/scoring/model/usePreviousShowNightWinner.js
+++ b/src/features/scoring/model/usePreviousShowNightWinner.js
@@ -1,0 +1,76 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { getShowBeforeDate, getShowStatus } from '../../../shared/utils/timeLogic.js';
+import { fetchPicksForShowDate } from '../api/standingsApi';
+import { computeShowWinnerOfTheNight } from './useShowWinnerOfTheNight.js';
+
+/**
+ * Global winner(s) of the **previous** tour night vs `selectedDate`, for
+ * Standings when the selected show is NEXT or LIVE (Option A).
+ *
+ * Reuses the same eligibility rules as {@link useShowWinnerOfTheNight}.
+ *
+ * @param {string | undefined} selectedDate — YYYY-MM-DD
+ * @param {{ date: string }[] | undefined} showDates
+ * @param {boolean} enabled — gate fetches (show/pools standings, NEXT/LIVE only)
+ */
+export function usePreviousShowNightWinner(selectedDate, showDates, enabled) {
+  const prevDate = useMemo(() => {
+    if (!enabled || !selectedDate || !Array.isArray(showDates) || showDates.length === 0) {
+      return null;
+    }
+    return getShowBeforeDate(selectedDate, showDates)?.date ?? null;
+  }, [selectedDate, showDates, enabled]);
+
+  const [picks, setPicks] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!prevDate || !Array.isArray(showDates) || showDates.length === 0) {
+      setPicks([]);
+      setLoading(false);
+      return;
+    }
+
+    const status = getShowStatus(prevDate, showDates);
+    if (status === 'FUTURE') {
+      setPicks([]);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    (async () => {
+      try {
+        const fetchedPicks = await fetchPicksForShowDate(prevDate);
+        if (cancelled) return;
+        setPicks(fetchedPicks);
+      } catch (err) {
+        if (!cancelled) {
+          console.error('Error fetching previous show standings:', err);
+          setPicks([]);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [prevDate, showDates]);
+
+  return useMemo(() => {
+    const { max, winners, eligiblePlayers, beats } = computeShowWinnerOfTheNight(picks);
+    return {
+      max,
+      winners,
+      eligiblePlayers,
+      beats,
+      loading,
+      prevDate,
+    };
+  }, [picks, loading, prevDate]);
+}

--- a/src/features/scoring/model/useShowWinnerOfTheNight.js
+++ b/src/features/scoring/model/useShowWinnerOfTheNight.js
@@ -34,7 +34,8 @@ export function computeShowWinnerOfTheNight(picks) {
  * (#219).
  *
  * Expects the full, un-filtered list of picks for a single show — the banner
- * is explicitly non-pool-scoped (pool-level winners live in pool details).
+ * is the **global** show winner (same row on Standings Show and Pools tabs;
+ * pool-only winners live in pool details).
  * Only picks with `isGraded === true` and at least one non-empty slot are
  * eligible, so the banner naturally stays hidden during live scoring until
  * the CF rollup runs.

--- a/src/features/scoring/model/useStandingsView.js
+++ b/src/features/scoring/model/useStandingsView.js
@@ -10,6 +10,7 @@ export const STANDINGS_VIEWS = Object.freeze(['show', 'tour', 'pools']);
 
 /** Default view when the URL has no `?view` query. */
 export const DEFAULT_STANDINGS_VIEW = 'show';
+const RECENT_STANDINGS_POOL_KEY = 'standings.recentPoolId';
 
 function isKnownView(v) {
   return typeof v === 'string' && STANDINGS_VIEWS.includes(v);
@@ -45,6 +46,45 @@ export function deriveStandingsView(query, userPools) {
     (p) => p && typeof p.id === 'string' && p.id === rawPool,
   );
   return { view, poolId: found ? rawPool : null };
+}
+
+/**
+ * Pick the default pool for the Pools view.
+ * - Prefer most-recent pool when it still exists.
+ * - Otherwise fall back to the first pool.
+ *
+ * @param {Array<{ id: string }> | null | undefined} userPools
+ * @param {string | null | undefined} recentPoolId
+ */
+export function deriveDefaultPoolId(userPools, recentPoolId) {
+  const ids = (userPools || [])
+    .map((p) => (p && typeof p.id === 'string' ? p.id : ''))
+    .filter(Boolean);
+  if (ids.length === 0) return null;
+  if (typeof recentPoolId === 'string' && ids.includes(recentPoolId)) {
+    return recentPoolId;
+  }
+  return ids[0];
+}
+
+function readRecentStandingsPoolId() {
+  if (typeof window === 'undefined') return null;
+  try {
+    const value = window.localStorage.getItem(RECENT_STANDINGS_POOL_KEY);
+    return typeof value === 'string' && value.trim() ? value.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeRecentStandingsPoolId(poolId) {
+  if (typeof window === 'undefined') return;
+  if (typeof poolId !== 'string' || !poolId.trim()) return;
+  try {
+    window.localStorage.setItem(RECENT_STANDINGS_POOL_KEY, poolId.trim());
+  } catch {
+    // Ignore storage write failures (private mode / blocked storage).
+  }
 }
 
 /**
@@ -163,6 +203,31 @@ export function useStandingsView({ userPools, navTargetPoolId } = {}) {
       { replace: true },
     );
   }, [view, rawPool, poolsById, setSearchParams]);
+
+  // In Pools view, auto-select a sensible default when no pool is selected.
+  useEffect(() => {
+    if (view !== 'pools') return;
+    if (poolId) return;
+    const defaultPoolId = deriveDefaultPoolId(userPools, readRecentStandingsPoolId());
+    if (!defaultPoolId) return;
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set('view', 'pools');
+        next.set('pool', defaultPoolId);
+        next.delete('poolId');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [view, poolId, userPools, setSearchParams]);
+
+  // Keep the most recently viewed Pools-selection for future visits.
+  useEffect(() => {
+    if (view !== 'pools') return;
+    if (!poolId) return;
+    writeRecentStandingsPoolId(poolId);
+  }, [view, poolId]);
 
   const setView = useCallback(
     (nextView) => {

--- a/src/features/scoring/model/useStandingsView.test.js
+++ b/src/features/scoring/model/useStandingsView.test.js
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_STANDINGS_VIEW,
   STANDINGS_VIEWS,
+  deriveDefaultPoolId,
   deriveStandingsView,
   normalizeView,
 } from './useStandingsView';
@@ -97,5 +98,31 @@ describe('deriveStandingsView', () => {
         [null, undefined, { id: null }, { id: 'pool-a' }],
       ),
     ).toEqual({ view: 'pools', poolId: 'pool-a' });
+  });
+});
+
+describe('deriveDefaultPoolId', () => {
+  const pools = [
+    { id: 'pool-a', name: 'A' },
+    { id: 'pool-b', name: 'B' },
+  ];
+
+  it('prefers the recent pool when still present', () => {
+    expect(deriveDefaultPoolId(pools, 'pool-b')).toBe('pool-b');
+  });
+
+  it('falls back to first pool when recent pool is missing', () => {
+    expect(deriveDefaultPoolId(pools, 'ghost')).toBe('pool-a');
+  });
+
+  it('returns null when there are no pools', () => {
+    expect(deriveDefaultPoolId([], 'pool-a')).toBeNull();
+    expect(deriveDefaultPoolId(null, 'pool-a')).toBeNull();
+  });
+
+  it('ignores malformed pool rows', () => {
+    expect(deriveDefaultPoolId([null, { id: null }, { id: 'pool-z' }], 'pool-a')).toBe(
+      'pool-z',
+    );
   });
 });

--- a/src/features/scoring/ui/Leaderboard.jsx
+++ b/src/features/scoring/ui/Leaderboard.jsx
@@ -8,6 +8,7 @@ const Leaderboard = ({
   title,
   headerEnd = null,
   selfUserId = null,
+  suppressLeadingCallout = false,
 }) => {
   const { sortedPicks, getPickPayload, expandedUser, toggleUserExpansion } = useLeaderboard(
     poolPicks,
@@ -25,6 +26,7 @@ const Leaderboard = ({
       title={title}
       headerEnd={headerEnd}
       selfUserId={selfUserId}
+      suppressLeadingCallout={suppressLeadingCallout}
     />
   );
 };

--- a/src/features/scoring/ui/LeaderboardList.jsx
+++ b/src/features/scoring/ui/LeaderboardList.jsx
@@ -18,6 +18,8 @@ export default function LeaderboardList({
   title = 'Everyone',
   headerEnd = null,
   selfUserId = null,
+  /** When true, hide the top “Leading this show” callout (e.g. Standings already shows “Tonight’s winner”). */
+  suppressLeadingCallout = false,
 }) {
   if (sortedPicks.length === 0) {
     return (
@@ -34,6 +36,7 @@ export default function LeaderboardList({
       ? calculateTotalScore(getPickPayload(leader), actualSetlist)
       : null;
   const showLeaderCallout =
+    !suppressLeadingCallout &&
     Boolean(actualSetlist && leader && leaderScore != null && sortedPicks.length > 0);
 
   return (

--- a/src/features/scoring/ui/StandingsPoolPicker.jsx
+++ b/src/features/scoring/ui/StandingsPoolPicker.jsx
@@ -5,8 +5,8 @@ import { Users } from 'lucide-react';
 import FilterPill from '../../../shared/ui/FilterPill';
 import PageTitle from '../../../shared/ui/PageTitle';
 
-const scrollRibbon =
-  'overflow-x-auto whitespace-nowrap [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden';
+const responsivePoolPillLayout =
+  'overflow-x-auto whitespace-nowrap [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden md:flex-wrap md:overflow-visible md:whitespace-normal';
 
 /**
  * Pool sub-selector for the Pools pill on `/dashboard/standings` (#255).
@@ -62,7 +62,7 @@ export default function StandingsPoolPicker({
       <PageTitle as="h3" variant="eyebrow" className="mb-2 px-2">
         Your pools
       </PageTitle>
-      <div className={`flex gap-1.5 px-1 pb-1 ${scrollRibbon}`}>
+      <div className={`flex gap-1.5 px-1 pb-1 ${responsivePoolPillLayout}`}>
         {pools.map((pool) => (
           <FilterPill
             key={pool.id}

--- a/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
+++ b/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
@@ -1,6 +1,9 @@
 import React, { Fragment } from 'react';
 
-import { tonightsWinnerHeading } from '../../../shared/config/dashboardVocabulary';
+import {
+  lastShowWinnerHeading,
+  tonightsWinnerHeading,
+} from '../../../shared/config/dashboardVocabulary';
 import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
 
 /**
@@ -22,14 +25,23 @@ import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
  *   } & Record<string, unknown>>,
  *   max: number | null,
  *   beats?: number,
+ *   variant?: 'tonight' | 'lastShow',
  * }} props
  */
-export default function StandingsWinnerOfTheNightBanner({ winners, max, beats = 0 }) {
+export default function StandingsWinnerOfTheNightBanner({
+  winners,
+  max,
+  beats = 0,
+  variant = 'tonight',
+}) {
   if (!Array.isArray(winners) || winners.length === 0 || max == null) {
     return null;
   }
 
-  const heading = tonightsWinnerHeading(winners.length);
+  const heading =
+    variant === 'lastShow'
+      ? lastShowWinnerHeading(winners.length)
+      : tonightsWinnerHeading(winners.length);
   const handlesLabel = winners.map((w) => w.handle || 'Anonymous').join(', ');
 
   return (

--- a/src/pages/standings/StandingsPage.jsx
+++ b/src/pages/standings/StandingsPage.jsx
@@ -15,6 +15,7 @@ import {
   TourStandingsSection,
   resolveCurrentTour,
   useDisplayedPicks,
+  usePreviousShowNightWinner,
   useShowWinnerOfTheNight,
   useStandings,
   useStandingsLeaderboardView,
@@ -69,11 +70,25 @@ export default function StandingsPage({ selectedDate }) {
 
   useStandingsLeaderboardView(selectedDate, loading, showDates);
 
-  const winnerOfTheNight = useShowWinnerOfTheNight(picks);
+  const globalWinnerOfTheNight = useShowWinnerOfTheNight(picks);
+  const poolWinnerOfTheNight = useShowWinnerOfTheNight(displayedPicks);
+  const winnerOfTheNight =
+    view === 'pools' && Boolean(poolId) ? poolWinnerOfTheNight : globalWinnerOfTheNight;
+  const showWinnerEligibleView =
+    view === 'show' || (view === 'pools' && Boolean(poolId));
   const showWinnerBanner =
-    view === 'show' &&
+    showWinnerEligibleView &&
     Boolean(actualSetlist) &&
     winnerOfTheNight.winners.length > 0;
+
+  const lastShowWinnerEnabled =
+    showWinnerEligibleView &&
+    (showStatus === 'NEXT' || showStatus === 'LIVE');
+  const previousShowWinner = usePreviousShowNightWinner(
+    selectedDate,
+    showDates,
+    lastShowWinnerEnabled,
+  );
 
   const currentTour = useMemo(
     () => resolveCurrentTour(selectedDate, todayYmd(), showDatesByTour),
@@ -148,6 +163,7 @@ export default function StandingsPage({ selectedDate }) {
           displayedPicks={displayedPicks}
           leaderboardTitle={leaderboardTitle}
           showWinnerBanner={showWinnerBanner}
+          previousShowWinner={previousShowWinner}
           winnerOfTheNight={winnerOfTheNight}
           activePoolName={activePoolName}
           selfUserId={user?.uid || null}
@@ -198,6 +214,7 @@ function ShowOrPoolView({
   displayedPicks,
   leaderboardTitle,
   showWinnerBanner,
+  previousShowWinner,
   winnerOfTheNight,
   activePoolName,
   selfUserId,
@@ -206,6 +223,9 @@ function ShowOrPoolView({
 }) {
   const isPoolsView = view === 'pools';
   const isShowView = view === 'show';
+
+  const showLastShowWinnerBanner =
+    !previousShowWinner.loading && previousShowWinner.winners.length > 0;
 
   if (isPoolsView && !poolId) {
     return (
@@ -245,6 +265,14 @@ function ShowOrPoolView({
   if (isShowView && showStatus === 'NEXT') {
     return (
       <>
+        {showLastShowWinnerBanner ? (
+          <StandingsWinnerOfTheNightBanner
+            variant="lastShow"
+            winners={previousShowWinner.winners}
+            max={previousShowWinner.max}
+            beats={previousShowWinner.beats}
+          />
+        ) : null}
         <StandingsActiveShowCard
           showLabel={showLabel}
           isShowToday={Boolean(isShowToday)}
@@ -261,6 +289,7 @@ function ShowOrPoolView({
               actualSetlist={actualSetlist}
               title={leaderboardTitle}
               selfUserId={selfUserId}
+              suppressLeadingCallout={Boolean(showWinnerBanner)}
             />
           </div>
         ) : null}
@@ -317,6 +346,15 @@ function ShowOrPoolView({
             Pool details
           </button>
         </div>
+      ) : null}
+
+      {showLastShowWinnerBanner ? (
+        <StandingsWinnerOfTheNightBanner
+          variant="lastShow"
+          winners={previousShowWinner.winners}
+          max={previousShowWinner.max}
+          beats={previousShowWinner.beats}
+        />
       ) : null}
 
       {showWinnerBanner ? (
@@ -377,6 +415,7 @@ function ShowOrPoolView({
           actualSetlist={actualSetlist}
           title={leaderboardTitle}
           selfUserId={selfUserId}
+          suppressLeadingCallout={Boolean(showWinnerBanner)}
         />
       )}
     </>

--- a/src/shared/config/dashboardVocabulary.js
+++ b/src/shared/config/dashboardVocabulary.js
@@ -103,3 +103,15 @@ export const TONIGHTS_WINNERS_PLURAL = "Tonight's winners";
 export function tonightsWinnerHeading(winnerCount) {
   return winnerCount > 1 ? TONIGHTS_WINNERS_PLURAL : TONIGHTS_WINNER_SINGULAR;
 }
+
+/** Standings callout for the prior tour night when the selected show is next or live. */
+export const LAST_SHOW_WINNER_SINGULAR = "Last show's winner";
+export const LAST_SHOW_WINNERS_PLURAL = "Last show's winners";
+
+/**
+ * @param {number} winnerCount
+ * @returns {string}
+ */
+export function lastShowWinnerHeading(winnerCount) {
+  return winnerCount > 1 ? LAST_SHOW_WINNERS_PLURAL : LAST_SHOW_WINNER_SINGULAR;
+}


### PR DESCRIPTION
Ensure winner messaging stays unambiguous by hiding "Leading this show" whenever winner banners are present, adding a "Last show's winner" callout for NEXT/LIVE contexts, and scoping Pools-view tonight winners to the selected pool. Improve Pools UX by auto-selecting a sensible default pool (recent or first) and wrapping pool pills on desktop to avoid empty space.

Made-with: Cursor