### PR TITLE
dx(qa): scaffold Playwright runners for Firestore cache + chunk-split…

### DIFF
--- a/.env.qa.example
+++ b/.env.qa.example
@@ -1,0 +1,18 @@
+# QA runner fixtures (scripts/qa/*.mjs). See scripts/qa/README.md.
+#
+# Copy this file to .env.qa.local (gitignored) and fill in real values.
+# Runners load it via Node's --env-file-if-exists flag, so it's optional —
+# a missing file fails with a clear pointer back to this template.
+
+# UID with rich graded-pick history in the staging Firestore project.
+# Required by scripts/qa/firestore-cache.mjs. Used to navigate to
+# /user/<uid> on the production preview build and measure the
+# `channel?VER=8` payload size on initial load vs. SPA-nav-back.
+#
+# Pick a UID that:
+#   - exists in the project the build talks to (typically staging),
+#   - has a populated `users/{uid}` materialized aggregate (post-rollup),
+#   - has graded picks across enough shows that the initial WebChannel
+#     read is comfortably > 5 kB (otherwise the cache assertion is
+#     trivial — empty payloads pass on every navigation).
+QA_PUBLIC_PROFILE_UID=YOUR_STAGING_FIREBASE_UID

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .env
 .env.*
 !.env.example
+!.env.*.example
 .DS_Store
 dist
 # Cursor agent per-session debug logs (pattern covers any session id).

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "autoprefixer": "^10.4.14",
         "eslint": "^9.39.4",
         "eslint-plugin-import": "^2.32.0",
+        "playwright": "^1.59.1",
         "postcss": "^8.4.27",
         "tailwindcss": "^3.3.3",
         "vite": "^4.4.0",
@@ -5546,6 +5547,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "print:phishnet-tour-clusters": "node scripts/print-phishnet-tour-clusters.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:rules": "firebase emulators:exec --only firestore --project setlist-pickem-rules-test \"node --test firestore.rules.test.cjs\""
+    "test:rules": "firebase emulators:exec --only firestore --project setlist-pickem-rules-test \"node --test firestore.rules.test.cjs\"",
+    "qa:cache": "node --env-file-if-exists=.env.qa.local scripts/qa/firestore-cache.mjs",
+    "qa:chunks": "node --env-file-if-exists=.env.qa.local scripts/qa/chunk-split.mjs"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.0.0",
@@ -36,6 +38,7 @@
     "autoprefixer": "^10.4.14",
     "eslint": "^9.39.4",
     "eslint-plugin-import": "^2.32.0",
+    "playwright": "^1.59.1",
     "postcss": "^8.4.27",
     "tailwindcss": "^3.3.3",
     "vite": "^4.4.0",

