### PR TITLE
feat(dashboard): mobile glass chrome, gradient titles, header seam

### DIFF
--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -177,6 +177,7 @@ export default function DashboardLayout() {
           <DashboardMobileContextBar
             scrollDirection={scrollDirection}
             contextTitle={meta.contextTitle}
+            contextTitleTone={meta.desktopHeadingTone}
             showDatePicker={meta.showDatePicker}
             selectedDate={selectedDate}
             onSelectedDateChange={setSelectedDate}
@@ -270,9 +271,9 @@ export default function DashboardLayout() {
         </div>
       </main>
 
-      {/* MOBILE BOTTOM BAR */}
-      <nav className="md:hidden fixed inset-x-0 bottom-0 z-50 w-full border-t border-border-subtle/35 bg-brand-bg/98 pb-[env(safe-area-inset-bottom,0px)] shadow-[0_-10px_28px_-14px_rgba(15,10,46,0.85)] backdrop-blur-sm supports-[backdrop-filter]:backdrop-saturate-125">
-        <div className={`grid ${isAdmin ? 'grid-cols-5' : 'grid-cols-4'} items-center h-16 px-2`}>
+      {/* MOBILE BOTTOM BAR — translucent tint + heavy blur (real glass); active pill keeps teal legible over scrolling content */}
+      <nav className="md:hidden fixed inset-x-0 bottom-0 z-50 w-full border-t border-border-subtle/35 bg-[linear-gradient(to_top,rgb(var(--brand-bg-deep)_/_0.76),rgb(var(--brand-bg)_/_0.60))] pb-[env(safe-area-inset-bottom,0px)] shadow-[inset_0_1px_0_0_rgb(var(--brand-primary)/0.12),0_-10px_28px_-14px_rgba(15,10,46,0.85)] ring-1 ring-inset ring-white/[0.06] backdrop-blur-xl supports-[backdrop-filter]:backdrop-blur-2xl supports-[backdrop-filter]:backdrop-saturate-150">
+        <div className={`grid ${isAdmin ? 'grid-cols-5' : 'grid-cols-4'} items-center gap-0.5 px-1.5 h-16`}>
           {navItems.map((item) => {
             const Icon = item.icon; // Extract the icon component
             const isProfileSection =
@@ -291,10 +292,20 @@ export default function DashboardLayout() {
                 (location.pathname === item.path ||
                   (item.path === '/dashboard' && location.pathname === '/dashboard/')));
             return (
-              <Link key={item.name} to={item.path} className={`flex h-full w-full flex-col items-center justify-center space-y-1 ${isActive ? 'text-brand-primary' : 'text-content-secondary hover:text-white'}`}>
+              <Link
+                key={item.name}
+                to={item.path}
+                className={`flex h-[calc(100%-10px)] min-h-0 w-full flex-col items-center justify-center space-y-1 self-center rounded-xl transition-colors ${
+                  isActive
+                    ? 'text-brand-primary bg-brand-primary/[0.14] ring-1 ring-inset ring-brand-primary/30 shadow-[inset_0_1px_0_0_rgb(255_255_255_/_0.06)]'
+                    : 'text-content-secondary hover:text-white'
+                }`}
+              >
                 {/* Render the Lucide icon */}
-                <Icon className="w-5 h-5 mb-0.5" />
-                <span className="text-[10px] font-bold tracking-wider">{item.name}</span>
+                <Icon className="w-5 h-5 mb-0.5 drop-shadow-[0_1px_1px_rgb(15_10_46_/_0.75)]" />
+                <span className="text-[10px] font-bold tracking-wider [text-shadow:0_1px_2px_rgb(15_10_46_/_0.88)]">
+                  {item.name}
+                </span>
               </Link>
             );
           })}

--- a/src/app/layout/ui/DashboardMobileBrandBar.jsx
+++ b/src/app/layout/ui/DashboardMobileBrandBar.jsx
@@ -11,7 +11,7 @@ export default function DashboardMobileBrandBar({ user }) {
   const wordmarkMarkup = useMemo(() => getBrandChromeWordmarkSvgMarkup(), []);
 
   return (
-    <div className="relative z-20 grid min-h-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 overflow-visible border-b border-border-subtle/35 bg-brand-bg/98 py-2 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-4 shadow-[0_8px_24px_-16px_rgba(15,10,46,0.95)] backdrop-blur-sm supports-[backdrop-filter]:backdrop-saturate-125 sm:flex sm:justify-between sm:gap-3 sm:pl-4 sm:pr-4">
+    <div className="relative z-20 grid min-h-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 overflow-visible border-b border-border-subtle/35 bg-[linear-gradient(to_bottom,rgb(var(--brand-bg-deep)_/_0.76),rgb(var(--brand-bg)_/_0.60))] py-2 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-4 shadow-[0_10px_28px_-14px_rgba(15,10,46,0.85)] ring-1 ring-inset ring-white/[0.06] backdrop-blur-xl supports-[backdrop-filter]:backdrop-blur-2xl supports-[backdrop-filter]:backdrop-saturate-150 sm:flex sm:justify-between sm:gap-3 sm:pl-4 sm:pr-4">
       <h1 className="flex min-h-0 min-w-0 items-center justify-start justify-self-start self-center overflow-visible text-left leading-none max-sm:-translate-x-[1.125rem] max-sm:translate-y-1 sm:flex-1 sm:translate-x-0 sm:translate-y-0 sm:justify-self-auto">
         <Link
           to="/dashboard"

--- a/src/app/layout/ui/DashboardMobileContextBar.jsx
+++ b/src/app/layout/ui/DashboardMobileContextBar.jsx
@@ -1,21 +1,33 @@
 import React from 'react';
+import {
+  dashboardMobileContextTitleGradientClasses,
+  dashboardMobileContextTitleWarRoomClasses,
+} from '../../../shared/config/dashboardHeadingTypography';
 import { showOptionLabelCompact, showOptionTitle } from '../../../shared/utils/showOptionLabel.js';
 
 export default function DashboardMobileContextBar({
   scrollDirection,
   contextTitle,
+  contextTitleTone = 'default',
   showDatePicker,
   selectedDate,
   onSelectedDateChange,
   showDatesByTour,
 }) {
+  const isWarRoom = contextTitleTone === 'warRoom';
   return (
     <div
-      className={`absolute top-full left-0 w-full bg-[rgb(var(--surface-chrome)_/_0.98)] backdrop-blur-sm supports-[backdrop-filter]:backdrop-saturate-125 shadow-[inset_0_1px_0_0_rgb(var(--brand-primary)/0.14),0_10px_26px_-18px_rgb(var(--brand-bg-deep)/0.9),0_0_24px_-16px_rgb(var(--brand-primary)/0.07)] px-4 py-3 flex flex-row flex-nowrap items-center justify-between gap-2 min-w-0 transition-transform duration-300 ease-in-out z-10 ${
+      className={`absolute top-full left-0 w-full bg-[rgb(var(--surface-chrome)_/_0.98)] backdrop-blur-sm supports-[backdrop-filter]:backdrop-saturate-125 shadow-[0_10px_26px_-18px_rgb(var(--brand-bg-deep)/0.9),0_0_24px_-16px_rgb(var(--brand-primary)/0.07)] px-4 py-3 flex flex-row flex-nowrap items-center justify-between gap-2 min-w-0 transition-transform duration-300 ease-in-out z-10 ${
         scrollDirection === 'down' ? '-translate-y-full' : 'translate-y-0'
       }`}
     >
-      <span className="min-w-0 flex-1 basis-0 text-sm font-bold text-slate-100 truncate">
+      <span
+        className={`min-w-0 flex-1 basis-0 truncate text-sm font-bold ${
+          isWarRoom
+            ? dashboardMobileContextTitleWarRoomClasses
+            : dashboardMobileContextTitleGradientClasses
+        }`}
+      >
         {contextTitle}
       </span>
 

--- a/src/app/layout/ui/DashboardPageHeading.jsx
+++ b/src/app/layout/ui/DashboardPageHeading.jsx
@@ -1,12 +1,17 @@
 import React from 'react';
 
+import {
+  dashboardPageTitleGradientClasses,
+  dashboardPageTitleWarRoomClasses,
+} from '../../../shared/config/dashboardHeadingTypography';
+
 export default function DashboardPageHeading({ title, tone = 'default' }) {
   const isWarRoom = tone === 'warRoom';
 
   return (
     <h2
       className={`hidden md:block font-display text-display-page md:text-display-page-lg font-bold mb-6 mt-1 tracking-tight ${
-        isWarRoom ? 'uppercase text-red-500' : 'text-white'
+        isWarRoom ? dashboardPageTitleWarRoomClasses : dashboardPageTitleGradientClasses
       }`}
     >
       {title}

--- a/src/features/profile/ui/AccountSecurity.jsx
+++ b/src/features/profile/ui/AccountSecurity.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
+import { dashboardPageTitleGradientClasses } from '../../../shared/config/dashboardHeadingTypography';
 import { useAccountSecurity } from '../model/useAccountSecurity';
 import AccountSecurityForm from './AccountSecurityForm';
 
@@ -60,7 +61,9 @@ export default function AccountSecurity({ user }) {
       </Link>
 
       <div className="mb-6 text-left">
-        <h2 className="hidden md:block font-display text-display-page md:text-display-page-lg font-bold text-white">
+        <h2
+          className={`hidden md:block font-display text-display-page md:text-display-page-lg font-bold ${dashboardPageTitleGradientClasses}`}
+        >
           Sign-in &amp; password
         </h2>
         <p className="mt-2 text-sm text-slate-400 leading-relaxed">

--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -4,6 +4,7 @@ import { ExternalLink } from 'lucide-react';
 
 import { useSignOut } from '../../features/auth';
 import { ProfileEditForm, useUserProfile } from '../../features/profile';
+import { dashboardPageTitleGradientClasses } from '../../shared/config/dashboardHeadingTypography';
 import Button from '../../shared/ui/Button';
 import DashboardActionRow from '../../shared/ui/DashboardActionRow';
 import DashboardRowPill from '../../shared/ui/DashboardRowPill';
@@ -47,7 +48,9 @@ export default function Profile({ user }) {
       </DashboardActionRow>
 
       <div className="mb-6 text-left">
-        <h2 className="hidden md:block font-display text-display-page md:text-display-page-lg font-bold text-white">
+        <h2
+          className={`hidden md:block font-display text-display-page md:text-display-page-lg font-bold ${dashboardPageTitleGradientClasses}`}
+        >
           Profile
         </h2>
         {joinDate && (

--- a/src/shared/config/dashboardHeadingTypography.js
+++ b/src/shared/config/dashboardHeadingTypography.js
@@ -1,0 +1,19 @@
+/**
+ * Dashboard route titles: Space Grotesk page headings + mobile context bar.
+ * Gradient pulls the venue teal into display type without flat “slate” meta gray.
+ */
+
+/** Desktop main h2 (hidden on mobile where context bar carries the title). */
+export const dashboardPageTitleGradientClasses =
+  'text-transparent bg-clip-text bg-gradient-to-r from-white from-[5%] via-white to-brand-primary drop-shadow-[0_2px_28px_rgb(var(--brand-primary)/0.2)]';
+
+/** Admin / War Room — keep destructive red, add soft glow for parity with default tone. */
+export const dashboardPageTitleWarRoomClasses =
+  'uppercase text-red-500 drop-shadow-[0_0_22px_rgb(239_68_68_/_0.28)]';
+
+/** Mobile context bar route name (compact display). */
+export const dashboardMobileContextTitleGradientClasses =
+  'font-display text-transparent bg-clip-text bg-gradient-to-r from-white from-[4%] to-brand-primary drop-shadow-[0_0_18px_rgb(var(--brand-primary)/0.22)]';
+
+export const dashboardMobileContextTitleWarRoomClasses =
+  'font-display uppercase text-red-500 drop-shadow-[0_0_14px_rgb(239_68_68_/_0.25)]';

--- a/src/shared/ui/PageTitle.jsx
+++ b/src/shared/ui/PageTitle.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
+import { dashboardPageTitleGradientClasses } from '../config/dashboardHeadingTypography';
+
 const variantStyles = {
-  /** Dashboard main h2 — font-display + display-page ladder */
-  page: 'font-display text-display-page md:text-display-page-lg font-bold text-white',
+  /** Dashboard main h2 — font-display + display-page ladder + venue gradient */
+  page: `font-display text-display-page md:text-display-page-lg font-bold ${dashboardPageTitleGradientClasses}`,
   /** Section titles inside cards (e.g. empty states) */
   section: 'font-display text-display-md font-bold text-white',
   /** Small uppercase label (filter labels, overlines) */


### PR DESCRIPTION
## Summary
- **Mobile bottom nav:** Frosted glass (translucent gradient + strong backdrop blur/saturate), tuned scrim alphas (~0.76 / ~0.60), active-tab pill and label/icon contrast so teal doesn’t fight scrolling primary buttons.
- **Mobile top brand bar (H1 row):** Same glass recipe as the bottom bar (mirrored gradient, shadows, ring), with opacity aligned to the nav.
- **Dashboard titles:** Shared `dashboardHeadingTypography` tokens — display headings use a white→`brand-primary` gradient with a soft teal glow; War Room stays red (desktop + mobile context bar via `contextTitleTone`).
- **Mobile header seam:** Removed stacked inset hairlines so the brand bar `border-b` is a single divider between wordmark and context rows.

## Test plan
- [ ] Mobile dashboard: scroll picks (or any screen with green CTAs) under bottom nav — labels/icons stay readable; bar still looks frosted, not opaque.
- [ ] Mobile: top bar and bottom bar glass match; title gradient reads on pool/standings/picks routes; **War Room** title red on admin.
- [ ] Desktop: page `h2` gradient on routes with `layoutDesktopHeading`; Profile + Sign-in & password desktop headings.
- [ ] Mobile: no double line between wordmark row and context/date row.
- [ ] `npm run lint` (CI verify matrix as usual before merge).

Made with [Cursor](https://cursor.com)