### PR TITLE
feat(time): venue-local picks lock + scheduler timezone alignment

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -12,8 +12,7 @@ const {
 } = require("./phishnetSongCatalog");
 const {
   candidateShowDates,
-  isWithinLiveSetlistPollWindow,
-  parseShowCalendarSnapshotToDateSet,
+  parseShowCalendarSnapshotToShows,
   pollSingleShowDate,
   scheduledCandidateShowDates,
 } = require("./phishnetLiveSetlistAutomation");
@@ -470,24 +469,20 @@ exports.scheduledPhishnetLiveSetlistPoll = onSchedule(
       return null;
     }
     const now = new Date();
-    if (!isWithinLiveSetlistPollWindow(now)) {
-      logger.info("scheduledPhishnetLiveSetlistPoll: outside 4pm–4am ET window; skip.");
-      return null;
-    }
     const calSnap = await db.collection("show_calendar").doc("snapshot").get();
-    const calendarSet = parseShowCalendarSnapshotToDateSet(
+    const calendarShows = parseShowCalendarSnapshotToShows(
       calSnap.exists ? calSnap.data() : null
     );
-    if (!calendarSet) {
+    if (!calendarShows) {
       logger.info(
         "scheduledPhishnetLiveSetlistPoll: show_calendar snapshot missing/empty; strict skip (no Phish.net)."
       );
       return null;
     }
-    const dates = scheduledCandidateShowDates(now, calendarSet);
+    const dates = scheduledCandidateShowDates(now, calendarShows);
     if (!dates.length) {
       logger.info(
-        "scheduledPhishnetLiveSetlistPoll: no matching show dates in calendar; skip."
+        "scheduledPhishnetLiveSetlistPoll: no show currently in local 4pm–4am window; skip."
       );
       return null;
     }

--- a/functions/phishnetLiveSetlistAutomation.js
+++ b/functions/phishnetLiveSetlistAutomation.js
@@ -4,6 +4,7 @@ const LIVE_AUTOMATION_COLLECTION = "live_setlist_automation";
 const OFFICIAL_SETLISTS_COLLECTION = "official_setlists";
 const PHISHNET_API_ROOT = "https://api.phish.net/v5/setlists/showdate";
 const MAX_BACKOFF_MINUTES = 30;
+const DEFAULT_SHOW_TIME_ZONE = "America/Los_Angeles";
 
 const SLOT_KEYS = ["s1o", "s1c", "s2o", "s2c", "enc"];
 
@@ -121,12 +122,40 @@ function getEtHour(now = new Date()) {
   return Number.parseInt(String(hPart?.value ?? "0"), 10);
 }
 
+/** YYYY-MM-DD in any IANA timezone. */
+function ymdInTimeZone(now = new Date(), timeZone = DEFAULT_SHOW_TIME_ZONE) {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+}
+
+/** Wall-clock hour 0–23 in any IANA timezone. */
+function hourInTimeZone(now = new Date(), timeZone = DEFAULT_SHOW_TIME_ZONE) {
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour: "numeric",
+    hour12: false,
+  });
+  const parts = dtf.formatToParts(now);
+  const hPart = parts.find((p) => p.type === "hour");
+  return Number.parseInt(String(hPart?.value ?? "0"), 10);
+}
+
 /**
  * Live setlist scheduled polling window: 4:00 PM ET through 4:00 AM ET the next
  * calendar day (active when hour ≥ 16 or hour < 4, America/New_York wall clock).
  */
 function isWithinLiveSetlistPollWindow(now = new Date()) {
   const h = getEtHour(now);
+  return h >= 16 || h < 4;
+}
+
+/** 4pm–4am local wall-clock window for a specific show timezone. */
+function isWithinShowLocalPollWindow(now = new Date(), timeZone = DEFAULT_SHOW_TIME_ZONE) {
+  const h = hourInTimeZone(now, timeZone);
   return h >= 16 || h < 4;
 }
 
@@ -148,46 +177,80 @@ function candidateShowDates(now = new Date()) {
 }
 
 /**
- * Parse `show_calendar/snapshot` into a Set of YYYY-MM-DD show dates.
+ * Parse `show_calendar/snapshot` into a list of show date records.
  * Returns `null` if missing, empty, or unreadable (strict — scheduled poller must skip).
  */
-function parseShowCalendarSnapshotToDateSet(snapshotData) {
+function parseShowCalendarSnapshotToShows(snapshotData) {
   if (!snapshotData || typeof snapshotData !== "object") return null;
   const raw = snapshotData.showDates;
   if (!Array.isArray(raw) || raw.length === 0) return null;
-  const set = new Set();
+  const shows = [];
+  const dedupe = new Set();
   for (const item of raw) {
-    const d =
+    const date =
       typeof item === "string"
-        ? item
+        ? item.trim()
         : item && typeof item === "object" && typeof item.date === "string"
-        ? item.date
-        : null;
-    if (d && /^\d{4}-\d{2}-\d{2}$/.test(d)) set.add(d);
+          ? item.date.trim()
+          : "";
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) continue;
+    if (dedupe.has(date)) continue;
+    const explicitTz =
+      item && typeof item === "object"
+        ? typeof item.timeZone === "string" && item.timeZone.trim()
+          ? item.timeZone.trim()
+          : typeof item.timezone === "string" && item.timezone.trim()
+            ? item.timezone.trim()
+            : ""
+        : "";
+    shows.push({ date, timeZone: explicitTz || DEFAULT_SHOW_TIME_ZONE });
+    dedupe.add(date);
   }
-  return set.size > 0 ? set : null;
+  return shows.length > 0 ? shows : null;
 }
 
 /**
- * Scheduled poller target dates (intersected with show_calendar in the caller).
+ * Back-compat parser used by tests/consumers that only need date membership.
+ * @param {import("firebase-admin").firestore.DocumentData | null | undefined} snapshotData
+ */
+function parseShowCalendarSnapshotToDateSet(snapshotData) {
+  const shows = parseShowCalendarSnapshotToShows(snapshotData);
+  if (!shows) return null;
+  return new Set(shows.map((s) => s.date));
+}
+
+/**
+ * Scheduled poller target dates based on each show's local timezone.
  *
- * - Always consider ET "today" when it is a show date in the calendar set.
- * - Do not include "yesterday" by default (before local ET midnight).
- * - After local midnight ET (hours 0–3), also include "yesterday" when that date
- *   is still a show date — same gig can receive encore/post-midnight updates until
+ * - Always consider local "today" when that local wall clock is in the active window.
+ * - Do not include local "yesterday" by default.
+ * - After local midnight (hours 0–3), also include local "yesterday" so a show
+ *   can receive encore/post-midnight updates until the 4 AM local window end.
  *   the 4 AM window end. This is **not** comparing two setlists: each `showDate`
  *   doc is still diffed only against its own last saved official payload/signature.
  */
