### PR TITLE
feat(picks): catalog-only picks, dedupe; public profile stats polish

### DIFF
--- a/src/features/picks/model/picksCatalogUtils.js
+++ b/src/features/picks/model/picksCatalogUtils.js
@@ -1,0 +1,31 @@
+import { FORM_FIELDS } from '../../../shared/data/gameConfig';
+import { resolveCatalogSongTitle } from '../../../shared/lib/resolveCatalogSongTitle';
+
+/**
+ * @param {Record<string, unknown>} formData
+ * @param {Array<string | { name?: string }>} songs
+ * @returns {{ ok: true } | { ok: false, message: string }}
+ */
+export function validatePicksForSave(formData, songs) {
+  const used = new Set();
+  for (const f of FORM_FIELDS) {
+    const raw = formData?.[f.id];
+    if (raw == null || !String(raw).trim()) continue;
+    const canonical = resolveCatalogSongTitle(raw, songs);
+    if (canonical === null) {
+      return {
+        ok: false,
+        message: 'Every filled pick must be a song from the catalog.',
+      };
+    }
+    const key = canonical.toLowerCase();
+    if (used.has(key)) {
+      return {
+        ok: false,
+        message: 'Each pick must be a different song.',
+      };
+    }
+    used.add(key);
+  }
+  return { ok: true };
+}

--- a/src/features/picks/model/picksCatalogUtils.test.js
+++ b/src/features/picks/model/picksCatalogUtils.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { FORM_FIELDS } from '../../../shared/data/gameConfig';
+import { validatePicksForSave } from './picksCatalogUtils';
+
+const catalog = [{ name: 'Fee' }, { name: 'Tweezer' }, { name: 'Ghost' }];
+
+describe('validatePicksForSave', () => {
+  it('accepts empty picks', () => {
+    expect(validatePicksForSave({}, catalog)).toEqual({ ok: true });
+  });
+
+  it('rejects non-catalog titles', () => {
+    const form = Object.fromEntries(FORM_FIELDS.map((f) => [f.id, '']));
+    form.s1o = 'Not A Real Phish Song Xyz';
+    expect(validatePicksForSave(form, catalog).ok).toBe(false);
+  });
+
+  it('rejects duplicate songs (case-insensitive)', () => {
+    const form = Object.fromEntries(FORM_FIELDS.map((f) => [f.id, '']));
+    form.s1o = 'Fee';
+    form.s1c = 'fee';
+    expect(validatePicksForSave(form, catalog).ok).toBe(false);
+  });
+
+  it('accepts distinct catalog songs', () => {
+    const form = Object.fromEntries(FORM_FIELDS.map((f) => [f.id, '']));
+    form.s1o = 'Fee';
+    form.s1c = 'Tweezer';
+    form.s2o = 'Ghost';
+    expect(validatePicksForSave(form, catalog)).toEqual({ ok: true });
+  });
+});

