### PR TITLE
fix(install): clarify unsupported browser install fallback copy

### DIFF
--- a/src/features/install/ui/InstallAppCard.jsx
+++ b/src/features/install/ui/InstallAppCard.jsx
@@ -75,9 +75,8 @@ export default function InstallAppCard() {
 
       {!canPrompt && !shouldShowIosFlow ? (
         <p className="mt-4 rounded-2xl border border-border-muted bg-surface-inset p-4 text-sm leading-relaxed text-content-secondary">
-          Install is not available in this browser yet. To test this flow now, open the app in iPhone
-          Safari for guided steps. Chromium native install prompt support arrives with the service worker
-          foundation.
+          Install is not available in this browser yet. For the best install experience, open Setlist
+          Pick &apos;Em in Safari on iPhone and use Add to Home Screen.
         </p>
       ) : null}
     </section>


### PR DESCRIPTION
## Summary
- Update unsupported-browser install fallback copy in the install card to give users a clear iPhone Safari Add to Home Screen path.
- Remove test-only phrasing and service-worker roadmap wording from the user-facing message.

## Test plan
- [ ] Open the install card in a browser without native install prompt support and verify the fallback text is shown.
- [ ] Verify the fallback message references Safari on iPhone and Add to Home Screen.
- [ ] Confirm no other install card states regress.

Made with [Cursor](https://cursor.com)