### PR TITLE
fix(push): normalize FCM message ids, PWA HTML cache headers, QA scri…

### DIFF
--- a/functions/fcmMessagingCore.js
+++ b/functions/fcmMessagingCore.js
@@ -12,6 +12,29 @@ const DASHBOARD_NOTIFICATIONS_URL =
   "https://www.setlistpickem.com/dashboard/notifications";
 
 /**
+ * `admin.messaging().send()` often returns a full resource path such as
+ * `projects/{project}/messages/0:167…`. Collapse to the final segment for
+ * client-visible copy, Firestore metadata, and logs.
+ *
+ * @param {unknown} raw
+ * @returns {string}
+ */
+function normalizeFcmSendMessageId(raw) {
+  if (raw == null) return "";
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (!trimmed) return "";
+    const slash = trimmed.lastIndexOf("/");
+    const tail = slash >= 0 ? trimmed.slice(slash + 1) : trimmed;
+    return tail.length > 80 ? `${tail.slice(0, 80)}…` : tail;
+  }
+  if (typeof raw === "object" && raw !== null && typeof raw.name === "string") {
+    return normalizeFcmSendMessageId(raw.name);
+  }
+  return String(raw);
+}
+
+/**
  * @param {string | undefined} code
  * @returns {boolean}
  */
