### PR TITLE
feat(standings): View results on last-show winner banner (Show tab only)

### DIFF
--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -99,6 +99,18 @@ export function useStandingsScreen(selectedDate) {
   const showLastShowWinnerBanner =
     !previousShowWinner.loading && previousShowWinner.winners.length > 0;
 
+  /** Deep link to full standings for the prior night (Show tab only; see #305). */
+  const lastShowViewResults = useMemo(() => {
+    const d = previousShowWinner.prevDate;
+    if (!d) return null;
+    const show = showDates.find((s) => s.date === d);
+    if (!show) return null;
+    return {
+      showDate: d,
+      labelCompact: showOptionLabelCompact(show),
+    };
+  }, [previousShowWinner.prevDate, showDates]);
+
   const currentTour = useMemo(
     () => resolveCurrentTour(selectedDate, todayYmd(), showDatesByTour),
     [selectedDate, showDatesByTour],
@@ -165,6 +177,7 @@ export function useStandingsScreen(selectedDate) {
     winnerOfTheNight,
     previousShowWinner,
     showLastShowWinnerBanner,
+    lastShowViewResults,
 
     redactOpponentPicksPreLock,
   };

--- a/src/features/scoring/ui/StandingsShowOrPoolView.jsx
+++ b/src/features/scoring/ui/StandingsShowOrPoolView.jsx
@@ -41,11 +41,14 @@ export default function StandingsShowOrPoolView({ screen }) {
     isSecured,
     picksStatusLoading,
     showLastShowWinnerBanner,
+    lastShowViewResults,
     redactOpponentPicksPreLock,
   } = screen;
 
   const isPoolsView = view === 'pools';
   const isShowView = view === 'show';
+  const lastShowViewResultsForShowTab =
+    isShowView && lastShowViewResults ? lastShowViewResults : null;
 
   if (isPoolsView && !poolId) {
     return (
@@ -91,6 +94,7 @@ export default function StandingsShowOrPoolView({ screen }) {
             winners={previousShowWinner.winners}
             max={previousShowWinner.max}
             beats={previousShowWinner.beats}
+            viewResults={lastShowViewResultsForShowTab}
           />
         ) : null}
         <StandingsActiveShowCard
@@ -175,6 +179,7 @@ export default function StandingsShowOrPoolView({ screen }) {
           winners={previousShowWinner.winners}
           max={previousShowWinner.max}
           beats={previousShowWinner.beats}
+          viewResults={lastShowViewResultsForShowTab}
         />
       ) : null}
 

--- a/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
+++ b/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
@@ -1,10 +1,12 @@
 import React, { Fragment } from 'react';
+import { ChevronRight } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 import {
   lastShowWinnerHeading,
   tonightsWinnerHeading,
 } from '../../../shared/config/dashboardVocabulary';
+import DashboardRowPill from '../../../shared/ui/DashboardRowPill';
 import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
 
 /**
@@ -63,13 +65,15 @@ export default function StandingsWinnerOfTheNightBanner({
       aria-label={`${heading}: ${handlesLabel} — ${max} points`}
       className="mx-0.5 mb-4 rounded-xl border border-amber-500/40 bg-gradient-to-br from-amber-500/[0.12] via-amber-500/[0.06] to-brand-primary/[0.08] px-3 py-2 shadow-inset-glass"
     >
-      <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-0.5">
+      <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
         <p className="min-w-0 text-[10px] font-black uppercase tracking-widest text-amber-300">
           {heading}
         </p>
         {showViewResultsLink ? (
-          <Link
+          <DashboardRowPill
+            as={Link}
             to={`/dashboard/standings?showDate=${encodeURIComponent(viewResults.showDate)}`}
+            tone="accent"
             title={
               viewResultsHint
                 ? `Open full standings for ${viewResultsHint}`
@@ -80,10 +84,11 @@ export default function StandingsWinnerOfTheNightBanner({
                 ? `View full standings for ${viewResultsHint}`
                 : 'View full standings for this show'
             }
-            className="shrink-0 text-[11px] font-bold uppercase tracking-wide text-amber-200/95 underline decoration-amber-200/50 underline-offset-2 transition-colors hover:text-white hover:decoration-white/70"
+            className="shrink-0"
           >
             View results
-          </Link>
+            <ChevronRight className="h-3 w-3 shrink-0 opacity-90" aria-hidden />
+          </DashboardRowPill>
         ) : null}
       </div>
       <p className="mt-0.5 text-sm font-bold leading-snug text-slate-100">

--- a/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
+++ b/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
@@ -47,16 +47,46 @@ export default function StandingsWinnerOfTheNightBanner({
       : tonightsWinnerHeading(winners.length);
   const handlesLabel = winners.map((w) => w.handle || 'Anonymous').join(', ');
 
+  const showViewResultsLink =
+    variant === 'lastShow' &&
+    viewResults &&
+    typeof viewResults.showDate === 'string' &&
+    viewResults.showDate.length > 0;
+
+  const viewResultsHint =
+    viewResults?.labelCompact ||
+    (showViewResultsLink ? viewResults.showDate : '');
+
   return (
     <section
       role="status"
       aria-label={`${heading}: ${handlesLabel} — ${max} points`}
-      className="mx-0.5 mb-4 rounded-xl border border-amber-500/40 bg-gradient-to-br from-amber-500/[0.12] via-amber-500/[0.06] to-brand-primary/[0.08] px-4 py-3 shadow-inset-glass"
+      className="mx-0.5 mb-4 rounded-xl border border-amber-500/40 bg-gradient-to-br from-amber-500/[0.12] via-amber-500/[0.06] to-brand-primary/[0.08] px-3 py-2 shadow-inset-glass"
     >
-      <p className="text-[10px] font-black uppercase tracking-widest text-amber-300">
-        {heading}
-      </p>
-      <p className="mt-1 text-sm font-bold text-slate-100">
+      <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-0.5">
+        <p className="min-w-0 text-[10px] font-black uppercase tracking-widest text-amber-300">
+          {heading}
+        </p>
+        {showViewResultsLink ? (
+          <Link
+            to={`/dashboard/standings?showDate=${encodeURIComponent(viewResults.showDate)}`}
+            title={
+              viewResultsHint
+                ? `Open full standings for ${viewResultsHint}`
+                : 'Open full standings for this show'
+            }
+            aria-label={
+              viewResultsHint
+                ? `View full standings for ${viewResultsHint}`
+                : 'View full standings for this show'
+            }
+            className="shrink-0 text-[11px] font-bold uppercase tracking-wide text-amber-200/95 underline decoration-amber-200/50 underline-offset-2 transition-colors hover:text-white hover:decoration-white/70"
+          >
+            View results
+          </Link>
+        ) : null}
+      </div>
+      <p className="mt-0.5 text-sm font-bold leading-snug text-slate-100">
         {winners.map((w, idx) => {
           const playerUserId = w.userId || w.uid;
           const handle = w.handle || 'Anonymous';
@@ -72,30 +102,11 @@ export default function StandingsWinnerOfTheNightBanner({
         <span className="tabular-nums text-white">{max}</span>
         <span className="font-semibold text-content-secondary"> pts</span>
         {beats > 0 ? (
-          <span className="ml-2 text-xs font-semibold text-content-secondary">
+          <span className="ml-1.5 text-xs font-semibold text-content-secondary">
             (beat {beats} {beats === 1 ? 'player' : 'players'})
           </span>
         ) : null}
       </p>
-      {variant === 'lastShow' &&
-      viewResults &&
-      typeof viewResults.showDate === 'string' &&
-      viewResults.showDate.length > 0 ? (
-        <p className="mt-2">
-          <Link
-            to={`/dashboard/standings?showDate=${encodeURIComponent(viewResults.showDate)}`}
-            className="text-sm font-semibold text-amber-200 underline decoration-amber-200/60 underline-offset-2 transition-colors hover:text-white hover:decoration-white/80"
-          >
-            View results
-            {viewResults.labelCompact ? (
-              <span className="font-normal text-amber-200/90">
-                {' '}
-                · {viewResults.labelCompact}
-              </span>
-            ) : null}
-          </Link>
-        </p>
-      ) : null}
     </section>
   );
 }

--- a/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
+++ b/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import { Link } from 'react-router-dom';
 
 import {
   lastShowWinnerHeading,
@@ -26,6 +27,7 @@ import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
  *   max: number | null,
  *   beats?: number,
  *   variant?: 'tonight' | 'lastShow',
+ *   viewResults?: { showDate: string, labelCompact: string } | null,
  * }} props
  */
 export default function StandingsWinnerOfTheNightBanner({
@@ -33,6 +35,7 @@ export default function StandingsWinnerOfTheNightBanner({
   max,
   beats = 0,
   variant = 'tonight',
+  viewResults = null,
 }) {
   if (!Array.isArray(winners) || winners.length === 0 || max == null) {
     return null;
@@ -74,6 +77,25 @@ export default function StandingsWinnerOfTheNightBanner({
           </span>
         ) : null}
       </p>
+      {variant === 'lastShow' &&
+      viewResults &&
+      typeof viewResults.showDate === 'string' &&
+      viewResults.showDate.length > 0 ? (
+        <p className="mt-2">
+          <Link
+            to={`/dashboard/standings?showDate=${encodeURIComponent(viewResults.showDate)}`}
+            className="text-sm font-semibold text-amber-200 underline decoration-amber-200/60 underline-offset-2 transition-colors hover:text-white hover:decoration-white/80"
+          >
+            View results
+            {viewResults.labelCompact ? (
+              <span className="font-normal text-amber-200/90">
+                {' '}
+                · {viewResults.labelCompact}
+              </span>
+            ) : null}
+          </Link>
+        </p>
+      ) : null}
     </section>
   );
 }


### PR DESCRIPTION
Closes #305

## Summary

- Adds a **View results** link on the last-show winner banner when the Standings **Show** tab is active. The link goes to `/dashboard/standings?showDate=<prevDate>` so `DashboardLayout` syncs the date picker to the night the banner summarizes.
- **`lastShowViewResults`** is derived in `useStandingsScreen`: only when `prevDate` matches a known calendar show (avoids broken URLs).
- **Pools** standings still show the last-show banner when applicable, but **no** View results link (per locked product decision on #305).

## Test plan

- [ ] On Standings → Show, with NEXT or LIVE selected and last-show banner visible: link appears, navigates to same route with date set to prior show; leaderboard reflects that date.
- [ ] Standings → Pools with pool selected: banner behavior unchanged, **no** View results link.
- [ ] `npm run lint` / `npm test` / `npm run verify:dashboard-meta` / `npm run verify:dashboard-ui`

Made with [Cursor](https://cursor.com)