### PR TITLE
Admin: hollow setlist guardrails for finalize and rollup (#320)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -201,6 +201,12 @@ exports.rollupScoresForShow = onCall(
         `official_setlists/${showDate} does not exist. Save the setlist first.`
       );
     }
+    if (result.hollowSetlist) {
+      throw new HttpsError(
+        "failed-precondition",
+        "Official setlist has no songs in slots or ordered list. Add the show before finalizing."
+      );
+    }
     return {
       ok: true,
       processedPicks: result.processedPicks,

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
-    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js poolDelete.test.js rollupSeasonAggregates.test.js",
+    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js",
     "serve": "firebase emulators:start --only functions",
     "shell": "firebase functions:shell",
     "start": "npm run shell",

--- a/functions/phishnetLiveSetlistAutomation.js
+++ b/functions/phishnetLiveSetlistAutomation.js
@@ -567,6 +567,17 @@ async function maybeAutoFinalize({
         showDate,
         trigger: "auto-reconcile",
       });
+      if (result.hollowSetlist) {
+        logger?.warn?.("auto-finalize reconcile skipped: hollow setlist", {
+          showDate,
+        });
+        return {
+          fired: false,
+          trigger: "auto-reconcile",
+          reason: "hollow-setlist",
+          result,
+        };
+      }
       return { fired: true, trigger: "auto-reconcile", result };
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -594,6 +605,18 @@ async function maybeAutoFinalize({
 
   try {
     const result = await runRollup({ showDate, trigger: "auto" });
+    if (result.hollowSetlist) {
+      logger?.warn?.("auto-finalize skipped: hollow setlist", {
+        showDate,
+        reason: decision.reason,
+      });
+      return {
+        fired: false,
+        trigger: "auto",
+        reason: "hollow-setlist",
+        result,
+      };
+    }
     // Stamp post-rollup so a rollup failure doesn't leave a misleading
     // "already finalized" flag that would suppress future retries.
     await automationRef.set(

--- a/functions/rollupCore.js
+++ b/functions/rollupCore.js
@@ -21,7 +21,11 @@
  * core is safe to invoke from both manual and automatic paths.
  */
 
-const { calculateTotalScore, actualSetlistFromOfficialDoc } = require("./scoringCore");
+const {
+  calculateTotalScore,
+  actualSetlistFromOfficialDoc,
+  setlistHasAnyPlayedSong,
+} = require("./scoringCore");
 const {
   computeGlobalMaxScore,
   computePerPickRollup,
@@ -39,7 +43,7 @@ const MAX_FIRESTORE_BATCH_WRITES = 500;
  * @param {string | null} [params.callerUid] Firebase UID of the caller (null for scheduler).
  * @param {"manual" | "auto" | "auto-reconcile"} [params.trigger] Audit tag.
  * @param {{ info?: Function, warn?: Function, error?: Function } | undefined} [params.logger]
- * @returns {Promise<{ processedPicks: number, skippedPicks: number, totalPicks: number, setlistExists: boolean }>}
+ * @returns {Promise<{ processedPicks: number, skippedPicks: number, totalPicks: number, setlistExists: boolean, hollowSetlist?: boolean }>}
  */
 async function runRollupForShow({
   db,
@@ -65,6 +69,20 @@ async function runRollupForShow({
   }
   const setlistDoc = setlistSnap.data() || {};
   const actualSetlist = actualSetlistFromOfficialDoc(setlistDoc);
+
+  if (!setlistHasAnyPlayedSong(actualSetlist)) {
+    logger?.warn?.("runRollupForShow: hollow setlist (no played songs); skipping rollup", {
+      showDate,
+      trigger,
+    });
+    return {
+      processedPicks: 0,
+      skippedPicks: 0,
+      totalPicks: 0,
+      setlistExists: true,
+      hollowSetlist: true,
+    };
+  }
 
   const picksSnap = await db
     .collection("picks")

--- a/functions/scoringCore.js
+++ b/functions/scoringCore.js
@@ -63,6 +63,11 @@ function buildAllPlayedNormalized(actualSetlist) {
   return [...new Set(combined)];
 }
 
+/** True if the persisted official payload contains at least one played song (slots + ordered list). */
+function setlistHasAnyPlayedSong(actualSetlist) {
+  return buildAllPlayedNormalized(actualSetlist).length > 0;
+}
+
 function calculateSlotScore(fieldId, guessedSong, actualSetlist) {
   if (!actualSetlist || !guessedSong) return 0;
 
@@ -144,6 +149,7 @@ module.exports = {
   normalizeSong,
   guessMatchesEncoreExact,
   buildAllPlayedNormalized,
+  setlistHasAnyPlayedSong,
   calculateSlotScore,
   calculateTotalScore,
   actualSetlistFromOfficialDoc,

--- a/functions/scoringCore.test.js
+++ b/functions/scoringCore.test.js
@@ -1,0 +1,33 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  setlistHasAnyPlayedSong,
+  actualSetlistFromOfficialDoc,
+} = require("./scoringCore");
+
+test("setlistHasAnyPlayedSong: false when all slots empty and no ordered list", () => {
+  const doc = {
+    setlist: { s1o: "", s1c: "", s2o: "", s2c: "", enc: "" },
+    officialSetlist: [],
+  };
+  assert.equal(setlistHasAnyPlayedSong(actualSetlistFromOfficialDoc(doc)), false);
+});
+
+test("setlistHasAnyPlayedSong: true when a slot has a song", () => {
+  const doc = {
+    setlist: { s1o: "Fee", s1c: "", s2o: "", s2c: "", enc: "" },
+    officialSetlist: [],
+  };
+  assert.equal(setlistHasAnyPlayedSong(actualSetlistFromOfficialDoc(doc)), true);
+});
+
+test("setlistHasAnyPlayedSong: true when ordered official list only", () => {
+  const doc = {
+    setlist: { s1o: "", s1c: "", s2o: "", s2c: "", enc: "" },
+    officialSetlist: ["Tweezer"],
+  };
+  assert.equal(setlistHasAnyPlayedSong(actualSetlistFromOfficialDoc(doc)), true);
+});

--- a/src/features/admin/model/useAdminSetlistForm.js
+++ b/src/features/admin/model/useAdminSetlistForm.js
@@ -17,6 +17,27 @@ import { fetchAndMapExternalSetlist, fetchBustoutsFromPhishnet } from './setlist
 
 export const ADMIN_SETLIST_FIELDS = FORM_FIELDS.filter((field) => field.id !== 'wild');
 
+/** True if draft state would yield at least one “played” song for scoring (slots + ordered list + encores). */
+function adminDraftHasPlayedSong(setlistData, officialSetlist, encoreSongs) {
+  for (const field of ADMIN_SETLIST_FIELDS) {
+    const v = setlistData[field.id];
+    if (v != null && String(v).trim() !== '') return true;
+  }
+  if (
+    Array.isArray(officialSetlist) &&
+    officialSetlist.some((s) => String(s ?? '').trim() !== '')
+  ) {
+    return true;
+  }
+  if (
+    Array.isArray(encoreSongs) &&
+    encoreSongs.some((s) => String(s ?? '').trim() !== '')
+  ) {
+    return true;
+  }
+  return false;
+}
+
 function createEmptySlotState() {
   const initialState = {};
   ADMIN_SETLIST_FIELDS.forEach((field) => {
@@ -159,6 +180,23 @@ export function useAdminSetlistForm({ user, selectedDate }) {
 
   const saveSetlist = async ({ finalizeRollup = false } = {}) => {
     if (!isAdmin || !selectedShow) return;
+
+    if (
+      finalizeRollup &&
+      !adminDraftHasPlayedSong(setlistData, officialSetlist, encoreSongs)
+    ) {
+      setMessage({
+        text: 'Cannot finalize: no songs in the official setlist (slots, ordered list, or encore). Add at least one song, or use Save only.',
+        type: 'error',
+      });
+      if (clearMessageTimeoutRef.current) {
+        clearTimeout(clearMessageTimeoutRef.current);
+      }
+      clearMessageTimeoutRef.current = setTimeout(() => {
+        setMessage({ text: '', type: '' });
+      }, 6000);
+      return;
+    }
 
     setIsSaving(true);
     setMessage({ text: '', type: '' });


### PR DESCRIPTION
Refs #320

## Summary
- **Client:** Block War Room finalize when the draft has no played songs (slots, ordered list, encores), with a clear error.
- **Server:** Reject hollow persisted official setlists on manual rollup (`failed-precondition`); skip auto-finalize / finalized stamping when the setlist would be hollow after the same shaping as save.
- **Shared:** `setlistHasAnyPlayedSong` in `scoringCore` plus unit tests; wired through `rollupCore`, live setlist automation, and callable exports as needed.

Issue #320 remains open for planned undo/repair and richer pre-flight; this PR covers the quick-win guardrails only.

## Test plan
- [x] `cd functions && npm test` (includes `scoringCore.test.js`)
- [ ] Admin UI: attempt finalize with empty/hollow draft → blocked with expected message
- [ ] Callable rollup with hollow doc → `failed-precondition` (emulator or staging)
- [ ] Auto-finalize path does not stamp finalized on hollow setlist (per automation tests / staging spot-check)
