### PR TITLE
docs: add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agents
+
+## Cursor Cloud specific instructions
+
+### Environment
+
+- **Node.js 24** is required (Cloud Functions `engines.node: "24"`). The VM uses `nvm` with Node 24 set as default.
+- **Package manager:** npm (lockfile: `package-lock.json`). Two install targets: root (`/workspace`) and `functions/`.
+- **`.env`** is gitignored. Copy `.env.example` to `.env` for local dev; most values can stay empty/default.
+
+### Running the application
+
+- **Dev server:** `npm run dev` — Vite on `http://localhost:5173` (`strictPort: true`; free that port or it will fail).
+- The app connects to the **remote Firebase project** (Firestore, Auth, Storage). There is no local emulator-first workflow for the SPA.
+- App Check is auto-disabled in dev mode (`FIREBASE_APPCHECK_DEBUG_TOKEN = true` when `import.meta.env.DEV`).
+
+### Lint / Test / Build (CI matrix)
+
+Standard commands are in `package.json` scripts. The CI matrix that must pass:
+
+| Check | Command |
+|-------|---------|
+| Lint | `npm run lint` |
+| Unit tests (frontend) | `npm test` |
+| Verify dashboard meta | `npm run verify:dashboard-meta` |
+| Verify dashboard UI tokens | `npm run verify:dashboard-ui` |
+| Functions unit tests | `cd functions && npm test` |
+| Build | `npm run build` |
+
+### PR workflow notes
+
+- **Base branch is `staging`**, not `main` (per `.cursorrules` §10).
+- Branch naming: `feat/<issue#>-<kebab-slug>`.
+- Firestore rules tests (`npm run test:rules`) require the Firebase emulator and are not part of the regular CI matrix for the web app.
+
+### Gotchas
+
+- The Vite build emits Rollup circular-dependency warnings for barrel re-exports. These are known and non-blocking.
+- `sharp` (devDependency) may fail to install on some architectures; it is only used by `scripts/generate-og-card.mjs` and is not required for dev/test/build.
+- Firebase Cloud Functions require Node 24 — if you see `engines` mismatch errors in `functions/`, ensure `nvm use 24`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting:
- Node.js 24 requirement and nvm setup
- Package manager (npm) and dual install targets (root + functions/)
- Dev server startup (`npm run dev` on port 5173)
- CI matrix commands (lint, test, verify scripts, functions tests, build)
- PR workflow notes (base branch is `staging`)
- Known gotchas (Rollup circular-dep warnings, sharp architecture issues, Node version for functions)

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` — 176 vitest tests pass
- [x] `cd functions && npm test` — 154 node:test tests pass
- [x] `npm run verify:dashboard-meta` — 12 cases OK
- [x] `npm run verify:dashboard-ui` — OK
- [x] `npm run build` — production build succeeds
- [x] `npm run dev` — Vite dev server on localhost:5173 responds 200

<a href="https://cursor.com/agents/bc-e244f583-5297-4f89-a944-8bfcbf5c4300/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsetlist-pickem-dev-environment-demo.mp4"><img src="https://cursor.com/artifacts/c/art-6e203760-6d5c-4e70-8843-1381e5bc497f" alt="setlist-pickem-dev-environment-demo.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e244f583-5297-4f89-a944-8bfcbf5c4300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e244f583-5297-4f89-a944-8bfcbf5c4300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

