### PR TITLE
feat(standings): pre-lock pick privacy + 7:55 PT lock (#303)

### DIFF
--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -6,7 +6,7 @@ import { useNextShowPicksStatus } from '../../picks';
 import { useUserPools } from '../../pools';
 import { useShowCalendar } from '../../show-calendar';
 import { todayYmd } from '../../../shared/utils/dateUtils';
-import { getShowStatus } from '../../../shared/utils/timeLogic';
+import { getShowStatus, shouldRedactOpponentPicksPreLock } from '../../../shared/utils/timeLogic';
 import { showOptionLabelCompact } from '../../../shared/utils/showOptionLabel';
 
 import { resolveCurrentTour } from './resolveCurrentTour';
@@ -60,6 +60,10 @@ export function useStandingsScreen(selectedDate) {
   });
 
   const showStatus = getShowStatus(selectedDate, showDates);
+  const redactOpponentPicksPreLock = shouldRedactOpponentPicksPreLock(
+    actualSetlist,
+    showStatus,
+  );
   const { openScoringRules } = useScoringRulesModal();
 
   // Only fetch pick-status for the "Now picking" active-show card — NEXT is
@@ -161,5 +165,7 @@ export function useStandingsScreen(selectedDate) {
     winnerOfTheNight,
     previousShowWinner,
     showLastShowWinnerBanner,
+
+    redactOpponentPicksPreLock,
   };
 }

