### PR TITLE
feat(standings): #305 follow-up — View results fixes + pool last-show winner

### DIFF
--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -247,7 +247,12 @@ export default function DashboardLayout() {
               />
               <Route
                 path="standings"
-                element={<StandingsPage selectedDate={selectedDate} />}
+                element={
+                  <StandingsPage
+                    selectedDate={selectedDate}
+                    onSelectShowDate={setSelectedDate}
+                  />
+                }
               />
               <Route
                 path="admin"

--- a/src/features/scoring/model/usePreviousShowNightWinner.js
+++ b/src/features/scoring/model/usePreviousShowNightWinner.js
@@ -2,19 +2,25 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { getShowBeforeDate, getShowStatus } from '../../../shared/utils/timeLogic.js';
 import { fetchPicksForShowDate } from '../api/standingsApi';
+import { filterPicksToAudience } from './useDisplayedPicks';
 import { computeShowWinnerOfTheNight } from './useShowWinnerOfTheNight.js';
 
 /**
- * Global winner(s) of the **previous** tour night vs `selectedDate`, for
- * Standings when the selected show is NEXT or LIVE (Option A).
+ * Winner(s) of the **previous** tour night vs `selectedDate`, for Standings when
+ * the selected show is NEXT or LIVE (Option A).
  *
- * Reuses the same eligibility rules as {@link useShowWinnerOfTheNight}.
+ * Reuses the same eligibility rules as {@link useShowWinnerOfTheNight}. When
+ * `audience` targets a pool, the hook still fetches global picks for that date
+ * (one read) then filters with {@link filterPicksToAudience} — same contract
+ * as the leaderboard.
  *
  * @param {string | undefined} selectedDate — YYYY-MM-DD
  * @param {{ date: string }[] | undefined} showDates
  * @param {boolean} enabled — gate fetches (show/pools standings, NEXT/LIVE only)
+ * @param {{ userPools?: Array<{ id: string, members?: string[], name?: string }> | null, activeFilter: 'global' | string } | null | undefined} [audience] —
+ *   omit or `activeFilter: 'global'` for everyone; pool id for pool-scoped winner.
  */
-export function usePreviousShowNightWinner(selectedDate, showDates, enabled) {
+export function usePreviousShowNightWinner(selectedDate, showDates, enabled, audience) {
   const prevDate = useMemo(() => {
     if (!enabled || !selectedDate || !Array.isArray(showDates) || showDates.length === 0) {
       return null;
@@ -62,6 +68,11 @@ export function usePreviousShowNightWinner(selectedDate, showDates, enabled) {
     };
   }, [prevDate, showDates]);
 
+  const { userPools, activeFilter } = audience ?? {
+    userPools: null,
+    activeFilter: 'global',
+  };
+
   return useMemo(() => {
     if (!prevDate) {
       return {
@@ -73,7 +84,13 @@ export function usePreviousShowNightWinner(selectedDate, showDates, enabled) {
         prevDate: null,
       };
     }
-    const { max, winners, eligiblePlayers, beats } = computeShowWinnerOfTheNight(picks);
+    const scopedPicks = filterPicksToAudience({
+      picks,
+      userPools,
+      activeFilter,
+    });
+    const { max, winners, eligiblePlayers, beats } =
+      computeShowWinnerOfTheNight(scopedPicks);
     return {
       max,
       winners,
@@ -82,5 +99,5 @@ export function usePreviousShowNightWinner(selectedDate, showDates, enabled) {
       loading,
       prevDate,
     };
-  }, [picks, loading, prevDate]);
+  }, [picks, loading, prevDate, userPools, activeFilter]);
 }

--- a/src/features/scoring/model/usePreviousShowNightWinner.js
+++ b/src/features/scoring/model/usePreviousShowNightWinner.js
@@ -63,6 +63,16 @@ export function usePreviousShowNightWinner(selectedDate, showDates, enabled) {
   }, [prevDate, showDates]);
 
   return useMemo(() => {
+    if (!prevDate) {
+      return {
+        max: null,
+        winners: [],
+        eligiblePlayers: 0,
+        beats: 0,
+        loading,
+        prevDate: null,
+      };
+    }
     const { max, winners, eligiblePlayers, beats } = computeShowWinnerOfTheNight(picks);
     return {
       max,

--- a/src/features/scoring/model/usePreviousShowNightWinner.test.js
+++ b/src/features/scoring/model/usePreviousShowNightWinner.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterPicksToAudience } from './useDisplayedPicks';
+import { computeShowWinnerOfTheNight } from './useShowWinnerOfTheNight';
+
+const userPools = [
+  { id: 'pool-a', name: 'Alpha', members: ['u-a', 'u-b'] },
+  { id: 'pool-b', name: 'Bravo', members: ['u-c'] },
+];
+
+const graded = (userId, score, poolIds) => ({
+  userId,
+  isGraded: true,
+  score,
+  picks: { s1: 'Tweezer' },
+  pools: poolIds.map((id) => ({ id })),
+  handle: userId,
+});
+
+describe('previous show night winner (pool scope, pure)', () => {
+  it('uses pool-high score, not global-high', () => {
+    const raw = [
+      graded('u-a', 12, ['pool-a']),
+      graded('u-b', 11, ['pool-a']),
+      graded('u-c', 99, ['pool-b']),
+    ];
+    const scoped = filterPicksToAudience({
+      picks: raw,
+      userPools,
+      activeFilter: 'pool-a',
+    });
+    const result = computeShowWinnerOfTheNight(scoped);
+    expect(result.max).toBe(12);
+    expect(result.winners.map((w) => w.userId)).toEqual(['u-a']);
+    expect(result.eligiblePlayers).toBe(2);
+    expect(result.beats).toBe(1);
+  });
+});

--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -32,8 +32,13 @@ import { useScoringRulesModal } from '../ui/ScoringRulesModalProvider';
  *
  * @param {string} selectedDate `YYYY-MM-DD` selected via the dashboard
  *   date picker (passed through from `DashboardLayout`).
+ * @param {{ onSelectShowDate?: (ymd: string) => void }} [options] —
+ *   `onSelectShowDate` updates the global date picker (layout state). Required
+ *   for **View results** so the picker moves even when `navigate` is a no-op
+ *   (same `?showDate=` already in the URL after the user changed the select).
  */
-export function useStandingsScreen(selectedDate) {
+export function useStandingsScreen(selectedDate, options = {}) {
+  const { onSelectShowDate } = options;
   const location = useLocation();
   const navigate = useNavigate();
   const targetPoolId =
@@ -178,6 +183,7 @@ export function useStandingsScreen(selectedDate) {
     previousShowWinner,
     showLastShowWinnerBanner,
     lastShowViewResults,
+    onSelectShowDate: onSelectShowDate ?? null,
 
     redactOpponentPicksPreLock,
   };

--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -6,7 +6,11 @@ import { useNextShowPicksStatus } from '../../picks';
 import { useUserPools } from '../../pools';
 import { useShowCalendar } from '../../show-calendar';
 import { todayYmd } from '../../../shared/utils/dateUtils';
-import { getShowStatus, shouldRedactOpponentPicksPreLock } from '../../../shared/utils/timeLogic';
+import {
+  getShowBeforeDate,
+  getShowStatus,
+  shouldRedactOpponentPicksPreLock,
+} from '../../../shared/utils/timeLogic';
 import { showOptionLabelCompact } from '../../../shared/utils/showOptionLabel';
 
 import { resolveCurrentTour } from './resolveCurrentTour';
@@ -104,17 +108,26 @@ export function useStandingsScreen(selectedDate, options = {}) {
   const showLastShowWinnerBanner =
     !previousShowWinner.loading && previousShowWinner.winners.length > 0;
 
-  /** Deep link to full standings for the prior night (Show tab only; see #305). */
+  /** Calendar night before `selectedDate` (same rule as {@link usePreviousShowNightWinner}). */
+  const priorNightDate = useMemo(() => {
+    if (!selectedDate || !Array.isArray(showDates) || showDates.length === 0) return null;
+    return getShowBeforeDate(selectedDate, showDates)?.date ?? null;
+  }, [selectedDate, showDates]);
+
+  /**
+   * Deep link to full standings for the prior night (Show tab only; see #305).
+   * Do not require `showDates.find` — `prevDate` already comes from that list; a failed
+   * lookup only dropped the pill while the banner still showed (#305 follow-up).
+   */
   const lastShowViewResults = useMemo(() => {
-    const d = previousShowWinner.prevDate;
+    const d = previousShowWinner.prevDate || priorNightDate;
     if (!d) return null;
     const show = showDates.find((s) => s.date === d);
-    if (!show) return null;
     return {
       showDate: d,
-      labelCompact: showOptionLabelCompact(show),
+      labelCompact: show ? showOptionLabelCompact(show) : d,
     };
-  }, [previousShowWinner.prevDate, showDates]);
+  }, [previousShowWinner.prevDate, priorNightDate, showDates]);
 
   const currentTour = useMemo(
     () => resolveCurrentTour(selectedDate, todayYmd(), showDatesByTour),

--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -104,6 +104,7 @@ export function useStandingsScreen(selectedDate, options = {}) {
     selectedDate,
     showDates,
     lastShowWinnerEnabled,
+    { userPools, activeFilter },
   );
   const showLastShowWinnerBanner =
     !previousShowWinner.loading && previousShowWinner.winners.length > 0;

--- a/src/features/scoring/ui/StandingsShowOrPoolView.jsx
+++ b/src/features/scoring/ui/StandingsShowOrPoolView.jsx
@@ -97,6 +97,7 @@ export default function StandingsShowOrPoolView({ screen }) {
             beats={previousShowWinner.beats}
             viewResults={lastShowViewResultsForShowTab}
             onSelectShowDate={onSelectShowDate}
+            lastShowPoolScopeLabel={isPoolsView ? activePoolName : null}
           />
         ) : null}
         <StandingsActiveShowCard
@@ -183,6 +184,7 @@ export default function StandingsShowOrPoolView({ screen }) {
           beats={previousShowWinner.beats}
           viewResults={lastShowViewResultsForShowTab}
           onSelectShowDate={onSelectShowDate}
+          lastShowPoolScopeLabel={isPoolsView ? activePoolName : null}
         />
       ) : null}
 

--- a/src/features/scoring/ui/StandingsShowOrPoolView.jsx
+++ b/src/features/scoring/ui/StandingsShowOrPoolView.jsx
@@ -42,6 +42,7 @@ export default function StandingsShowOrPoolView({ screen }) {
     picksStatusLoading,
     showLastShowWinnerBanner,
     lastShowViewResults,
+    onSelectShowDate,
     redactOpponentPicksPreLock,
   } = screen;
 
@@ -95,6 +96,7 @@ export default function StandingsShowOrPoolView({ screen }) {
             max={previousShowWinner.max}
             beats={previousShowWinner.beats}
             viewResults={lastShowViewResultsForShowTab}
+            onSelectShowDate={onSelectShowDate}
           />
         ) : null}
         <StandingsActiveShowCard
@@ -180,6 +182,7 @@ export default function StandingsShowOrPoolView({ screen }) {
           max={previousShowWinner.max}
           beats={previousShowWinner.beats}
           viewResults={lastShowViewResultsForShowTab}
+          onSelectShowDate={onSelectShowDate}
         />
       ) : null}
 

--- a/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
+++ b/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
@@ -31,6 +31,7 @@ import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
  *   variant?: 'tonight' | 'lastShow',
  *   viewResults?: { showDate: string, labelCompact: string } | null,
  *   onSelectShowDate?: ((ymd: string) => void) | null,
+ *   lastShowPoolScopeLabel?: string | null,
  * }} props
  */
 export default function StandingsWinnerOfTheNightBanner({
@@ -40,6 +41,7 @@ export default function StandingsWinnerOfTheNightBanner({
   variant = 'tonight',
   viewResults = null,
   onSelectShowDate = null,
+  lastShowPoolScopeLabel = null,
 }) {
   const navigate = useNavigate();
 
@@ -49,7 +51,7 @@ export default function StandingsWinnerOfTheNightBanner({
 
   const heading =
     variant === 'lastShow'
-      ? lastShowWinnerHeading(winners.length)
+      ? lastShowWinnerHeading(winners.length, lastShowPoolScopeLabel)
       : tonightsWinnerHeading(winners.length);
   const handlesLabel = winners.map((w) => w.handle || 'Anonymous').join(', ');
 

--- a/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
+++ b/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { ChevronRight } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import {
   lastShowWinnerHeading,
@@ -30,6 +30,7 @@ import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
  *   beats?: number,
  *   variant?: 'tonight' | 'lastShow',
  *   viewResults?: { showDate: string, labelCompact: string } | null,
+ *   onSelectShowDate?: ((ymd: string) => void) | null,
  * }} props
  */
 export default function StandingsWinnerOfTheNightBanner({
@@ -38,7 +39,10 @@ export default function StandingsWinnerOfTheNightBanner({
   beats = 0,
   variant = 'tonight',
   viewResults = null,
+  onSelectShowDate = null,
 }) {
+  const navigate = useNavigate();
+
   if (!Array.isArray(winners) || winners.length === 0 || max == null) {
     return null;
   }
@@ -75,8 +79,8 @@ export default function StandingsWinnerOfTheNightBanner({
         </p>
         {showViewResultsLink ? (
           <DashboardRowPill
-            as={Link}
-            to={`/dashboard/standings?showDate=${encodeURIComponent(viewResults.showDate)}`}
+            as="button"
+            type="button"
             tone="accent"
             title={
               viewResultsHint
@@ -89,6 +93,17 @@ export default function StandingsWinnerOfTheNightBanner({
                 : 'View full standings for this show'
             }
             className="relative z-10 shrink-0 !border-amber-400/45 !bg-amber-950/35 !text-amber-100 !shadow-none hover:!border-amber-300/55 hover:!bg-amber-500/20 hover:!text-amber-50 focus-visible:!ring-amber-300/70"
+            onClick={() => {
+              const d = viewResults.showDate;
+              // Layout `selectedDate` can differ from URL (picker does not write
+              // `showDate`). Re-applying the same `?showDate=` is a navigate
+              // no-op — still move the picker via layout state.
+              onSelectShowDate?.(d);
+              navigate({
+                pathname: '/dashboard/standings',
+                search: `?showDate=${encodeURIComponent(d)}`,
+              });
+            }}
           >
             View results
             <ChevronRight className="pointer-events-none h-3 w-3 shrink-0 opacity-90" aria-hidden />

--- a/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
+++ b/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
@@ -60,13 +60,17 @@ export default function StandingsWinnerOfTheNightBanner({
     (showViewResultsLink ? viewResults.showDate : '');
 
   return (
-    <section
-      role="status"
+    <div
+      role="region"
       aria-label={`${heading}: ${handlesLabel} — ${max} points`}
-      className="mx-0.5 mb-4 rounded-xl border border-amber-500/40 bg-gradient-to-br from-amber-500/[0.12] via-amber-500/[0.06] to-brand-primary/[0.08] px-3 py-2 shadow-inset-glass"
+      className="relative mx-0.5 mb-4 rounded-xl border border-amber-500/40 bg-gradient-to-br from-amber-500/[0.12] via-amber-500/[0.06] to-brand-primary/[0.08] px-3 py-2 shadow-inset-glass"
     >
       <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
-        <p className="min-w-0 text-[10px] font-black uppercase tracking-widest text-amber-300">
+        {/*
+          If the heading flex item ever paints over the pill (min-width / overflow),
+          keep the link above in the hit-test order.
+        */}
+        <p className="relative z-0 min-w-0 text-[10px] font-black uppercase tracking-widest text-amber-300">
           {heading}
         </p>
         {showViewResultsLink ? (
@@ -84,10 +88,10 @@ export default function StandingsWinnerOfTheNightBanner({
                 ? `View full standings for ${viewResultsHint}`
                 : 'View full standings for this show'
             }
-            className="shrink-0"
+            className="relative z-10 shrink-0 !border-amber-400/45 !bg-amber-950/35 !text-amber-100 !shadow-none hover:!border-amber-300/55 hover:!bg-amber-500/20 hover:!text-amber-50 focus-visible:!ring-amber-300/70"
           >
             View results
-            <ChevronRight className="h-3 w-3 shrink-0 opacity-90" aria-hidden />
+            <ChevronRight className="pointer-events-none h-3 w-3 shrink-0 opacity-90" aria-hidden />
           </DashboardRowPill>
         ) : null}
       </div>
@@ -112,6 +116,6 @@ export default function StandingsWinnerOfTheNightBanner({
           </span>
         ) : null}
       </p>
-    </section>
+    </div>
   );
 }

--- a/src/pages/standings/StandingsPage.jsx
+++ b/src/pages/standings/StandingsPage.jsx
@@ -8,8 +8,8 @@ import {
   useStandingsScreen,
 } from '../../features/scoring';
 
-export default function StandingsPage({ selectedDate }) {
-  const screen = useStandingsScreen(selectedDate);
+export default function StandingsPage({ selectedDate, onSelectShowDate }) {
+  const screen = useStandingsScreen(selectedDate, { onSelectShowDate });
 
   return (
     <div className="w-full">

--- a/src/shared/config/dashboardVocabulary.js
+++ b/src/shared/config/dashboardVocabulary.js
@@ -110,10 +110,16 @@ export const LAST_SHOW_WINNERS_PLURAL = "Last show's winners";
 
 /**
  * @param {number} winnerCount
+ * @param {string | null | undefined} [poolScopeLabel] — pool name on Standings Pools tab (#305 pool-scoped last show).
  * @returns {string}
  */
-export function lastShowWinnerHeading(winnerCount) {
-  return winnerCount > 1 ? LAST_SHOW_WINNERS_PLURAL : LAST_SHOW_WINNER_SINGULAR;
+export function lastShowWinnerHeading(winnerCount, poolScopeLabel) {
+  const phrase =
+    winnerCount > 1 ? LAST_SHOW_WINNERS_PLURAL : LAST_SHOW_WINNER_SINGULAR;
+  if (typeof poolScopeLabel === 'string' && poolScopeLabel.trim()) {
+    return `${phrase} · ${poolScopeLabel.trim()}`;
+  }
+  return phrase;
 }
 
 /** Compact one-line hint next to the info control (#303). */

--- a/vite.config.js
+++ b/vite.config.js
@@ -61,6 +61,10 @@ export default defineConfig({
       '@': path.resolve(__dirname, 'src'),
     },
   },
+  server: {
+    port: 5173,
+    strictPort: true,
+  },
   build: {
     rollupOptions: {
       output: {


### PR DESCRIPTION
Refs #305

## Summary

Follow-up to #308: four commits were on this branch locally but had not been pushed before the original PR merged, so they never reached `staging`. This PR adds:

- **View results:** picker sync when `navigate` is a no-op, clickability/stacking + amber pill chrome, and `lastShowViewResults` robustness so the pill does not disappear spuriously.
- **Pools:** **Last show's winner** is computed from the same pool-filtered picks as the leaderboard (one global fetch unchanged), with heading suffix `· {pool name}`.

## Test plan

- [ ] Standings → Show (NEXT/LIVE): **View results** updates URL and date picker; repeat after changing the picker away and back.
- [ ] Standings → Pools: last-show banner reflects **this pool’s** prior-night winner, not global.
- [ ] `npm run lint` && `npm test` && `npm run verify:dashboard-meta` && `npm run verify:dashboard-ui`

Made with [Cursor](https://cursor.com)