### PR TITLE
feat(qa): App Check debug token for Playwright qa:cache and CI prep docs

### DIFF
--- a/.cursor/skills/pr-qa/SKILL.md
+++ b/.cursor/skills/pr-qa/SKILL.md
@@ -148,12 +148,16 @@ the machine has `scripts/qa` fixtures configured.
 
 **Setup (once per machine):** copy `.env.qa.example` → `.env.qa.local`
 and set `QA_PUBLIC_PROFILE_UID` to a real Firebase UID with rich graded
-data (see `scripts/qa/README.md`). `npm ci` installs `playwright`; first
-Chromium launch may download browsers.
+data (see `scripts/qa/README.md`). For **`qa:cache`**, also set
+**`QA_APPCHECK_DEBUG_TOKEN`** to a UUID registered under Firebase App Check
+→ Manage debug tokens (headless Chromium cannot use ReCAPTCHA Enterprise
+otherwise; see `scripts/qa/README.md`). `npm ci` installs `playwright`;
+first Chromium launch may download browsers.
 
 **If env is missing or still placeholder:** the runner exits immediately
 with a pointer to the README — note **`qa:* skipped (no .env.qa.local)`**
-in the Step 4 report and fall back to the **manual** recipes in Step 3.
+or **`qa:cache` skipped (no `QA_APPCHECK_DEBUG_TOKEN`)** in the Step 4 report
+and fall back to the **manual** recipes in Step 3.
 
 **If a runner exits non-zero:** treat that as a **blocking** regression
 (same as a failed `npm test`) unless the failure is clearly environmental