--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -1,0 +1,87 @@
+# `scripts/qa/` — agent-runnable browser QA recipes
+
+Codified versions of the browser-side recipes documented in
+[`.cursor/skills/pr-qa/recipes.md`](../../.cursor/skills/pr-qa/recipes.md).
+The agent can run these directly without the human-in-the-loop screenshot
+hand-off described in `.cursor/skills/pr-qa/SKILL.md` §3.
+
+Pilot scope tracked in [#251](https://github.com/pat792/set-picks/issues/251).
+
+## Why this exists
+
+The PR QA playbook treats every browser-observable check (Firestore read
+cache, chunk-load on SPA nav, cache-control headers, telemetry in the
+production build) as a hand-off to the human. That's correct given the
+agent's current toolbelt — `Shell` plus file ops, no browser — but it's
+friction on every PR.
+
+These runners convert deterministic browser checks into shell-runnable
+scripts the agent can execute as part of `Step 2 — Agent-side checks`,
+falling back to the manual recipe only when the script can't reach the
+test data (logged-in routes pre-emulator, production-only signals, etc.).
+
+## Setup (one time)
+
+```bash
+cp .env.qa.example .env.qa.local
+# Edit .env.qa.local and fill in the values per the comments.
+```
+
+`.env.qa.local` is gitignored — it stays on your machine. The committed
+`.env.qa.example` is the template with placeholder values.
+
+The npm scripts load the file via Node's `--env-file-if-exists` flag, so
+a missing file fails inside the runner with a clear pointer back to this
+README rather than a cryptic "undefined" error.
+
+## Available runners
+
+| Script | npm task | Recipe (recipes.md) |
+|---|---|---|
+| `firestore-cache.mjs` | `npm run qa:cache` | §B Firestore read cache |
+| `chunk-split.mjs` | `npm run qa:chunks` | §A chunk-load verification |
+
+Each runner:
+
+1. Spawns `npm run preview` (production build, served on a throwaway
+   port) so we exercise the same artifact a Vercel preview would.
+2. Drives a headless Chromium (Playwright) against `localhost:<port>`.
+3. Asserts the recipe's pass/fail observable.
+4. Exits 0 (pass) or non-zero (fail), with a one-line diagnostic on
+   failure.
+
+## Adding a new runner
+
+Convention for `scripts/qa/<recipe>.mjs`:
+
+1. **Self-contained.** Spawn `npm run preview` on a throwaway port,
+   tear it down on exit (including on `SIGINT` / thrown error). Don't
+   assume an external dev server.
+2. **Deterministic.** No timing-dependent assertions; wait on
+   network-idle / DOM signals, not `setTimeout`. If the recipe is
+   inherently empirical (e.g. "payload < 2 kB"), document the threshold
+   and how it was chosen at the top of the file.
+3. **One concern per runner.** Don't bundle Firestore-cache and
+   chunk-split assertions in the same script — the failure modes are
+   independent and split runners give cleaner diagnostics.
+4. **Failure messages point to the recipe.** A failed assertion should
+   print "see `.cursor/skills/pr-qa/recipes.md` §X for context."
+5. **Fixtures live in `fixtures.js`.** UIDs, sample show dates, etc.
+   Add a new `requireEnv(...)` export and document it in
+   `.env.qa.example`. Never hard-code real-account identifiers in
+   committed JS.
+6. **Wire `npm run qa:<name>`.** Always with `--env-file-if-exists`
+   so the script fails inside `requireEnv` with a clear message rather
+   than at Node startup.
+
+## Out of scope (deferred follow-ups, per #251)
+
+- **Cache-control header runner** (recipe §C). Needs a Vercel
+  deployment-protection bypass token to fetch preview asset headers —
+  separate ticket.
+- **Telemetry runner** (recipe §E). Already well-covered by vitest on
+  the emitter; low marginal value for a runner.
+- **Auth-gated routes** (e.g. `/dashboard/standings`). Needs Firebase
+  Auth emulator wiring — separate ticket.
+- **CI job.** Pilot stays developer-run; CI wiring lands once the
+  runners are stable across a few PRs.

--- a/scripts/qa/_lib/preview.mjs
+++ b/scripts/qa/_lib/preview.mjs
@@ -1,0 +1,138 @@
+/**
+ * Shared `vite build && vite preview` lifecycle for QA runners (#251).
+ *
+ * Why this lives in a shared helper:
+ *   - Both runners need the same artifact: a fresh production build,
+ *     served on a throwaway port, torn down deterministically. Copying
+ *     the spawn/teardown logic between runners would drift over time.
+ *   - The preview server is the only difference vs. a Vercel preview
+ *     URL (no deployment-protection 401, same vite-built dist/). That
+ *     makes it the right local stand-in for cache-headers / chunk-graph
+ *     / Firestore-cache recipes — see `.cursor/skills/pr-qa/recipes.md`.
+ *
+ * Why not just use a fixed port:
+ *   - Multiple runners shouldn't collide. Each picks an ephemeral port
+ *     and announces it via stdout, just like `vite preview --port 0`
+ *     would — except vite doesn't actually accept `--port 0`, so we
+ *     pick from a small high-numbered range and retry on conflict.
+ */
+
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const READY_TIMEOUT_MS = 60_000;
+const READY_POLL_INTERVAL_MS = 250;
+
+/**
+ * Run `npm run build` synchronously. Surfaces build errors immediately
+ * so the runner doesn't waste time launching a browser against stale
+ * dist/ contents.
+ *
+ * @returns {Promise<void>}
+ */
+async function runBuild() {
+  const proc = spawn('npm', ['run', 'build'], {
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+  const [code] = await once(proc, 'exit');
+  if (code !== 0) {
+    throw new Error(`[scripts/qa] npm run build exited with code ${code}`);
+  }
+}
+
+/**
+ * Pick a high-numbered port in the user-private range, far away from
+ * vite's 4173 default and the dev server's 5173 to avoid collisions
+ * with humans running both.
+ */
+function pickPort() {
+  const RANGE_START = 14_173;
+  const RANGE_END = 14_273;
+  return (
+    RANGE_START + Math.floor(Math.random() * (RANGE_END - RANGE_START + 1))
+  );
+}
+
+/**
+ * Poll the preview URL until it responds with 200 or we time out. Vite
+ * preview prints "Local: http://..." early but the HTTP server isn't
+ * always immediately reachable; polling is more robust than parsing
+ * stdout.
+ *
+ * @param {string} url
+ */
+async function waitForReady(url) {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { method: 'GET' });
+      if (res.ok) return;
+    } catch {
+      // Connection refused / DNS / etc. — keep polling.
+    }
+    await sleep(READY_POLL_INTERVAL_MS);
+  }
+  throw new Error(
+    `[scripts/qa] vite preview did not become ready at ${url} within ` +
+      `${READY_TIMEOUT_MS}ms.`,
+  );
+}
+
+/**
+ * Build and start `vite preview` on a throwaway port.
+ *
+ * @returns {Promise<{ url: string, kill: () => Promise<void> }>}
+ */
+export async function startPreview() {
+  await runBuild();
+
+  const port = pickPort();
+  const url = `http://localhost:${port}`;
+
+  // `--strictPort` makes vite fail fast on conflict instead of silently
+  // picking another port (which would invalidate `url`). If we collide,
+  // bubble up — the runner can be retried.
+  const proc = spawn(
+    'npm',
+    ['run', 'preview', '--', '--port', String(port), '--strictPort'],
+    {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+
+  let exited = false;
+  proc.on('exit', () => {
+    exited = true;
+  });
+
+  // Race readiness vs. early exit so a bind failure surfaces fast.
+  const exitPromise = once(proc, 'exit').then(([code]) => {
+    throw new Error(
+      `[scripts/qa] vite preview exited unexpectedly with code ${code} ` +
+        `before becoming ready on ${url}.`,
+    );
+  });
+
+  await Promise.race([waitForReady(url), exitPromise]);
+
+  const kill = async () => {
+    if (exited) return;
+    proc.kill('SIGTERM');
+    // Give vite a moment to release the port; if it's still alive
+    // after 2s, hard-kill so we don't leak processes.
+    await Promise.race([once(proc, 'exit'), sleep(2_000)]);
+    if (!exited) proc.kill('SIGKILL');
+  };
+
+  // Clean up on process exit signals (Ctrl-C, kill, uncaught throw).
+  // Without this, a runner crash leaves vite preview holding the port.
+  const onSignal = () => {
+    void kill();
+  };
+  process.once('SIGINT', onSignal);
+  process.once('SIGTERM', onSignal);
+  process.once('exit', onSignal);
+
+  return { url, kill };
+}

--- a/scripts/qa/chunk-split.mjs
+++ b/scripts/qa/chunk-split.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * QA runner for `.cursor/skills/pr-qa/recipes.md` §A — chunk-load
+ * verification (issue #251 pilot).
+ *
+ * What it asserts: when SPA-navigating from one route to another, only
+ * the destination route's chunk loads — chunks for unrelated routes
+ * never appear. This is the runtime complement to `npm run build`'s
+ * static graph inspection (recipes.md §A bash one-liner).
+ *
+ * What it doesn't assert: vendor-chunk shape (vendor-react-query,
+ * firebase-core, etc.) or chunk SIZE drift. Those are static signals
+ * better caught at build time, not by a Playwright runner.
+ *
+ * Architecture notes:
+ *   - The runner snapshots the cumulative set of loaded chunks at
+ *     each phase boundary, and computes the delta = new - previous.
+ *     Each scenario asserts the delta contains exactly the expected
+ *     route component AND no chunks for other lazy routes.
+ *   - The list of `LAZY_ROUTE_COMPONENTS` mirrors `src/app/App.jsx`'s
+ *     `lazy()` calls. Keep them in sync; treat App.jsx as the source
+ *     of truth and update this list whenever a new top-level lazy
+ *     route lands.
+ *   - SPA navigation uses pushState + popstate (same as
+ *     firestore-cache.mjs). See that file's header for why this
+ *     works against react-router-dom v6.
+ */
+
+import { chromium } from 'playwright';
+
+import { PUBLIC_PROFILE_UID } from './fixtures.js';
+import { startPreview } from './_lib/preview.mjs';
+
+// Mirrors `src/app/App.jsx`'s lazy()-imported routes. A chunk for any
+// of these appearing on a navigation to a *different* route is a
+// cross-route leak — the static-import graph reaches across routes
+// and partially defeats route-level code splitting (#240/#242).
+const LAZY_ROUTE_COMPONENTS = [
+  'PasswordResetCompletePage',
+  'PublicProfilePage',
+  'PoolInviteMissingCodePage',
+  'PoolInvitePage',
+  'SetupRoute',
+  'DashboardRoute',
+];
+
+const NAV_TIMEOUT_MS = 20_000;
+
+/**
+ * Extract the "named" component from a Vite chunk URL.
+ *
+ * Vite's default `output.chunkFileNames` shape is
+ * `assets/[name]-[hash].js` where `[name]` is allowed to contain
+ * dashes (e.g. `firebase-storage`) and `[hash]` is alphanumeric only.
+ * The non-greedy name capture plus a `[A-Za-z0-9_]+` (dash-free) hash
+ * pattern lets us correctly parse both `PublicProfilePage-AbCd1234.js`
+ * and `firebase-storage-AbCd1234.js`.
+ *
+ * @param {string} url
+ * @returns {string | null}
+ */
+function chunkNameFromUrl(url) {
+  const match = url.match(
+    /\/assets\/([A-Za-z0-9_-]+?)-[A-Za-z0-9_]+\.js(?:\?.*)?$/,
+  );
+  return match ? match[1] : null;
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {string} path
+ */
+async function spaNavigate(page, path) {
+  await page.evaluate((next) => {
+    window.history.pushState(null, '', next);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }, path);
+}
+
+/**
+ * Wait until react-router has rendered for `expectedPath` and the
+ * network has gone idle (proxy for "all lazy chunks resolved").
+ *
+ * @param {import('playwright').Page} page
+ * @param {string} expectedPath
+ */
+async function settleAt(page, expectedPath) {
+  await page.waitForFunction(
+    (expected) => window.location.pathname === expected,
+    expectedPath,
+    { timeout: NAV_TIMEOUT_MS },
+  );
+  await page.waitForLoadState('networkidle');
+}
+
+async function run() {
+  console.log('[qa:chunks] building production artifact + starting vite preview…');
+  const preview = await startPreview();
+  console.log(`[qa:chunks] preview ready at ${preview.url}`);
+
+  const browser = await chromium.launch({ headless: true });
+  let exitCode = 1;
+
+  try {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    // Cumulative set of every chunk URL that resolved. We snapshot
+    // this at phase boundaries and diff to get per-nav deltas.
+    const loadedChunks = new Set();
+    page.on('response', (response) => {
+      const url = response.url();
+      // Limit to chunks served by the local preview — third-party
+      // assets (Firebase SDK CDN, GA4, etc.) shouldn't match the
+      // /assets/<name>-<hash>.js shape anyway, but the origin filter
+      // is cheap insurance.
+      if (!url.startsWith(preview.url)) return;
+      const name = chunkNameFromUrl(url);
+      if (!name) return;
+      loadedChunks.add(name);
+    });
+
+    // Initial paint: hard-load splash. Anything Vite emits
+    // <link rel="modulepreload"> for ends up in `initialChunks` and
+    // is correctly excluded from later deltas.
+    await page.goto(`${preview.url}/`, { waitUntil: 'networkidle' });
+    const initialChunks = new Set(loadedChunks);
+
+    // Scenario 1: / -> /user/<UID> expects PublicProfilePage chunk.
+    await spaNavigate(page, `/user/${PUBLIC_PROFILE_UID}`);
+    await settleAt(page, `/user/${PUBLIC_PROFILE_UID}`);
+    const afterUser = new Set(loadedChunks);
+    const userDelta = [...afterUser].filter((c) => !initialChunks.has(c));
+
+    // Scenario 2: /user/<UID> -> /password-reset-complete expects
+    // PasswordResetCompletePage chunk. Picked over /join (which
+    // <Navigate>'s straight back to /, making the chunk transient and
+    // the assertion racy) and /setup (which redirects when not
+    // authenticated, same problem).
+    await spaNavigate(page, '/password-reset-complete');
+    await settleAt(page, '/password-reset-complete');
+    const afterReset = new Set(loadedChunks);
+    const resetDelta = [...afterReset].filter((c) => !afterUser.has(c));
+
+    const scenarios = [
+      {
+        from: '/',
+        to: '/user/<uid>',
+        expected: 'PublicProfilePage',
+        delta: userDelta,
+      },
+      {
+        from: '/user/<uid>',
+        to: '/password-reset-complete',
+        expected: 'PasswordResetCompletePage',
+        delta: resetDelta,
+      },
+    ];
+
+    let allPass = true;
+    for (const s of scenarios) {
+      const containsExpected = s.delta.includes(s.expected);
+      const leakedRoutes = s.delta.filter(
+        (c) => LAZY_ROUTE_COMPONENTS.includes(c) && c !== s.expected,
+      );
+      const deltaStr = s.delta.length === 0 ? '<none>' : s.delta.join(', ');
+
+      if (!containsExpected) {
+        console.error(
+          `[qa:chunks] FAIL ${s.from} -> ${s.to}: expected chunk ` +
+            `'${s.expected}-*.js' did not load on this nav. ` +
+            `Delta: [${deltaStr}].`,
+        );
+        console.error(
+          '[qa:chunks]   Either the route component was bundled into ' +
+            'the main entry (route splitting broke), or the lazy chunk ' +
+            'name no longer matches the component name. See ' +
+            '`.cursor/skills/pr-qa/recipes.md` §A.',
+        );
+        allPass = false;
+        continue;
+      }
+
+      if (leakedRoutes.length > 0) {
+        console.error(
+          `[qa:chunks] FAIL ${s.from} -> ${s.to}: route chunks for ` +
+            `unrelated pages loaded: [${leakedRoutes.join(', ')}].`,
+        );
+        console.error(
+          '[qa:chunks]   See `.cursor/skills/pr-qa/recipes.md` §A for context.',
+        );
+        console.error(
+          '[qa:chunks]   Common cause: a static import chain reaches ' +
+            'across routes. Trace with: ' +
+            `\`grep -l '${leakedRoutes[0]}-' dist/assets/*.js\`.`,
+        );
+        allPass = false;
+        continue;
+      }
+
+      console.log(
+        `[qa:chunks] PASS ${s.from} -> ${s.to}: ` +
+          `${s.expected} loaded; no cross-route leakage. ` +
+          `Delta: [${deltaStr}].`,
+      );
+    }
+
+    if (allPass) exitCode = 0;
+  } finally {
+    await browser.close().catch(() => {});
+    await preview.kill();
+  }
+
+  process.exit(exitCode);
+}
+
+run().catch((err) => {
+  console.error('[qa:chunks] runner crashed:', err);
+  process.exit(1);
+});

--- a/scripts/qa/firestore-cache.mjs
+++ b/scripts/qa/firestore-cache.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+/**
+ * QA runner for `.cursor/skills/pr-qa/recipes.md` §B — Firestore read
+ * cache verification (issue #251 pilot).
+ *
+ * What it asserts: navigating away from `/user/<uid>` and back via SPA
+ * routing reuses the React Query cache for `useUserSeasonStats`,
+ * skipping the Firestore read that initially populated the page.
+ *
+ * What it doesn't assert: `usePublicProfile` (profile + pools) is NOT
+ * yet React Query'd, so it re-fetches on every uid mount. The threshold
+ * below is calibrated to allow that traffic while still failing on a
+ * full season-stats re-fetch.
+ *
+ * Architecture notes that justified the pattern:
+ *   - We can't navigate via Playwright's `page.goto()` because that's a
+ *     hard reload and destroys the QueryClient at the React root (in
+ *     `src/main.jsx`). Cache hits require a soft (SPA) nav.
+ *   - The PublicProfilePage component owns its own ShowCalendarProvider
+ *     instance. Navigating splash → /user/<uid> → splash unmounts and
+ *     remounts that provider, which re-subscribes to
+ *     `show_calendar/snapshot`. That re-subscription's bytes muddy the
+ *     measurement. We sidestep this by bouncing /user/A → /user/<bogus>
+ *     → /user/A: react-router v6 keeps the route element mounted when
+ *     only `:userId` changes, so ShowCalendarProvider stays alive.
+ *   - SPA navigation is triggered via `pushState` + `popstate`. The
+ *     `history` package (which react-router-dom v6 uses internally)
+ *     subscribes to popstate and re-publishes location updates to
+ *     subscribers, so a manual popstate dispatch is enough to make
+ *     react-router re-render against the new URL.
+ *
+ * Failure messages cite recipes.md §B so a failing run is actionable
+ * without context-switching.
+ */
+
+import { chromium } from 'playwright';
+
+import { PUBLIC_PROFILE_UID } from './fixtures.js';
+import { startPreview } from './_lib/preview.mjs';
+
+// Why these thresholds (empirical, calibrated against staging data on
+// 2026-04-29 staging build):
+//
+// - BASELINE_MIN_BYTES: an initial /user/<uid> render fans out into
+//   show_calendar/snapshot subscription + the user's profile doc + the
+//   user's pools query + the season-stats compute (live or
+//   materialized). For any UID with picks across multiple shows, the
+//   total channel?VER=8 traffic comfortably crosses 5 kB. If the
+//   configured UID's baseline is below this, the test data is too
+//   sparse to make the cache assertion meaningful — we'd risk a
+//   false-pass when the cache is actually broken.
+//
+// - SAVED_MIN_BYTES: the cache benefit we expect to observe after the
+//   bounce. A working cache skips the season-stats Firestore read
+//   entirely (cache hit on `[uid, showDatesKey]`); a broken cache
+//   re-fetches it. The materialized fast path is single-doc and small
+//   (~1-2 kB), but the live fallback can be 10s of kB. 5 kB strikes
+//   the balance: tight enough to fail when ALL of season stats is
+//   re-fetched, loose enough to absorb the
+//   profile/pools-not-yet-cached traffic that's intentionally out of
+//   scope for #251.
+const BASELINE_MIN_BYTES = 5 * 1024;
+const SAVED_MIN_BYTES = 5 * 1024;
+
+// Bogus UID used for the bounce. PublicProfilePage renders 'Player not
+// found' for unknown uids, which is enough of a UI signal to wait on
+// without firing useUserSeasonStats. The string is deliberately
+// non-Firebase-shape so it can never collide with a real account.
+const BOUNCE_UID = 'qa-cache-bounce-not-a-real-uid';
+
+const NAV_TIMEOUT_MS = 20_000;
+
+/**
+ * SPA-navigate to `path` via pushState + popstate. See file header for
+ * why this works against react-router-dom v6.
+ *
+ * @param {import('playwright').Page} page
+ * @param {string} path
+ */
+async function spaNavigate(page, path) {
+  await page.evaluate((next) => {
+    window.history.pushState(null, '', next);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }, path);
+}
+
+/**
+ * Wait for the public profile UI to fully settle (no spinners). The
+ * stat cells render a Loader2 with `aria-label="Loading <metric>"`
+ * while React Query is in-flight; once they're all gone, the data is
+ * either cached or freshly fetched.
+ *
+ * @param {import('playwright').Page} page
+ */
+async function waitForProfileSettled(page) {
+  await page.waitForSelector('text=/Total points/i', { timeout: NAV_TIMEOUT_MS });
+  await page.waitForFunction(
+    () => !document.querySelector('[aria-label^="Loading "]'),
+    null,
+    { timeout: NAV_TIMEOUT_MS },
+  );
+  await page.waitForLoadState('networkidle');
+}
+
+/**
+ * Wait for the 'Player not found' UI on the bounce target.
+ *
+ * @param {import('playwright').Page} page
+ */
+async function waitForNotFound(page) {
+  await page.waitForSelector('text=/Player not found/i', {
+    timeout: NAV_TIMEOUT_MS,
+  });
+  await page.waitForLoadState('networkidle');
+}
+
+/**
+ * Format a byte count for log lines. Keeps output greppable with a
+ * stable shape regardless of magnitude.
+ *
+ * @param {number} bytes
+ */
+function fmtBytes(bytes) {
+  return `${bytes}B (${(bytes / 1024).toFixed(1)}kB)`;
+}
+
+async function run() {
+  console.log('[qa:cache] building production artifact + starting vite preview…');
+  const preview = await startPreview();
+  console.log(`[qa:cache] preview ready at ${preview.url}`);
+
+  const browser = await chromium.launch({ headless: true });
+  let exitCode = 1;
+
+  try {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    // Phase-tagged byte counter. The response listener routes each
+    // matching response into the active phase's bucket; phases that
+    // don't appear in the bucket map are silently dropped (used for
+    // navigation steps whose traffic we don't care about).
+    let phase = /** @type {'idle'|'baseline'|'postNav'} */ ('idle');
+    const phaseBytes = { baseline: 0, postNav: 0 };
+
+    page.on('response', async (response) => {
+      const url = response.url();
+      if (!url.includes('firestore.googleapis.com')) return;
+      if (!url.includes('channel?VER=8')) return;
+      if (!(phase in phaseBytes)) return;
+      try {
+        const body = await response.body();
+        phaseBytes[/** @type {'baseline'|'postNav'} */ (phase)] += body.length;
+      } catch {
+        // Body unavailable (already consumed, request aborted, etc.) —
+        // skip rather than throw. The measurement is best-effort.
+      }
+    });
+
+    // Hard-load splash so the SPA shell mounts. After this, all
+    // navigation is soft.
+    await page.goto(`${preview.url}/`, { waitUntil: 'networkidle' });
+
+    // Step 1: navigate to /user/<uid> and capture baseline.
+    phase = 'baseline';
+    await spaNavigate(page, `/user/${PUBLIC_PROFILE_UID}`);
+    await waitForProfileSettled(page);
+
+    if (phaseBytes.baseline < BASELINE_MIN_BYTES) {
+      console.error(
+        `[qa:cache] FAIL: baseline payload was ${fmtBytes(phaseBytes.baseline)}, ` +
+          `expected >= ${fmtBytes(BASELINE_MIN_BYTES)}.`,
+      );
+      console.error(
+        '[qa:cache]   The configured QA_PUBLIC_PROFILE_UID does not have ' +
+          'enough Firestore-heavy season-stats data for the cache assertion ' +
+          'to be meaningful. Pick a UID with graded picks across multiple ' +
+          'shows. See scripts/qa/README.md.',
+      );
+      return;
+    }
+
+    // Step 2: bounce to a bogus uid. ShowCalendarProvider stays
+    // mounted (same route, only :userId changes), so no calendar
+    // resubscribe traffic during the bounce or the return.
+    phase = 'idle';
+    await spaNavigate(page, `/user/${BOUNCE_UID}`);
+    await waitForNotFound(page);
+
+    // Step 3: SPA-nav back to /user/<uid> and capture post-nav.
+    phase = 'postNav';
+    await spaNavigate(page, `/user/${PUBLIC_PROFILE_UID}`);
+    await waitForProfileSettled(page);
+
+    const saved = phaseBytes.baseline - phaseBytes.postNav;
+    const verdict = saved >= SAVED_MIN_BYTES ? 'PASS' : 'FAIL';
+
+    console.log(
+      `[qa:cache] baseline=${fmtBytes(phaseBytes.baseline)}  ` +
+        `post-nav=${fmtBytes(phaseBytes.postNav)}  ` +
+        `saved=${fmtBytes(saved)}  ` +
+        `threshold=${fmtBytes(SAVED_MIN_BYTES)}  ` +
+        verdict,
+    );
+
+    if (verdict !== 'PASS') {
+      console.error(
+        '[qa:cache] FAIL: post-nav re-fetched approximately the same ' +
+          'channel?VER=8 payload as baseline. useUserSeasonStats does not ' +
+          'appear to be hitting React Query cache on SPA back-navigation.',
+      );
+      console.error(
+        '[qa:cache]   See `.cursor/skills/pr-qa/recipes.md` §B for context.',
+      );
+      console.error(
+        '[qa:cache]   Common cause: queryKey instability across mounts ' +
+          '(e.g. a freshly-built array/object in the key derived per render).',
+      );
+      return;
+    }
+
+    exitCode = 0;
+  } finally {
+    await browser.close().catch(() => {});
+    await preview.kill();
+  }
+
+  process.exit(exitCode);
+}
+
+run().catch((err) => {
+  console.error('[qa:cache] runner crashed:', err);
+  process.exit(1);
+});

--- a/scripts/qa/fixtures.js
+++ b/scripts/qa/fixtures.js
@@ -1,0 +1,51 @@
+/**
+ * Shared fixtures for `scripts/qa/*.mjs` runners (issue #251).
+ *
+ * Values come from `process.env`, populated by the QA runner npm scripts
+ * via Node's `--env-file-if-exists=.env.qa.local` flag (see package.json).
+ * `.env.qa.local` is gitignored; `.env.qa.example` is the committed
+ * template documenting expected values.
+ *
+ * Why env vars instead of hard-coded constants:
+ *   - The default values point at real staging Firestore data (a UID
+ *     with rich graded-pick history), which we don't want in repo
+ *     history forever — it locks future work to a specific user account
+ *     and leaks mild PII into git log / PR diffs / IDE search hits.
+ *   - When a dedicated `qa-test-public-profile` UID gets seeded
+ *     (deferred follow-up per #251), the migration is a one-line
+ *     change to `.env.qa.example` — no code churn.
+ *   - CI (also a deferred follow-up) populates these from repo secrets
+ *     without touching this file.
+ */
+
+const PLACEHOLDER_PUBLIC_PROFILE_UID = 'YOUR_STAGING_FIREBASE_UID';
+
+/**
+ * Read a required env var. Throws with a pointer to the setup docs if
+ * missing or still set to the placeholder from `.env.qa.example`.
+ *
+ * @param {string} name
+ * @param {string} placeholder
+ * @returns {string}
+ */
+function requireEnv(name, placeholder) {
+  const value = process.env[name];
+  if (!value || value === placeholder) {
+    throw new Error(
+      `[scripts/qa/fixtures] ${name} is not set. Copy .env.qa.example to ` +
+        '.env.qa.local and fill in the real value. See scripts/qa/README.md.',
+    );
+  }
+  return value;
+}
+
+/**
+ * UID navigated to as `/user/<uid>` by `firestore-cache.mjs`. Public
+ * profile route — no auth required. Must have a populated
+ * `users/{uid}` materialized aggregate AND graded picks across enough
+ * shows that the initial WebChannel read is comfortably > 5 kB.
+ */
+export const PUBLIC_PROFILE_UID = requireEnv(
+  'QA_PUBLIC_PROFILE_UID',
+  PLACEHOLDER_PUBLIC_PROFILE_UID,
+);


### PR DESCRIPTION
… (#251)

Codifies recipes.md §A and §B as agent-runnable Node scripts so the PR-QA playbook can stop handing those checks back to the human.

- scripts/qa/firestore-cache.mjs — asserts useUserSeasonStats hits React Query cache on SPA back-nav by diffing channel?VER=8 payload bytes across a baseline → bounce → return cycle.
- scripts/qa/chunk-split.mjs — asserts SPA navigation between unrelated routes only fetches the destination's lazy chunk; flags cross-route static-import leakage.
- scripts/qa/_lib/preview.mjs — shared 'vite build && vite preview' lifecycle helper.
- scripts/qa/fixtures.js — env-var-backed QA_PUBLIC_PROFILE_UID with a clear failure mode pointing at README setup.

UID lives in .env.qa.local (gitignored); .env.qa.example documents the convention so future migration to a dedicated qa-test-public- profile UID is a one-line change. Wired as 'npm run qa:cache' and 'npm run qa:chunks' via Node's --env-file-if-exists flag.

SKILL.md §2.6 + recipes.md §A/§B updates and smoke/break-test runs land in follow-up commits on this branch.

Made-with: Cursor