### PR TITLE
feat(setlist-automation): extend finalize window and add two-stage s1…

### DIFF
--- a/docs/OFFICIAL_SETLISTS_SCHEMA.md
+++ b/docs/OFFICIAL_SETLISTS_SCHEMA.md
@@ -39,9 +39,9 @@ Written on save from `saveOfficialSetlistByDate` (`src/features/admin/api/offici
 `s1c` is populated when **either**:
 
 1. Set 2 has started (original rule — live feeds list the current last song), **or**
-2. **Both** of these hold on a poll:
-   - Elapsed since the first observed row for this show ≥ **85 min** (`MIN_SET1_ELAPSED_MS`).
-   - No new set-1 song appended for ≥ **10 min** (`SET1_IDLE_MS`).
+2. A two-stage timing gate fires:
+   - **Provisional:** elapsed since first observed row ≥ **75 min** (`PROVISIONAL_SET1_ELAPSED_MS`) and no set-1 change for ≥ **8 min** (`PROVISIONAL_SET1_IDLE_MS`).
+   - **Confirmed:** elapsed since first observed row ≥ **85 min** (`CONFIRMED_SET1_ELAPSED_MS`) and no set-1 change for ≥ **12 min** (`CONFIRMED_SET1_IDLE_MS`).
 
 State used for (2) lives on `live_setlist_automation/{showDate}` and is written by `pollSingleShowDate`:
 
@@ -50,6 +50,9 @@ State used for (2) lives on `live_setlist_automation/{showDate}` and is written 
 | `firstRowObservedAt` | Timestamp of the first poll that saw any row for this show. Stamped once, never overwritten. |
 | `lastSet1ChangeAt` | Timestamp of the most recent poll where the set-1 title sequence changed. |
 | `set1TitleSignature` | sha256 of the set-1 title sequence; used to detect (2)'s idle reset without being sensitive to set-2/encore activity. |
+| `s1cStage` | Current two-stage closer state (`"provisional"` or `"confirmed"`); cleared when timing confidence drops and set 2 has not started. |
+| `s1cProvisionalAt` | Timestamp of the most recent transition into provisional stage. |
+| `s1cConfirmedAt` | Timestamp of the most recent transition into confirmed stage. |
 
 Long-set safeguard is inherent — `buildSetlistDocFromRows` re-derives `s1c` from rows every poll and does not preserve closers across writes, so an unusually long set 1 that plays another song after timing fires resets `lastSet1ChangeAt` and `s1c` rewrites to the new last song on the next poll where timing re-fires (or when set 2 starts, whichever first).
 
@@ -70,7 +73,7 @@ Additional automation-doc state used by auto-finalize:
 | `autoFinalizedAt` | Stamped when auto-finalize first runs rollup. Prevents double-firing. |
 | `autoFinalizeTrigger` | `"encore-idle"` or `"safety-cap"` — which rule fired. |
 
-**Reconciliation path:** if Phish.net edits a setlist after auto-finalize has fired (rare but possible within the ~3.5h post-encore poll window), the next changed-rows poll re-invokes `runRollupForShow` with `trigger: "auto-reconcile"`. The per-pick math in `computePerPickRollup` is delta-based, so `users.totalPoints` / `showsPlayed` / `wins` reconcile correctly rather than double-incrementing.
+**Reconciliation path:** if Phish.net edits a setlist after auto-finalize has fired (rare but possible within the ~4.5h post-encore poll window), the next changed-rows poll re-invokes `runRollupForShow` with `trigger: "auto-reconcile"`. The per-pick math in `computePerPickRollup` is delta-based, so `users.totalPoints` / `showsPlayed` / `wins` reconcile correctly rather than double-incrementing.
 
 **Manual override / pre-emption:** the admin "Finalize & Rollup Points" button (`rollupScoresForShow` callable, `trigger: "manual"`) keeps full control:
 

--- a/docs/PHISHNET_CALLABLE_RUNBOOK.md
+++ b/docs/PHISHNET_CALLABLE_RUNBOOK.md
@@ -126,10 +126,10 @@ Deploy with **`npm run deploy:functions:phishnet`**, which deploys: `getPhishnet
 | Item | Location / value |
 |------|------------------|
 | Scheduled poller | `scheduledPhishnetLiveSetlistPoll` (`functions/index.js`) |
-| ET window | **4:00 PM–3:00 AM** `America/New_York` (hour ≥ 16 or hour < 3). Outside the window the job **no-ops** with **no** Phish.net HTTP calls. |
+| ET window | **4:00 PM–4:00 AM** `America/New_York` (hour ≥ 16 or hour < 4). Outside the window the job **no-ops** with **no** Phish.net HTTP calls. |
 | Cron wake | Every **3** minutes (`*/3 * * * *`, `America/New_York`). Actual spacing vs Phish.net is **3–5 minutes** per show date via `live_setlist_automation/{showDate}.nextPollAt` jitter after each **scheduled** fetch (success, no-change, or empty rows). |
 | Calendar (scheduled only) | **`show_calendar/snapshot.showDates`** — scheduled polling **only** considers dates in this set (strict). Missing/empty/unreadable snapshot → scheduled path skips (**no** Phish.net). |
-| Target dates (scheduled) | `scheduledCandidateShowDates` in `functions/phishnetLiveSetlistAutomation.js`: ET **today** if a show date; ET **yesterday** only in the **0:00–2:59 AM** ET slice **and** only if that date is still in the calendar (late encore / post-midnight updates). **Not** “compare two setlists” — each date is still diffed only against its own last saved payload/signature. |
+| Target dates (scheduled) | `scheduledCandidateShowDates` in `functions/phishnetLiveSetlistAutomation.js`: ET **today** if a show date; ET **yesterday** only in the **0:00–3:59 AM** ET slice **and** only if that date is still in the calendar (late encore / post-midnight updates). **Not** “compare two setlists” — each date is still diffed only against its own last saved payload/signature. |
 | Admin / force poll | `pollLiveSetlistNow` stays **unrestricted**: default still uses ET today + yesterday (`candidateShowDates`) with **no** calendar gate — recovery when the calendar is stale, you’re outside the ET window, or scheduled strict mode would skip. Optional explicit `showDate` unchanged. |
 | Pause/resume callable | `setLiveSetlistAutomationState` |
 | Manual recovery callable | `pollLiveSetlistNow` (forces one poll + one score recompute) |

--- a/functions/index.js
+++ b/functions/index.js
@@ -465,7 +465,7 @@ exports.scheduledPhishnetLiveSetlistPoll = onSchedule(
     }
     const now = new Date();
     if (!isWithinLiveSetlistPollWindow(now)) {
-      logger.info("scheduledPhishnetLiveSetlistPoll: outside 4pm–3am ET window; skip.");
+      logger.info("scheduledPhishnetLiveSetlistPoll: outside 4pm–4am ET window; skip.");
       return null;
     }
     const calSnap = await db.collection("show_calendar").doc("snapshot").get();

--- a/functions/phishnetLiveSetlistAutomation.js
+++ b/functions/phishnetLiveSetlistAutomation.js
@@ -11,29 +11,27 @@ const SLOT_KEYS = ["s1o", "s1c", "s2o", "s2c", "enc"];
 const BUSTOUT_MIN_GAP = 30;
 
 /**
- * Time-gated set 1 closer thresholds (issue #264).
+ * Two-stage set 1 closer thresholds (#264 follow-up).
  *
  * Phish.net v5 `/setlists/showdate` rows carry no per-song timestamps, so we
- * use our own poll clock as the only available time signal. `s1c` stays empty
- * until set 2 starts (original behavior) OR until BOTH:
- *   - set 1 has been running for at least `MIN_SET1_ELAPSED_MS` (elapsed
- *     since the first row was observed for this show), AND
- *   - no new set-1 song has been appended for at least `SET1_IDLE_MS`.
+ * use poll-time signals:
  *
- * 85 min is the low end of typical Phish set-1 durations (75–90 min window
- * observed over the last year); 10 min idle is longer than any realistic
- * within-set silence (jam + transition + next song) and shorter than typical
- * setbreak (20–30 min), so we reveal `s1c` ~10–15 min earlier than the
- * "wait for set 2" rule without risking a mid-set false positive.
+ * - Provisional stage: `s1c` can surface early once set 1 has run long enough
+ *   and set-1 rows have been idle for a shorter window.
+ * - Confirmed stage: stronger idle/elapsed threshold (or set 2 start).
  *
- * Long-set safeguard: `buildSetlistDocFromRows` re-derives `s1c` from rows
- * every poll and does not preserve closers across writes, so if set 1 keeps
- * going after timing fires, the next poll with a new set-1 row resets
- * `lastSet1ChangeAt`, and `s1c` rewrites to the new last song the next time
- * timing re-fires (or when set 2 starts, whichever is first).
+ * Long-set safeguard: `buildSetlistDocFromRows` re-derives `s1c` every poll
+ * and does not preserve closers across writes. If set 1 continues after a
+ * provisional/confirmed stamp, the next set-1 row resets idle and `s1c` clears
+ * until one of the stage conditions re-fires.
  */
-const MIN_SET1_ELAPSED_MS = 85 * 60_000;
-const SET1_IDLE_MS = 10 * 60_000;
+const PROVISIONAL_SET1_ELAPSED_MS = 75 * 60_000;
+const PROVISIONAL_SET1_IDLE_MS = 8 * 60_000;
+const CONFIRMED_SET1_ELAPSED_MS = 85 * 60_000;
+const CONFIRMED_SET1_IDLE_MS = 12 * 60_000;
+// Back-compat aliases used by tests/docs that referenced the original names.
+const MIN_SET1_ELAPSED_MS = PROVISIONAL_SET1_ELAPSED_MS;
+const SET1_IDLE_MS = PROVISIONAL_SET1_IDLE_MS;
 
 /**
  * Auto-finalize thresholds (issue #266).
@@ -41,7 +39,7 @@ const SET1_IDLE_MS = 10 * 60_000;
  * - `AUTO_FINALIZE_IDLE_MS`: after an encore is reported, the show is
  *   considered finished once no new song has been appended to the setlist
  *   for this long. 25 min is well past the longest realistic encore
- *   transition and still lands well inside the natural 3.5h post-encore
+ *   transition and still lands well inside the natural 4.5h post-encore
  *   poll window.
  * - `SHOW_SAFETY_CAP_MS`: hard cutoff from first observed row. Fires
  *   finalize even without a detected encore as long as set 2 has at least
@@ -124,12 +122,12 @@ function getEtHour(now = new Date()) {
 }
 
 /**
- * Live setlist scheduled polling window: 4:00 PM ET through 3:00 AM ET the next
- * calendar day (active when hour ≥ 16 or hour < 3, America/New_York wall clock).
+ * Live setlist scheduled polling window: 4:00 PM ET through 4:00 AM ET the next
+ * calendar day (active when hour ≥ 16 or hour < 4, America/New_York wall clock).
  */
 function isWithinLiveSetlistPollWindow(now = new Date()) {
   const h = getEtHour(now);
-  return h >= 16 || h < 3;
+  return h >= 16 || h < 4;
 }
 
 function ymdDaysAgo(ymd, days) {
@@ -175,9 +173,9 @@ function parseShowCalendarSnapshotToDateSet(snapshotData) {
  *
  * - Always consider ET "today" when it is a show date in the calendar set.
  * - Do not include "yesterday" by default (before local ET midnight).
- * - After local midnight ET (hours 0–2), also include "yesterday" when that date
+ * - After local midnight ET (hours 0–3), also include "yesterday" when that date
  *   is still a show date — same gig can receive encore/post-midnight updates until
- *   the 3 AM window end. This is **not** comparing two setlists: each `showDate`
+ *   the 4 AM window end. This is **not** comparing two setlists: each `showDate`
  *   doc is still diffed only against its own last saved official payload/signature.
  */
 function scheduledCandidateShowDates(now, calendarDateSet) {
@@ -186,10 +184,41 @@ function scheduledCandidateShowDates(now, calendarDateSet) {
   const hourEt = getEtHour(now);
   const out = [];
   if (calendarDateSet.has(etToday)) out.push(etToday);
-  if (hourEt >= 0 && hourEt < 3 && calendarDateSet.has(etYesterday)) {
+  if (hourEt >= 0 && hourEt < 4 && calendarDateSet.has(etYesterday)) {
     out.push(etYesterday);
   }
   return out;
+}
+
+/**
+ * @param {{
+ *   set1Count: number,
+ *   set2Count: number,
+ *   nowMs?: number | null,
+ *   firstRowObservedAtMs?: number | null,
+ *   lastSet1ChangeAtMs?: number | null,
+ * }} state
+ * @returns {"confirmed" | "provisional" | null}
+ */
+function evaluateSet1CloserStage(state) {
+  if (!Number.isFinite(state.set1Count) || state.set1Count <= 0) return null;
+  if (state.set2Count >= 1) return "confirmed";
+  if (
+    !Number.isFinite(state.nowMs) ||
+    !Number.isFinite(state.firstRowObservedAtMs) ||
+    !Number.isFinite(state.lastSet1ChangeAtMs)
+  ) {
+    return null;
+  }
+  const elapsedMs = state.nowMs - state.firstRowObservedAtMs;
+  const idleMs = state.nowMs - state.lastSet1ChangeAtMs;
+  if (elapsedMs >= CONFIRMED_SET1_ELAPSED_MS && idleMs >= CONFIRMED_SET1_IDLE_MS) {
+    return "confirmed";
+  }
+  if (elapsedMs >= PROVISIONAL_SET1_ELAPSED_MS && idleMs >= PROVISIONAL_SET1_IDLE_MS) {
+    return "provisional";
+  }
+  return null;
 }
 
 /** Uniform random delay in [3, 5] minutes — scheduled cadence jitter (issue #180). */
@@ -278,7 +307,8 @@ function normalizeSetlistRows(payload) {
  * @param {number | null} [timing.firstRowObservedAtMs] — epoch ms of the first poll that saw any row for this show.
  * @param {number | null} [timing.lastSet1ChangeAtMs] — epoch ms of the most recent poll where the set-1 title list changed.
  *
- * When `timing` is absent (or inputs are null), behavior matches pre-#264: `s1c` is populated only once set 2 starts.
+ * When `timing` is absent (or inputs are null), behavior falls back to
+ * "set 2 started = confirmed", matching pre-#264.
  */
 function buildSetlistDocFromRows(rows, existingDoc = {}, timing = null) {
   const officialSetlist = rows.map((r) => r.title).filter(Boolean);
@@ -297,22 +327,14 @@ function buildSetlistDocFromRows(rows, existingDoc = {}, timing = null) {
     .flatMap(([, arr]) => arr)
     .sort((a, b) => a.position - b.position);
 
-  /**
-   * Set 1 closer is considered known when either:
-   *  - set 2 has started (original rule), OR
-   *  - the set has run long enough AND no new set-1 song has been appended
-   *    for the idle threshold (see `MIN_SET1_ELAPSED_MS` / `SET1_IDLE_MS`).
-   */
-  const set1TimingClosed =
-    Boolean(set1?.length) &&
-    !set2?.length &&
-    timing != null &&
-    Number.isFinite(timing.nowMs) &&
-    Number.isFinite(timing.firstRowObservedAtMs) &&
-    Number.isFinite(timing.lastSet1ChangeAtMs) &&
-    timing.nowMs - timing.firstRowObservedAtMs >= MIN_SET1_ELAPSED_MS &&
-    timing.nowMs - timing.lastSet1ChangeAtMs >= SET1_IDLE_MS;
-  const set1Complete = Boolean(set2?.length) || set1TimingClosed;
+  const set1CloserStage = evaluateSet1CloserStage({
+    set1Count: set1?.length || 0,
+    set2Count: set2?.length || 0,
+    nowMs: timing?.nowMs,
+    firstRowObservedAtMs: timing?.firstRowObservedAtMs,
+    lastSet1ChangeAtMs: timing?.lastSet1ChangeAtMs,
+  });
+  const set1Complete = set1CloserStage != null;
   /** Set 2 closer is unknown until the encore has started. */
   const set2Complete = Boolean(encRows.length);
 
@@ -374,6 +396,7 @@ function buildSetlistDocFromRows(rows, existingDoc = {}, timing = null) {
     officialSetlist,
     encoreSongs,
     bustouts,
+    set1CloserStage,
   };
 }
 
@@ -715,11 +738,46 @@ async function pollSingleShowDate({
       ? prevLastRowsChangedAtMs
       : firstRowObservedAtMs;
 
+    const prevSet1CloserStage =
+      automation.s1cStage === "provisional" || automation.s1cStage === "confirmed"
+        ? automation.s1cStage
+        : null;
+    const nextSet1CloserStage =
+      nextPayload.set1CloserStage === "provisional" ||
+      nextPayload.set1CloserStage === "confirmed"
+        ? nextPayload.set1CloserStage
+        : null;
+    const set1CloserStateUpdate =
+      nextSet1CloserStage == null
+        ? prevSet1CloserStage
+          ? {
+              s1cStage: admin.firestore.FieldValue.delete(),
+              s1cProvisionalAt: admin.firestore.FieldValue.delete(),
+              s1cConfirmedAt: admin.firestore.FieldValue.delete(),
+            }
+          : {}
+        : {
+            s1cStage: nextSet1CloserStage,
+            ...(nextSet1CloserStage === "provisional" &&
+            prevSet1CloserStage !== "provisional"
+              ? {
+                  s1cProvisionalAt: admin.firestore.Timestamp.fromMillis(nowMs),
+                }
+              : {}),
+            ...(nextSet1CloserStage === "confirmed" &&
+            prevSet1CloserStage !== "confirmed"
+              ? {
+                  s1cConfirmedAt: admin.firestore.Timestamp.fromMillis(nowMs),
+                }
+              : {}),
+          };
+
     // Merge timing-state updates into every automation write below so the
     // next poll has monotonic anchors. Stamp `firstRowObservedAt` only on
     // first observation; update `lastSet1ChangeAt` + `set1TitleSignature`
     // only when the set-1 title sequence actually changed; update
-    // `lastRowsChangedAt` whenever the full-rows signature changed.
+    // `lastRowsChangedAt` whenever the full-rows signature changed; and track
+    // two-stage set-1 closer state (`s1cStage` + stage timestamps).
     const timingStateUpdate = {
       ...(prevFirstRowObservedAtMs == null
         ? {
@@ -739,6 +797,7 @@ async function pollSingleShowDate({
             lastRowsChangedAt: admin.firestore.Timestamp.fromMillis(nowMs),
           }
         : {}),
+      ...set1CloserStateUpdate,
     };
 
     // Context for the #266 auto-finalize step (runs after either write
@@ -873,13 +932,18 @@ async function pollSingleShowDate({
 module.exports = {
   AUTO_FINALIZE_IDLE_MS,
   BUSTOUT_MIN_GAP,
+  CONFIRMED_SET1_ELAPSED_MS,
+  CONFIRMED_SET1_IDLE_MS,
   MIN_SET1_ELAPSED_MS,
+  PROVISIONAL_SET1_ELAPSED_MS,
+  PROVISIONAL_SET1_IDLE_MS,
   SET1_IDLE_MS,
   SHOW_SAFETY_CAP_MS,
   buildSetlistDocFromRows,
   candidateShowDates,
   deriveBustoutsFromRows,
   evaluateAutoFinalize,
+  evaluateSet1CloserStage,
   fetchPhishnetSetlistForDate,
   getEtHour,
   isWithinLiveSetlistPollWindow,

--- a/functions/phishnetLiveSetlistAutomation.test.js
+++ b/functions/phishnetLiveSetlistAutomation.test.js
@@ -4,13 +4,16 @@ const assert = require("node:assert/strict");
 const {
   AUTO_FINALIZE_IDLE_MS,
   BUSTOUT_MIN_GAP,
-  MIN_SET1_ELAPSED_MS,
-  SET1_IDLE_MS,
+  CONFIRMED_SET1_ELAPSED_MS,
+  CONFIRMED_SET1_IDLE_MS,
+  PROVISIONAL_SET1_ELAPSED_MS,
+  PROVISIONAL_SET1_IDLE_MS,
   SHOW_SAFETY_CAP_MS,
   buildSetlistDocFromRows,
   candidateShowDates,
   deriveBustoutsFromRows,
   evaluateAutoFinalize,
+  evaluateSet1CloserStage,
   isWithinLiveSetlistPollWindow,
   normalizeSetlistRows,
   parseShowCalendarSnapshotToDateSet,
@@ -61,7 +64,7 @@ test("parseShowCalendarSnapshotToDateSet returns null when strict-invalid", () =
   assert.equal(parseShowCalendarSnapshotToDateSet({ showDates: [{ venue: "x" }] }), null);
 });
 
-test("isWithinLiveSetlistPollWindow: 4pm–3am ET (summer EDT)", () => {
+test("isWithinLiveSetlistPollWindow: 4pm–4am ET (summer EDT)", () => {
   assert.equal(
     isWithinLiveSetlistPollWindow(new Date("2026-07-04T20:00:00-04:00")),
     true
@@ -76,6 +79,14 @@ test("isWithinLiveSetlistPollWindow: 4pm–3am ET (summer EDT)", () => {
   );
   assert.equal(
     isWithinLiveSetlistPollWindow(new Date("2026-07-04T03:00:00-04:00")),
+    true
+  );
+  assert.equal(
+    isWithinLiveSetlistPollWindow(new Date("2026-07-04T03:59:00-04:00")),
+    true
+  );
+  assert.equal(
+    isWithinLiveSetlistPollWindow(new Date("2026-07-04T04:00:00-04:00")),
     false
   );
 });
@@ -104,6 +115,15 @@ test("scheduledCandidateShowDates: after midnight adds yesterday when still a sh
   const cal = parseShowCalendarSnapshotToDateSet(SHOW_CALENDAR_SNAPSHOT_FIXTURE);
   const dates = scheduledCandidateShowDates(
     new Date("2026-07-04T01:30:00-04:00"),
+    cal
+  );
+  assert.deepEqual(dates, ["2026-07-04", "2026-07-03"]);
+});
+
+test("scheduledCandidateShowDates: 3am hour still includes yesterday", () => {
+  const cal = parseShowCalendarSnapshotToDateSet(SHOW_CALENDAR_SNAPSHOT_FIXTURE);
+  const dates = scheduledCandidateShowDates(
+    new Date("2026-07-04T03:15:00-04:00"),
     cal
   );
   assert.deepEqual(dates, ["2026-07-04", "2026-07-03"]);
@@ -409,16 +429,52 @@ test("set1TitleSignatureFromRows: stable for identical set 1, ignores set 2 / en
   assert.equal(set1TitleSignatureFromRows([]), "");
 });
 
-test("buildSetlistDocFromRows: timing-close fires when elapsed ≥ 85m and idle ≥ 10m", () => {
+test("evaluateSet1CloserStage: provisional at 75m + 8m idle", () => {
+  const nowMs = 1_000_000_000_000;
+  const stage = evaluateSet1CloserStage({
+    set1Count: 3,
+    set2Count: 0,
+    nowMs,
+    firstRowObservedAtMs: nowMs - PROVISIONAL_SET1_ELAPSED_MS,
+    lastSet1ChangeAtMs: nowMs - PROVISIONAL_SET1_IDLE_MS,
+  });
+  assert.equal(stage, "provisional");
+});
+
+test("evaluateSet1CloserStage: confirmed at 85m + 12m idle", () => {
+  const nowMs = 1_000_000_000_000;
+  const stage = evaluateSet1CloserStage({
+    set1Count: 3,
+    set2Count: 0,
+    nowMs,
+    firstRowObservedAtMs: nowMs - CONFIRMED_SET1_ELAPSED_MS,
+    lastSet1ChangeAtMs: nowMs - CONFIRMED_SET1_IDLE_MS,
+  });
+  assert.equal(stage, "confirmed");
+});
+
+test("evaluateSet1CloserStage: set 2 start hard-confirms", () => {
+  const stage = evaluateSet1CloserStage({
+    set1Count: 2,
+    set2Count: 1,
+    nowMs: null,
+    firstRowObservedAtMs: null,
+    lastSet1ChangeAtMs: null,
+  });
+  assert.equal(stage, "confirmed");
+});
+
+test("buildSetlistDocFromRows: provisional close fires at elapsed ≥ 75m and idle ≥ 8m", () => {
   const rows = set1OnlyRows(["AC/DC Bag", "Bathtub Gin", "Carini"]);
   const nowMs = 1_000_000_000_000;
   const out = buildSetlistDocFromRows(rows, {}, {
     nowMs,
-    firstRowObservedAtMs: nowMs - MIN_SET1_ELAPSED_MS,
-    lastSet1ChangeAtMs: nowMs - SET1_IDLE_MS,
+    firstRowObservedAtMs: nowMs - PROVISIONAL_SET1_ELAPSED_MS,
+    lastSet1ChangeAtMs: nowMs - PROVISIONAL_SET1_IDLE_MS,
   });
   assert.equal(out.setlist.s1o, "AC/DC Bag");
   assert.equal(out.setlist.s1c, "Carini");
+  assert.equal(out.set1CloserStage, "provisional");
   assert.equal(out.setlist.s2o, "");
   assert.equal(out.setlist.s2c, "");
 });
@@ -428,10 +484,11 @@ test("buildSetlistDocFromRows: early-elapsed guard keeps s1c empty even when idl
   const nowMs = 1_000_000_000_000;
   const out = buildSetlistDocFromRows(rows, {}, {
     nowMs,
-    firstRowObservedAtMs: nowMs - (60 * 60_000), // 60 min elapsed (< 85)
-    lastSet1ChangeAtMs: nowMs - (30 * 60_000),   // 30 min idle (> 10)
+    firstRowObservedAtMs: nowMs - (60 * 60_000), // 60 min elapsed (< 75)
+    lastSet1ChangeAtMs: nowMs - (30 * 60_000),   // 30 min idle (> 8)
   });
   assert.equal(out.setlist.s1c, "");
+  assert.equal(out.set1CloserStage, null);
 });
 
 test("buildSetlistDocFromRows: idle guard keeps s1c empty during a long jam", () => {
@@ -439,16 +496,18 @@ test("buildSetlistDocFromRows: idle guard keeps s1c empty during a long jam", ()
   const nowMs = 1_000_000_000_000;
   const out = buildSetlistDocFromRows(rows, {}, {
     nowMs,
-    firstRowObservedAtMs: nowMs - (90 * 60_000), // 90 min elapsed (> 85)
-    lastSet1ChangeAtMs: nowMs - (5 * 60_000),    // 5 min idle (< 10)
+    firstRowObservedAtMs: nowMs - (90 * 60_000), // 90 min elapsed (> 75)
+    lastSet1ChangeAtMs: nowMs - (5 * 60_000),    // 5 min idle (< 8)
   });
   assert.equal(out.setlist.s1c, "");
+  assert.equal(out.set1CloserStage, null);
 });
 
 test("buildSetlistDocFromRows: missing timing state behaves like pre-#264 (no timing close)", () => {
   const rows = set1OnlyRows(["AC/DC Bag", "Bathtub Gin"]);
   const out = buildSetlistDocFromRows(rows, {});
   assert.equal(out.setlist.s1c, "");
+  assert.equal(out.set1CloserStage, null);
 });
 
 test("buildSetlistDocFromRows: set 2 start still forces s1c regardless of timing inputs", () => {
@@ -468,61 +527,81 @@ test("buildSetlistDocFromRows: set 2 start still forces s1c regardless of timing
   });
   assert.equal(out.setlist.s1c, "Bathtub Gin");
   assert.equal(out.setlist.s2o, "Carini");
+  assert.equal(out.set1CloserStage, "confirmed");
 });
 
-test("buildSetlistDocFromRows: long-set edge — new set-1 song after timing fires rewrites s1c on re-fire", () => {
+test("buildSetlistDocFromRows: long-set edge — new set-1 song after stage fires rewrites s1c on re-fire", () => {
   const nowMs = 1_000_000_000_000;
-  // Poll A: 3 songs, elapsed+idle both past threshold → s1c = "Carini".
+  // Poll A: 3 songs, provisional threshold met → s1c = "Carini".
   const pollA = buildSetlistDocFromRows(
     set1OnlyRows(["AC/DC Bag", "Bathtub Gin", "Carini"]),
     {},
     {
       nowMs,
-      firstRowObservedAtMs: nowMs - (95 * 60_000),
-      lastSet1ChangeAtMs: nowMs - (15 * 60_000),
+      firstRowObservedAtMs: nowMs - (80 * 60_000),
+      lastSet1ChangeAtMs: nowMs - (9 * 60_000),
     }
   );
   assert.equal(pollA.setlist.s1c, "Carini");
+  assert.equal(pollA.set1CloserStage, "provisional");
 
-  // Poll B: 4th song just arrived; lastSet1ChangeAt reset to now → idle < 10m → no timing close.
+  // Poll B: 4th song just arrived; lastSet1ChangeAt reset to now → idle < 8m.
   const pollBNow = nowMs + (4 * 60_000);
   const pollB = buildSetlistDocFromRows(
     set1OnlyRows(["AC/DC Bag", "Bathtub Gin", "Carini", "Down with Disease"]),
     pollA,
     {
       nowMs: pollBNow,
-      firstRowObservedAtMs: nowMs - (95 * 60_000),
+      firstRowObservedAtMs: nowMs - (80 * 60_000),
       lastSet1ChangeAtMs: pollBNow, // just changed
     }
   );
   assert.equal(pollB.setlist.s1c, "");
+  assert.equal(pollB.set1CloserStage, null);
 
-  // Poll C: 10+ min later, no new song → timing re-fires, s1c = new last song.
-  const pollCNow = pollBNow + (11 * 60_000);
+  // Poll C: 8+ min later, no new song → provisional stage re-fires.
+  const pollCNow = pollBNow + (8 * 60_000);
   const pollC = buildSetlistDocFromRows(
     set1OnlyRows(["AC/DC Bag", "Bathtub Gin", "Carini", "Down with Disease"]),
     pollB,
     {
       nowMs: pollCNow,
-      firstRowObservedAtMs: nowMs - (95 * 60_000),
+      firstRowObservedAtMs: nowMs - (80 * 60_000),
       lastSet1ChangeAtMs: pollBNow,
     }
   );
   assert.equal(pollC.setlist.s1c, "Down with Disease");
+  assert.equal(pollC.set1CloserStage, "provisional");
 });
 
-test("buildSetlistDocFromRows: exact-threshold elapsed + idle fires (inclusive)", () => {
+test("buildSetlistDocFromRows: exact-threshold provisional elapsed + idle fires (inclusive)", () => {
   const nowMs = 1_000_000_000_000;
   const out = buildSetlistDocFromRows(
     set1OnlyRows(["AC/DC Bag", "Bathtub Gin"]),
     {},
     {
       nowMs,
-      firstRowObservedAtMs: nowMs - MIN_SET1_ELAPSED_MS,
-      lastSet1ChangeAtMs: nowMs - SET1_IDLE_MS,
+      firstRowObservedAtMs: nowMs - PROVISIONAL_SET1_ELAPSED_MS,
+      lastSet1ChangeAtMs: nowMs - PROVISIONAL_SET1_IDLE_MS,
     }
   );
   assert.equal(out.setlist.s1c, "Bathtub Gin");
+  assert.equal(out.set1CloserStage, "provisional");
+});
+
+test("buildSetlistDocFromRows: confirmed stage fires on stricter idle threshold", () => {
+  const nowMs = 1_000_000_000_000;
+  const out = buildSetlistDocFromRows(
+    set1OnlyRows(["AC/DC Bag", "Bathtub Gin", "Carini"]),
+    {},
+    {
+      nowMs,
+      firstRowObservedAtMs: nowMs - CONFIRMED_SET1_ELAPSED_MS,
+      lastSet1ChangeAtMs: nowMs - CONFIRMED_SET1_IDLE_MS,
+    }
+  );
+  assert.equal(out.setlist.s1c, "Carini");
+  assert.equal(out.set1CloserStage, "confirmed");
 });
 
 // ---------- #266 auto-finalize ----------


### PR DESCRIPTION
… closer

Reduce missed live-night automation by extending scheduled polling to 4am ET and keeping yesterday eligible through the 3am hour. Add two-stage set 1 closer detection (75m/8m provisional, 85m/12m confirmed) with persisted stage telemetry so closer confidence can advance and recover safely across long-set edits.

Made-with: Cursor