--- a/src/features/picks/model/usePicksForm.js
+++ b/src/features/picks/model/usePicksForm.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { useSongCatalog } from '../../song-catalog';
 import {
   fetchPickDoc,
   fetchPoolsSnapshotForPick,
@@ -8,6 +9,7 @@ import {
 } from '../api/picksApi';
 import { FORM_FIELDS } from '../../../shared/data/gameConfig';
 import { getShowStatus } from '../../../shared/utils/timeLogic';
+import { validatePicksForSave } from './picksCatalogUtils';
 import { trackEditPicks, trackSubmitPicks } from './picksAnalytics';
 
 function tourLabelForShowDate(selectedDate, showDatesByTour) {
@@ -37,6 +39,8 @@ export default function usePicksForm({
   /** True once we've loaded non-empty picks from Firestore for this show (or after first successful save). */
   const [hadPersistedPicksOnServer, setHadPersistedPicksOnServer] = useState(false);
   const [saveFeedback, setSaveFeedback] = useState(null);
+  const [pickConstraintMessage, setPickConstraintMessage] = useState(null);
+  const { songs } = useSongCatalog();
 
   const showStatus =
     selectedDate && Array.isArray(showDates) && showDates.length > 0
@@ -92,7 +96,33 @@ export default function usePicksForm({
   }, [selectedDate, user?.uid]);
 
   const handleInput = useCallback((fieldId, value) => {
-    setFormData((prev) => ({ ...prev, [fieldId]: value }));
+    let rejectedDuplicate = false;
+    setFormData((prev) => {
+      const trimmed = String(value ?? '').trim();
+      if (!trimmed) {
+        return { ...prev, [fieldId]: '' };
+      }
+      const key = trimmed.toLowerCase();
+      for (const f of FORM_FIELDS) {
+        if (f.id === fieldId) continue;
+        const other = prev[f.id];
+        if (other != null && String(other).trim().toLowerCase() === key) {
+          rejectedDuplicate = true;
+          return prev;
+        }
+      }
+      return { ...prev, [fieldId]: value };
+    });
+    if (!String(value ?? '').trim()) {
+      setPickConstraintMessage(null);
+      return;
+    }
+    if (rejectedDuplicate) {
+      setPickConstraintMessage('Each pick must be a different song.');
+      window.setTimeout(() => setPickConstraintMessage(null), 3500);
+    } else {
+      setPickConstraintMessage(null);
+    }
   }, []);
 
   const handleSave = useCallback(
@@ -106,6 +136,16 @@ export default function usePicksForm({
           tone: 'error',
           text: 'Error: You must be logged in to save picks.',
         });
+        return;
+      }
+
+      const validation = validatePicksForSave(formData, songs);
+      if (!validation.ok) {
+        setSaveFeedback({
+          tone: 'error',
+          text: validation.message,
+        });
+        setTimeout(() => setSaveFeedback(null), 4500);
         return;
       }
 
@@ -174,6 +214,7 @@ export default function usePicksForm({
       showDates,
       showDatesByTour,
       formData,
+      songs,
       isLocked,
       isSaving,
       hadPersistedPicksOnServer,
@@ -190,5 +231,6 @@ export default function usePicksForm({
     hasExistingPicks,
     showStatus,
     saveFeedback,
+    pickConstraintMessage,
   };
 }

--- a/src/features/picks/ui/PicksFieldsForm.jsx
+++ b/src/features/picks/ui/PicksFieldsForm.jsx
@@ -23,7 +23,11 @@ export default function PicksFieldsForm({
             songs={songs}
             value={formData[field.id] || ''}
             onChange={(val) => onChange(field.id, val)}
-            placeholder="Type a song..."
+            placeholder="Search and choose a song…"
+            requireCatalogMatch
+            excludeTitles={FORM_FIELDS.filter((f) => f.id !== field.id)
+              .map((f) => formData[f.id])
+              .filter(Boolean)}
             readOnly={isLocked}
             disabled={disabled || isLocked}
           />

--- a/src/features/profile/ui/PublicProfileView.jsx
+++ b/src/features/profile/ui/PublicProfileView.jsx
@@ -9,26 +9,6 @@ function formatPlayingSince(createdAt) {
   return value || null;
 }
 
-function StatCell({ label, value, loading }) {
-  return (
-    <div className="rounded-2xl border border-border-subtle bg-surface-field p-4">
-      <p className="mb-1 text-[10px] font-black uppercase tracking-wider text-content-secondary">
-        {label}
-      </p>
-      {loading ? (
-        <Loader2
-          className="mx-auto h-5 w-5 animate-spin text-brand-primary"
-          aria-label={`Loading ${label.toLowerCase()}`}
-        />
-      ) : (
-        <p className="text-xl font-black tabular-nums text-brand-primary">
-          {value}
-        </p>
-      )}
-    </div>
-  );
-}
-
 /**
  * Read-only public profile: handle, favorite song, pools, and season stats.
  * Stats are the global cross-pool view (points from the user's own graded
@@ -56,6 +36,12 @@ export default function PublicProfileView({
     typeof stats?.totalPoints === 'number' ? stats.totalPoints : 0;
   const wins = typeof stats?.wins === 'number' ? stats.wins : 0;
   const shows = typeof stats?.shows === 'number' ? stats.shows : 0;
+
+  const statColumns = [
+    { key: 'points', label: 'Total points', value: totalPoints },
+    { key: 'wins', label: 'Wins', value: wins },
+    { key: 'shows', label: 'Shows', value: shows },
+  ];
 
   return (
     <div className="min-h-screen bg-transparent text-white">
@@ -106,14 +92,32 @@ export default function PublicProfileView({
           <h2 className="mb-4 text-xs font-black uppercase tracking-widest text-content-secondary">
             Stats
           </h2>
-          <div className="grid grid-cols-3 gap-3 text-center">
-            <StatCell
-              label="Total points"
-              value={totalPoints}
-              loading={statsLoading}
-            />
-            <StatCell label="Wins" value={wins} loading={statsLoading} />
-            <StatCell label="Shows" value={shows} loading={statsLoading} />
+          <div className="grid grid-cols-3 gap-x-3 gap-y-1.5 text-center">
+            {statColumns.map(({ key, label }) => (
+              <p
+                key={`${key}-label`}
+                className="self-end px-0.5 text-[10px] font-black uppercase leading-snug tracking-wider text-content-secondary"
+              >
+                {label}
+              </p>
+            ))}
+            {statColumns.map(({ key, label, value }) => (
+              <div
+                key={`${key}-value`}
+                className="flex min-h-[3.25rem] items-center justify-center rounded-2xl border border-border-subtle bg-surface-field px-2 py-3"
+              >
+                {statsLoading ? (
+                  <Loader2
+                    className="h-5 w-5 shrink-0 animate-spin text-brand-primary"
+                    aria-label={`Loading ${label}`}
+                  />
+                ) : (
+                  <span className="text-2xl font-black tabular-nums leading-none tracking-tight text-brand-primary">
+                    {value}
+                  </span>
+                )}
+              </div>
+            ))}
           </div>
           <p className="mt-3 text-[11px] font-medium leading-relaxed text-content-secondary">
             Running totals across every graded night. Wins count shows where

--- a/src/pages/picks/PicksPage.jsx
+++ b/src/pages/picks/PicksPage.jsx
@@ -18,6 +18,7 @@ export default function PicksPage({ user, selectedDate }) {
     isLocked,
     hasExistingPicks,
     saveFeedback,
+    pickConstraintMessage,
   } = usePicksForm({ user, selectedDate, showDates, showDatesByTour });
 
   const { openScoringRules } = useScoringRulesModal();
@@ -105,6 +106,14 @@ export default function PicksPage({ user, selectedDate }) {
           variant="venue"
           className="space-y-4 transition-all duration-300"
         >
+          {pickConstraintMessage ? (
+            <div
+              className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm font-bold text-amber-100"
+              role="status"
+            >
+              {pickConstraintMessage}
+            </div>
+          ) : null}
           <PicksFieldsForm
             formData={formData}
             onChange={handleInput}

--- a/src/shared/lib/resolveCatalogSongTitle.js
+++ b/src/shared/lib/resolveCatalogSongTitle.js
@@ -1,0 +1,20 @@
+/**
+ * Case-insensitive match of user input to a catalog row; returns canonical `name` or null.
+ *
+ * @param {unknown} input
+ * @param {Array<string | { name?: string }>} songs
+ * @returns {string | null}
+ */
+export function resolveCatalogSongTitle(input, songs) {
+  const t = String(input ?? '').trim();
+  if (!t) return null;
+  const lower = t.toLowerCase();
+  if (!Array.isArray(songs)) return null;
+  for (const song of songs) {
+    const name =
+      typeof song === 'string' ? song : song?.name != null ? String(song.name) : '';
+    const n = name.trim();
+    if (n && n.toLowerCase() === lower) return n;
+  }
+  return null;
+}

--- a/src/shared/ui/SongAutocomplete.jsx
+++ b/src/shared/ui/SongAutocomplete.jsx
@@ -1,7 +1,8 @@
 // src/components/SongAutocomplete.jsx
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { PHISH_SONGS } from '../data/phishSongs.js';
+import { resolveCatalogSongTitle } from '../lib/resolveCatalogSongTitle.js';
 import Input from './Input';
 
 export default function SongAutocomplete({
@@ -13,10 +14,42 @@ export default function SongAutocomplete({
   onBlur,
   readOnly = false,
   disabled = false,
+  /**
+   * When true, blur clears non-catalog text and normalizes casing to the catalog `name`.
+   * Typing still filters suggestions; only selections / exact catalog matches stick.
+   */
+  requireCatalogMatch = false,
+  /** Song titles (other slots) to omit from suggestions — case-insensitive. */
+  excludeTitles = [],
   /** @type {{ name: string, total?: string, gap?: string, last?: string }[] | undefined} */
   songs: songsProp,
 }) {
   const songs = songsProp ?? PHISH_SONGS;
+  const excludedLower = useMemo(
+    () =>
+      new Set(
+        excludeTitles
+          .map((t) => String(t ?? '').trim().toLowerCase())
+          .filter(Boolean),
+      ),
+    [excludeTitles],
+  );
+
+  const filterCatalog = useCallback(
+    (query) => {
+      const q = String(query ?? '').trim().toLowerCase();
+      if (!q) return [];
+      return songs
+        .filter((song) => {
+          const name = typeof song === 'string' ? song : song.name;
+          const n = String(name ?? '').trim().toLowerCase();
+          if (!n || excludedLower.has(n)) return false;
+          return n.includes(q);
+        })
+        .slice(0, 10);
+    },
+    [songs, excludedLower],
+  );
   const [isOpen, setIsOpen] = useState(false);
   const [filteredSongs, setFilteredSongs] = useState([]);
   const [activeIndex, setActiveIndex] = useState(-1);
@@ -50,10 +83,7 @@ export default function SongAutocomplete({
     onChange?.(val);
 
     if (val.length > 0) {
-      const matches = songs.filter(song => 
-        (typeof song === 'string' ? song : song.name).toLowerCase().includes(val.toLowerCase())
-      ).slice(0, 10);
-      
+      const matches = filterCatalog(val);
       setFilteredSongs(matches);
       setIsOpen(true);
       setActiveIndex(-1);
@@ -103,7 +133,9 @@ export default function SongAutocomplete({
     if (readOnly || disabled) return;
     const v = String(value ?? '');
     if (v.length > 0) {
-      setIsOpen(true);
+      const matches = filterCatalog(v);
+      setFilteredSongs(matches);
+      setIsOpen(matches.length > 0);
     }
   };
 
@@ -112,10 +144,24 @@ export default function SongAutocomplete({
     // Defer close so a mousedown on a suggestion (onMouseDown + preventDefault) can select
     // before the menu unmounts; Tab/click-away still closes on the next tick.
     clearBlurCloseTimeout();
+    const rawValue = e?.target?.value;
     blurCloseTimeoutRef.current = window.setTimeout(() => {
       blurCloseTimeoutRef.current = null;
       setIsOpen(false);
       setActiveIndex(-1);
+      if (requireCatalogMatch && !readOnly && !disabled) {
+        const raw = String(rawValue ?? '').trim();
+        if (!raw) {
+          onChange?.('');
+          return;
+        }
+        const canonical = resolveCatalogSongTitle(rawValue, songs);
+        if (canonical === null) {
+          onChange?.('');
+        } else if (canonical !== raw) {
+          onChange?.(canonical);
+        }
+      }
     }, 0);
   };
 


### PR DESCRIPTION
## Summary
- **Picks:** Song catalog required (no freeform); blur clears invalid text and normalizes casing. Suggestions hide songs already used in other slots. Duplicate selection blocked with inline message; save runs catalog + uniqueness validation.
- **Public profile:** Stats use a shared label row + value row so numbers align on mobile; tighter gap between labels and scores.

## Tracking
Umbrella verification / discussion: **#315** (stay open until you finish QA).

## Related
- Dashboard / mobile chrome / headings: **#312** (merged).

## Test plan
- [ ] Picks: cannot keep non-catalog text after blur; cannot pick same song twice; save blocked with clear error if invalid.
- [ ] Public profile `/user/:id` on narrow width: stats numbers align; spacing looks right.
- [ ] `npm run lint` + vitest `picksCatalogUtils.test.js`