### PR TITLE
fix(scoring): suppress tonight's winner banner during partial-grade state (#323)

### DIFF
--- a/src/features/scoring/model/useShowWinnerOfTheNight.js
+++ b/src/features/scoring/model/useShowWinnerOfTheNight.js
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import {
+  hasNonEmptyPicksObject,
   pickCountsTowardSeason,
   reduceShowWinners,
 } from '../../../shared/utils/showAggregation';
@@ -10,12 +11,20 @@ import {
  * tests and any non-React caller that needs the same shape (e.g. the Tour
  * standings reducer in #219).
  *
+ * `hasUngradedNonEmptyPick` flags partial-grade state: the show has at least
+ * one non-empty pick that hasn't been graded yet. Callers gate the
+ * "tonight's winner" banner on this so an accidental early manual finalize
+ * (or any other path that grades a subset of picks) doesn't crown a winner
+ * picked from a stale subset while newer ungraded picks dominate the live
+ * leaderboard.
+ *
  * @param {Array<{ isGraded?: boolean, score?: number, picks?: unknown } & Record<string, unknown>>} picks
  * @returns {{
  *   max: number | null,
  *   winners: Array<Record<string, unknown>>,
  *   eligiblePlayers: number,
  *   beats: number,
+ *   hasUngradedNonEmptyPick: boolean,
  * }}
  */
 export function computeShowWinnerOfTheNight(picks) {
@@ -24,7 +33,10 @@ export function computeShowWinnerOfTheNight(picks) {
   const { max, winners } = reduceShowWinners(eligible);
   const eligiblePlayers = eligible.length;
   const beats = Math.max(0, eligiblePlayers - winners.length);
-  return { max, winners, eligiblePlayers, beats };
+  const hasUngradedNonEmptyPick = list.some(
+    (p) => p?.isGraded !== true && hasNonEmptyPicksObject(p?.picks),
+  );
+  return { max, winners, eligiblePlayers, beats, hasUngradedNonEmptyPick };
 }
 
 /**

--- a/src/features/scoring/model/useShowWinnerOfTheNight.test.js
+++ b/src/features/scoring/model/useShowWinnerOfTheNight.test.js
@@ -20,6 +20,7 @@ describe('computeShowWinnerOfTheNight', () => {
       winners: [],
       eligiblePlayers: 0,
       beats: 0,
+      hasUngradedNonEmptyPick: true,
     });
   });
 
@@ -32,6 +33,7 @@ describe('computeShowWinnerOfTheNight', () => {
     expect(result.winners).toEqual([]);
     expect(result.eligiblePlayers).toBe(2);
     expect(result.beats).toBe(2);
+    expect(result.hasUngradedNonEmptyPick).toBe(false);
   });
 
   it('identifies a lone winner and computes beats', () => {
@@ -43,6 +45,7 @@ describe('computeShowWinnerOfTheNight', () => {
     expect(result.winners).toEqual([b]);
     expect(result.eligiblePlayers).toBe(3);
     expect(result.beats).toBe(2);
+    expect(result.hasUngradedNonEmptyPick).toBe(false);
   });
 
   it('lists every tied winner and reports beats relative to the tie size', () => {
@@ -57,6 +60,33 @@ describe('computeShowWinnerOfTheNight', () => {
     expect(result.winners.map((r) => r.uid)).toEqual(['a', 'c']);
     expect(result.eligiblePlayers).toBe(4);
     expect(result.beats).toBe(2);
+    expect(result.hasUngradedNonEmptyPick).toBe(false);
+  });
+
+  it('flags partial-grade state when graded picks coexist with ungraded non-empty picks', () => {
+    // Real-world trigger: admin hit "Finalize and rollup" before the show.
+    // Those 5 picks flipped to isGraded: true; new picks landed afterwards
+    // with isGraded: false. The banner must NOT crown a winner from the
+    // stale graded subset while the live leaderboard ranks someone else.
+    const rows = [
+      graded(40, { uid: 'a' }),
+      graded(30, { uid: 'b' }),
+      { isGraded: false, picks: { s1: 'Tweezer' }, score: 80, uid: 'c' },
+    ];
+    const result = computeShowWinnerOfTheNight(rows);
+    expect(result.hasUngradedNonEmptyPick).toBe(true);
+    expect(result.winners.map((r) => r.uid)).toEqual(['a']);
+  });
+
+  it('ignores ungraded picks that have no songs entered', () => {
+    const rows = [
+      graded(40, { uid: 'a' }),
+      { isGraded: false, picks: {}, score: 0, uid: 'empty' },
+      { isGraded: false, picks: { s1: '   ', s2: '' }, score: 0, uid: 'blank' },
+    ];
+    const result = computeShowWinnerOfTheNight(rows);
+    expect(result.hasUngradedNonEmptyPick).toBe(false);
+    expect(result.winners.map((r) => r.uid)).toEqual(['a']);
   });
 
   it('tolerates missing / null input', () => {
@@ -65,12 +95,14 @@ describe('computeShowWinnerOfTheNight', () => {
       winners: [],
       eligiblePlayers: 0,
       beats: 0,
+      hasUngradedNonEmptyPick: false,
     });
     expect(computeShowWinnerOfTheNight(undefined)).toEqual({
       max: null,
       winners: [],
       eligiblePlayers: 0,
       beats: 0,
+      hasUngradedNonEmptyPick: false,
     });
   });
 });

--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -92,10 +92,17 @@ export function useStandingsScreen(selectedDate, options = {}) {
     view === 'pools' && Boolean(poolId) ? poolWinnerOfTheNight : globalWinnerOfTheNight;
   const showWinnerEligibleView =
     view === 'show' || (view === 'pools' && Boolean(poolId));
+  // Suppress the "tonight's winner" banner whenever any non-empty pick is
+  // still ungraded — that's the partial-grade state, e.g. an admin hit
+  // "Finalize and rollup" early and more picks landed afterwards. The
+  // banner reads stored `pick.score` filtered to `isGraded: true`, which
+  // would otherwise crown a winner from a stale subset while the live
+  // leaderboard (computed across every pick) ranks someone else first.
   const showWinnerBanner =
     showWinnerEligibleView &&
     Boolean(actualSetlist) &&
-    winnerOfTheNight.winners.length > 0;
+    winnerOfTheNight.winners.length > 0 &&
+    !winnerOfTheNight.hasUngradedNonEmptyPick;
 
   const lastShowWinnerEnabled =
     showWinnerEligibleView &&


### PR DESCRIPTION
Closes #323

## Summary

- `computeShowWinnerOfTheNight` now also reports `hasUngradedNonEmptyPick`; `useStandingsScreen` gates `showWinnerBanner` on `!hasUngradedNonEmptyPick`, so the banner only surfaces once every non-empty pick for the show is graded.
- Restores the correct "leading the show" callout during partial-grade state (any path that grades a subset of picks while others remain ungraded — e.g. an early manual finalize, or anything that lands new picks after rollup).
- New unit test covers the exact failure mode (graded subset coexisting with a higher-scoring ungraded pick).

## Why this is needed (live diagnosis from `2026-04-30`)

An accidental "Finalize and rollup" before showtime stamped `isGraded: true` on the 5 picks that existed at that moment (audit doc: `rollup_audit/2026-04-30`, `processedPicks: 5`, `trigger: "manual"`). More users submitted picks afterwards. At set break the banner was showing the highest-scoring user out of those 5 finalized picks while the actual live leader was a different user, and `suppressLeadingCallout` hid the correct "leading the show" callout because the banner was visible.

The trigger was too permissive: it only required `actualSetlist` to exist and `winners.length > 0`. Mid-show that's true any time a subset of picks is graded, because the live setlist automation progressively populates `official_setlists/{showDate}` as songs are reported.

## Test plan

- [x] `npm run lint` clean.
- [x] `npm test` — 147 tests pass, including the new partial-grade case in `useShowWinnerOfTheNight.test.js`.
- [ ] Vercel preview: load `/dashboard/standings` for `2026-04-30` while the show is mid-set-2; confirm the banner is hidden and "leading the show" callout reappears with the correct leader.
- [ ] After the post-encore auto-finalize fires (every non-empty pick gets `isGraded: true`), confirm "tonight's winner" banner displays the actual highest-scoring user.

## Follow-ups (separate tickets, not in this PR)

- Admin guardrail on "Finalize and rollup" to refuse when `showStatus !== 'PAST'` (current hollow-setlist guard from #320 doesn't catch a non-hollow set 1 mid-show).
- Manual-recovery procedure for accidental finalize: flip the prematurely-graded pick docs back to `isGraded: false` (and zero `score`) before auto-finalize so the post-encore rollup credits user totals as first-grade rather than zero-delta re-grade.


Made with [Cursor](https://cursor.com)