### PR TITLE
feat(auth): proxy Firebase auth handler via www.setlistpickem.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ firebase-debug.log
 
 # Local credentials (GCP service accounts, etc.). Prefer ~/… or secrets/ and never commit.
 secrets/
+.vercel
+.env*.local

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,14 @@
 {
   "rewrites": [
     {
+      "source": "/__/firebase/init.json",
+      "destination": "https://set-picks.firebaseapp.com/__/firebase/init.json"
+    },
+    {
+      "source": "/__/auth/(.*)",
+      "destination": "https://set-picks.firebaseapp.com/__/auth/$1"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
Part of #282

## Summary
- Adds two Vercel rewrites so `https://www.setlistpickem.com/__/firebase/init.json` and `https://www.setlistpickem.com/__/auth/*` reverse-proxy to `set-picks.firebaseapp.com`. This is the Firebase-documented "custom authDomain" recipe — it lets us serve Firebase's OAuth helper HTML/JS under our branded origin without moving the Firebase project.
- Ignores `.vercel/` (Vercel CLI metadata) and `.env*.local` (auto-generated secret files) which were inadvertently appearing in `git status`.

## Why this is safe to merge alone
Today no client bundle sets `authDomain` to `www.setlistpickem.com`, so `signInWithPopup` never opens the new URL. The rewrites sit dormant on production until PR B ships the authDomain flip (and even then, only when the Vercel env var is set). Existing production auth flow still goes to `set-picks.firebaseapp.com` and is not touched.

The rewrite entries are placed **above** the SPA catch-all (`/(.*) → /index.html`) so they win path matching. Today `https://www.setlistpickem.com/__/auth/handler` incorrectly returns the SPA's `index.html` (confirmed by curl, cached by Vercel) — merging this PR fixes that by routing the path to the real handler.

## Test plan
- [ ] Merge to `staging`, auto-promote to `main`, wait for prod deploy.
- [ ] Hard-refresh prod and run from terminal:
  ```bash
  curl -sSI https://www.setlistpickem.com/__/firebase/init.json
  curl -sS  https://www.setlistpickem.com/__/firebase/init.json | head -c 200
  curl -sSI https://www.setlistpickem.com/__/auth/handler
  curl -sS  https://www.setlistpickem.com/__/auth/handler | head -c 200
  ```
  Expected:
  - `init.json` returns `200` with `content-type: application/json` and a body starting with `{"projectId":"set-picks",...}`.
  - `handler` returns `200` with `content-type: text/html` and a body containing `fireauth.oauthhelper` and `handler.js`.
  - Neither response should look like `<!DOCTYPE html><html lang="en">...favicon` — that's the SPA shell leaking through.
- [ ] Smoke-test existing Google sign-in on the deployed prod site. Expected: unchanged (popup still opens at `set-picks.firebaseapp.com` because `authDomain` has not changed yet).
- [ ] CI: verify matrix (`npm run lint`, `npm test`, `npm run verify:dashboard-meta`, `npm run verify:dashboard-ui`) green; Vercel preview green.

## Follow-up
PR B makes `authDomain` env-driven (`VITE_FIREBASE_AUTH_DOMAIN` with fallback to the current value), and the actual flip happens in Vercel's per-environment env var dashboard — Preview first, Production last.

Made with [Cursor](https://cursor.com)