### PR TITLE
feat(dashboard): Tour Date gradient label + gradient select frame

### DIFF
--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -53,6 +53,10 @@ import {
   brandWordmarkDashboardSidebarScaleWrapperClassNames,
   brandWordmarkImgClassNames,
 } from '../../shared/config/branding';
+import {
+  dashboardTourDateLabelGradientClasses,
+  dashboardTourDateSelectChromeDesktopWrap,
+} from '../../shared/config/dashboardHeadingTypography';
 import { getDashboardPageMeta } from './model/dashboardPageMeta';
 import DashboardMobileBrandBar from './ui/DashboardMobileBrandBar';
 import DashboardMobileContextBar from './ui/DashboardMobileContextBar';
@@ -193,15 +197,18 @@ export default function DashboardLayout() {
           {/* DESKTOP Global Date Picker */}
           {meta.showDatePicker && (
             <div className="hidden md:flex mb-6 bg-surface-panel-strong backdrop-blur-md p-3 rounded-2xl border border-border-muted/70 items-center justify-between gap-4 min-w-0 shadow-inset-glass ring-1 ring-border-glass/45">
-              <span className="shrink-0 px-2 text-xs font-black uppercase tracking-widest text-content-secondary">
-                Select Show:
+              <span
+                className={`shrink-0 px-2 text-xs font-black uppercase tracking-widest ${dashboardTourDateLabelGradientClasses}`}
+              >
+                Tour Date:
               </span>
               <div className="min-w-0 w-64 max-w-full shrink">
-                <select
-                  value={selectedDate}
-                  onChange={(e) => setSelectedDate(e.target.value)}
-                  className="show-date-select w-full min-w-0 max-w-full appearance-none bg-surface-field border-2 border-border-subtle text-white text-base font-bold py-2.5 px-3 rounded-xl outline-none focus:border-brand-primary transition-colors cursor-pointer"
-                >
+                <div className={dashboardTourDateSelectChromeDesktopWrap}>
+                  <select
+                    value={selectedDate}
+                    onChange={(e) => setSelectedDate(e.target.value)}
+                    className="show-date-select w-full min-w-0 max-w-full appearance-none rounded-[11px] border-0 bg-surface-field py-2.5 px-3 text-base font-bold text-white outline-none ring-0 transition-colors cursor-pointer focus:border-transparent focus:ring-0"
+                  >
                   {showDatesByTour.map(({ tour, shows }, idx) => (
                     <optgroup
                       key={`${tour}-${shows[0]?.date ?? idx}`}
@@ -215,7 +222,8 @@ export default function DashboardLayout() {
                       ))}
                     </optgroup>
                   ))}
-                </select>
+                  </select>
+                </div>
               </div>
             </div>
           )}

--- a/src/app/layout/ui/DashboardMobileContextBar.jsx
+++ b/src/app/layout/ui/DashboardMobileContextBar.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {
   dashboardMobileContextTitleGradientClasses,
   dashboardMobileContextTitleWarRoomClasses,
+  dashboardTourDateLabelGradientClasses,
+  dashboardTourDateSelectChromeMobileWrap,
 } from '../../../shared/config/dashboardHeadingTypography';
 import { showOptionLabelCompact, showOptionTitle } from '../../../shared/utils/showOptionLabel.js';
 
