### PR TITLE
feat(admin): show venue-local picks cutoff in war room

### DIFF
--- a/src/features/admin/ui/AdminForm.jsx
+++ b/src/features/admin/ui/AdminForm.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import Card from '../../../shared/ui/Card';
 import { AlertTriangle } from 'lucide-react';
+import { useShowCalendar } from '../../show-calendar';
+import { resolveShowTimeZone } from '../../../shared/utils/showTimeZone';
 import { useAdminSetlistForm } from '../model/useAdminSetlistForm';
 import AdminSetlistSlotInputs from './AdminSetlistSlotInputs';
 import AdminSetlistFetchButton from './AdminSetlistFetchButton';
@@ -18,6 +20,7 @@ function normalizeDashboardShowDate(value) {
 }
 
 export default function AdminForm({ user, selectedDate }) {
+  const { showDates } = useShowCalendar();
   const [warRoomShowDate, setWarRoomShowDate] = useState(() =>
     normalizeDashboardShowDate(selectedDate),
   );
@@ -56,6 +59,8 @@ export default function AdminForm({ user, selectedDate }) {
     handleToggleAutomation,
     handlePollAutomationNow,
   } = useAdminSetlistForm({ user, selectedDate: warRoomShowDate });
+  const warRoomShow = showDates.find((show) => show.date === warRoomShowDate) || null;
+  const warRoomTimeZone = resolveShowTimeZone(warRoomShow);
 
   if (!isAdmin) {
     return (
@@ -72,6 +77,7 @@ export default function AdminForm({ user, selectedDate }) {
         value={warRoomShowDate}
         onChange={setWarRoomShowDate}
         disabled={isSaving}
+        timeZone={warRoomTimeZone}
       />
       <AdminClaimBootstrap user={user} />
       <Card variant="danger" padding="sm" className="mb-6 mt-4">

--- a/src/features/admin/ui/AdminWarRoomShowDate.jsx
+++ b/src/features/admin/ui/AdminWarRoomShowDate.jsx
@@ -1,13 +1,30 @@
 import React from 'react';
 import { CalendarRange } from 'lucide-react';
+import {
+  SHOW_PICKS_LOCK_HOUR_LOCAL,
+  SHOW_PICKS_LOCK_MINUTE_LOCAL,
+} from '../../../shared/utils/timeLogic';
+
+function formatLockTime(hour24, minute) {
+  const hour12 = ((hour24 + 11) % 12) + 1;
+  const suffix = hour24 >= 12 ? 'PM' : 'AM';
+  return `${hour12}:${String(minute).padStart(2, '0')} ${suffix}`;
+}
 
 /**
  * Admin-only: pick the Firestore `official_setlists/{showDate}` key independently of the
  * global dashboard tour picker (which may omit past legs or reset to “next show”).
  *
- * @param {{ value: string, onChange: (ymd: string) => void, disabled?: boolean }} props
+ * @param {{ value: string, onChange: (ymd: string) => void, disabled?: boolean, timeZone: string }} props
  */
-export default function AdminWarRoomShowDate({ value, onChange, disabled = false }) {
+export default function AdminWarRoomShowDate({
+  value,
+  onChange,
+  disabled = false,
+  timeZone,
+}) {
+  const lockTimeLabel = formatLockTime(SHOW_PICKS_LOCK_HOUR_LOCAL, SHOW_PICKS_LOCK_MINUTE_LOCAL);
+
   return (
     <div className="rounded-xl border border-border-subtle bg-[rgb(var(--surface-field)_/_0.35)] px-4 py-3 ring-1 ring-border-glass/20">
       <div className="flex items-start gap-2">
@@ -31,6 +48,10 @@ export default function AdminWarRoomShowDate({ value, onChange, disabled = false
             onChange={(e) => onChange(e.target.value)}
             className="mt-2 w-full max-w-[14rem] rounded-xl border-2 border-border-subtle bg-surface-field px-3 py-2 text-sm font-bold text-content-primary outline-none focus:border-brand-primary disabled:opacity-50"
           />
+          <p className="text-[11px] font-bold leading-relaxed text-content-secondary">
+            Picks lock: <span className="text-content-primary">{lockTimeLabel}</span>{' '}
+            <span className="text-slate-400">({timeZone})</span>
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Add a read-only lock-time line to the Admin War Room date card so admins can see the selected show's local picks cutoff timezone while editing and polling setlists.