### PR TITLE
docs(pr-qa): complete #251 playbook wiring for QA runners

### DIFF
--- a/.cursor/skills/pr-qa/SKILL.md
+++ b/.cursor/skills/pr-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-qa
-description: Runs QA on an open pull request for the set-picks repo. Covers lint/test/build verification, FSD boundary checks, Vite chunk-graph inspection, Vercel preview URL discovery, and scripted DevTools recipes the user runs in the browser (Firestore read cache, route splitting, cache-control headers, telemetry). Use when the user says "QA this PR", "verify PR #N", "test this pull request", "run QA steps", or asks the agent to review a PR before merge. Also covers `gh pr review` verb conventions so agents know when approval vs request-changes is appropriate.
+description: Runs QA on an open pull request for the set-picks repo. Covers lint/test/build verification, FSD boundary checks, Vite chunk-graph inspection, Vercel preview URL discovery, codified Playwright runners (`npm run qa:cache`, `npm run qa:chunks` — issue #251), and scripted DevTools recipes the user runs in the browser for cases runners do not cover (cache-control on protected previews, telemetry, auth-gated flows). Use when the user says "QA this PR", "verify PR #N", "test this pull request", "run QA steps", or asks the agent to review a PR before merge. Also covers `gh pr review` verb conventions so agents know when approval vs request-changes is appropriate.
 ---
 
 # PR QA Playbook for `set-picks`
@@ -11,9 +11,16 @@ perf epic #239 — follow it instead of improvising.
 ## Non-negotiables
 
 - **Base branch is `staging`**, not `main`.
-- **You cannot open URLs, take screenshots, or run JS.** Every browser
-  step MUST be walked through the user. Never claim you've "verified"
-  something in the browser — you've verified their screenshot of it.
+- **You cannot open remote URLs, take screenshots, or drive a visible
+  browser.** Hand off anything that still needs a human looking at a
+  **per-PR preview** in Chrome (e.g. §C cache headers behind Vercel 401,
+  GA4 DebugView). **Exception (#251):** With a local checkout and
+  `.env.qa.local` configured (see `scripts/qa/README.md`), you **may**
+  run `npm run build` then `npm run qa:cache` / `npm run qa:chunks` —
+  headless Playwright against `vite preview` on localhost. That is not
+  "verifying the Vercel preview"; it's verifying the **same production
+  artifact** the preview would serve. Never claim you verified the
+  **deployed preview URL** without a user screenshot.
 - **Only commit/push/comment/review when the user asks.** QA on an
   already-open PR is read-only by default.
 - **Pre-existing warnings are not regressions.** Check against
@@ -128,11 +135,37 @@ When the diff touches `src/app/App.jsx` or `src/app/layout/DashboardLayout.jsx`:
 - Confirm the `lazy()` wrappers match the PR's claims.
 - If dashboard child routes changed, confirm `src/app/layout/model/dashboardPageMeta.js` AND `scripts/verify-dashboard-meta.mjs` were updated together (`.cursorrules` §6).
 
+### 2.6 Codified browser recipes (Playwright, issue #251)
+
+After **§2.2** has produced a fresh `dist/`, run the matching **npm
+scripts** before asking the user for manual Network-tab work — **if**
+the machine has `scripts/qa` fixtures configured.
+
+| When | Command | Replaces manual |
+|---|---|---|
+| PR touches **route splitting / lazy routes / chunk graph** (recipes §A) | `npm run qa:chunks` | §A scripted nav + chunk assertions for the runner's path |
+| PR touches **`useUserSeasonStats` / React Query cache** on public profile (recipes §B) | `npm run qa:cache` | §B baseline vs SPA-bounce `channel?VER=8` size check |
+
+**Setup (once per machine):** copy `.env.qa.example` → `.env.qa.local`
+and set `QA_PUBLIC_PROFILE_UID` to a real Firebase UID with rich graded
+data (see `scripts/qa/README.md`). `npm ci` installs `playwright`; first
+Chromium launch may download browsers.
+
+**If env is missing or still placeholder:** the runner exits immediately
+with a pointer to the README — note **`qa:* skipped (no .env.qa.local)`**
+in the Step 4 report and fall back to the **manual** recipes in Step 3.
+
+**If a runner exits non-zero:** treat that as a **blocking** regression
+(same as a failed `npm test`) unless the failure is clearly environmental
+(port bind, offline, etc.).
+
 ## Step 3 — Guided user checks (browser steps)
 
-Match the PR pattern to a recipe in **[recipes.md](recipes.md)**. Each
-recipe specifies: exact URL, exact DevTools flags, click sequence, and
-**pass vs. fail observables**. Don't improvise.
+Prefer **§2.6** (`npm run qa:cache` / `npm run qa:chunks`) when the PR
+matches those runners and env is available. Otherwise match the PR
+pattern to a recipe in **[recipes.md](recipes.md)**. Each recipe
+specifies: exact URL, exact DevTools flags, click sequence, and **pass
+vs. fail observables**. Don't improvise.
 
 Common triggers → recipes.md sections:
 
@@ -160,6 +193,7 @@ Paste this template in chat, filled in:
 ### Agent-side
 - [x] verify matrix: <lint/test/dashboard-meta/dashboard-ui results>
 - [x] `npm run build`: <one-line chunk delta>
+- [x] codified runners (§2.6): `qa:cache` / `qa:chunks` — <passed | skipped — no .env.qa.local | n/a>
 - [x] static-import graph: <what you grepped for, what you found>
 - [x] FSD boundary skim: <clean / violated at <file:line>>
 - [x] CI status: <gh pr checks output summary>
@@ -212,6 +246,13 @@ EOF
 - `gh pr close` — never.
 
 ## Step 6 — When to hand QA back unfinished
+
+**Runners reduce handoff (#251):** If **`npm run qa:cache`** exited **0**,
+treat recipes **§B** (that hook on `/user/:uid`) as satisfied — no
+separate user screenshot for the same cache signal. If
+**`npm run qa:chunks`** exited **0**, treat the runner's **§A** path as
+satisfied. If either runner was **skipped** (missing `.env.qa.local`) or
+**failed**, use the manual recipes in Step 3 or block on the failure.
 
 Don't force a green bill of health when:
 

--- a/.cursor/skills/pr-qa/recipes.md
+++ b/.cursor/skills/pr-qa/recipes.md
@@ -30,7 +30,18 @@ Use for: `perf(app): route splitting` (#240), `perf(build): manualChunks`
 (#241), `perf(firebase): defer X` (#242) when confirming a module is
 absent from unrelated routes.
 
-**Script:**
+**Preferred (agent, issue #251):** On a local checkout of the PR branch,
+run `npm run build` then **`npm run qa:chunks`** (loads `vite preview` +
+Playwright). See **`scripts/qa/README.md`**. Exit **0** ⇒ the runner's
+chunk / SPA-nav assertions passed for its scripted path. This does
+**not** replace every §A variant (e.g. "firebase-storage absent on
+profile" is still manual unless extended in the runner).
+
+**Manual fallback:** PR preview URL + user + DevTools — use when the
+runner was skipped, failed for an env reason you fixed by hand, or you
+need a route the runner does not cover.
+
+**Script (manual):**
 
 ```
 1. PR preview URL, fresh incognito, DevTools open.
@@ -79,6 +90,17 @@ still eager on a path it shouldn't be.
 Use for: `perf(stats): React Query caching` (#243), or any PR wrapping a
 hook that calls Firestore in a cache layer.
 
+**Preferred (agent, issue #251):** On a local checkout, configure
+**`.env.qa.local`** from **`.env.qa.example`** (`QA_PUBLIC_PROFILE_UID`),
+then run `npm run build` then **`npm run qa:cache`**. Exit **0** ⇒ the
+`useUserSeasonStats` cache assertion for `/user/<uid>` SPA bounce passed
+(see `scripts/qa/firestore-cache.mjs` header comments). **Not applicable**
+to auth-gated stats routes (`/dashboard/standings`, etc.) — those still
+need manual recipe or a future emulator-backed runner.
+
+**Manual fallback:** Same as below when env is missing, the UID is too
+sparse for thresholds, or you're validating a different hook.
+
 ### Critical facts to communicate up front
 
 Otherwise the user misinterprets every screenshot:
@@ -94,7 +116,7 @@ Otherwise the user misinterprets every screenshot:
   caching is that soft navigation (`<Link>` clicks, `navigate(...)`)
   reuses the cache. Use soft nav, not refresh.
 
-### Script — "is this query cached?"
+### Script — "is this query cached?" (manual)
 
 ```
 1. PR preview URL, fresh incognito, DevTools open.
@@ -227,10 +249,10 @@ when you just didn't see the console line.
 
 | PR pattern | Agent-side (SKILL.md §2) | Recipes to run |
 |---|---|---|
-| `perf(app): route splitting` | 2.1, 2.2, 2.5 | §A on 2–3 routes |
-| `perf(build): manualChunks + headers` | 2.1, 2.2, 2.3 | §A + §C |
+| `perf(app): route splitting` | 2.1, 2.2, 2.5, **2.6** `qa:chunks` | §A (prefer runner, then manual gaps) |
+| `perf(build): manualChunks + headers` | 2.1, 2.2, 2.3, **2.6** `qa:chunks` | §A + §C |
 | `perf(firebase): defer X` | 2.1, 2.2, 2.3 | §A variant "module absent" |
-| `perf(stats): React Query` | 2.1, 2.2 | §B on the wrapped hooks |
+| `perf(stats): React Query` | 2.1, 2.2, **2.6** `qa:cache` | §B (prefer runner for `/user/:uid` hook) |
 | `perf(stats): server aggregates` | 2.1 + `test:rules` | Production-only; defer |
 | `feat(...)` | 2.1, 2.4, 2.5 | §D |
 | Any GA4-touching PR | 2.1 | §E (preferably E.1) |

--- a/docs/GITHUB_AUTOMATION_CONTEXT.md
+++ b/docs/GITHUB_AUTOMATION_CONTEXT.md
@@ -71,6 +71,13 @@ Do **not** propose new non-Firebase backends. Avoid unnecessary npm packages.
 
 ---
 
+## PR QA codified runners (#251)
+
+- **Playbook:** **`.cursor/skills/pr-qa/SKILL.md`** §2.6, **`recipes.md`** §A/§B “Preferred” paths.
+- **Scripts:** **`scripts/qa/`** (`npm run qa:cache`, `npm run qa:chunks`); local env from **`.env.qa.example`** → **`.env.qa.local`** (gitignored). Headless Playwright + `vite preview`, not Vercel preview URLs.
+
+---
+
 ## PRD “Proposed file changes” guidance
 
 Prefer paths such as:


### PR DESCRIPTION
Closes #251

## Summary

Wires the shipped `scripts/qa/` runners into the PR QA skill and recipes: **SKILL.md §2.6**, **Step 4** report line, **Step 6** handoff rules, **recipes.md** §A/§B “Preferred” paths + combination table, and **docs/GITHUB_AUTOMATION_CONTEXT.md** pointer.

## Test plan

- [x] `npm run lint` (N/A for markdown-only; no `src` changes)
- [x] Read-through: SKILL ↔ recipes cross-links consistent
- [ ] After merge: maintainer with `.env.qa.local` runs `npm run build && npm run qa:cache` once on `staging` to confirm green UID path (agent sandbox hit a profile settle timeout — env-specific)

Made with [Cursor](https://cursor.com)