--- a/src/features/scoring/ui/Leaderboard.jsx
+++ b/src/features/scoring/ui/Leaderboard.jsx
@@ -9,6 +9,7 @@ const Leaderboard = ({
   headerEnd = null,
   selfUserId = null,
   suppressLeadingCallout = false,
+  redactOpponentPicksPreLock = false,
 }) => {
   const { sortedPicks, getPickPayload, expandedUser, toggleUserExpansion } = useLeaderboard(
     poolPicks,
@@ -27,6 +28,7 @@ const Leaderboard = ({
       headerEnd={headerEnd}
       selfUserId={selfUserId}
       suppressLeadingCallout={suppressLeadingCallout}
+      redactOpponentPicksPreLock={redactOpponentPicksPreLock}
     />
   );
 };

--- a/src/features/scoring/ui/LeaderboardList.jsx
+++ b/src/features/scoring/ui/LeaderboardList.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import { Info } from 'lucide-react';
 
 import {
   LEADING_THIS_SHOW,
   SHOW_STANDINGS_EYEBROW,
+  STANDINGS_PICK_PRIVACY_INFO_LABEL,
+  STANDINGS_PICK_PRIVACY_TOOLTIP,
 } from '../../../shared/config/dashboardVocabulary';
 import { calculateTotalScore } from '../../../shared/utils/scoring';
 import MetaChip from '../../../shared/ui/MetaChip';
@@ -20,6 +23,8 @@ export default function LeaderboardList({
   selfUserId = null,
   /** When true, hide the top “Leading this show” callout (e.g. Standings already shows “Tonight’s winner”). */
   suppressLeadingCallout = false,
+  /** Pre-lock: blur opponent pick titles in expanded rows (#303). */
+  redactOpponentPicksPreLock = false,
 }) {
   if (sortedPicks.length === 0) {
     return (
@@ -74,6 +79,16 @@ export default function LeaderboardList({
         </div>
         <div className="flex items-center gap-1.5 sm:gap-2 shrink-0 self-start sm:self-center pt-0.5 sm:pt-0">
           {headerEnd}
+          {redactOpponentPicksPreLock && !selfUserId ? (
+            <button
+              type="button"
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border-subtle bg-surface-panel text-content-secondary transition-colors hover:bg-surface-panel-strong hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+              title={STANDINGS_PICK_PRIVACY_TOOLTIP}
+              aria-label={`${STANDINGS_PICK_PRIVACY_INFO_LABEL}. ${STANDINGS_PICK_PRIVACY_TOOLTIP}`}
+            >
+              <Info className="h-4 w-4" aria-hidden />
+            </button>
+          ) : null}
           <MetaChip>
             {sortedPicks.length} {sortedPicks.length === 1 ? 'player' : 'players'}
           </MetaChip>
@@ -86,6 +101,8 @@ export default function LeaderboardList({
         const isExpanded = expandedUser === uniqueId;
         const rank = index + 1;
         const isSelf = Boolean(selfUserId) && (p.userId || p.uid) === selfUserId;
+        const maskPickTitles =
+          Boolean(redactOpponentPicksPreLock) && !isSelf;
         // Pre-grade, the self row is pinned to rank 1 by `useLeaderboard`;
         // skip the natural rank badge so users don't misread "1" as a
         // scoring result before the setlist lands.
@@ -102,6 +119,7 @@ export default function LeaderboardList({
             isExpanded={isExpanded}
             onToggle={() => onToggle(uniqueId)}
             userPicks={userPicks}
+            maskPickTitles={maskPickTitles}
           />
         );
       })}

--- a/src/features/scoring/ui/LeaderboardList.jsx
+++ b/src/features/scoring/ui/LeaderboardList.jsx
@@ -79,21 +79,24 @@ export default function LeaderboardList({
         </div>
         <div className="flex items-center gap-1.5 sm:gap-2 shrink-0 self-start sm:self-center pt-0.5 sm:pt-0">
           {headerEnd}
-          {redactOpponentPicksPreLock && !selfUserId ? (
-            <button
-              type="button"
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border-subtle bg-surface-panel text-content-secondary transition-colors hover:bg-surface-panel-strong hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
-              title={STANDINGS_PICK_PRIVACY_TOOLTIP}
-              aria-label={`${STANDINGS_PICK_PRIVACY_INFO_LABEL}. ${STANDINGS_PICK_PRIVACY_TOOLTIP}`}
-            >
-              <Info className="h-4 w-4" aria-hidden />
-            </button>
-          ) : null}
           <MetaChip>
             {sortedPicks.length} {sortedPicks.length === 1 ? 'player' : 'players'}
           </MetaChip>
         </div>
       </div>
+
+      {redactOpponentPicksPreLock ? (
+        <div
+          role="note"
+          aria-label={STANDINGS_PICK_PRIVACY_INFO_LABEL}
+          className="mx-0.5 mb-2 flex gap-3 rounded-xl border border-brand-primary/30 bg-brand-primary/[0.08] px-4 py-3 shadow-inset-glass"
+        >
+          <Info className="h-5 w-5 shrink-0 text-brand-primary mt-0.5" aria-hidden />
+          <p className="text-sm font-semibold leading-relaxed text-slate-100">
+            {STANDINGS_PICK_PRIVACY_TOOLTIP}
+          </p>
+        </div>
+      ) : null}
 
       {sortedPicks.map((p, index) => {
         const uniqueId = p.uid || p.id;

--- a/src/features/scoring/ui/LeaderboardList.jsx
+++ b/src/features/scoring/ui/LeaderboardList.jsx
@@ -91,14 +91,26 @@ export default function LeaderboardList({
           <span className="min-w-0 flex-1 truncate text-[11px] font-medium leading-tight text-content-secondary sm:text-xs">
             {STANDINGS_PICK_PRIVACY_INLINE}
           </span>
-          <button
-            type="button"
-            className="shrink-0 rounded p-0.5 text-brand-primary/85 transition-colors hover:text-brand-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
-            title={STANDINGS_PICK_PRIVACY_TOOLTIP}
-            aria-label={`${STANDINGS_PICK_PRIVACY_INFO_LABEL}. ${STANDINGS_PICK_PRIVACY_TOOLTIP}`}
-          >
-            <Info className="h-3.5 w-3.5" strokeWidth={2} aria-hidden />
-          </button>
+          {/*
+            Native `title` on <button> is often delayed, truncated, or ignored (#303 follow-up).
+            <details> gives a reliable tap/click surface with the full message; `title` on
+            <summary> remains a best-effort hover hint where the browser cooperates.
+          */}
+          <details className="relative shrink-0">
+            <summary
+              className="list-none cursor-pointer rounded p-0.5 text-brand-primary/85 transition-colors hover:text-brand-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg [&::-webkit-details-marker]:hidden"
+              title={STANDINGS_PICK_PRIVACY_TOOLTIP}
+              aria-label={STANDINGS_PICK_PRIVACY_INFO_LABEL}
+            >
+              <Info className="h-3.5 w-3.5" strokeWidth={2} aria-hidden />
+            </summary>
+            <div
+              role="tooltip"
+              className="absolute right-0 top-full z-30 mt-1.5 w-[min(22rem,calc(100vw-2rem))] rounded-lg border border-border-subtle bg-surface-panel-strong px-3 py-2 text-left text-xs font-medium leading-snug text-slate-100 shadow-lg"
+            >
+              {STANDINGS_PICK_PRIVACY_TOOLTIP}
+            </div>
+          </details>
         </div>
       ) : null}
 

--- a/src/features/scoring/ui/LeaderboardList.jsx
+++ b/src/features/scoring/ui/LeaderboardList.jsx
@@ -5,6 +5,7 @@ import {
   LEADING_THIS_SHOW,
   SHOW_STANDINGS_EYEBROW,
   STANDINGS_PICK_PRIVACY_INFO_LABEL,
+  STANDINGS_PICK_PRIVACY_INLINE,
   STANDINGS_PICK_PRIVACY_TOOLTIP,
 } from '../../../shared/config/dashboardVocabulary';
 import { calculateTotalScore } from '../../../shared/utils/scoring';
@@ -86,15 +87,18 @@ export default function LeaderboardList({
       </div>
 
       {redactOpponentPicksPreLock ? (
-        <div
-          role="note"
-          aria-label={STANDINGS_PICK_PRIVACY_INFO_LABEL}
-          className="mx-0.5 mb-2 flex gap-3 rounded-xl border border-brand-primary/30 bg-brand-primary/[0.08] px-4 py-3 shadow-inset-glass"
-        >
-          <Info className="h-5 w-5 shrink-0 text-brand-primary mt-0.5" aria-hidden />
-          <p className="text-sm font-semibold leading-relaxed text-slate-100">
-            {STANDINGS_PICK_PRIVACY_TOOLTIP}
-          </p>
+        <div className="mx-2 mb-1 flex min-h-0 items-center gap-1 border-b border-border-subtle/40 pb-1.5">
+          <span className="min-w-0 flex-1 truncate text-[11px] font-medium leading-tight text-content-secondary sm:text-xs">
+            {STANDINGS_PICK_PRIVACY_INLINE}
+          </span>
+          <button
+            type="button"
+            className="shrink-0 rounded p-0.5 text-brand-primary/85 transition-colors hover:text-brand-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
+            title={STANDINGS_PICK_PRIVACY_TOOLTIP}
+            aria-label={`${STANDINGS_PICK_PRIVACY_INFO_LABEL}. ${STANDINGS_PICK_PRIVACY_TOOLTIP}`}
+          >
+            <Info className="h-3.5 w-3.5" strokeWidth={2} aria-hidden />
+          </button>
         </div>
       ) : null}
 

--- a/src/features/scoring/ui/LeaderboardRow.jsx
+++ b/src/features/scoring/ui/LeaderboardRow.jsx
@@ -20,6 +20,8 @@ export default function LeaderboardRow({
   isExpanded,
   onToggle,
   userPicks,
+  /** Pre-lock privacy (#303): blur opponent song titles in the breakdown. */
+  maskPickTitles = false,
 }) {
   const uniqueId = p.uid || p.id;
   const playerUserId = p.userId || p.uid;
@@ -102,7 +104,11 @@ export default function LeaderboardRow({
 
       {isExpanded && (
         <div className="p-4 border-t border-border-subtle/30 bg-surface-inset">
-          <ScoreBreakdownGrid userPicks={userPicks} actualSetlist={actualSetlist} />
+          <ScoreBreakdownGrid
+            userPicks={userPicks}
+            actualSetlist={actualSetlist}
+            maskPickTitles={maskPickTitles}
+          />
         </div>
       )}
     </div>

--- a/src/features/scoring/ui/ScoreBreakdownGrid.jsx
+++ b/src/features/scoring/ui/ScoreBreakdownGrid.jsx
@@ -6,7 +6,7 @@ import {
   SCORING_RULES,
 } from '../../../shared/utils/scoring';
 
-export default function ScoreBreakdownGrid({ userPicks, actualSetlist }) {
+export default function ScoreBreakdownGrid({ userPicks, actualSetlist, maskPickTitles = false }) {
   return (
     <div className="grid grid-cols-2 gap-3">
       {FORM_FIELDS.map((field) => {
@@ -39,11 +39,24 @@ export default function ScoreBreakdownGrid({ userPicks, actualSetlist }) {
         }
 
         const kindLabel = SCORE_BREAKDOWN_KIND_LABEL[kind] || '';
+        const showMaskedPick = Boolean(maskPickTitles && trimmedGuess);
 
         return (
           <div key={field.id} className={`p-3 rounded-xl border ${borderStyle} flex flex-col gap-1.5`}>
             <span className="text-[8px] font-bold uppercase text-content-secondary">{field.label}</span>
-            <span className={`text-xs font-bold truncate ${textColor}`}>{userGuess || '—'}</span>
+            {showMaskedPick ? (
+              <>
+                <span
+                  className="text-xs font-bold truncate text-slate-400 blur-sm select-none"
+                  aria-hidden="true"
+                >
+                  {userGuess}
+                </span>
+                <span className="sr-only">Pick hidden until showtime.</span>
+              </>
+            ) : (
+              <span className={`text-xs font-bold truncate ${textColor}`}>{userGuess || '—'}</span>
+            )}
             {actualSetlist && trimmedGuess && kindLabel ? (
               <span className={`text-[9px] font-black uppercase tracking-wider ${markerColor}`}>
                 {kindLabel}

--- a/src/features/scoring/ui/StandingsShowOrPoolView.jsx
+++ b/src/features/scoring/ui/StandingsShowOrPoolView.jsx
@@ -41,6 +41,7 @@ export default function StandingsShowOrPoolView({ screen }) {
     isSecured,
     picksStatusLoading,
     showLastShowWinnerBanner,
+    redactOpponentPicksPreLock,
   } = screen;
 
   const isPoolsView = view === 'pools';
@@ -109,6 +110,7 @@ export default function StandingsShowOrPoolView({ screen }) {
               title={leaderboardTitle}
               selfUserId={selfUserId}
               suppressLeadingCallout={Boolean(showWinnerBanner)}
+              redactOpponentPicksPreLock={redactOpponentPicksPreLock}
             />
           </div>
         ) : null}
@@ -235,6 +237,7 @@ export default function StandingsShowOrPoolView({ screen }) {
           title={leaderboardTitle}
           selfUserId={selfUserId}
           suppressLeadingCallout={Boolean(showWinnerBanner)}
+          redactOpponentPicksPreLock={redactOpponentPicksPreLock}
         />
       )}
     </>

--- a/src/shared/config/dashboardVocabulary.js
+++ b/src/shared/config/dashboardVocabulary.js
@@ -115,3 +115,9 @@ export const LAST_SHOW_WINNERS_PLURAL = "Last show's winners";
 export function lastShowWinnerHeading(winnerCount) {
   return winnerCount > 1 ? LAST_SHOW_WINNERS_PLURAL : LAST_SHOW_WINNER_SINGULAR;
 }
+
+/** Logged-out / info affordance for pre-lock pick privacy on standings (#303). */
+export const STANDINGS_PICK_PRIVACY_INFO_LABEL = 'About hidden picks';
+
+export const STANDINGS_PICK_PRIVACY_TOOLTIP =
+  "We've made a key change our users have asked for: hiding other players' picks until showtime. You'll still see players and their picks, but those picks are now blurred to improve competition!";

--- a/src/shared/config/dashboardVocabulary.js
+++ b/src/shared/config/dashboardVocabulary.js
@@ -123,6 +123,6 @@ export const STANDINGS_PICK_PRIVACY_INLINE =
 /** Accessible name for the info control. */
 export const STANDINGS_PICK_PRIVACY_INFO_LABEL = 'About hidden picks';
 
-/** Full detail in `title` / screen-reader label on the info control (#303). */
+/** Full detail: disclosure panel + optional native `title` on summary (#303). */
 export const STANDINGS_PICK_PRIVACY_TOOLTIP =
   "We've made a key change our users have asked for: hiding other players' picks until showtime. You'll still see players and their picks, but those picks are now blurred to improve competition!";

--- a/src/shared/config/dashboardVocabulary.js
+++ b/src/shared/config/dashboardVocabulary.js
@@ -116,8 +116,13 @@ export function lastShowWinnerHeading(winnerCount) {
   return winnerCount > 1 ? LAST_SHOW_WINNERS_PLURAL : LAST_SHOW_WINNER_SINGULAR;
 }
 
-/** Logged-out / info affordance for pre-lock pick privacy on standings (#303). */
+/** Compact one-line hint next to the info control (#303). */
+export const STANDINGS_PICK_PRIVACY_INLINE =
+  "Other players' picks stay hidden until showtime.";
+
+/** Accessible name for the info control. */
 export const STANDINGS_PICK_PRIVACY_INFO_LABEL = 'About hidden picks';
 
+/** Full detail in `title` / screen-reader label on the info control (#303). */
 export const STANDINGS_PICK_PRIVACY_TOOLTIP =
   "We've made a key change our users have asked for: hiding other players' picks until showtime. You'll still see players and their picks, but those picks are now blurred to improve competition!";

--- a/src/shared/utils/timeLogic.js
+++ b/src/shared/utils/timeLogic.js
@@ -4,9 +4,12 @@ import { ymdInTimeZone } from './dateUtils';
 /** Venue / broadcast schedule — picks lock uses wall time in this zone (not the viewer’s local zone). */
 export const SHOW_SCHEDULE_TIMEZONE = 'America/Los_Angeles';
 
-/** Picks lock at this local time in {@link SHOW_SCHEDULE_TIMEZONE} on the show’s calendar date (15 min before a typical 8pm PT start). */
+/**
+ * Picks lock at this local time in {@link SHOW_SCHEDULE_TIMEZONE} on the show’s calendar date.
+ * Interim 7:55pm PT (#303); venue-local lock tracked in #278.
+ */
 export const SHOW_PICKS_LOCK_HOUR_PT = 19;
-export const SHOW_PICKS_LOCK_MINUTE_PT = 45;
+export const SHOW_PICKS_LOCK_MINUTE_PT = 55;
 
 export function scheduleTodayYmd() {
   return ymdInTimeZone(new Date(), SHOW_SCHEDULE_TIMEZONE);
@@ -58,7 +61,7 @@ export function getNextShow(showDates) {
 
 /**
  * NEXT — only date users can enter picks (the upcoming show from “today” in {@link SHOW_SCHEDULE_TIMEZONE}, before lock).
- * LIVE — that show date in PT and wall time there is at/after 7:45pm PT: picks locked, live standings UX.
+ * LIVE — that show date in PT and wall time there is at/after picks lock ({@link SHOW_PICKS_LOCK_HOUR_PT}:{@link SHOW_PICKS_LOCK_MINUTE_PT} PT): picks locked, live standings UX.
  * PAST — calendar date before schedule “today” in PT (show already happened).
  * FUTURE — any other listed date (e.g. later tour nights): too early until that show becomes "next".
  */
@@ -92,3 +95,15 @@ export const getShowStatus = (selectedDate, showDates) => {
   }
   return 'FUTURE';
 };
+
+/**
+ * Standings pick privacy (#303): opponent song titles stay obscured until picks
+ * lock flips the show to LIVE (wall clock) or an official setlist exists for scoring.
+ *
+ * @param {unknown} actualSetlist — official setlist snapshot when graded (truthy => never redact).
+ * @param {string} showStatus — from {@link getShowStatus}
+ * @returns {boolean}
+ */
+export function shouldRedactOpponentPicksPreLock(actualSetlist, showStatus) {
+  return !actualSetlist && showStatus === 'NEXT';
+}

--- a/src/shared/utils/timeLogic.test.js
+++ b/src/shared/utils/timeLogic.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldRedactOpponentPicksPreLock } from './timeLogic';
+
+describe('shouldRedactOpponentPicksPreLock (#303)', () => {
+  it('redacts before picks lock / grading when show is still NEXT', () => {
+    expect(shouldRedactOpponentPicksPreLock(null, 'NEXT')).toBe(true);
+    expect(shouldRedactOpponentPicksPreLock(undefined, 'NEXT')).toBe(true);
+  });
+
+  it('does not redact once a setlist exists', () => {
+    expect(shouldRedactOpponentPicksPreLock({ s1o: 'Fee' }, 'NEXT')).toBe(false);
+  });
+
+  it('does not redact after wall-clock lock (LIVE) without setlist yet', () => {
+    expect(shouldRedactOpponentPicksPreLock(null, 'LIVE')).toBe(false);
+  });
+
+  it('does not redact for other statuses', () => {
+    expect(shouldRedactOpponentPicksPreLock(null, 'PAST')).toBe(false);
+    expect(shouldRedactOpponentPicksPreLock(null, 'FUTURE')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #303.

## Summary

Implements **#303**: opponent pick titles on show/pool standings stay **obscured until Pacific picks lock**, with an **interim lock time of 7:55pm PT** (was 7:45). **UI-only** redaction (blur + compact hint); full copy in tooltip / `aria-label`. Venue-local lock remains tracked in **#278**.

## What changed

- **`timeLogic.js`**: `SHOW_PICKS_LOCK_MINUTE_PT` **45 → 55**; JSDoc references constants instead of a fixed “7:45” string. New helper **`shouldRedactOpponentPicksPreLock(actualSetlist, showStatus)`** — redacts when `!actualSetlist && showStatus === 'NEXT'` (after lock → `LIVE`, picks readable again even before setlist).
- **`useStandingsScreen`**: exposes `redactOpponentPicksPreLock` to standings views.
- **`StandingsShowOrPoolView` → `Leaderboard` → `LeaderboardList` / `LeaderboardRow` / `ScoreBreakdownGrid`**: non-self expanded rows use **blurred** song text + **sr-only** “Pick hidden until showtime.”
- **`dashboardVocabulary.js`**: `STANDINGS_PICK_PRIVACY_INLINE`, `STANDINGS_PICK_PRIVACY_TOOLTIP`, `STANDINGS_PICK_PRIVACY_INFO_LABEL` for the compact one-line hint + **ⓘ** `title` / `aria-label`.
- **`LeaderboardList`**: minimal chrome — one truncated line + small info button (full paragraph only in tooltip / SR).
- **Tests**: `src/shared/utils/timeLogic.test.js` for `shouldRedactOpponentPicksPreLock`.

## Commits on this branch

1. `feat(standings): pre-lock pick privacy + 7:55 PT lock (#303)`
2. `fix(standings): show pick-privacy note for all users when redacting (#303)`
3. `ux(standings): compact pick-privacy hint + tooltip on info (#303)`

## Checklist

- [ ] Smoke Standings (Show + Pool) for **NEXT** ungraded show: self row clear, others blurred when expanded; hint row visible.
- [ ] After simulated/post-merge **7:55 PT** on show day: **LIVE** without setlist → opponent text **not** blurred.
