### PR TITLE
feat(install): dashboard A2HS banner, iOS non-Safari copy, push nudge…

### DIFF
--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -47,6 +47,7 @@ import {
   showOptionTitle,
 } from '../../shared/utils/showOptionLabel.js';
 import { PastShowLockBanner, TooEarlyBanner } from '../../features/picks';
+import { DashboardInstallEngageBanner } from '../../features/install';
 
 import { persistDashboardPath } from '../../shared/lib/dashboardLastPath';
 import {
@@ -234,6 +235,8 @@ export default function DashboardLayout() {
           {showTooEarlyBanner && (
             <TooEarlyBanner priorShowLabel={tooEarlyPriorLabel} />
           )}
+
+          <DashboardInstallEngageBanner userId={user?.uid} pathname={location.pathname} />
 
           {meta.layoutDetailEyebrow ? (
             <p className="mb-3 ml-1 hidden text-xs font-bold uppercase tracking-widest text-content-secondary md:block">

--- a/src/features/install/index.js
+++ b/src/features/install/index.js
@@ -1,1 +1,5 @@
 export { default as InstallAppCard } from './ui/InstallAppCard.jsx';
+export {
+  default as DashboardInstallEngageBanner,
+  dashboardRouteShowsInstallEngage,
+} from './ui/DashboardInstallEngageBanner.jsx';

--- a/src/features/install/model/installEngageKeys.js
+++ b/src/features/install/model/installEngageKeys.js
@@ -1,0 +1,2 @@
+/** Session flag: user just completed A2HS — prioritize push permission nudge (#334). */
+export const SESSION_PUSH_NUDGE_AFTER_INSTALL_KEY = 'set-picks-pending-push-nudge';

--- a/src/features/install/model/installPromptPlatform.js
+++ b/src/features/install/model/installPromptPlatform.js
@@ -1,5 +1,6 @@
 const IOS_USER_AGENT_RE = /iPad|iPhone|iPod/;
 const SAFARI_RE = /Safari/;
+/** iOS browsers that use WebKit but are not system Safari (Chrome, Firefox, Edge, etc.). */
 const IOS_NON_SAFARI_RE = /CriOS|FxiOS|EdgiOS|OPiOS|DuckDuckGo/;
 
 export function isStandaloneDisplayMode(win = window) {
@@ -13,6 +14,20 @@ export function isStandaloneNavigator(nav = navigator) {
 
 export function isInstalled(win = window, nav = navigator) {
   return isStandaloneDisplayMode(win) || isStandaloneNavigator(nav);
+}
+
+export function isIosDevice(nav = navigator) {
+  if (!nav || typeof nav.userAgent !== 'string') return false;
+  return IOS_USER_AGENT_RE.test(nav.userAgent);
+}
+
+/**
+ * iPhone/iPad in Chrome, Firefox, Edge, etc. Install + reliable push require
+ * opening the site in **Safari** (#334).
+ */
+export function isIosNonSafariBrowser(nav = navigator) {
+  if (!isIosDevice(nav)) return false;
+  return IOS_NON_SAFARI_RE.test(nav.userAgent);
 }
 
 export function isIosSafariBrowser(nav = navigator) {

--- a/src/features/install/model/installPromptPlatform.test.js
+++ b/src/features/install/model/installPromptPlatform.test.js
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
   isInstalled,
+  isIosDevice,
+  isIosNonSafariBrowser,
   isIosSafariBrowser,
   isStandaloneDisplayMode,
   isStandaloneNavigator,
@@ -32,6 +34,9 @@ describe('installPromptPlatform', () => {
 
     expect(isIosSafariBrowser(iosSafari)).toBe(true);
     expect(isIosSafariBrowser(iosChrome)).toBe(false);
+    expect(isIosDevice(iosSafari)).toBe(true);
+    expect(isIosNonSafariBrowser(iosSafari)).toBe(false);
+    expect(isIosNonSafariBrowser(iosChrome)).toBe(true);
   });
 
   it('combines display and navigator standalone detection', () => {

--- a/src/features/install/model/useDashboardPushNudge.js
+++ b/src/features/install/model/useDashboardPushNudge.js
@@ -1,0 +1,78 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { ga4Event } from '../../../shared/lib/ga4';
+
+import { SESSION_PUSH_NUDGE_AFTER_INSTALL_KEY } from './installEngageKeys';
+
+const PUSH_NUDGE_DISMISS_KEY = 'set-picks-push-nudge-dismissed';
+
+function readDismissed() {
+  if (typeof window === 'undefined') return false;
+  return window.localStorage.getItem(PUSH_NUDGE_DISMISS_KEY) === '1';
+}
+
+function readSessionPending() {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.sessionStorage.getItem(SESSION_PUSH_NUDGE_AFTER_INSTALL_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Optional push follow-up (#334): after the app is installed (or added to home
+ * screen), nudge users who have not decided on notification permission yet.
+ * One tap routes to Notifications with the push section opened — closest to
+ * "one-click" the web platform allows (browser still shows its own prompt).
+ *
+ * @param {{ userId: string | null | undefined, isInstalled: boolean }} params
+ */
+export function useDashboardPushNudge({ userId, isInstalled }) {
+  const [tick, setTick] = useState(0);
+
+  const dismissPushNudge = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(PUSH_NUDGE_DISMISS_KEY, '1');
+    try {
+      window.sessionStorage.removeItem(SESSION_PUSH_NUDGE_AFTER_INSTALL_KEY);
+    } catch {
+      /* ignore */
+    }
+    setTick((t) => t + 1);
+    ga4Event('push_nudge_dismissed', { surface: 'dashboard' });
+  }, []);
+
+  const clearSessionInstallFlag = useCallback(() => {
+    try {
+      if (typeof window !== 'undefined') {
+        window.sessionStorage.removeItem(SESSION_PUSH_NUDGE_AFTER_INSTALL_KEY);
+      }
+    } catch {
+      /* ignore */
+    }
+    setTick((t) => t + 1);
+  }, []);
+
+  return useMemo(() => {
+    void tick;
+    const permission =
+      typeof Notification !== 'undefined' ? Notification.permission : 'denied';
+    const dismissed = readDismissed();
+    const sessionPending = readSessionPending();
+    const shouldShowPushNudge = Boolean(
+      userId &&
+      isInstalled &&
+      permission === 'default' &&
+      !dismissed
+    );
+
+    return {
+      shouldShowPushNudge,
+      /** True right after `appinstalled` / standalone — slightly stronger copy. */
+      highlightAfterInstall: sessionPending && shouldShowPushNudge,
+      dismissPushNudge,
+      clearSessionInstallFlag,
+    };
+  }, [userId, isInstalled, tick, dismissPushNudge, clearSessionInstallFlag]);
+}

--- a/src/features/install/model/useInstallPrompt.js
+++ b/src/features/install/model/useInstallPrompt.js
@@ -1,22 +1,36 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { ga4Event } from '../../../shared/lib/ga4';
-import { isInstalled, isIosSafariBrowser } from './installPromptPlatform';
+import {
+  isInstalled,
+  isIosNonSafariBrowser,
+  isIosSafariBrowser,
+} from './installPromptPlatform';
+import { SESSION_PUSH_NUDGE_AFTER_INSTALL_KEY } from './installEngageKeys';
 
 const IOS_DISMISS_KEY = 'set-picks-install-ios-dismissed';
+const DASHBOARD_INSTALL_SNOOZE_KEY = 'set-picks-install-dashboard-snooze-until';
 
 function getIosDismissed() {
   if (typeof window === 'undefined') return false;
   return window.localStorage.getItem(IOS_DISMISS_KEY) === '1';
 }
 
-function setIosDismissed(value) {
+function setIosDismissedStorage(value) {
   if (typeof window === 'undefined') return;
   if (value) {
     window.localStorage.setItem(IOS_DISMISS_KEY, '1');
   } else {
     window.localStorage.removeItem(IOS_DISMISS_KEY);
   }
+}
+
+function isDashboardInstallSnoozed() {
+  if (typeof window === 'undefined') return false;
+  const raw = window.localStorage.getItem(DASHBOARD_INSTALL_SNOOZE_KEY);
+  if (!raw) return false;
+  const t = Number(raw);
+  return Number.isFinite(t) && t > Date.now();
 }
 
 export function useInstallPrompt() {
@@ -27,8 +41,12 @@ export function useInstallPrompt() {
   const [isIosSafari, setIsIosSafari] = useState(() =>
     typeof window === 'undefined' ? false : isIosSafariBrowser(navigator)
   );
+  const [isIosNonSafari, setIsIosNonSafari] = useState(() =>
+    typeof navigator === 'undefined' ? false : isIosNonSafariBrowser(navigator)
+  );
   const [iosDismissed, setIosDismissedState] = useState(getIosDismissed);
   const [showIosGuide, setShowIosGuide] = useState(false);
+  const [snoozeTick, setSnoozeTick] = useState(0);
 
   useEffect(() => {
     if (typeof window === 'undefined') return undefined;
@@ -43,6 +61,11 @@ export function useInstallPrompt() {
       setInstalled(true);
       setDeferredPrompt(null);
       ga4Event('a2hs_installed');
+      try {
+        window.sessionStorage.setItem(SESSION_PUSH_NUDGE_AFTER_INSTALL_KEY, '1');
+      } catch {
+        /* ignore quota / privacy mode */
+      }
     };
     const onBeforeInstallPrompt = (event) => {
       event.preventDefault();
@@ -51,6 +74,7 @@ export function useInstallPrompt() {
 
     updateInstalled();
     setIsIosSafari(isIosSafariBrowser(navigator));
+    setIsIosNonSafari(isIosNonSafariBrowser(navigator));
     if (typeof mediaQuery.addEventListener === 'function') {
       mediaQuery.addEventListener('change', onDisplayModeChange);
     } else if (typeof mediaQuery.addListener === 'function') {
@@ -70,17 +94,50 @@ export function useInstallPrompt() {
     };
   }, []);
 
+  /** iOS “Add to Home Screen” / display-mode standalone may not fire `appinstalled`. */
+  const prevInstalledRef = useRef(null);
+  useEffect(() => {
+    if (prevInstalledRef.current === null) {
+      prevInstalledRef.current = installed;
+      return;
+    }
+    if (!prevInstalledRef.current && installed) {
+      try {
+        if (typeof window !== 'undefined') {
+          window.sessionStorage.setItem(SESSION_PUSH_NUDGE_AFTER_INSTALL_KEY, '1');
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    prevInstalledRef.current = installed;
+  }, [installed]);
+
   const canPrompt = Boolean(deferredPrompt) && !installed;
   const shouldShowIosFlow = isIosSafari && !installed && !iosDismissed;
-  const shouldShowCard = canPrompt || shouldShowIosFlow;
+  const shouldShowIosNonSafariFlow = isIosNonSafari && !installed && !iosDismissed;
+  const shouldShowCard = canPrompt || shouldShowIosFlow || shouldShowIosNonSafariFlow;
+
+  const dashboardSnoozed = useMemo(() => {
+    void snoozeTick;
+    return isDashboardInstallSnoozed();
+  }, [snoozeTick, installed]);
+
+  const shouldShowDashboardInstallBanner =
+    !installed &&
+    !dashboardSnoozed &&
+    (canPrompt || shouldShowIosFlow || shouldShowIosNonSafariFlow);
 
   useEffect(() => {
     if (!shouldShowCard) return;
-    ga4Event('a2hs_cta_shown', { platform: canPrompt ? 'chromium' : 'ios_safari' });
-  }, [shouldShowCard, canPrompt]);
+    let platform = 'ios_safari';
+    if (canPrompt) platform = 'chromium';
+    else if (isIosNonSafari) platform = 'ios_non_safari';
+    ga4Event('a2hs_cta_shown', { platform });
+  }, [shouldShowCard, canPrompt, isIosNonSafari]);
 
   const dismissIos = useCallback(() => {
-    setIosDismissed(true);
+    setIosDismissedStorage(true);
     setIosDismissedState(true);
     setShowIosGuide(false);
     ga4Event('a2hs_ios_dismissed');
@@ -93,6 +150,14 @@ export function useInstallPrompt() {
 
   const closeIosGuide = useCallback(() => {
     setShowIosGuide(false);
+  }, []);
+
+  const snoozeInstallDashboard = useCallback((days = 7) => {
+    if (typeof window === 'undefined') return;
+    const until = Date.now() + days * 86_400_000;
+    window.localStorage.setItem(DASHBOARD_INSTALL_SNOOZE_KEY, String(until));
+    setSnoozeTick((t) => t + 1);
+    ga4Event('a2hs_dashboard_snoozed', { days });
   }, []);
 
   const promptInstall = useCallback(async () => {
@@ -110,26 +175,34 @@ export function useInstallPrompt() {
     () => ({
       canPrompt,
       isIosSafari,
+      isIosNonSafari,
       isInstalled: installed,
       showIosGuide,
       shouldShowCard,
+      shouldShowIosFlow,
+      shouldShowIosNonSafariFlow,
+      shouldShowDashboardInstallBanner,
       promptInstall,
       dismissIos,
       openIosGuide,
       closeIosGuide,
-      shouldShowIosFlow,
+      snoozeInstallDashboard,
     }),
     [
       canPrompt,
       isIosSafari,
+      isIosNonSafari,
       installed,
       showIosGuide,
       shouldShowCard,
+      shouldShowIosFlow,
+      shouldShowIosNonSafariFlow,
+      shouldShowDashboardInstallBanner,
       promptInstall,
       dismissIos,
       openIosGuide,
       closeIosGuide,
-      shouldShowIosFlow,
+      snoozeInstallDashboard,
     ]
   );
 }

--- a/src/features/install/ui/DashboardInstallEngageBanner.jsx
+++ b/src/features/install/ui/DashboardInstallEngageBanner.jsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Bell, Download, Share2 } from 'lucide-react';
+
+import { ga4Event } from '../../../shared/lib/ga4';
+import { useDashboardPushNudge } from '../model/useDashboardPushNudge';
+import { useInstallPrompt } from '../model/useInstallPrompt';
+
+/**
+ * Routes where the compact install + push nudge may appear (#334). Profile keeps
+ * the full `InstallAppCard`; pool detail and settings routes stay focused.
+ *
+ * @param {string} pathname
+ * @returns {boolean}
+ */
+export function dashboardRouteShowsInstallEngage(pathname) {
+  const n = pathname.replace(/\/$/, '') || '/dashboard';
+  if (
+    n === '/dashboard/profile' ||
+    n === '/dashboard/account-security' ||
+    n === '/dashboard/notifications' ||
+    n === '/dashboard/admin'
+  ) {
+    return false;
+  }
+  if (n.startsWith('/dashboard/pool/')) return false;
+  return (
+    n === '/dashboard' ||
+    n === '/dashboard/picks' ||
+    n === '/dashboard/standings' ||
+    n === '/dashboard/pools'
+  );
+}
+
+/**
+ * Inner component: only mounts on routes where the banner may show, so
+ * `useInstallPrompt` is not duplicated with `InstallAppCard` on Profile (#334).
+ *
+ * @param {{ userId: string | null | undefined }} props
+ */
+function DashboardInstallEngageBannerLoaded({ userId }) {
+  const install = useInstallPrompt();
+  const push = useDashboardPushNudge({
+    userId,
+    isInstalled: install.isInstalled,
+  });
+
+  const showInstall = install.shouldShowDashboardInstallBanner;
+  const showPush = push.shouldShowPushNudge;
+
+  if (!showInstall && !showPush) return null;
+
+  return (
+    <div className="mb-4 space-y-2 md:mb-5">
+      {showInstall ? (
+        <div className="rounded-2xl border border-border-subtle bg-surface-panel px-4 py-3 shadow-inset-glass md:px-5">
+          <p className="text-[11px] font-black uppercase tracking-widest text-brand-primary">
+            Faster launch &amp; full screen
+          </p>
+          <p className="mt-1 text-xs font-bold leading-snug text-content-secondary">
+            Add Setlist Pick &apos;Em to your home screen for quick access on show night.
+          </p>
+
+          {install.canPrompt ? (
+            <button
+              type="button"
+              onClick={() => install.promptInstall()}
+              className="mt-3 flex w-full items-center justify-center gap-2 rounded-xl border-2 border-brand-primary/45 bg-brand-primary/10 py-2.5 text-xs font-black uppercase tracking-widest text-brand-primary transition-colors hover:border-brand-primary hover:bg-brand-primary/20"
+            >
+              <Download className="h-4 w-4 shrink-0" aria-hidden />
+              Add to Home Screen
+            </button>
+          ) : null}
+
+          {install.shouldShowIosFlow ? (
+            <div className="mt-3 space-y-2">
+              <button
+                type="button"
+                onClick={() =>
+                  install.showIosGuide ? install.closeIosGuide() : install.openIosGuide()
+                }
+                className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-border-subtle bg-surface-field py-2.5 text-xs font-black uppercase tracking-widest text-white transition-colors hover:border-brand-primary/50 hover:bg-surface-panel"
+              >
+                <Share2 className="h-4 w-4 shrink-0" aria-hidden />
+                {install.showIosGuide ? 'Hide steps' : 'iPhone: Add to Home Screen'}
+              </button>
+              {install.showIosGuide ? (
+                <ol className="space-y-1.5 rounded-xl border border-border-muted bg-surface-inset p-3 text-xs text-content-secondary">
+                  <li>
+                    1. Tap <span className="font-bold text-white">Share</span> in Safari.
+                  </li>
+                  <li>
+                    2. Tap <span className="font-bold text-white">Add to Home Screen</span>.
+                  </li>
+                  <li>
+                    3. Tap <span className="font-bold text-white">Add</span>.
+                  </li>
+                </ol>
+              ) : null}
+              <button
+                type="button"
+                onClick={() => install.dismissIos()}
+                className="text-[11px] font-black uppercase tracking-widest text-content-secondary underline decoration-border-muted underline-offset-4 hover:text-white"
+              >
+                Don&apos;t show again
+              </button>
+            </div>
+          ) : null}
+
+          {install.shouldShowIosNonSafariFlow ? (
+            <div className="mt-3 space-y-2">
+              <p className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-3 text-xs font-bold leading-relaxed text-content-secondary">
+                On iPhone, <span className="text-white">Chrome and other browsers can&apos;t install</span> this
+                app. Open <span className="text-white">setlistpickem.com</span> in{' '}
+                <span className="text-white">Safari</span>, then use Share → Add to Home Screen.
+              </p>
+              <button
+                type="button"
+                onClick={() => install.dismissIos()}
+                className="text-[11px] font-black uppercase tracking-widest text-content-secondary underline decoration-border-muted underline-offset-4 hover:text-white"
+              >
+                Don&apos;t show again
+              </button>
+            </div>
+          ) : null}
+
+          <div className="mt-3 flex flex-wrap gap-2 border-t border-border-muted/60 pt-3">
+            <button
+              type="button"
+              onClick={() => install.snoozeInstallDashboard(7)}
+              className="text-[11px] font-black uppercase tracking-widest text-content-secondary hover:text-white"
+            >
+              Not now · ask again in 7 days
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {showPush ? (
+        <div className="rounded-2xl border border-brand-primary/35 bg-brand-primary/[0.07] px-4 py-3 md:px-5">
+          <p className="text-[11px] font-black uppercase tracking-widest text-brand-primary">
+            {push.highlightAfterInstall ? "You're set up — one more tap" : 'Stay in the loop'}
+          </p>
+          <p className="mt-1 text-xs font-bold text-content-secondary">
+            {push.highlightAfterInstall
+              ? 'Turn on alerts for lock reminders and score updates (your browser will ask permission once).'
+              : 'Get lock reminders and score alerts on this device.'}
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <Link
+              to="/dashboard/notifications?openPush=1"
+              onClick={() => {
+                ga4Event('push_nudge_cta_clicked', { surface: 'dashboard' });
+                push.clearSessionInstallFlag();
+              }}
+              className="inline-flex flex-1 items-center justify-center gap-2 rounded-xl border-2 border-brand-primary/50 bg-brand-primary/15 px-4 py-2.5 text-xs font-black uppercase tracking-widest text-brand-primary transition-colors hover:border-brand-primary hover:bg-brand-primary/25 min-[400px]:flex-none"
+            >
+              <Bell className="h-4 w-4 shrink-0" aria-hidden />
+              Turn on alerts
+            </Link>
+            <button
+              type="button"
+              onClick={() => push.dismissPushNudge()}
+              className="rounded-lg px-3 py-2 text-[11px] font-black uppercase tracking-widest text-content-secondary hover:text-white"
+            >
+              Not now
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * @param {{ userId: string | null | undefined, pathname: string }} props
+ */
+export default function DashboardInstallEngageBanner({ userId, pathname }) {
+  if (!dashboardRouteShowsInstallEngage(pathname)) return null;
+  return <DashboardInstallEngageBannerLoaded userId={userId} />;
+}

--- a/src/features/install/ui/InstallAppCard.jsx
+++ b/src/features/install/ui/InstallAppCard.jsx
@@ -13,6 +13,7 @@ export default function InstallAppCard() {
     openIosGuide,
     closeIosGuide,
     shouldShowIosFlow,
+    shouldShowIosNonSafariFlow,
   } = useInstallPrompt();
 
   if (isInstalled) return null;
@@ -73,10 +74,28 @@ export default function InstallAppCard() {
         </>
       ) : null}
 
-      {!canPrompt && !shouldShowIosFlow ? (
+      {shouldShowIosNonSafariFlow ? (
+        <>
+          <p className="mt-4 rounded-2xl border border-amber-500/35 bg-amber-500/5 p-4 text-sm font-bold leading-relaxed text-content-secondary">
+            On iPhone, <span className="text-white">Chrome and other browsers can&apos;t install</span>{' '}
+            this app. Open <span className="text-white">setlistpickem.com</span> in{' '}
+            <span className="text-white">Safari</span>, then use Share → Add to Home Screen.
+          </p>
+          <button
+            type="button"
+            onClick={dismissIos}
+            className="mt-3 text-xs font-black uppercase tracking-widest text-content-secondary underline decoration-border-muted underline-offset-4 transition-colors hover:text-white"
+          >
+            Don&apos;t show this again
+          </button>
+        </>
+      ) : null}
+
+      {!canPrompt && !shouldShowIosFlow && !shouldShowIosNonSafariFlow ? (
         <p className="mt-4 rounded-2xl border border-border-muted bg-surface-inset p-4 text-sm leading-relaxed text-content-secondary">
-          Install is not available in this browser yet. For the best install experience, open Setlist
-          Pick &apos;Em in Safari on iPhone and use Add to Home Screen.
+          Install is not available in this browser yet. For the best install experience on iPhone,
+          open Setlist Pick &apos;Em in <span className="font-bold text-white">Safari</span> and use
+          Add to Home Screen.
         </p>
       ) : null}
     </section>

--- a/src/features/notifications/ui/NotificationsPrototypeScreen.jsx
+++ b/src/features/notifications/ui/NotificationsPrototypeScreen.jsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Bell, ChevronDown, Mail, Smartphone } from 'lucide-react';
 
 import { dashboardPageTitleGradientClasses } from '../../../shared/config/dashboardHeadingTypography';
@@ -91,7 +92,21 @@ function NotificationAccordionSection({
 }
 
 export default function NotificationsPrototypeScreen() {
+  const [searchParams, setSearchParams] = useSearchParams();
   const [openSection, setOpenSection] = useState(null);
+
+  useEffect(() => {
+    const open =
+      searchParams.get('openPush') === '1' || searchParams.get('section') === 'push';
+    if (!open) return;
+    setOpenSection('push');
+    const next = new URLSearchParams(searchParams);
+    next.delete('openPush');
+    next.delete('section');
+    if (next.toString() !== searchParams.toString()) {
+      setSearchParams(next, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
 
   const handleAccordion = useCallback((id) => {
     setOpenSection((prev) => (prev === id ? null : id));


### PR DESCRIPTION
… (#334)

- Prominent compact install CTA on Picks/Standings/Pools (snooze 7d); Profile keeps full InstallAppCard; avoid duplicate useInstallPrompt on Profile.
- iOS Chrome/Firefox: explicit Safari + Add to Home Screen guidance.
- Optional push follow-up when installed + Notification permission default: Turn on alerts → /dashboard/notifications?openPush=1 with accordion opened.
- Session flag after install / standalone transition for stronger nudge copy.

Closes #334