@@ -33,14 +35,19 @@ export default function DashboardMobileContextBar({
 
       {showDatePicker && (
         <div className="flex shrink-0 flex-row flex-nowrap items-center gap-1.5 min-w-0">
-          <span className="text-[10px] font-semibold text-slate-200 uppercase tracking-wide whitespace-nowrap leading-none">
-            Select Show:
-          </span>
-          <select
-            value={selectedDate}
-            onChange={(e) => onSelectedDateChange(e.target.value)}
-            className="show-date-select shrink-0 max-w-[180px] min-w-0 appearance-none bg-surface-field border border-border-subtle/45 text-white text-xs font-bold py-1.5 px-2.5 rounded-lg outline-none focus:border-brand-primary transition-colors cursor-pointer"
+          <span
+            className={`font-display text-[10px] font-semibold uppercase tracking-wide whitespace-nowrap leading-none ${dashboardTourDateLabelGradientClasses}`}
           >
+            Tour Date:
+          </span>
+          <div
+            className={`${dashboardTourDateSelectChromeMobileWrap} shrink-0 max-w-[180px] min-w-0`}
+          >
+            <select
+              value={selectedDate}
+              onChange={(e) => onSelectedDateChange(e.target.value)}
+              className="show-date-select w-full max-w-full min-w-0 appearance-none rounded-[7px] border-0 bg-surface-field py-1.5 pl-2.5 pr-2 text-xs font-bold text-white outline-none ring-0 transition-colors cursor-pointer focus:border-transparent focus:ring-0"
+            >
             {showDatesByTour.map(({ tour, shows }, idx) => (
               <optgroup
                 key={`${tour}-${shows[0]?.date ?? idx}`}
@@ -54,7 +61,8 @@ export default function DashboardMobileContextBar({
                 ))}
               </optgroup>
             ))}
-          </select>
+            </select>
+          </div>
         </div>
       )}
     </div>

--- a/src/features/admin/ui/AdminWarRoomShowDate.jsx
+++ b/src/features/admin/ui/AdminWarRoomShowDate.jsx
@@ -21,7 +21,7 @@ export default function AdminWarRoomShowDate({ value, onChange, disabled = false
           </label>
           <p className="text-[11px] font-bold leading-relaxed text-content-secondary">
             Choose the Phish <code className="text-slate-400">YYYY-MM-DD</code> you are editing or
-            polling. This can differ from the global “Select Show” list (e.g. Mexico or test dates).
+            polling. This can differ from the global “Tour Date” list (e.g. Mexico or test dates).
           </p>
           <input
             id="admin-war-room-show-date"

--- a/src/shared/config/dashboardHeadingTypography.js
+++ b/src/shared/config/dashboardHeadingTypography.js
@@ -17,3 +17,17 @@ export const dashboardMobileContextTitleGradientClasses =
 
 export const dashboardMobileContextTitleWarRoomClasses =
   'font-display uppercase text-red-500 drop-shadow-[0_0_14px_rgb(239_68_68_/_0.25)]';
+
+/** “Tour Date” label — same white→teal gradient language as route titles, compact glow. */
+export const dashboardTourDateLabelGradientClasses =
+  'text-transparent bg-clip-text bg-gradient-to-r from-white from-[5%] via-white to-brand-primary drop-shadow-[0_0_14px_rgb(var(--brand-primary)/0.2)]';
+
+/**
+ * 1px gradient frame around the global show `<select>` (venue halo).
+ * Inner control should use matching inner radius, `border-0`, field background.
+ */
+export const dashboardTourDateSelectChromeMobileWrap =
+  'rounded-lg bg-gradient-to-r from-white/35 via-brand-primary/85 to-brand-primary p-px shadow-[0_0_18px_rgb(var(--brand-primary)/0.22)] focus-within:ring-2 focus-within:ring-brand-primary/45 focus-within:ring-offset-0 focus-within:ring-offset-transparent';
+
+export const dashboardTourDateSelectChromeDesktopWrap =
+  'rounded-xl bg-gradient-to-r from-white/35 via-brand-primary/85 to-brand-primary p-px shadow-[0_0_20px_rgb(var(--brand-primary)/0.24)] focus-within:ring-2 focus-within:ring-brand-primary/45 focus-within:ring-offset-0 focus-within:ring-offset-transparent';


### PR DESCRIPTION
## Summary
- Renamed copy already uses **Tour Date**; this PR applies the same **white→teal gradient** treatment to that label on mobile (context bar) and desktop (global date row).
- Wraps the show `<select>` in a **1px gradient halo** (mobile + desktop) with `focus-within` ring so the current/default date control matches venue chrome.
- Adds shared tokens in `dashboardHeadingTypography.js`; War Room help text refers to the **Tour Date** list for consistency.

## Tracking
Umbrella / verification thread: **#315** (comment added there for this PR).

## Test plan
- [ ] Mobile dashboard (date picker visible): **Tour Date:** reads with gradient; select has gradient border and focuses cleanly.
- [ ] Desktop: global date row — same label + select treatment.
- [ ] War Room: helper paragraph still accurate.
- [ ] `npm run lint`

Made with [Cursor](https://cursor.com)