### PR TITLE
Staging

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -640,9 +640,9 @@ exports.scheduledPicksLockReminder = onSchedule(
 
 exports.scheduledPhishnetLiveSetlistPoll = onSchedule(
   {
-    // Wake every 3m; in-window spacing vs Phish.net is enforced by per-date
-    // `nextPollAt` (3–5m jitter after each scheduled fetch — issue #180).
-    schedule: "*/3 * * * *",
+    // Wake every 2m; in-window spacing vs Phish.net is enforced by per-date
+    // `nextPollAt` (~90–150s jitter — issue #311).
+    schedule: "*/2 * * * *",
     timeZone: "America/New_York",
     region: PHISHNET_FUNCTIONS_REGION,
     secrets: [phishnetApiKey],

--- a/functions/phishnetLiveSetlistAutomation.js
+++ b/functions/phishnetLiveSetlistAutomation.js
@@ -284,10 +284,14 @@ function evaluateSet1CloserStage(state) {
   return null;
 }
 
-/** Uniform random delay in [3, 5] minutes — scheduled cadence jitter (issue #180). */
+/**
+ * Uniform random delay in [90, 150] seconds (~2–3 min) — per-show spacing vs
+ * Phish.net after each scheduled wake (#311). Scheduler runs every 2 minutes
+ * so `nextPollAt` is re-evaluated promptly.
+ */
 function randomScheduledPollDelayMs(rng = Math.random) {
-  const min = 3 * 60 * 1000;
-  const max = 5 * 60 * 1000;
+  const min = 90 * 1000;
+  const max = 150 * 1000;
   return min + Math.floor(rng() * (max - min + 1));
 }
 

--- a/functions/phishnetLiveSetlistAutomation.test.js
+++ b/functions/phishnetLiveSetlistAutomation.test.js
@@ -181,13 +181,13 @@ test("scheduledCandidateShowDates: different zones evaluated independently", () 
   assert.deepEqual(dates, ["2026-07-04"]);
 });
 
-test("randomScheduledPollDelayMs is within 3–5 minutes", () => {
+test("randomScheduledPollDelayMs is within 90–150 seconds (#311)", () => {
   for (let i = 0; i < 50; i += 1) {
     const ms = randomScheduledPollDelayMs(Math.random);
-    assert.ok(ms >= 3 * 60 * 1000 && ms <= 5 * 60 * 1000);
+    assert.ok(ms >= 90 * 1000 && ms <= 150 * 1000);
   }
-  assert.equal(randomScheduledPollDelayMs(() => 0), 3 * 60 * 1000);
-  assert.equal(randomScheduledPollDelayMs(() => 0.999999), 5 * 60 * 1000);
+  assert.equal(randomScheduledPollDelayMs(() => 0), 90 * 1000);
+  assert.equal(randomScheduledPollDelayMs(() => 0.999999), 150 * 1000);
 });
 
 test("normalizeSetlistRows parses + sorts phish.net row shape", () => {

--- a/src/app/layout/ui/DashboardMobileBrandBar.jsx
+++ b/src/app/layout/ui/DashboardMobileBrandBar.jsx
@@ -5,32 +5,36 @@ import {
   BRAND_APP_CHROME_MARK_SRC,
   brandAppChromeMarkImgClassNames,
   brandWordmarkDashboardMobileBarScaleWrapperClassNames,
+  brandWordmarkDashboardMobileLeadingClassNames,
 } from '../../../shared/config/branding';
+import BrandWordmarkBarRow from '../../../shared/ui/BrandWordmarkBarRow';
 
 export default function DashboardMobileBrandBar({ user }) {
   return (
-    <div className="relative z-20 grid min-h-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 overflow-visible border-b border-border-subtle/35 bg-[linear-gradient(to_bottom,rgb(var(--brand-bg-deep)_/_0.76),rgb(var(--brand-bg)_/_0.60))] py-2 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-4 shadow-[0_10px_28px_-14px_rgba(15,10,46,0.85)] ring-1 ring-inset ring-white/[0.06] backdrop-blur-xl supports-[backdrop-filter]:backdrop-blur-2xl supports-[backdrop-filter]:backdrop-saturate-150 sm:flex sm:justify-between sm:gap-3 sm:pl-4 sm:pr-4">
-      <h1 className="flex min-h-0 min-w-0 items-center justify-start justify-self-start self-center overflow-visible text-left leading-none max-sm:ml-1 max-sm:translate-y-1 sm:flex-1 sm:ml-0 sm:translate-y-0 sm:justify-self-auto">
-        <Link
-          to="/dashboard"
-          className="inline-flex max-w-full items-center justify-start overflow-visible text-left outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm hover:opacity-80 transition-opacity"
-          aria-label="Setlist Pick 'Em — dashboard home"
-        >
-          <span className={brandWordmarkDashboardMobileBarScaleWrapperClassNames}>
-            <img
-              className={brandAppChromeMarkImgClassNames.dashboardMobileBar}
-              src={BRAND_APP_CHROME_MARK_SRC}
-              alt=""
-              aria-hidden="true"
-              loading="eager"
-            />
-          </span>
-        </Link>
-      </h1>
+    <div className="border-b border-border-subtle/35 bg-[linear-gradient(to_bottom,rgb(var(--brand-bg-deep)_/_0.76),rgb(var(--brand-bg)_/_0.60))] py-2 shadow-[0_10px_28px_-14px_rgba(15,10,46,0.85)] ring-1 ring-inset ring-white/[0.06] backdrop-blur-xl supports-[backdrop-filter]:backdrop-blur-2xl supports-[backdrop-filter]:backdrop-saturate-150">
+      <BrandWordmarkBarRow variant="dashboard">
+        <h1 className={brandWordmarkDashboardMobileLeadingClassNames}>
+          <Link
+            to="/dashboard"
+            className="inline-flex max-w-full items-center justify-start overflow-visible text-left outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm hover:opacity-80 transition-opacity"
+            aria-label="Setlist Pick 'Em — dashboard home"
+          >
+            <span className={brandWordmarkDashboardMobileBarScaleWrapperClassNames}>
+              <img
+                className={brandAppChromeMarkImgClassNames.dashboardMobileBar}
+                src={BRAND_APP_CHROME_MARK_SRC}
+                alt=""
+                aria-hidden="true"
+                loading="eager"
+              />
+            </span>
+          </Link>
+        </h1>
 
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center self-center rounded-full border border-border-subtle/35 bg-surface-panel-strong text-xs">
-        {user?.email?.charAt(0).toUpperCase() || '👤'}
-      </div>
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center self-center rounded-full border border-border-subtle/35 bg-surface-panel-strong text-xs">
+          {user?.email?.charAt(0).toUpperCase() || '👤'}
+        </div>
+      </BrandWordmarkBarRow>
     </div>
   );
 }

--- a/src/features/landing/ui/SplashHeader.jsx
+++ b/src/features/landing/ui/SplashHeader.jsx
@@ -3,7 +3,9 @@ import React from 'react';
 import {
   BRAND_SPLASH_HEADER_VINYL_MARK_SRC,
   brandSplashHeaderVinylMarkImgClassNames,
+  brandWordmarkSplashHeaderLeadingClassNames,
 } from '../../../shared/config/branding';
+import BrandWordmarkBarRow from '../../../shared/ui/BrandWordmarkBarRow';
 import Button from '../../../shared/ui/Button';
 
 export default function SplashHeader({
@@ -13,11 +15,11 @@ export default function SplashHeader({
   // If `h-[5.35rem]` / `sm:h-[5.25rem]` change, update `splashScrollPadding.js` (html scroll-padding).
   return (
     <header className="fixed left-0 right-0 top-0 z-50 flex h-[5.35rem] items-center overflow-visible border-b border-white/5 bg-brand-bg/80 backdrop-blur-lg transition-all duration-300 sm:h-[5.25rem]">
-      <div className="grid h-full w-full max-w-7xl min-h-0 min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 overflow-visible pl-[max(1rem,env(safe-area-inset-left,0px))] pr-4 sm:flex sm:justify-between sm:gap-3 sm:px-6 lg:px-8">
+      <BrandWordmarkBarRow variant="splash">
         <button
           type="button"
           onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-          className="inline-flex min-w-0 items-center justify-start justify-self-start overflow-visible pl-0 pr-1 text-left outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm sm:shrink-0 sm:justify-self-auto sm:pr-2"
+          className={brandWordmarkSplashHeaderLeadingClassNames}
           aria-label={"Setlist Pick 'Em — scroll to top"}
         >
           <img
@@ -49,7 +51,7 @@ export default function SplashHeader({
             Jump on Tour
           </Button>
         </div>
-      </div>
+      </BrandWordmarkBarRow>
     </header>
   );
 }

--- a/src/features/scoring/api/standingsApi.js
+++ b/src/features/scoring/api/standingsApi.js
@@ -1,10 +1,42 @@
-import { collection, doc, getDoc, getDocs, query, where } from 'firebase/firestore';
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  onSnapshot,
+  query,
+  where,
+} from 'firebase/firestore';
 
 import { db } from '../../../shared/lib/firebase';
 import {
   sanitizeBustouts,
   sanitizeOfficialSongList,
 } from '../../../shared/utils/officialSetlistSanitize.js';
+
+/**
+ * Normalizes `official_setlists/{showDate}` document data for scoring UIs.
+ * Shared by one-shot reads and realtime snapshots (#311).
+ *
+ * @param {Record<string, unknown> | undefined} data
+ * @returns {null | { officialSetlist: unknown[] } & Record<string, unknown>}
+ */
+export function normalizeOfficialSetlistDocData(data) {
+  if (!data || typeof data !== 'object') return null;
+
+  const rawEnc = data.encoreSongs;
+  const encoreSongs =
+    Array.isArray(rawEnc) && rawEnc.length > 0
+      ? sanitizeOfficialSongList(rawEnc)
+      : [];
+  const bustouts = sanitizeBustouts(data.bustouts);
+  return {
+    ...(data.setlist || {}),
+    officialSetlist: Array.isArray(data.officialSetlist) ? data.officialSetlist : [],
+    ...(encoreSongs.length > 0 ? { encoreSongs } : {}),
+    bustouts,
+  };
+}
 
 /**
  * @param {string} showDate
@@ -34,19 +66,55 @@ export async function fetchOfficialSetlistForShow(showDate) {
 
   if (!setlistSnap.exists()) return null;
 
-  const data = setlistSnap.data();
-  const rawEnc = data.encoreSongs;
-  const encoreSongs =
-    Array.isArray(rawEnc) && rawEnc.length > 0
-      ? sanitizeOfficialSongList(rawEnc)
-      : [];
-  const bustouts = sanitizeBustouts(data.bustouts);
-  return {
-    ...(data.setlist || {}),
-    officialSetlist: Array.isArray(data.officialSetlist) ? data.officialSetlist : [],
-    ...(encoreSongs.length > 0 ? { encoreSongs } : {}),
-    // Always include the bustouts key (even when empty) so downstream scoring
-    // treats absence = empty without ambiguity (#214).
-    bustouts,
-  };
+  return normalizeOfficialSetlistDocData(setlistSnap.data());
+}
+
+/**
+ * LIVE standings: subscribe to all picks for a show (same query as fetch).
+ *
+ * @param {string} showDate
+ * @param {(picks: Array<{ id: string } & Record<string, unknown>>) => void} onNext
+ * @param {(err: Error) => void} onError
+ * @returns {() => void}
+ */
+export function subscribePicksForShowDate(showDate, onNext, onError) {
+  if (!showDate) {
+    return () => {};
+  }
+  const picksQuery = query(collection(db, 'picks'), where('showDate', '==', showDate));
+  return onSnapshot(
+    picksQuery,
+    (snapshot) => {
+      onNext(
+        snapshot.docs.map((pickDoc) => ({
+          id: pickDoc.id,
+          ...pickDoc.data(),
+        }))
+      );
+    },
+    onError
+  );
+}
+
+/**
+ * LIVE standings: subscribe to official setlist doc for a show.
+ *
+ * @param {string} showDate
+ * @param {(setlist: null | ReturnType<typeof normalizeOfficialSetlistDocData>) => void} onNext
+ * @param {(err: Error) => void} onError
+ * @returns {() => void}
+ */
+export function subscribeOfficialSetlistForShow(showDate, onNext, onError) {
+  if (!showDate) {
+    return () => {};
+  }
+  const setlistRef = doc(db, 'official_setlists', showDate);
+  return onSnapshot(
+    setlistRef,
+    (snap) => {
+      if (!snap.exists()) onNext(null);
+      else onNext(normalizeOfficialSetlistDocData(snap.data()));
+    },
+    onError
+  );
 }

--- a/src/features/scoring/api/standingsApi.test.js
+++ b/src/features/scoring/api/standingsApi.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeOfficialSetlistDocData } from './standingsApi';
+
+describe('normalizeOfficialSetlistDocData', () => {
+  it('returns null for empty / non-object input', () => {
+    expect(normalizeOfficialSetlistDocData(undefined)).toBeNull();
+    expect(normalizeOfficialSetlistDocData(null)).toBeNull();
+  });
+
+  it('maps officialSetlist, encoreSongs, and bustouts like fetch path', () => {
+    const out = normalizeOfficialSetlistDocData({
+      officialSetlist: ['A'],
+      encoreSongs: ['E1'],
+      bustouts: ['First Tube'],
+      setlist: { foo: 1 },
+    });
+    expect(out?.officialSetlist).toEqual(['A']);
+    expect(out?.encoreSongs).toEqual(['E1']);
+    expect(out?.bustouts).toEqual(['First Tube']);
+    expect(out?.foo).toBe(1);
+  });
+});

--- a/src/features/scoring/model/useStandings.js
+++ b/src/features/scoring/model/useStandings.js
@@ -4,7 +4,12 @@ import { getShowStatus } from '../../../shared/utils/timeLogic.js';
 import {
   fetchOfficialSetlistForShow,
   fetchPicksForShowDate,
+  subscribeOfficialSetlistForShow,
+  subscribePicksForShowDate,
 } from '../api/standingsApi';
+
+/** Tab hidden → tear down LIVE Firestore listeners after this delay (#311). */
+const LIVE_LISTENER_HIDE_DEBOUNCE_MS = 60_000;
 
 export function useStandings(showDate, showDates) {
   const [picks, setPicks] = useState([]);
@@ -25,6 +30,7 @@ export function useStandings(showDate, showDates) {
       Array.isArray(showDates) && showDates.length > 0
         ? getShowStatus(showDate, showDates)
         : 'FUTURE';
+
     if (showStatus === 'FUTURE') {
       setPicks([]);
       setActualSetlist(null);
@@ -34,6 +40,98 @@ export function useStandings(showDate, showDates) {
     }
 
     let cancelled = false;
+
+    if (showStatus !== 'LIVE') {
+      setLoading(true);
+      setError(null);
+
+      (async () => {
+        try {
+          const [fetchedPicks, setlist] = await Promise.all([
+            fetchPicksForShowDate(showDate),
+            fetchOfficialSetlistForShow(showDate),
+          ]);
+          if (!cancelled) {
+            setPicks(fetchedPicks);
+            setActualSetlist(setlist);
+          }
+        } catch (err) {
+          if (!cancelled) {
+            setError(err);
+            console.error('Error fetching standings data:', err);
+          }
+        } finally {
+          if (!cancelled) setLoading(false);
+        }
+      })();
+
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    let unsubscribers = [];
+    let hideTimer = null;
+
+    const clearHideTimer = () => {
+      if (hideTimer != null) {
+        clearTimeout(hideTimer);
+        hideTimer = null;
+      }
+    };
+
+    const tearDownListeners = () => {
+      unsubscribers.forEach((u) => u());
+      unsubscribers = [];
+    };
+
+    const attachLiveListeners = () => {
+      tearDownListeners();
+      if (cancelled) return;
+
+      const onErr = (err) => {
+        if (!cancelled) {
+          setError(err);
+          console.error('useStandings live listener error:', err);
+        }
+      };
+
+      unsubscribers.push(
+        subscribePicksForShowDate(
+          showDate,
+          (nextPicks) => {
+            if (!cancelled) setPicks(nextPicks);
+          },
+          onErr
+        )
+      );
+      unsubscribers.push(
+        subscribeOfficialSetlistForShow(
+          showDate,
+          (nextSetlist) => {
+            if (!cancelled) setActualSetlist(nextSetlist);
+          },
+          onErr
+        )
+      );
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        clearHideTimer();
+        attachLiveListeners();
+      } else {
+        clearHideTimer();
+        hideTimer = window.setTimeout(() => {
+          if (document.visibilityState === 'hidden') {
+            tearDownListeners();
+          }
+        }, LIVE_LISTENER_HIDE_DEBOUNCE_MS);
+      }
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
     setLoading(true);
     setError(null);
 
@@ -55,10 +153,19 @@ export function useStandings(showDate, showDates) {
       } finally {
         if (!cancelled) setLoading(false);
       }
+
+      if (cancelled) return;
+
+      if (document.visibilityState === 'visible') {
+        attachLiveListeners();
+      }
     })();
 
     return () => {
       cancelled = true;
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      clearHideTimer();
+      tearDownListeners();
     };
   }, [showDate, showDates]);
 

--- a/src/features/scoring/ui/StandingsBannerWaitingSetlist.jsx
+++ b/src/features/scoring/ui/StandingsBannerWaitingSetlist.jsx
@@ -1,11 +1,59 @@
-import React from 'react';
+import React, { useId, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
 
 import Card from '../../../shared/ui/Card';
 
+/**
+ * Waiting-for-setlist callout on Standings. Mobile-first: thin strip with
+ * optional expand so the leaderboard stays near the fold (#317). Desktop
+ * keeps the full alert card.
+ */
 export default function StandingsBannerWaitingSetlist() {
+  const panelId = useId();
+  const [open, setOpen] = useState(false);
+
+  const copy = 'Waiting for official setlist. Stay tuned...';
+
   return (
-    <Card variant="alert" padding="sm" className="mb-6 text-center">
-      <p className="text-amber-400 font-bold text-sm">Waiting for official setlist. Stay tuned...</p>
-    </Card>
+    <div className="mb-3 md:mb-6">
+      <div className="md:hidden">
+        {!open ? (
+          <button
+            type="button"
+            className="flex w-full items-center justify-between gap-2 rounded-lg border border-amber-500/35 bg-amber-950/25 px-3 py-2 text-left transition-colors hover:border-amber-400/45 hover:bg-amber-950/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60"
+            aria-expanded={false}
+            aria-controls={panelId}
+            onClick={() => setOpen(true)}
+          >
+            <p className="text-xs font-bold text-amber-400">{copy}</p>
+            <ChevronDown className="h-4 w-4 shrink-0 text-amber-300/90" aria-hidden />
+          </button>
+        ) : (
+          <Card
+            id={panelId}
+            variant="alert"
+            padding="sm"
+            className="text-center"
+            role="region"
+            aria-label="Official setlist status"
+          >
+            <p className="text-sm font-bold text-amber-400">{copy}</p>
+            <button
+              type="button"
+              className="mt-2 text-[11px] font-semibold uppercase tracking-wide text-amber-200/90 hover:text-amber-100"
+              onClick={() => setOpen(false)}
+            >
+              Collapse
+            </button>
+          </Card>
+        )}
+      </div>
+
+      <div className="hidden md:block">
+        <Card variant="alert" padding="sm" className="text-center">
+          <p className="text-sm font-bold text-amber-400">{copy}</p>
+        </Card>
+      </div>
+    </div>
   );
 }

--- a/src/features/scoring/ui/StandingsShowOrPoolView.jsx
+++ b/src/features/scoring/ui/StandingsShowOrPoolView.jsx
@@ -92,6 +92,7 @@ export default function StandingsShowOrPoolView({ screen }) {
         {showLastShowWinnerBanner ? (
           <StandingsWinnerOfTheNightBanner
             variant="lastShow"
+            compact
             winners={previousShowWinner.winners}
             max={previousShowWinner.max}
             beats={previousShowWinner.beats}
@@ -107,7 +108,7 @@ export default function StandingsShowOrPoolView({ screen }) {
           picksStatusLoading={Boolean(picksStatusLoading)}
         />
         {displayedPicks.length > 0 ? (
-          <div className="mt-6">
+          <div className="mt-4 md:mt-6">
             {!actualSetlist && picks.length > 0 ? (
               <StandingsBannerWaitingSetlist />
             ) : null}
@@ -179,6 +180,7 @@ export default function StandingsShowOrPoolView({ screen }) {
       {showLastShowWinnerBanner ? (
         <StandingsWinnerOfTheNightBanner
           variant="lastShow"
+          compact={Boolean(showWinnerBanner)}
           winners={previousShowWinner.winners}
           max={previousShowWinner.max}
           beats={previousShowWinner.beats}

--- a/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
+++ b/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
@@ -29,6 +29,7 @@ import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
  *   max: number | null,
  *   beats?: number,
  *   variant?: 'tonight' | 'lastShow',
+ *   compact?: boolean,
  *   viewResults?: { showDate: string, labelCompact: string } | null,
  *   onSelectShowDate?: ((ymd: string) => void) | null,
  *   lastShowPoolScopeLabel?: string | null,
@@ -39,6 +40,7 @@ export default function StandingsWinnerOfTheNightBanner({
   max,
   beats = 0,
   variant = 'tonight',
+  compact = false,
   viewResults = null,
   onSelectShowDate = null,
   lastShowPoolScopeLabel = null,
@@ -69,14 +71,24 @@ export default function StandingsWinnerOfTheNightBanner({
     <div
       role="region"
       aria-label={`${heading}: ${handlesLabel} — ${max} points`}
-      className="relative mx-0.5 mb-4 rounded-xl border border-amber-500/40 bg-gradient-to-br from-amber-500/[0.12] via-amber-500/[0.06] to-brand-primary/[0.08] px-3 py-2 shadow-inset-glass"
+      className={
+        compact
+          ? 'relative mx-0.5 mb-2 rounded-lg border border-amber-500/35 bg-gradient-to-br from-amber-500/[0.1] via-amber-500/[0.05] to-brand-primary/[0.06] px-2 py-1.5 shadow-inset-glass'
+          : 'relative mx-0.5 mb-4 rounded-xl border border-amber-500/40 bg-gradient-to-br from-amber-500/[0.12] via-amber-500/[0.06] to-brand-primary/[0.08] px-3 py-2 shadow-inset-glass'
+      }
     >
-      <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
+      <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1">
         {/*
           If the heading flex item ever paints over the pill (min-width / overflow),
           keep the link above in the hit-test order.
         */}
-        <p className="relative z-0 min-w-0 text-[10px] font-black uppercase tracking-widest text-amber-300">
+        <p
+          className={
+            compact
+              ? 'relative z-0 min-w-0 text-[9px] font-black uppercase tracking-widest text-amber-300'
+              : 'relative z-0 min-w-0 text-[10px] font-black uppercase tracking-widest text-amber-300'
+          }
+        >
           {heading}
         </p>
         {showViewResultsLink ? (
@@ -112,7 +124,13 @@ export default function StandingsWinnerOfTheNightBanner({
           </DashboardRowPill>
         ) : null}
       </div>
-      <p className="mt-0.5 text-sm font-bold leading-snug text-slate-100">
+      <p
+        className={
+          compact
+            ? 'mt-0.5 line-clamp-2 text-xs font-bold leading-snug text-slate-100 sm:line-clamp-none sm:text-sm'
+            : 'mt-0.5 text-sm font-bold leading-snug text-slate-100'
+        }
+      >
         {winners.map((w, idx) => {
           const playerUserId = w.userId || w.uid;
           const handle = w.handle || 'Anonymous';
@@ -127,7 +145,7 @@ export default function StandingsWinnerOfTheNightBanner({
         {' — '}
         <span className="tabular-nums text-white">{max}</span>
         <span className="font-semibold text-content-secondary"> pts</span>
-        {beats > 0 ? (
+        {beats > 0 && !compact ? (
           <span className="ml-1.5 text-xs font-semibold text-content-secondary">
             (beat {beats} {beats === 1 ? 'player' : 'players'})
           </span>

--- a/src/shared/config/branding.js
+++ b/src/shared/config/branding.js
@@ -93,3 +93,29 @@ export const brandWordmarkDashboardMobileBarScaleWrapperClassNames =
  */
 export const brandWordmarkDashboardSidebarScaleWrapperClassNames =
   'block w-full max-w-full origin-left scale-[1.02] motion-reduce:scale-100 md:flex md:origin-center md:justify-center md:scale-100';
+
+/**
+ * Shared two-column shell for splash header + dashboard mobile brand bar (#174).
+ * Keeps safe-area insets, grid track widths, and `sm:flex` handoff aligned.
+ */
+export const brandWordmarkBarRowGridBaseClassNames =
+  'grid min-h-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 overflow-visible pl-[max(1rem,env(safe-area-inset-left,0px))] pr-4 sm:flex sm:justify-between sm:gap-3';
+
+/** Full-bleed row inside fixed splash header (`max-w-7xl` + responsive horizontal padding). */
+export const brandWordmarkBarRowSplashExtrasClassNames =
+  'h-full w-full max-w-7xl min-w-0 sm:px-6 lg:px-8';
+
+/** Mobile dashboard bar: z-index stacks above scroll content; `sm:` horizontal matches legacy chrome. */
+export const brandWordmarkBarRowDashboardExtrasClassNames =
+  'relative z-20 sm:pl-4 sm:pr-4';
+
+/**
+ * Leading cell: splash vinyl / wordmark control — optical left edge (#174).
+ * (Former ad-hoc `max-sm:-translate-x-*` lives here when we reintroduce it.)
+ */
+export const brandWordmarkSplashHeaderLeadingClassNames =
+  'inline-flex min-w-0 items-center justify-start justify-self-start overflow-visible pl-0 pr-1 text-left outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm sm:shrink-0 sm:justify-self-auto sm:pr-2';
+
+/** Leading cell: dashboard mobile H1 + link — micro nudge for vinyl square vs safe area (#174). */
+export const brandWordmarkDashboardMobileLeadingClassNames =
+  'flex min-h-0 min-w-0 items-center justify-start justify-self-start self-center overflow-visible text-left leading-none max-sm:ml-1 max-sm:translate-y-1 sm:flex-1 sm:ml-0 sm:translate-y-0 sm:justify-self-auto';

--- a/src/shared/ui/BrandWordmarkBarRow.jsx
+++ b/src/shared/ui/BrandWordmarkBarRow.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import {
+  brandWordmarkBarRowDashboardExtrasClassNames,
+  brandWordmarkBarRowGridBaseClassNames,
+  brandWordmarkBarRowSplashExtrasClassNames,
+} from '../config/branding';
+
+/**
+ * Two-column brand row shared by splash header and dashboard mobile chrome (#174).
+ *
+ * @param {{ variant?: 'splash' | 'dashboard', children: React.ReactNode, className?: string }} props
+ */
+export default function BrandWordmarkBarRow({
+  variant = 'splash',
+  children,
+  className = '',
+}) {
+  const extras =
+    variant === 'dashboard'
+      ? brandWordmarkBarRowDashboardExtrasClassNames
+      : brandWordmarkBarRowSplashExtrasClassNames;
+  return (
+    <div
+      className={`${brandWordmarkBarRowGridBaseClassNames} ${extras} ${className}`.trim()}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
- Extract BrandWordmarkBarRow + branding tokens; wire SplashHeader and
  DashboardMobileBrandBar (https://github.com/pat792/set-picks/issues/174).
- Demote last-show winner (compact) on NEXT + when tonight banner shows;
  mobile-first collapsible waiting-for-setlist strip (https://github.com/pat792/set-picks/issues/317).
- LIVE standings: Firestore listeners for picks + official_setlist with
  60s post-hide teardown; Phish.net poll */2 ET + 90–150s jitter (https://github.com/pat792/set-picks/issues/311).

Closes https://github.com/pat792/set-picks/issues/174
Closes https://github.com/pat792/set-picks/issues/311
Closes https://github.com/pat792/set-picks/issues/317

Refs https://github.com/pat792/set-picks/issues/362

Merge to prod