### PR TITLE
feat(auth): make Firebase authDomain configurable via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,16 @@
 # Staging/production builds should set this to your GA4 Measurement ID (G-XXXXXXXXXX).
 VITE_GA_MEASUREMENT_ID=
 
+# Firebase Auth custom domain (issue #282). Leave unset to use the default
+# `set-picks.firebaseapp.com` (original Firebase-hosted OAuth handler URL).
+# Set to `www.setlistpickem.com` to rebrand the Google OAuth popup and
+# consent screen — requires the Vercel rewrite in vercel.json that proxies
+# `/__/auth/*` and `/__/firebase/init.json` back to the Firebase project,
+# and `www.setlistpickem.com` listed as an Authorized domain in Firebase
+# Auth and as an Authorized redirect URI (`/__/auth/handler`) on the
+# Google OAuth client.
+# VITE_FIREBASE_AUTH_DOMAIN=
+
 # --- External setlist APIs (epic #42) ---
 # phishin | phishnet
 VITE_SETLIST_API_SOURCE=phishin

--- a/src/shared/lib/firebase.js
+++ b/src/shared/lib/firebase.js
@@ -2,9 +2,17 @@ import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 
+// Custom auth domain rollout (issue #282): `authDomain` is the URL that
+// signInWithPopup opens and that appears in Google's OAuth consent line.
+// Leaving the fallback as `set-picks.firebaseapp.com` preserves today's
+// behavior when the env var is unset. Flip by setting
+// `VITE_FIREBASE_AUTH_DOMAIN=www.setlistpickem.com` in Vercel (Preview
+// first, then Production) once the Firebase handler proxy in `vercel.json`
+// is live. Removing the env var is a zero-code-change rollback.
 const firebaseConfig = {
   apiKey: "AIzaSyAJskQFM62Fyr-EjxlGJD3svAhf9gp9CHI",
-  authDomain: "set-picks.firebaseapp.com",
+  authDomain:
+    import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || "set-picks.firebaseapp.com",
   projectId: "set-picks",
   /** Default Storage bucket (same as Firebase console → Storage). */
   storageBucket: "set-picks.firebasestorage.app",


### PR DESCRIPTION
Closes #282

## Summary
- Routes `authDomain` in `src/shared/lib/firebase.js` through `import.meta.env.VITE_FIREBASE_AUTH_DOMAIN`, falling back to the current `set-picks.firebaseapp.com` when unset. Same pattern already used for `VITE_GA_MEASUREMENT_ID` in that file.
- Documents the new env var in `.env.example`.

This PR is dormant on merge — no env var is set in `.env.staging`/`.env.production`, and the Vercel dashboard vars stay unset until the actual flip.

## Why this PR is dormant
Behavior change is gated entirely by the env var. Three scenarios:

| Env var | Effect | Who sees it |
|---|---|---|
| Unset anywhere | Falls back to `set-picks.firebaseapp.com` (today's value) | Everyone — **no change** |
| Set on Vercel → Preview only | Preview bundles get new domain | Staging preview URL clicks only |
| Set on Vercel → Preview + Production | Prod bundles get new domain | Everyone — **the flip** |

The rollout plan is therefore "merge → test on preview → flip production env var" with instant rollback = delete the production env var.

## Prereqs (all satisfied, attached PR/issue evidence)
- [x] Vercel rewrite for `/__/auth/*` and `/__/firebase/init.json` (PR #283 merged)
- [x] Firebase Auth → Authorized domains includes `www.setlistpickem.com`, `setlistpickem.com`, `localhost` (user screenshot, issue #282)
- [x] Google OAuth client → Authorized redirect URIs includes `https://www.setlistpickem.com/__/auth/handler` (user screenshot, issue #282)

## Test plan

### Agent-side (already run)
- [x] `npm run lint` — clean
- [x] `npm test` — 17 files / 122 tests passed
- [x] `npm run build` (no env) — bundle contains `set-picks.firebaseapp.com`
- [x] `VITE_FIREBASE_AUTH_DOMAIN=www.setlistpickem.com npm run build` — bundle contains `www.setlistpickem.com`

### After merge (manual)
- [ ] Vercel project → Settings → Environment Variables → add `VITE_FIREBASE_AUTH_DOMAIN=www.setlistpickem.com` for **Preview** only. Trigger a redeploy of staging preview.
- [ ] On staging preview URL, click Google sign-in. PASS = popup URL bar shows `www.setlistpickem.com/__/auth/handler?…` and consent sheet reads "to continue to **setlistpickem.com**". FAIL = navy blank popup (means PR #283 rewrite not live on prod yet — rollback via deleting Vercel env var).
- [ ] Local: add the same line to `.env.local`, `npm run dev`, repeat. Same PASS/FAIL.
- [ ] Flip Vercel Production env var to the same value. Redeploy. Production users get the rebranded popup on next page load.

### Rollback (if anything looks wrong post-flip)
Delete the env var in Vercel and redeploy — clients fall back to `set-picks.firebaseapp.com` on next load. No code revert.

Made with [Cursor](https://cursor.com)