-function scheduledCandidateShowDates(now, calendarDateSet) {
-  const etToday = formatEtShowDate(now);
-  const etYesterday = ymdDaysAgo(etToday, 1);
-  const hourEt = getEtHour(now);
-  const out = [];
-  if (calendarDateSet.has(etToday)) out.push(etToday);
-  if (hourEt >= 0 && hourEt < 4 && calendarDateSet.has(etYesterday)) {
-    out.push(etYesterday);
+function scheduledCandidateShowDates(now, calendarShows) {
+  if (!Array.isArray(calendarShows) || calendarShows.length === 0) return [];
+  const todayDates = [];
+  const carryoverDates = [];
+  for (const show of calendarShows) {
+    if (!show || typeof show !== "object") continue;
+    const date = typeof show.date === "string" ? show.date.trim() : "";
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) continue;
+    const timeZone =
+      typeof show.timeZone === "string" && show.timeZone.trim()
+        ? show.timeZone.trim()
+        : DEFAULT_SHOW_TIME_ZONE;
+    if (!isWithinShowLocalPollWindow(now, timeZone)) continue;
+    const localToday = ymdInTimeZone(now, timeZone);
+    const localYesterday = ymdDaysAgo(localToday, 1);
+    const localHour = hourInTimeZone(now, timeZone);
+    if (date === localToday) todayDates.push(date);
+    if (localHour >= 0 && localHour < 4 && date === localYesterday) {
+      carryoverDates.push(date);
+    }
   }
-  return out;
+  return [...new Set([...todayDates, ...carryoverDates])];
 }
 
 /**
@@ -969,13 +1032,17 @@ module.exports = {
   evaluateSet1CloserStage,
   fetchPhishnetSetlistForDate,
   getEtHour,
+  hourInTimeZone,
   isWithinLiveSetlistPollWindow,
+  isWithinShowLocalPollWindow,
   normalizeSetlistRows,
   parseShowCalendarSnapshotToDateSet,
+  parseShowCalendarSnapshotToShows,
   pollSingleShowDate,
   randomScheduledPollDelayMs,
   scheduledCandidateShowDates,
   set1TitleSignatureFromRows,
   setlistPayloadEqual,
   signatureFromRows,
+  ymdInTimeZone,
 };

--- a/functions/phishnetLiveSetlistAutomation.test.js
+++ b/functions/phishnetLiveSetlistAutomation.test.js
@@ -14,9 +14,12 @@ const {
   deriveBustoutsFromRows,
   evaluateAutoFinalize,
   evaluateSet1CloserStage,
+  hourInTimeZone,
   isWithinLiveSetlistPollWindow,
+  isWithinShowLocalPollWindow,
   normalizeSetlistRows,
   parseShowCalendarSnapshotToDateSet,
+  parseShowCalendarSnapshotToShows,
   pollSingleShowDate,
   randomScheduledPollDelayMs,
   scheduledCandidateShowDates,
@@ -29,8 +32,8 @@ const {
 const SHOW_CALENDAR_SNAPSHOT_FIXTURE = {
   schemaVersion: 2,
   showDates: [
-    { date: "2026-07-03", venue: "A" },
-    { date: "2026-07-04", venue: "B" },
+    { date: "2026-07-03", venue: "A", timeZone: "America/New_York" },
+    { date: "2026-07-04", venue: "B", timeZone: "America/New_York" },
   ],
 };
 
@@ -47,6 +50,19 @@ test("parseShowCalendarSnapshotToDateSet reads flat showDates", () => {
   assert.ok(set);
   assert.equal(set.has("2026-07-03"), true);
   assert.equal(set.has("2026-07-04"), true);
+});
+
+test("parseShowCalendarSnapshotToShows reads date + timezone records", () => {
+  const shows = parseShowCalendarSnapshotToShows({
+    showDates: [
+      { date: "2026-07-03", venue: "A", timeZone: "America/Chicago" },
+      { date: "2026-07-04", venue: "B" },
+    ],
+  });
+  assert.deepEqual(shows, [
+    { date: "2026-07-03", timeZone: "America/Chicago" },
+    { date: "2026-07-04", timeZone: "America/Los_Angeles" },
+  ]);
 });
 
 test("parseShowCalendarSnapshotToDateSet accepts string dates", () => {
@@ -102,8 +118,21 @@ test("isWithinLiveSetlistPollWindow: winter EST", () => {
   );
 });
 
+test("isWithinShowLocalPollWindow: evaluates window in provided timezone", () => {
+  const now = new Date("2026-07-04T20:00:00.000Z");
+  assert.equal(isWithinShowLocalPollWindow(now, "America/New_York"), true); // 16:00
+  assert.equal(isWithinShowLocalPollWindow(now, "America/Los_Angeles"), false); // 13:00
+});
+
+test("hourInTimeZone: handles DST fall-back repeated hour", () => {
+  const beforeFallback = new Date("2026-11-01T05:30:00.000Z");
+  const afterFallback = new Date("2026-11-01T06:30:00.000Z");
+  assert.equal(hourInTimeZone(beforeFallback, "America/New_York"), 1);
+  assert.equal(hourInTimeZone(afterFallback, "America/New_York"), 1);
+});
+
 test("scheduledCandidateShowDates: evening uses today only when in calendar", () => {
-  const cal = parseShowCalendarSnapshotToDateSet(SHOW_CALENDAR_SNAPSHOT_FIXTURE);
+  const cal = parseShowCalendarSnapshotToShows(SHOW_CALENDAR_SNAPSHOT_FIXTURE);
   const dates = scheduledCandidateShowDates(
     new Date("2026-07-04T22:00:00-04:00"),
     cal
@@ -112,7 +141,7 @@ test("scheduledCandidateShowDates: evening uses today only when in calendar", ()
 });
 
 test("scheduledCandidateShowDates: after midnight adds yesterday when still a show date", () => {
-  const cal = parseShowCalendarSnapshotToDateSet(SHOW_CALENDAR_SNAPSHOT_FIXTURE);
+  const cal = parseShowCalendarSnapshotToShows(SHOW_CALENDAR_SNAPSHOT_FIXTURE);
   const dates = scheduledCandidateShowDates(
     new Date("2026-07-04T01:30:00-04:00"),
     cal
@@ -121,7 +150,7 @@ test("scheduledCandidateShowDates: after midnight adds yesterday when still a sh
 });
 
 test("scheduledCandidateShowDates: 3am hour still includes yesterday", () => {
-  const cal = parseShowCalendarSnapshotToDateSet(SHOW_CALENDAR_SNAPSHOT_FIXTURE);
+  const cal = parseShowCalendarSnapshotToShows(SHOW_CALENDAR_SNAPSHOT_FIXTURE);
   const dates = scheduledCandidateShowDates(
     new Date("2026-07-04T03:15:00-04:00"),
     cal
@@ -130,7 +159,7 @@ test("scheduledCandidateShowDates: 3am hour still includes yesterday", () => {
 });
 
 test("scheduledCandidateShowDates: post-midnight only prior night when today not on calendar", () => {
-  const cal = parseShowCalendarSnapshotToDateSet({
+  const cal = parseShowCalendarSnapshotToShows({
     showDates: [{ date: "2026-07-03", venue: "x" }],
   });
   const dates = scheduledCandidateShowDates(
@@ -138,6 +167,18 @@ test("scheduledCandidateShowDates: post-midnight only prior night when today not
     cal
   );
   assert.deepEqual(dates, ["2026-07-03"]);
+});
+
+test("scheduledCandidateShowDates: different zones evaluated independently", () => {
+  const cal = parseShowCalendarSnapshotToShows({
+    showDates: [
+      { date: "2026-07-04", venue: "MSG", timeZone: "America/New_York" },
+      { date: "2026-07-04", venue: "Hollywood Bowl", timeZone: "America/Los_Angeles" },
+    ],
+  });
+  // 20:00Z = 16:00 ET, 13:00 PT
+  const dates = scheduledCandidateShowDates(new Date("2026-07-04T20:00:00.000Z"), cal);
+  assert.deepEqual(dates, ["2026-07-04"]);
 });
 
 test("randomScheduledPollDelayMs is within 3–5 minutes", () => {

--- a/functions/phishnetShowCalendar.js
+++ b/functions/phishnetShowCalendar.js
@@ -59,6 +59,77 @@ function formatRunTourLabel(firstYmd, lastYmd) {
 
 const GENERIC_TOUR = "Not Part of a Tour";
 const MAX_GAP_DAYS = 14;
+const DEFAULT_SHOW_TIME_ZONE = "America/Los_Angeles";
+
+const US_STATE_TIME_ZONES = {
+  AL: "America/Chicago",
+  AK: "America/Anchorage",
+  AZ: "America/Phoenix",
+  AR: "America/Chicago",
+  CA: "America/Los_Angeles",
+  CO: "America/Denver",
+  CT: "America/New_York",
+  DE: "America/New_York",
+  FL: "America/New_York",
+  GA: "America/New_York",
+  HI: "Pacific/Honolulu",
+  IA: "America/Chicago",
+  ID: "America/Denver",
+  IL: "America/Chicago",
+  IN: "America/Indiana/Indianapolis",
+  KS: "America/Chicago",
+  KY: "America/New_York",
+  LA: "America/Chicago",
+  MA: "America/New_York",
+  MD: "America/New_York",
+  ME: "America/New_York",
+  MI: "America/Detroit",
+  MN: "America/Chicago",
+  MO: "America/Chicago",
+  MS: "America/Chicago",
+  MT: "America/Denver",
+  NC: "America/New_York",
+  ND: "America/Chicago",
+  NE: "America/Chicago",
+  NH: "America/New_York",
+  NJ: "America/New_York",
+  NM: "America/Denver",
+  NV: "America/Los_Angeles",
+  NY: "America/New_York",
+  OH: "America/New_York",
+  OK: "America/Chicago",
+  OR: "America/Los_Angeles",
+  PA: "America/New_York",
+  RI: "America/New_York",
+  SC: "America/New_York",
+  SD: "America/Chicago",
+  TN: "America/Chicago",
+  TX: "America/Chicago",
+  UT: "America/Denver",
+  VA: "America/New_York",
+  VT: "America/New_York",
+  WA: "America/Los_Angeles",
+  WI: "America/Chicago",
+  WV: "America/New_York",
+  WY: "America/Denver",
+  DC: "America/New_York",
+};
+
+const CANADA_PROVINCE_TIME_ZONES = {
+  AB: "America/Edmonton",
+  BC: "America/Vancouver",
+  MB: "America/Winnipeg",
+  NB: "America/Moncton",
+  NL: "America/St_Johns",
+  NS: "America/Halifax",
+  NT: "America/Yellowknife",
+  NU: "America/Iqaluit",
+  ON: "America/Toronto",
+  PE: "America/Halifax",
+  QC: "America/Toronto",
+  SK: "America/Regina",
+  YT: "America/Whitehorse",
+};
 
 /**
  * Friendly optgroup titles for Phish.net **"Not Part of a Tour"** clusters only.
@@ -199,13 +270,13 @@ function buildApiNamedTourByDate(shows) {
 
 /**
  * Regroup flat shows when per-date tour strings may differ from Phish.net clustering.
- * @param {{ date: string, venue: string }[]} flatSorted
+ * @param {{ date: string, venue: string, timeZone: string }[]} flatSorted
  * @param {(date: string) => string} tourFor
  */
 function regroupConsecutiveTours(flatSorted, tourFor) {
-  /** @type {{ tour: string, shows: { date: string, venue: string }[] }[]} */
+  /** @type {{ tour: string, shows: { date: string, venue: string, timeZone: string }[] }[]} */
   const out = [];
-  let cur = /** @type {{ tour: string, shows: { date: string, venue: string }[] } | null} */ (
+  let cur = /** @type {{ tour: string, shows: { date: string, venue: string, timeZone: string }[] } | null} */ (
     null
   );
   for (const s of flatSorted) {
@@ -215,14 +286,14 @@ function regroupConsecutiveTours(flatSorted, tourFor) {
       cur = { tour: label, shows: [] };
       out.push(cur);
     }
-    cur.shows.push({ date: s.date, venue: s.venue });
+    cur.shows.push({ date: s.date, venue: s.venue, timeZone: s.timeZone });
   }
   return out;
 }
 
 /**
- * @param {{ date: string, venue: string, tour_name: string }[]} shows — sorted ascending by date
- * @param {{ tour: string, shows: { date: string, venue: string }[] }[]} computedGroups — from buildShowDatesByTour
+ * @param {{ date: string, venue: string, tour_name: string, timeZone: string }[]} shows — sorted ascending by date
+ * @param {{ tour: string, shows: { date: string, venue: string, timeZone: string }[] }[]} computedGroups — from buildShowDatesByTour
  * @param {Map<string, string>} prevTourByDate
  * @param {Map<string, string>} overridesByDate
  * @param {{ isFirstSnapshot: boolean }}
@@ -239,7 +310,7 @@ function mergeToursWithSnapshotPreservation(
 ) {
   const computedByDate = computedTourByDateFromGroups(computedGroups);
   const apiNamedByDate = buildApiNamedTourByDate(shows);
-  const flat = shows.map((s) => ({ date: s.date, venue: s.venue }));
+  const flat = shows.map((s) => ({ date: s.date, venue: s.venue, timeZone: s.timeZone }));
 
   function tourFor(date) {
     if (overridesByDate.has(date)) return /** @type {string} */ (overridesByDate.get(date));
@@ -292,6 +363,24 @@ function buildVenueLine(row) {
   return parts.join(", ") || venue || city || "TBA";
 }
 
+function deriveTimeZoneFromLocationParts({ state, country, city, venue }) {
+  const stateCode = String(state ?? "").trim().toUpperCase();
+  if (US_STATE_TIME_ZONES[stateCode]) return US_STATE_TIME_ZONES[stateCode];
+  if (CANADA_PROVINCE_TIME_ZONES[stateCode]) {
+    return CANADA_PROVINCE_TIME_ZONES[stateCode];
+  }
+
+  const merged = [venue, city, state, country].join(" ").toLowerCase();
+  if (/\bcancun\b|\bmexico\b|\bquintana roo\b/.test(merged)) {
+    return "America/Cancun";
+  }
+  if (/\blondon\b|\bengland\b|\buk\b|\bunited kingdom\b/.test(merged)) {
+    return "Europe/London";
+  }
+
+  return DEFAULT_SHOW_TIME_ZONE;
+}
+
 function phishNetResponseOk(data) {
   const apiErr = data && typeof data === "object" ? data.error : undefined;
   return (
@@ -339,10 +428,10 @@ async function fetchShowsForYear(year, apiKey) {
 
 /**
  * @param {Record<string, unknown>[]} rawRows
- * @returns {{ date: string, venue: string, tour_name: string }[]}
+ * @returns {{ date: string, venue: string, tour_name: string, timeZone: string }[]}
  */
 function normalizePhishShows(rawRows) {
-  /** @type {Map<string, { date: string, venue: string, tour_name: string }>} */
+  /** @type {Map<string, { date: string, venue: string, tour_name: string, timeZone: string }>} */
   const byDate = new Map();
 
   for (const row of rawRows) {
@@ -353,22 +442,28 @@ function normalizePhishShows(rawRows) {
     if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) continue;
     const venue = buildVenueLine(row);
     const tour_name = String(row.tour_name ?? "").trim() || GENERIC_TOUR;
-    byDate.set(date, { date, venue, tour_name });
+    const timeZone = deriveTimeZoneFromLocationParts({
+      state: row.state,
+      country: row.country,
+      city: row.city,
+      venue,
+    });
+    byDate.set(date, { date, venue, tour_name, timeZone });
   }
 
   return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
 }
 
 /**
- * @param {{ date: string, venue: string, tour_name: string }[]} shows
- * @returns {{ tour: string, shows: { date: string, venue: string }[] }[]}
+ * @param {{ date: string, venue: string, tour_name: string, timeZone: string }[]} shows
+ * @returns {{ tour: string, shows: { date: string, venue: string, timeZone: string }[] }[]}
  */
 function buildShowDatesByTour(shows) {
   if (shows.length === 0) return [];
 
   /** @type {string[]} */
   const orderedKeys = [];
-  /** @type {Map<string, { tour: string, shows: { date: string, venue: string }[], firstDate: string, lastDate: string, isGeneric: boolean }>} */
+  /** @type {Map<string, { tour: string, shows: { date: string, venue: string, timeZone: string }[], firstDate: string, lastDate: string, isGeneric: boolean }>} */
   const map = new Map();
 
   let prev = /** @type {typeof shows[0] | null} */ (null);
@@ -403,7 +498,7 @@ function buildShowDatesByTour(shows) {
 
     const g = map.get(key);
     if (!g) continue;
-    g.shows.push({ date: s.date, venue: s.venue });
+    g.shows.push({ date: s.date, venue: s.venue, timeZone: s.timeZone });
     g.lastDate = s.date;
 
     prev = s;

--- a/functions/phishnetShowCalendar.test.js
+++ b/functions/phishnetShowCalendar.test.js
@@ -6,6 +6,7 @@ const {
   buildShowDatesByTour,
   flattenSnapshotTourByDate,
   mergeToursWithSnapshotPreservation,
+  normalizePhishShows,
   parseTourOverridesDoc,
 } = require("./phishnetShowCalendar");
 
@@ -214,4 +215,30 @@ test("parseTourOverridesDoc", () => {
     byShowDate: { "2026-09-04": "Summer Tour 2026" },
   });
   assert.equal(m.get("2026-09-04"), "Summer Tour 2026");
+});
+
+test("normalizePhishShows: stamps per-show IANA timezone from location", () => {
+  const out = normalizePhishShows([
+    {
+      artistid: 1,
+      showdate: "2026-07-07",
+      venue: "Kohl Center",
+      city: "Madison",
+      state: "WI",
+      country: "USA",
+      tour_name: "Not Part of a Tour",
+    },
+    {
+      artistid: 1,
+      showdate: "2026-01-28",
+      venue: "Moon Palace",
+      city: "Cancun",
+      state: "",
+      country: "Mexico",
+      tour_name: "2026 Mexico",
+    },
+  ]);
+
+  assert.equal(out[0].timeZone, "America/Cancun");
+  assert.equal(out[1].timeZone, "America/Chicago");
 });

--- a/src/features/show-calendar/model/ShowCalendarContext.jsx
+++ b/src/features/show-calendar/model/ShowCalendarContext.jsx
@@ -16,7 +16,7 @@ import { normalizeShowCalendarDoc } from './normalizeShowCalendarDoc';
 /** @typedef {'firestore' | 'fallback'} ShowCalendarSource */
 
 const ShowCalendarContext = createContext(
-  /** @type {{ showDatesByTour: { tour: string, shows: { date: string, venue: string }[] }[], showDates: { date: string, venue: string }[], source: ShowCalendarSource, loading: boolean, subscriptionError: Error | null, syncError: string | null } | null} */ (
+  /** @type {{ showDatesByTour: { tour: string, shows: { date: string, venue: string, timeZone: string }[] }[], showDates: { date: string, venue: string, timeZone: string }[], source: ShowCalendarSource, loading: boolean, subscriptionError: Error | null, syncError: string | null } | null} */ (
     null
   )
 );

--- a/src/features/show-calendar/model/normalizeShowCalendarDoc.js
+++ b/src/features/show-calendar/model/normalizeShowCalendarDoc.js
@@ -1,7 +1,9 @@
+import { resolveShowTimeZone } from '../../../shared/utils/showTimeZone';
+
 /**
  * Validates Firestore `show_calendar/snapshot` written by Cloud Functions (issue #160).
  * @param {import('firebase/firestore').DocumentData | null | undefined} data
- * @returns {{ showDatesByTour: { tour: string, shows: { date: string, venue: string }[] }[], showDates: { date: string, venue: string }[], syncError?: string | null } | null}
+ * @returns {{ showDatesByTour: { tour: string, shows: { date: string, venue: string, timeZone: string }[] }[], showDates: { date: string, venue: string, timeZone: string }[], syncError?: string | null } | null}
  */
 export function normalizeShowCalendarDoc(data) {
   if (!data || typeof data !== 'object') return null;
@@ -25,7 +27,13 @@ export function normalizeShowCalendarDoc(data) {
         const date = typeof s.date === 'string' ? s.date.trim() : '';
         const venue = typeof s.venue === 'string' ? s.venue.trim() : '';
         if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || !venue) return null;
-        normShows.push({ date, venue });
+        normShows.push({
+          date,
+          venue,
+          timeZone: resolveShowTimeZone(
+            /** @type {{ timeZone?: string, timezone?: string, venue: string }} */ (s)
+          ),
+        });
       }
       groups.push({ tour, shows: normShows });
     }
@@ -41,7 +49,13 @@ export function normalizeShowCalendarDoc(data) {
       const date = typeof s.date === 'string' ? s.date.trim() : '';
       const venue = typeof s.venue === 'string' ? s.venue.trim() : '';
       if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || !venue) return null;
-      flat.push({ date, venue });
+      flat.push({
+        date,
+        venue,
+        timeZone: resolveShowTimeZone(
+          /** @type {{ timeZone?: string, timezone?: string, venue: string }} */ (s)
+        ),
+      });
     }
     return {
       showDatesByTour: [{ tour: 'Scheduled shows', shows: flat }],

--- a/src/features/show-calendar/model/normalizeShowCalendarDoc.test.js
+++ b/src/features/show-calendar/model/normalizeShowCalendarDoc.test.js
@@ -19,9 +19,24 @@ describe('normalizeShowCalendarDoc', () => {
     };
     const n = normalizeShowCalendarDoc(doc);
     expect(n?.showDates).toEqual([
-      { date: '2026-04-16', venue: 'Sphere, Las Vegas, NV' },
+      {
+        date: '2026-04-16',
+        venue: 'Sphere, Las Vegas, NV',
+        timeZone: 'America/Los_Angeles',
+      },
     ]);
-    expect(n?.showDatesByTour).toEqual(doc.showDatesByTour);
+    expect(n?.showDatesByTour).toEqual([
+      {
+        tour: 'Test Tour',
+        shows: [
+          {
+            date: '2026-04-16',
+            venue: 'Sphere, Las Vegas, NV',
+            timeZone: 'America/Los_Angeles',
+          },
+        ],
+      },
+    ]);
   });
 
   it('accepts flat showDates only', () => {
@@ -29,8 +44,28 @@ describe('normalizeShowCalendarDoc', () => {
       showDates: [{ date: '2026-04-16', venue: 'Sphere, Las Vegas, NV' }],
     };
     const n = normalizeShowCalendarDoc(doc);
-    expect(n?.showDates).toEqual(doc.showDates);
+    expect(n?.showDates).toEqual([
+      {
+        date: '2026-04-16',
+        venue: 'Sphere, Las Vegas, NV',
+        timeZone: 'America/Los_Angeles',
+      },
+    ]);
     expect(n?.showDatesByTour?.[0]?.tour).toBe('Scheduled shows');
+  });
+
+  it('uses explicit `timeZone` when provided', () => {
+    const doc = {
+      showDates: [
+        {
+          date: '2026-06-21',
+          venue: 'Royal Albert Hall, London, England',
+          timeZone: 'Europe/London',
+        },
+      ],
+    };
+    const n = normalizeShowCalendarDoc(doc);
+    expect(n?.showDates?.[0]?.timeZone).toBe('Europe/London');
   });
 
   it('rejects bad dates', () => {

--- a/src/shared/utils/showTimeZone.js
+++ b/src/shared/utils/showTimeZone.js
@@ -1,0 +1,114 @@
+const DEFAULT_SHOW_TIME_ZONE = 'America/Los_Angeles';
+
+const US_STATE_TIME_ZONES = {
+  AL: 'America/Chicago',
+  AK: 'America/Anchorage',
+  AZ: 'America/Phoenix',
+  AR: 'America/Chicago',
+  CA: 'America/Los_Angeles',
+  CO: 'America/Denver',
+  CT: 'America/New_York',
+  DE: 'America/New_York',
+  FL: 'America/New_York',
+  GA: 'America/New_York',
+  HI: 'Pacific/Honolulu',
+  IA: 'America/Chicago',
+  ID: 'America/Denver',
+  IL: 'America/Chicago',
+  IN: 'America/Indiana/Indianapolis',
+  KS: 'America/Chicago',
+  KY: 'America/New_York',
+  LA: 'America/Chicago',
+  MA: 'America/New_York',
+  MD: 'America/New_York',
+  ME: 'America/New_York',
+  MI: 'America/Detroit',
+  MN: 'America/Chicago',
+  MO: 'America/Chicago',
+  MS: 'America/Chicago',
+  MT: 'America/Denver',
+  NC: 'America/New_York',
+  ND: 'America/Chicago',
+  NE: 'America/Chicago',
+  NH: 'America/New_York',
+  NJ: 'America/New_York',
+  NM: 'America/Denver',
+  NV: 'America/Los_Angeles',
+  NY: 'America/New_York',
+  OH: 'America/New_York',
+  OK: 'America/Chicago',
+  OR: 'America/Los_Angeles',
+  PA: 'America/New_York',
+  RI: 'America/New_York',
+  SC: 'America/New_York',
+  SD: 'America/Chicago',
+  TN: 'America/Chicago',
+  TX: 'America/Chicago',
+  UT: 'America/Denver',
+  VA: 'America/New_York',
+  VT: 'America/New_York',
+  WA: 'America/Los_Angeles',
+  WI: 'America/Chicago',
+  WV: 'America/New_York',
+  WY: 'America/Denver',
+  DC: 'America/New_York',
+};
+
+const CANADA_PROVINCE_TIME_ZONES = {
+  AB: 'America/Edmonton',
+  BC: 'America/Vancouver',
+  MB: 'America/Winnipeg',
+  NB: 'America/Moncton',
+  NL: 'America/St_Johns',
+  NS: 'America/Halifax',
+  NT: 'America/Yellowknife',
+  NU: 'America/Iqaluit',
+  ON: 'America/Toronto',
+  PE: 'America/Halifax',
+  QC: 'America/Toronto',
+  SK: 'America/Regina',
+  YT: 'America/Whitehorse',
+};
+
+function compactToken(value) {
+  return String(value ?? '').trim().toUpperCase();
+}
+
+function inferZoneFromVenueLine(venueLine) {
+  const parts = String(venueLine ?? '')
+    .split(',')
+    .map((p) => p.trim())
+    .filter(Boolean);
+  if (parts.length === 0) return null;
+
+  const tail = compactToken(parts[parts.length - 1]);
+  if (US_STATE_TIME_ZONES[tail]) return US_STATE_TIME_ZONES[tail];
+  if (CANADA_PROVINCE_TIME_ZONES[tail]) return CANADA_PROVINCE_TIME_ZONES[tail];
+
+  const merged = parts.join(' ').toLowerCase();
+  if (/\bcancun\b|\bmexico\b|\bquintana roo\b/.test(merged)) {
+    return 'America/Cancun';
+  }
+  if (/\blondon\b|\bengland\b|\buk\b|\bunited kingdom\b/.test(merged)) {
+    return 'Europe/London';
+  }
+  return null;
+}
+
+/**
+ * Resolve a show's IANA timezone from explicit data first, then venue fallback.
+ * @param {{ timeZone?: string, timezone?: string, venue?: string } | null | undefined} show
+ * @param {string} [fallback]
+ */
+export function resolveShowTimeZone(show, fallback = DEFAULT_SHOW_TIME_ZONE) {
+  const explicit =
+    typeof show?.timeZone === 'string'
+      ? show.timeZone.trim()
+      : typeof show?.timezone === 'string'
+        ? show.timezone.trim()
+        : '';
+  if (explicit) return explicit;
+  return inferZoneFromVenueLine(show?.venue) || fallback;
+}
+
+export { DEFAULT_SHOW_TIME_ZONE };

--- a/src/shared/utils/showTimeZone.test.js
+++ b/src/shared/utils/showTimeZone.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveShowTimeZone } from './showTimeZone';
+
+describe('resolveShowTimeZone', () => {
+  it('prefers explicit timeZone field', () => {
+    expect(
+      resolveShowTimeZone({
+        venue: 'Any Venue',
+        timeZone: 'Europe/London',
+      })
+    ).toBe('Europe/London');
+  });
+
+  it('infers zone from US state in venue line', () => {
+    expect(resolveShowTimeZone({ venue: 'Kohl Center, Madison, WI' })).toBe(
+      'America/Chicago'
+    );
+    expect(resolveShowTimeZone({ venue: 'MSG, New York, NY' })).toBe(
+      'America/New_York'
+    );
+  });
+
+  it('infers non-US fallback patterns', () => {
+    expect(
+      resolveShowTimeZone({ venue: 'Moon Palace, Cancun, Quintana Roo, Mexico' })
+    ).toBe('America/Cancun');
+    expect(
+      resolveShowTimeZone({ venue: 'Royal Albert Hall, London, England' })
+    ).toBe('Europe/London');
+  });
+});

--- a/src/shared/utils/timeLogic.js
+++ b/src/shared/utils/timeLogic.js
@@ -1,23 +1,27 @@
 // src/shared/utils/timeLogic.js
 import { ymdInTimeZone } from './dateUtils';
+import { DEFAULT_SHOW_TIME_ZONE, resolveShowTimeZone } from './showTimeZone';
 
-/** Venue / broadcast schedule — picks lock uses wall time in this zone (not the viewer’s local zone). */
-export const SHOW_SCHEDULE_TIMEZONE = 'America/Los_Angeles';
+/** Fallback when a show does not carry an explicit `timeZone` field. */
+export const SHOW_SCHEDULE_TIMEZONE = DEFAULT_SHOW_TIME_ZONE;
 
 /**
- * Picks lock at this local time in {@link SHOW_SCHEDULE_TIMEZONE} on the show’s calendar date.
- * Interim 7:55pm PT (#303); venue-local lock tracked in #278.
+ * Picks lock at this local time on the show's calendar date in the show's local timezone.
+ * Interim 7:55pm local wall clock (#303 / #278).
  */
-export const SHOW_PICKS_LOCK_HOUR_PT = 19;
-export const SHOW_PICKS_LOCK_MINUTE_PT = 55;
+export const SHOW_PICKS_LOCK_HOUR_LOCAL = 19;
+export const SHOW_PICKS_LOCK_MINUTE_LOCAL = 55;
+// Back-compat aliases for existing imports.
+export const SHOW_PICKS_LOCK_HOUR_PT = SHOW_PICKS_LOCK_HOUR_LOCAL;
+export const SHOW_PICKS_LOCK_MINUTE_PT = SHOW_PICKS_LOCK_MINUTE_LOCAL;
 
-export function scheduleTodayYmd() {
-  return ymdInTimeZone(new Date(), SHOW_SCHEDULE_TIMEZONE);
+export function scheduleTodayYmd(timeZone = SHOW_SCHEDULE_TIMEZONE, now = new Date()) {
+  return ymdInTimeZone(now, timeZone);
 }
 
-function pacificClockOnShowYmd(showYmd) {
+function showClockOnShowYmd(showYmd, showTimeZone, now = new Date()) {
   const dtf = new Intl.DateTimeFormat('en-US', {
-    timeZone: SHOW_SCHEDULE_TIMEZONE,
+    timeZone: showTimeZone,
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
@@ -25,7 +29,7 @@ function pacificClockOnShowYmd(showYmd) {
     minute: '2-digit',
     hour12: false,
   });
-  const parts = dtf.formatToParts(new Date());
+  const parts = dtf.formatToParts(now);
   const map = Object.fromEntries(
     parts.filter((p) => p.type !== 'literal').map((p) => [p.type, p.value])
   );
@@ -34,16 +38,25 @@ function pacificClockOnShowYmd(showYmd) {
   return { hour: Number(map.hour), minute: Number(map.minute) };
 }
 
-/** True when it is still `showYmd` in the show timezone and local time there is at/after the picks lock. */
-export function isPastPicksLockPacific(showYmd) {
-  const clock = pacificClockOnShowYmd(showYmd);
+/**
+ * True when it is still `showYmd` in the show timezone and local time there is
+ * at/after the picks lock.
+ *
+ * DST fall-back ambiguity is handled by deriving wall-clock parts from a real
+ * instant (`now`) in the show's timezone; both repeated local hours map to the
+ * same show date boundary and compare consistently against lock hh:mm.
+ */
+export function isPastPicksLock(showYmd, showTimeZone = SHOW_SCHEDULE_TIMEZONE, now = new Date()) {
+  const clock = showClockOnShowYmd(showYmd, showTimeZone, now);
   if (!clock) return false;
   const { hour, minute } = clock;
   return (
-    hour > SHOW_PICKS_LOCK_HOUR_PT ||
-    (hour === SHOW_PICKS_LOCK_HOUR_PT && minute >= SHOW_PICKS_LOCK_MINUTE_PT)
+    hour > SHOW_PICKS_LOCK_HOUR_LOCAL ||
+    (hour === SHOW_PICKS_LOCK_HOUR_LOCAL && minute >= SHOW_PICKS_LOCK_MINUTE_LOCAL)
   );
 }
+// Back-compat alias.
+export const isPastPicksLockPacific = isPastPicksLock;
 
 /**
  * @param {{ date: string }[]} showDates — chronological flat list from show calendar (Phish.net or fallback).
@@ -52,17 +65,20 @@ export function getNextShow(showDates) {
   if (!Array.isArray(showDates) || showDates.length === 0) {
     throw new Error('getNextShow requires a non-empty showDates array.');
   }
-  const today = scheduleTodayYmd();
-
-  const nextShow = showDates.find((show) => show.date >= today);
+  const now = new Date();
+  const nextShow = showDates.find((show) => {
+    const tz = resolveShowTimeZone(show);
+    const showToday = scheduleTodayYmd(tz, now);
+    return show.date >= showToday;
+  });
 
   return nextShow || showDates[showDates.length - 1];
 }
 
 /**
- * NEXT — only date users can enter picks (the upcoming show from “today” in {@link SHOW_SCHEDULE_TIMEZONE}, before lock).
- * LIVE — that show date in PT and wall time there is at/after picks lock ({@link SHOW_PICKS_LOCK_HOUR_PT}:{@link SHOW_PICKS_LOCK_MINUTE_PT} PT): picks locked, live standings UX.
- * PAST — calendar date before schedule “today” in PT (show already happened).
+ * NEXT — only date users can enter picks (the upcoming show from each show's local "today", before lock).
+ * LIVE — selected show date in local timezone and wall time there is at/after picks lock ({@link SHOW_PICKS_LOCK_HOUR_LOCAL}:{@link SHOW_PICKS_LOCK_MINUTE_LOCAL} local): picks locked, live standings UX.
+ * PAST — calendar date before local "today" in the selected show timezone (show already happened there).
  * FUTURE — any other listed date (e.g. later tour nights): too early until that show becomes "next".
  */
 
@@ -83,13 +99,15 @@ export function getShowBeforeDate(ymd, showDates) {
  * @param {{ date: string }[]} showDates
  */
 export const getShowStatus = (selectedDate, showDates) => {
-  const today = scheduleTodayYmd();
   const nextShow = getNextShow(showDates);
+  const selectedShow = showDates.find((show) => show.date === selectedDate) || null;
+  const selectedTimeZone = resolveShowTimeZone(selectedShow);
+  const today = scheduleTodayYmd(selectedTimeZone);
 
   if (selectedDate < today) return 'PAST';
   if (selectedDate === nextShow.date) {
     if (selectedDate === today) {
-      if (isPastPicksLockPacific(selectedDate)) return 'LIVE';
+      if (isPastPicksLock(selectedDate, selectedTimeZone)) return 'LIVE';
     }
     return 'NEXT';
   }

--- a/src/shared/utils/timeLogic.test.js
+++ b/src/shared/utils/timeLogic.test.js
@@ -1,6 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { shouldRedactOpponentPicksPreLock } from './timeLogic';
+import {
+  getNextShow,
+  getShowStatus,
+  isPastPicksLock,
+  scheduleTodayYmd,
+  shouldRedactOpponentPicksPreLock,
+} from './timeLogic';
 
 describe('shouldRedactOpponentPicksPreLock (#303)', () => {
   it('redacts before picks lock / grading when show is still NEXT', () => {
@@ -19,5 +25,61 @@ describe('shouldRedactOpponentPicksPreLock (#303)', () => {
   it('does not redact for other statuses', () => {
     expect(shouldRedactOpponentPicksPreLock(null, 'PAST')).toBe(false);
     expect(shouldRedactOpponentPicksPreLock(null, 'FUTURE')).toBe(false);
+  });
+});
+
+describe('venue-local lock + status (#278)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('evaluates lock time in the show timezone instead of fixed PT', () => {
+    const at1940Chicago = new Date('2026-07-11T00:40:00.000Z');
+    const at1956Chicago = new Date('2026-07-11T00:56:00.000Z');
+
+    expect(isPastPicksLock('2026-07-10', 'America/Chicago', at1940Chicago)).toBe(false);
+    expect(isPastPicksLock('2026-07-10', 'America/Chicago', at1956Chicago)).toBe(true);
+    expect(isPastPicksLock('2026-07-10', 'America/Los_Angeles', at1956Chicago)).toBe(false);
+  });
+
+  it('chooses next show using each show local today', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-11T06:00:00.000Z'));
+
+    const shows = [
+      { date: '2026-07-10', venue: 'MSG, New York, NY', timeZone: 'America/New_York' },
+      { date: '2026-07-10', venue: 'Hollywood Bowl, Los Angeles, CA', timeZone: 'America/Los_Angeles' },
+      { date: '2026-07-11', venue: 'Hollywood Bowl, Los Angeles, CA', timeZone: 'America/Los_Angeles' },
+    ];
+
+    expect(getNextShow(shows)).toEqual(shows[1]);
+  });
+
+  it('marks a show LIVE at 7:55 in the venue timezone on show date', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-11T00:56:00.000Z'));
+
+    const shows = [
+      { date: '2026-07-10', venue: 'Kohl Center, Madison, WI', timeZone: 'America/Chicago' },
+    ];
+
+    expect(getShowStatus('2026-07-10', shows)).toBe('LIVE');
+  });
+
+  it('keeps fallback venue parsing for old docs without explicit timeZone', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-11T00:56:00.000Z'));
+
+    const shows = [{ date: '2026-07-10', venue: 'Kohl Center, Madison, WI' }];
+
+    expect(getShowStatus('2026-07-10', shows)).toBe('LIVE');
+  });
+
+  it('treats DST fall-back repeated local hour as same show date', () => {
+    const beforeFallback = new Date('2026-11-01T05:30:00.000Z');
+    const afterFallback = new Date('2026-11-01T06:30:00.000Z');
+
+    expect(scheduleTodayYmd('America/New_York', beforeFallback)).toBe('2026-11-01');
+    expect(scheduleTodayYmd('America/New_York', afterFallback)).toBe('2026-11-01');
   });
 });


### PR DESCRIPTION
Closes #278

## Summary
- propagate per-show IANA `timeZone` from Phish.net calendar sync through normalized `show_calendar` data and client show-calendar context
- switch lock/status helpers to evaluate picks lock and show status in each show’s local timezone (with fallback venue inference for legacy rows)
- align scheduled live-setlist candidate selection to each show’s local 4pm-4am window instead of ET-only date math
- add DST fall-back coverage and multi-zone tests for client and functions logic

## AC / UAT checklist
- [x] Non-PT lock behavior validated: at least one Chicago show now flips lock at 7:55 local, not 7:55 PT
- [x] `timeLogic` covers multiple IANA zones and DST fall-back repeated-hour handling
- [x] Calendar normalization/sync carries `timeZone` on show records (client + functions)
- [x] Scheduled automation candidate selection uses per-show local windows
- [ ] UAT: verify `/dashboard/picks` status transitions (`NEXT -> LIVE`) on a non-PT show date in staging data
- [ ] UAT: verify scheduled automation still polls expected dates around local midnight for at least one ET and one PT show

## Test plan
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run verify:dashboard-meta`
- [x] `npm run verify:dashboard-ui`
- [x] `npm test --prefix functions`

Made with [Cursor](https://cursor.com)