--- a/.cursor/skills/pr-qa/recipes.md
+++ b/.cursor/skills/pr-qa/recipes.md
@@ -91,7 +91,9 @@ Use for: `perf(stats): React Query caching` (#243), or any PR wrapping a
 hook that calls Firestore in a cache layer.
 
 **Preferred (agent, issue #251):** On a local checkout, configure
-**`.env.qa.local`** from **`.env.qa.example`** (`QA_PUBLIC_PROFILE_UID`),
+**`.env.qa.local`** from **`.env.qa.example`**
+(`QA_PUBLIC_PROFILE_UID` + **`QA_APPCHECK_DEBUG_TOKEN`** — a UUID registered
+in Firebase App Check → Manage debug tokens; see `scripts/qa/README.md`),
 then run `npm run build` then **`npm run qa:cache`**. Exit **0** ⇒ the
 `useUserSeasonStats` cache assertion for `/user/<uid>` SPA bounce passed
 (see `scripts/qa/firestore-cache.mjs` header comments). **Not applicable**

--- a/.env.qa.example
+++ b/.env.qa.example
@@ -16,3 +16,10 @@
 #     read is comfortably > 5 kB (otherwise the cache assertion is
 #     trivial — empty payloads pass on every navigation).
 QA_PUBLIC_PROFILE_UID=YOUR_STAGING_FIREBASE_UID
+
+# Registered Firebase App Check **debug** token (UUID string). Required for
+# `npm run qa:cache` only — the headless browser cannot complete ReCAPTCHA
+# Enterprise; App Check accepts a fixed debug token you add under Firebase
+# Console → App Check → Apps → (web app) → Manage debug tokens.
+# Generate any UUID v4 locally, register it once, paste the same string here.
+QA_APPCHECK_DEBUG_TOKEN=YOUR_REGISTERED_APPCHECK_DEBUG_UUID

--- a/docs/GITHUB_AUTOMATION_CONTEXT.md
+++ b/docs/GITHUB_AUTOMATION_CONTEXT.md
@@ -74,7 +74,8 @@ Do **not** propose new non-Firebase backends. Avoid unnecessary npm packages.
 ## PR QA codified runners (#251)
 
 - **Playbook:** **`.cursor/skills/pr-qa/SKILL.md`** §2.6, **`recipes.md`** §A/§B “Preferred” paths.
-- **Scripts:** **`scripts/qa/`** (`npm run qa:cache`, `npm run qa:chunks`); local env from **`.env.qa.example`** → **`.env.qa.local`** (gitignored). Headless Playwright + `vite preview`, not Vercel preview URLs.
+- **Scripts:** **`scripts/qa/`** (`npm run qa:cache`, `npm run qa:chunks`); local env from **`.env.qa.example`** → **`.env.qa.local`** (gitignored). `qa:cache` needs **`QA_APPCHECK_DEBUG_TOKEN`** (UUID registered in Firebase App Check) plus **`QA_PUBLIC_PROFILE_UID`**. Headless Playwright + `vite preview`, not Vercel preview URLs.
+- **Autonomous E2E follow-ups (post-#251):** [#347](https://github.com/pat792/set-picks/issues/347) (CI + same runners + secrets), [#348](https://github.com/pat792/set-picks/issues/348) (Vercel preview / §C / bypass), [#349](https://github.com/pat792/set-picks/issues/349) (auth-gated / emulators vs test harness). Third-party constraints are spelled out in each issue body.
 
 ---
 

--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -34,6 +34,21 @@ The npm scripts load the file via Node's `--env-file-if-exists` flag, so
 a missing file fails inside the runner with a clear pointer back to this
 README rather than a cryptic "undefined" error.
 
+### App Check (`qa:cache` only)
+
+`npm run qa:chunks` does not talk to Firestore. `npm run qa:cache` does, and
+the production build uses App Check with the ReCAPTCHA Enterprise provider —
+headless Chromium cannot pass that without a **debug token**.
+
+1. Generate a UUID (any v4).
+2. Firebase Console → **App Check** → your **Web** app → **Manage debug
+   tokens** → add that UUID.
+3. Put the same string in `.env.qa.local` as **`QA_APPCHECK_DEBUG_TOKEN`**.
+
+If this variable is missing or not registered, the runner used to hang on
+“Total points” while Firestore logged `403` / offline errors in the browser
+console.
+
 ## Available runners
 
 | Script | npm task | Recipe (recipes.md) |

--- a/scripts/qa/_lib/qaBrowserInit.mjs
+++ b/scripts/qa/_lib/qaBrowserInit.mjs
@@ -1,0 +1,30 @@
+/**
+ * Playwright bootstrap for QA runners hitting Firebase (Firestore) on
+ * `vite preview` production builds.
+ *
+ * `firebaseAppCheck.js` only sets `FIREBASE_APPCHECK_DEBUG_TOKEN` when
+ * `import.meta.env.DEV` — that branch is stripped from prod bundles, so
+ * headless Chromium must set the global before the app bundle runs.
+ *
+ * **Important:** `FIREBASE_APPCHECK_DEBUG_TOKEN = true` generates a **new**
+ * UUID on every fresh browser profile; the App Check exchange returns **403**
+ * until that UUID is registered in Firebase Console. For deterministic
+ * automation, set **`QA_APPCHECK_DEBUG_TOKEN`** (see `.env.qa.example`) to a
+ * single UUID string you registered under App Check → Manage debug tokens.
+ *
+ * @param {import('playwright').BrowserContext} context
+ */
+export async function enableFirebaseAppCheckDebug(context) {
+  const token =
+    process.env.QA_APPCHECK_DEBUG_TOKEN?.trim() ||
+    process.env.FIREBASE_APPCHECK_DEBUG_TOKEN?.trim();
+  if (token) {
+    await context.addInitScript((t) => {
+      self.FIREBASE_APPCHECK_DEBUG_TOKEN = t;
+    }, token);
+    return;
+  }
+  await context.addInitScript(() => {
+    self.FIREBASE_APPCHECK_DEBUG_TOKEN = true;
+  });
+}

--- a/scripts/qa/chunk-split.mjs
+++ b/scripts/qa/chunk-split.mjs
@@ -28,6 +28,7 @@
 
 import { chromium } from 'playwright';
 
+import { enableFirebaseAppCheckDebug } from './_lib/qaBrowserInit.mjs';
 import { PUBLIC_PROFILE_UID } from './fixtures.js';
 import { startPreview } from './_lib/preview.mjs';
 
@@ -103,6 +104,7 @@ async function run() {
 
   try {
     const ctx = await browser.newContext();
+    await enableFirebaseAppCheckDebug(ctx);
     const page = await ctx.newPage();
 
     // Cumulative set of every chunk URL that resolved. We snapshot

--- a/scripts/qa/firestore-cache.mjs
+++ b/scripts/qa/firestore-cache.mjs
@@ -35,6 +35,7 @@
 
 import { chromium } from 'playwright';
 
+import { enableFirebaseAppCheckDebug } from './_lib/qaBrowserInit.mjs';
 import { PUBLIC_PROFILE_UID } from './fixtures.js';
 import { startPreview } from './_lib/preview.mjs';
 
@@ -124,7 +125,21 @@ function fmtBytes(bytes) {
   return `${bytes}B (${(bytes / 1024).toFixed(1)}kB)`;
 }
 
+const QA_APPCHECK_DEBUG_TOKEN_PLACEHOLDER = 'YOUR_REGISTERED_APPCHECK_DEBUG_UUID';
+
 async function run() {
+  const appCheckToken = process.env.QA_APPCHECK_DEBUG_TOKEN?.trim();
+  if (!appCheckToken || appCheckToken === QA_APPCHECK_DEBUG_TOKEN_PLACEHOLDER) {
+    console.error(
+      '[qa:cache] QA_APPCHECK_DEBUG_TOKEN is not set (or still the placeholder ' +
+        'from `.env.qa.example`). Headless Playwright hits App Check–enforced ' +
+        'Firestore; use a **registered** debug UUID in `.env.qa.local` — same ' +
+        'value as in Firebase Console → App Check → your web app → Manage ' +
+        'debug tokens. See `scripts/qa/README.md`.',
+    );
+    process.exit(1);
+  }
+
   console.log('[qa:cache] building production artifact + starting vite preview…');
   const preview = await startPreview();
   console.log(`[qa:cache] preview ready at ${preview.url}`);
@@ -134,6 +149,7 @@ async function run() {
 
   try {
     const ctx = await browser.newContext();
+    await enableFirebaseAppCheckDebug(ctx);
     const page = await ctx.newPage();
 
     // Phase-tagged byte counter. The response listener routes each

--- a/src/features/profile/api/publicProfileApi.js
+++ b/src/features/profile/api/publicProfileApi.js
@@ -9,6 +9,7 @@ import {
 } from 'firebase/firestore';
 
 import { db } from '../../../shared/lib/firebase';
+import { whenFirebaseReady } from '../../../shared/lib/firebaseAppCheck';
 
 /**
  * Read-only public profile by Firebase uid (`users/{uid}`).
@@ -17,6 +18,7 @@ import { db } from '../../../shared/lib/firebase';
 export async function fetchPublicProfileByUid(uid) {
   const id = uid?.trim();
   if (!id) return null;
+  await whenFirebaseReady();
   const snap = await getDoc(doc(db, 'users', id));
   if (!snap.exists()) return null;
   return snap.data();
@@ -29,6 +31,7 @@ export async function fetchPublicProfileByUid(uid) {
 export async function fetchPublicProfileByHandle(handle) {
   const h = handle?.trim();
   if (!h) return null;
+  await whenFirebaseReady();
   const q = query(
     collection(db, 'users'),
     where('handle', '==', h),
@@ -46,6 +49,7 @@ export async function fetchPublicProfileByHandle(handle) {
 export async function fetchPoolsForMember(uid) {
   const id = uid?.trim();
   if (!id) return [];
+  await whenFirebaseReady();
   const poolsQuery = query(
     collection(db, 'pools'),
     where('members', 'array-contains', id)


### PR DESCRIPTION
Refs #347, #348, #349

## Summary

This change makes the **`npm run qa:cache`** Playwright runner reliable against App Check–enforced Firestore by requiring a **registered** Firebase App Check debug UUID (`QA_APPCHECK_DEBUG_TOKEN`) instead of `true` (which produced a new unregistered token per run and **403** / offline Firestore in headless Chromium). Shared browser bootstrap lives in **`scripts/qa/_lib/qaBrowserInit.mjs`** (used by `qa:chunks` and `qa:cache`).

Public profile Firestore reads now **`await whenFirebaseReady()`** before `getDoc` / pool queries so the client does not race ahead of deferred App Check initialization.

Documentation updates: **`.env.qa.example`**, **`scripts/qa/README.md`**, PR QA **`SKILL.md` / `recipes.md`**, and **`docs/GITHUB_AUTOMATION_CONTEXT.md`** (links to follow-on issues **#347–#349** for full autonomous E2E).

## Test plan

- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run verify:dashboard-meta` and `npm run verify:dashboard-ui`
- [x] `npm run build` && `npm run qa:chunks`
- [ ] `npm run qa:cache` with `.env.qa.local` containing real `QA_APPCHECK_DEBUG_TOKEN` + `QA_PUBLIC_PROFILE_UID` (operator machine; not run in this agent session)

Made with [Cursor](https://cursor.com)