### PR TITLE
feat(analytics): gate GA4 init on production hostname

### DIFF
--- a/src/shared/lib/firebase.js
+++ b/src/shared/lib/firebase.js
@@ -18,7 +18,7 @@ const firebaseConfig = {
   storageBucket: "set-picks.firebasestorage.app",
   messagingSenderId: "927420107250",
   appId: "1:927420107250:web:1b9f52a72ef8dd9096836b",
-  measurementId: import.meta.env.VITE_GA_MEASUREMENT_ID || "G-K3YZ8FNM3V",
+  measurementId: import.meta.env.VITE_GA_MEASUREMENT_ID,
 };
 
 const app = initializeApp(firebaseConfig);

--- a/src/shared/lib/ga4.js
+++ b/src/shared/lib/ga4.js
@@ -8,6 +8,16 @@ let lastEventSig = '';
 let lastEventTime = 0;
 
 /**
+ * Hostnames where GA4 is allowed to initialize. Anything else (localhost,
+ * Vercel preview deployments like *.vercel.app, custom staging domains)
+ * stays GA-silent so analytics only reflects real production usage.
+ */
+const PROD_HOSTNAMES = new Set([
+  'www.setlistpickem.com',
+  'setlistpickem.com',
+]);
+
+/**
  * Read GA4 Measurement ID from the Vite env. Safe to call when unset (no-op).
  */
 export function getGaMeasurementId() {
@@ -16,11 +26,21 @@ export function getGaMeasurementId() {
   return String(id).trim();
 }
 
+function isProductionHost() {
+  if (typeof window === 'undefined') return false;
+  return PROD_HOSTNAMES.has(window.location.hostname);
+}
+
 /**
- * Initialize GA4 once when a Measurement ID is configured.
+ * Initialize GA4 once when a Measurement ID is configured AND the build is
+ * running on a production hostname. The hostname guard is defense-in-depth
+ * against the GA Measurement ID leaking into preview/staging/local builds via
+ * Vite env files — without it, every deploy with `VITE_GA_MEASUREMENT_ID` set
+ * would phone home to prod analytics.
  */
 export function initGa4() {
   if (initialized) return;
+  if (!isProductionHost()) return;
   const id = getGaMeasurementId();
   if (!id) return;
   ReactGA.initialize(id);


### PR DESCRIPTION
Refs #291 (this PR ships the code half; #291 stays open until the two GA4 custom dimensions are registered in the dashboard).

## Summary
- Adds a runtime hostname allow-list to `initGa4()` so GA only loads on `www.setlistpickem.com` / `setlistpickem.com`. Local dev, Vercel previews (`*.vercel.app`), and any future custom staging domain are now GA-silent regardless of env-file contents.
- Drops the hardcoded `"G-K3YZ8FNM3V"` fallback in `src/shared/lib/firebase.js` so the prod GA ID is no longer baked into source. (No-op at runtime today since nothing imports `firebase/analytics`, but removes a footgun.)

## Why
A breakdown of recent `auth_error` events showed ~half of the volume came from `vercel.com` referrals, `*-pat-4867s-projects.vercel.app` preview URLs, and `http://localhost/` — i.e. our own QA traffic polluting the real-user error baseline. The runtime guard makes this leak-proof: even if `VITE_GA_MEASUREMENT_ID` ends up in `.env.local` / `.env.staging` / a Vercel Preview env, no hits are sent.

## Files
- `src/shared/lib/ga4.js` — new `PROD_HOSTNAMES` set + `isProductionHost()` short-circuit in `initGa4()`. Downstream `ga4Event` / `ga4SendPageView` already early-return when `initialized === false`, so no other call sites change.
- `src/shared/lib/firebase.js` — `measurementId` is now `import.meta.env.VITE_GA_MEASUREMENT_ID` (undefined when unset, harmless because we don't call `getAnalytics(app)`).

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run test` — 122/122 passing (incl. `profileStatsTelemetry.test.js` which exercises the GA event surface via mocks)
- [x] `npm run verify:dashboard-meta` — 11 cases OK
- [x] `npm run verify:dashboard-ui` — ok
- [ ] Vercel preview: confirm DevTools Network has **no** `https://www.google-analytics.com/g/collect` or `https://region1.google-analytics.com/g/collect` requests on the splash and dashboard pages
- [ ] Production (post-merge to `main`): on `https://www.setlistpickem.com/`, confirm GA `collect` requests still fire on page-view and on a deliberate `auth_error` (e.g. submit invalid credentials in the sign-in modal)
- [ ] GA4 Realtime → Events: production hits still appear within ~30s of the smoke test above; preview/localhost traffic produces zero realtime users

## Follow-ups (out of scope)
- #291 — register `method` / `error_code` as event-scoped custom dimensions in GA4 Admin (manual UI step; no code).
- Optional Vercel hardening: scope `VITE_GA_MEASUREMENT_ID` to **Production** only in Vercel project settings (defense-in-depth alongside this guard).

Made with [Cursor](https://cursor.com)