@@ -60,7 +83,7 @@ async function sendWebPushToToken({
   logger = undefined,
 }) {
   try {
-    const messageId = await admin.messaging().send({
+    const rawId = await admin.messaging().send({
       token,
       notification: { title, body },
       data,
@@ -68,7 +91,7 @@ async function sendWebPushToToken({
         fcmOptions: { link: DASHBOARD_NOTIFICATIONS_URL },
       },
     });
-    return { ok: true, messageId };
+    return { ok: true, messageId: normalizeFcmSendMessageId(rawId) };
   } catch (error) {
     const code =
       typeof error?.code === "string"
@@ -90,6 +113,7 @@ module.exports = {
   DASHBOARD_NOTIFICATIONS_URL,
   deleteFcmTokenDocForRawToken,
   isInvalidOrUnregisteredToken,
+  normalizeFcmSendMessageId,
   sendWebPushToToken,
 };
 

--- a/functions/fcmMessagingCore.test.js
+++ b/functions/fcmMessagingCore.test.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { normalizeFcmSendMessageId } = require("./fcmMessagingCore");
+
+test("normalizeFcmSendMessageId keeps final path segment", () => {
+  assert.equal(
+    normalizeFcmSendMessageId("projects/set-picks/messages/0:abc123"),
+    "0:abc123"
+  );
+});
+
+test("normalizeFcmSendMessageId passes through short strings", () => {
+  assert.equal(normalizeFcmSendMessageId("0:short"), "0:short");
+});
+
+test("normalizeFcmSendMessageId reads .name from object shape", () => {
+  assert.equal(
+    normalizeFcmSendMessageId({
+      name: "projects/p/messages/0:z",
+    }),
+    "0:z"
+  );
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -36,6 +36,7 @@ const { runPicksLockReminderFanout } = require("./picksLockReminder");
 const {
   deleteFcmTokenDocForRawToken,
   isInvalidOrUnregisteredToken,
+  normalizeFcmSendMessageId,
 } = require("./fcmMessagingCore");
 const { applyRevertRollupForShow } = require("./revertRollupCore");
 const { evaluateManualFinalizeTimingGate } = require("./showFinalizationGate");
@@ -438,7 +439,7 @@ exports.sendPushCanary = onCall(
     const timestamp = new Date().toISOString();
     const tokenTail = token.slice(-12);
     try {
-      const response = await admin.messaging().send({
+      const rawMessageId = await admin.messaging().send({
         token,
         notification: {
           title: "Setlist Pick Em",
@@ -454,16 +455,17 @@ exports.sendPushCanary = onCall(
           },
         },
       });
+      const messageId = normalizeFcmSendMessageId(rawMessageId);
       if (tokenDoc) {
         await tokenDoc.ref.set(
           {
             lastCanaryAt: admin.firestore.FieldValue.serverTimestamp(),
-            lastCanaryMessageId: response,
+            lastCanaryMessageId: messageId,
           },
           { merge: true }
         );
       }
-      return { ok: true, messageId: response };
+      return { ok: true, messageId };
     } catch (error) {
       const code =
         typeof error?.code === "string"

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
-    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js showFinalizationGate.test.js revertRollupCore.test.js postShowRollupPush.test.js picksLockReminder.test.js",
+    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js showFinalizationGate.test.js revertRollupCore.test.js postShowRollupPush.test.js picksLockReminder.test.js fcmMessagingCore.test.js",
     "serve": "firebase emulators:start --only functions",
     "shell": "firebase functions:shell",
     "start": "npm run shell",

--- a/functions/scripts/sendPostShowRollupPushTest.js
+++ b/functions/scripts/sendPostShowRollupPushTest.js
@@ -17,7 +17,11 @@
  *   --global-max=<n>        For nearMiss body only (default 9).
  *   --project=<project-id>  Override project (else GOOGLE_CLOUD_PROJECT / .env VITE_FIREBASE_PROJECT_ID).
  *
- * Auth: `gcloud auth application-default login` (same as sendPushCanaryForUser.js).
+ * Auth (pick one):
+ *   - User ADC: `gcloud auth application-default login` (same as sendPushCanaryForUser.js).
+ *   - If you see `invalid_rapt` / `invalid_grant` / "reauth": revoke and log in again, or use a
+ *     **service account** JSON via `GOOGLE_APPLICATION_CREDENTIALS` (org policy often blocks
+ *     long-lived user ADC for Firestore). https://support.google.com/a/answer/9368756
  *
  * Re-runs: after a successful send, the same --pick-id is skipped (log exists). Use a new
  * --pick-id or delete the matching `fcm_notification_log` doc to test again.
@@ -183,7 +187,22 @@ async function main() {
 }
 
 main().catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
   console.error("\nsendPostShowRollupPushTest.js failed:");
   console.error(err instanceof Error ? err.stack || err.message : err);
+  if (/invalid_rapt|invalid_grant|reauth/i.test(msg)) {
+    console.error(`
+Google rejected Application Default Credentials (often Google Workspace / session policy).
+
+Try:
+  gcloud auth application-default revoke
+  gcloud auth application-default login
+
+Or set a service account key (must have Firestore + Cloud Messaging access to this project):
+  export GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to-key.json
+
+https://support.google.com/a/answer/9368756
+`);
+  }
   process.exit(1);
 });

--- a/functions/scripts/sendPushCanaryForUser.js
+++ b/functions/scripts/sendPushCanaryForUser.js
@@ -18,6 +18,8 @@ const admin = require("firebase-admin");
 const fs = require("node:fs");
 const path = require("node:path");
 
+const { normalizeFcmSendMessageId } = require("../fcmMessagingCore");
+
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
 const ENV_PATH = path.join(REPO_ROOT, ".env");
 
@@ -166,7 +168,7 @@ async function main() {
     return;
   }
 
-  const response = await admin.messaging().send({
+  const rawMessageId = await admin.messaging().send({
     token,
     notification: { title, body },
     data: {
@@ -180,17 +182,18 @@ async function main() {
       },
     },
   });
+  const messageId = normalizeFcmSendMessageId(rawMessageId);
 
   await tokenDoc.ref.set(
     {
       lastCanaryAt: admin.firestore.FieldValue.serverTimestamp(),
-      lastCanaryMessageId: response,
+      lastCanaryMessageId: messageId,
       lastCanaryBy: `script:${process.env.USER || "unknown"}`,
     },
     { merge: true }
   );
 
-  console.log(`Sent canary. Message id: ${response}`);
+  console.log(`Sent canary. Message id: ${messageId}`);
 }
 
 main().catch((err) => {

--- a/src/features/notifications/ui/NotificationsPrototypeScreen.jsx
+++ b/src/features/notifications/ui/NotificationsPrototypeScreen.jsx
@@ -106,7 +106,6 @@ export default function NotificationsPrototypeScreen() {
     lastMessageTitle,
     triggerPushCanary,
     canaryStatus,
-    canaryMessageId,
   } = usePushTokenRegistration();
   const {
     prefs,
@@ -189,11 +188,12 @@ export default function NotificationsPrototypeScreen() {
           <p className="mt-2 text-xs text-content-secondary">
             Browser permission: <span className="font-bold text-white">{permission}</span>
           </p>
-          {canaryStatus === 'sent' && canaryMessageId ? (
-            <p className="mt-2 text-xs text-emerald-300">
-              Test notification sent ({canaryMessageId.slice(0, 16)}...)
-            </p>
-          ) : null}
+              {canaryStatus === 'sent' ? (
+                <p className="mt-2 text-xs text-emerald-300">
+                  Test notification sent. Check this device for the alert (including the system
+                  notification tray if the app is in the background).
+                </p>
+              ) : null}
           {lastMessageTitle ? (
             <p className="mt-2 text-xs text-emerald-300">
               Foreground message received: <span className="font-bold">{lastMessageTitle}</span>

--- a/vercel.json
+++ b/vercel.json
@@ -42,6 +42,60 @@
       ]
     },
     {
+      "source": "/dashboard(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/setup",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/join(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/user/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/password-reset-complete",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/firebase-messaging-sw.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
       "source": "/robots.txt",
       "headers": [
         {


### PR DESCRIPTION
…pt hints

Return short message ids from sendPushCanary and shared send path; user-facing test notification copy without raw id. Add must-revalidate headers for SPA routes and firebase-messaging-sw.js on Vercel. Document invalid_rapt ADC recovery in post-show push test; add fcmMessagingCore tests.