### PR TITLE
feat(notifications): Firestore comms inbox, Sphere recap delivery, dashboard bell

### DIFF
--- a/content/comms/README.md
+++ b/content/comms/README.md
@@ -4,7 +4,18 @@
 
 **Authoritative for production:** The owning **`implementationModule`** path listed in each recap Markdown front matter / metadata table (and in **`src/features/comms/registry.js`**). Keep **`content/comms/**`** and that module **in sync** when copy ships.
 
-**Push / in-app / email epic:** Channel behavior and orchestration are tracked in GitHub **#272**. This folder does **not** send messages; it documents copy. Orchestration should read **`src/features/comms/registry.js`** for template IDs and supported channels (`inApp`, `emailAbbreviated`, `emailFull`, `push`).
+**Push / in-app / email epic:** Channel behavior and orchestration are tracked in GitHub **#272**. Broader in-app comms (inbox, toasts, confirmations) align with **#120**. This folder does **not** send messages; it documents copy. Orchestration should read **`src/features/comms/registry.js`** for template IDs and supported channels (`inApp`, `emailAbbreviated`, `emailFull`, `push`).
+
+### In-app inbox (dashboard)
+
+Variable recap copy **renders in the product** from the same template builders as email/push once a message exists in Firestore:
+
+- **Path:** `users/{uid}/commsInbox/{messageId}` (see **`COMMS_INBOX_COLLECTION_ID`** in `src/features/notifications/api/commsInboxApi.js`).
+- **Writes:** Admin SDK / Cloud Functions only (clients **cannot** create rows). Owners may set **`readAt`** when they open a message.
+- **Shape:** `templateId` (registry key, e.g. `sphere-2026-inaugural`), `payload` (variables for the template — rank, points, wins, showsPlayed, optional `participantCount`), **`createdAt`** (server timestamp at delivery).
+- **UI:** Notifications screen (`/dashboard/notifications`) — **Messages** section + bell in dashboard chrome. Renderer maps `templateId` to components such as **`Sphere2026TourRecapInApp`** (see `src/features/notifications/ui/CommsRecapMessageBody.jsx`).
+
+**Manual QA:** In Firebase Console, add a doc under your test user’s `commsInbox` subcollection using the shape above, reload the app, open the bell → message should expand with personalized paragraphs. Automated delivery from standings / rollups is tracked in **#370**; a manual QA runbook is **#371**.
 
 ---
 

--- a/content/comms/README.md
+++ b/content/comms/README.md
@@ -8,11 +8,15 @@
 
 ### In-app inbox (dashboard)
 
-Variable recap copy **renders in the product** from the same template builders as email/push once a message exists in Firestore:
+**Where the variable copy “lives” editorially:** Under **`content/comms/`** (e.g. tour recap Markdown like **`content/comms/tours/sphere-2026-inaugural.md`** — placeholders such as `{{rank}}`, sections for per-player branches). That file is the human-facing contract; **`implementationModule`** in the metadata table is still the shipped runtime source until a loader reads Markdown directly.
+
+**What Firestore stores for delivery:** Not the Markdown file. Each inbox row is **`templateId`** (matches registry + draft edition) plus a **`payload`** map of **values** for that template (e.g. numeric `rank`, `points`, `wins`, `showsPlayed`). Those fields align with the variables described in the **`content/comms`** draft and implemented in JS (e.g. `getSphere2026PersonalParagraph`).
+
+Once that doc exists, variable recap copy **renders in the app** from the same builders / UI as other channels:
 
 - **Path:** `users/{uid}/commsInbox/{messageId}` (see **`COMMS_INBOX_COLLECTION_ID`** in `src/features/notifications/api/commsInboxApi.js`).
 - **Writes:** Admin SDK / Cloud Functions only (clients **cannot** create rows). Owners may set **`readAt`** when they open a message.
-- **Shape:** `templateId` (registry key, e.g. `sphere-2026-inaugural`), `payload` (variables for the template — rank, points, wins, showsPlayed, optional `participantCount`), **`createdAt`** (server timestamp at delivery).
+- **Shape:** `templateId`, **`payload`** (per-user values), **`createdAt`** (server timestamp at delivery).
 - **UI:** Notifications screen (`/dashboard/notifications`) — **Messages** section + bell in dashboard chrome. Renderer maps `templateId` to components such as **`Sphere2026TourRecapInApp`** (see `src/features/notifications/ui/CommsRecapMessageBody.jsx`).
 
 **Manual QA:** In Firebase Console, add a doc under your test user’s `commsInbox` subcollection using the shape above, reload the app, open the bell → message should expand with personalized paragraphs. Automated delivery from standings / rollups is tracked in **#370**; a manual QA runbook is **#371**.

--- a/content/comms/README.md
+++ b/content/comms/README.md
@@ -19,7 +19,16 @@ Once that doc exists, variable recap copy **renders in the app** from the same b
 - **Shape:** `templateId`, **`payload`** (per-user values), **`createdAt`** (server timestamp at delivery).
 - **UI:** Notifications screen (`/dashboard/notifications`) — **Messages** section + bell in dashboard chrome. Renderer maps `templateId` to components such as **`Sphere2026TourRecapInApp`** (see `src/features/notifications/ui/CommsRecapMessageBody.jsx`).
 
-**Manual QA:** In Firebase Console, add a doc under your test user’s `commsInbox` subcollection using the shape above, reload the app, open the bell → message should expand with personalized paragraphs. Automated delivery from standings / rollups is tracked in **#370**; a manual QA runbook is **#371**.
+**Manual QA:** In Firebase Console, add a doc under your test user’s `commsInbox` subcollection using the shape above, reload the app, open the bell → message should expand with personalized paragraphs.
+
+**Phased delivery (orchestration):**
+
+| Phase | Who triggers | Mechanism |
+|-------|----------------|-----------|
+| **1 — Ship today** | Admin / PM (War Room) | HTTPS callable **`deliverSphere2026TourRecapInbox`** (`functions/index.js`): **`dryRun`** defaults to **true**; pass **`dryRun: false`** to write rows. Aggregates **graded** picks on the nine **Sphere Run** dates (same math as dashboard Tour standings) and writes **`users/{uid}/commsInbox/sphere-2026-inaugural`**. UI: **War Room → Tour recap copy → Deliver recap to user inboxes** (`AdminSphereTourRecapDelivery`). CLI (ADC): `functions/scripts/deliverSphere2026TourRecapInbox.js` — omit flag for dry run, **`--execute`** to write. |
+| **2** | Automation | Scheduled or rollup-triggered job calling the same delivery helper (extend **`sphereTourRecapDelivery.js`** or add registry-driven modules). Tracked in **#370** / epic **#272**. |
+
+Sphere inaugural **show-date list** in code must stay aligned with **`src/shared/data/showDates.js`** (`Sphere Run`). Follow-up runbook: **#371**.
 
 ---
 

--- a/content/comms/tours/sphere-2026-inaugural.md
+++ b/content/comms/tours/sphere-2026-inaugural.md
@@ -6,6 +6,7 @@
 | **Implementation** | `src/features/tour-recap/model/sphere2026Recap.js` |
 | **In-app UI** | `src/features/tour-recap/ui/Sphere2026TourRecapInApp.jsx` |
 | **Admin preview** | War Room → “Tour recap copy (Sphere '26)” (`AdminTourRecapPreview`) |
+| **Inbox delivery** | Callable `deliverSphere2026TourRecapInbox` + War Room “Deliver recap to user inboxes” (graded picks on Sphere dates → `users/{uid}/commsInbox/sphere-2026-inaugural`) |
 
 Edit **either** this file (proposal / source draft) **or** the implementation module. Production strings are the **JS module** until a content loader exists; keep this doc aligned when marketing copy changes.
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -74,6 +74,21 @@ service cloud.firestore {
       match /private_fcmTokens/{tokenId} {
         allow read, write: if signedIn() && request.auth.uid == userId;
       }
+
+      /**
+       * In-app comms inbox (issue #120 / epic #272): recap + editorial messages.
+       * Clients read; Admin SDK / Cloud Functions create. Owners may set `readAt` only.
+       */
+      match /commsInbox/{messageId} {
+        allow read: if signedIn() && request.auth.uid == userId;
+        allow create, delete: if false;
+        allow update: if signedIn()
+          && request.auth.uid == userId
+          && request.resource.data.templateId == resource.data.templateId
+          && request.resource.data.payload == resource.data.payload
+          && request.resource.data.createdAt == resource.data.createdAt
+          && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['readAt']);
+      }
     }
 
     /**

--- a/firestore.rules.test.cjs
+++ b/firestore.rules.test.cjs
@@ -33,6 +33,7 @@ const {
   getDocs,
   query,
   where,
+  Timestamp,
 } = require("firebase/firestore");
 
 const PROJECT_ID = "setlist-pickem-rules-test";
@@ -199,6 +200,78 @@ test("fcmTokens: non-owner cannot read another user's token doc", async () => {
   const db = signedInAs("alice");
   await assertFails(
     getDoc(doc(db, "users", "bob", "private_fcmTokens", "tok1"))
+  );
+});
+
+// ─── users/{userId}/commsInbox/{messageId} ───────────────────────────────────
+
+test("commsInbox: owner may read own inbox doc", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "users", "alice", "commsInbox", "msg1"), {
+      templateId: "sphere-2026-inaugural",
+      payload: { rank: 3, points: 120, wins: 1, showsPlayed: 9 },
+      createdAt: Timestamp.fromMillis(1_700_000_000_000),
+    });
+  });
+  const db = signedInAs("alice");
+  await assertSucceeds(getDoc(doc(db, "users", "alice", "commsInbox", "msg1")));
+});
+
+test("commsInbox: non-owner cannot read another user's inbox doc", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "users", "bob", "commsInbox", "msg1"), {
+      templateId: "sphere-2026-inaugural",
+      payload: {},
+      createdAt: Timestamp.fromMillis(1_700_000_000_000),
+    });
+  });
+  const db = signedInAs("alice");
+  await assertFails(getDoc(doc(db, "users", "bob", "commsInbox", "msg1")));
+});
+
+test("commsInbox: client cannot create inbox docs", async () => {
+  const db = signedInAs("alice");
+  await assertFails(
+    setDoc(doc(db, "users", "alice", "commsInbox", "msgX"), {
+      templateId: "x",
+      payload: {},
+      createdAt: Timestamp.now(),
+    })
+  );
+});
+
+test("commsInbox: owner may set readAt only (preserves payload)", async () => {
+  const ts = Timestamp.fromMillis(1_700_000_000_000);
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "users", "alice", "commsInbox", "msg1"), {
+      templateId: "sphere-2026-inaugural",
+      payload: { rank: 3, points: 120, wins: 1, showsPlayed: 9 },
+      createdAt: ts,
+    });
+  });
+  const db = signedInAs("alice");
+  await assertSucceeds(
+    updateDoc(doc(db, "users", "alice", "commsInbox", "msg1"), {
+      readAt: Timestamp.now(),
+    })
+  );
+});
+
+test("commsInbox: owner cannot rewrite templateId", async () => {
+  const ts = Timestamp.fromMillis(1_700_000_000_000);
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "users", "alice", "commsInbox", "msg1"), {
+      templateId: "sphere-2026-inaugural",
+      payload: { rank: 3 },
+      createdAt: ts,
+    });
+  });
+  const db = signedInAs("alice");
+  await assertFails(
+    updateDoc(doc(db, "users", "alice", "commsInbox", "msg1"), {
+      templateId: "other",
+      readAt: Timestamp.now(),
+    })
   );
 });
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -39,6 +39,7 @@ const {
   normalizeFcmSendMessageId,
 } = require("./fcmMessagingCore");
 const { applyRevertRollupForShow } = require("./revertRollupCore");
+const { deliverSphere2026TourRecapInbox } = require("./sphereTourRecapDelivery");
 const { evaluateManualFinalizeTimingGate } = require("./showFinalizationGate");
 
 const phishnetApiKey = defineSecret("PHISHNET_API_KEY");
@@ -287,6 +288,29 @@ exports.revertRollupForShow = onCall(
       revertedPicks: result.revertedPicks,
       noop: result.noop === true,
     };
+  }
+);
+
+/**
+ * Admin-only: write Sphere ’26 inaugural recap rows to each player’s
+ * `users/{uid}/commsInbox/sphere-2026-inaugural` using tour standings math
+ * (same as dashboard tour leaderboard). Use `dryRun: true` first (#120).
+ */
+exports.deliverSphere2026TourRecapInbox = onCall(
+  {
+    region: PHISHNET_FUNCTIONS_REGION,
+    invoker: "public",
+    enforceAppCheck: false,
+  },
+  async (request) => {
+    assertAdminClaim(request);
+    const dryRun = request.data?.dryRun !== false;
+    return deliverSphere2026TourRecapInbox({
+      db,
+      admin,
+      dryRun,
+      logger,
+    });
   }
 );
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
-    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js showFinalizationGate.test.js revertRollupCore.test.js postShowRollupPush.test.js picksLockReminder.test.js fcmMessagingCore.test.js",
+    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js showFinalizationGate.test.js revertRollupCore.test.js postShowRollupPush.test.js picksLockReminder.test.js fcmMessagingCore.test.js sphereTourRecapDelivery.test.js",
     "serve": "firebase emulators:start --only functions",
     "shell": "firebase functions:shell",
     "start": "npm run shell",
@@ -16,7 +16,8 @@
     "qa:post-show-push-test": "node scripts/sendPostShowRollupPushTest.js",
     "backfill:bustouts": "node scripts/backfillBustouts.js",
     "backfill:season-aggregates": "node scripts/backfillSeasonAggregates.js",
-    "rollup:reset-premature-grade": "node scripts/resetPrematureGrade.js"
+    "rollup:reset-premature-grade": "node scripts/resetPrematureGrade.js",
+    "comms:deliver-sphere-inbox": "node scripts/deliverSphere2026TourRecapInbox.js"
   },
   "engines": {
     "node": "24"

--- a/functions/scripts/deliverSphere2026TourRecapInbox.js
+++ b/functions/scripts/deliverSphere2026TourRecapInbox.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * CLI: deliver Sphere ’26 inaugural recap rows to `users/{uid}/commsInbox`
+ * (same logic as `deliverSphere2026TourRecapInbox` callable).
+ *
+ * Usage:
+ *   node scripts/deliverSphere2026TourRecapInbox.js           # dry run (default)
+ *   node scripts/deliverSphere2026TourRecapInbox.js --execute # writes Firestore
+ *
+ * Requires Application Default Credentials with Firestore write access
+ * (e.g. `gcloud auth application-default login` or service account).
+ */
+
+const admin = require("firebase-admin");
+const {
+  deliverSphere2026TourRecapInbox,
+} = require("../sphereTourRecapDelivery");
+
+admin.initializeApp();
+const db = admin.firestore();
+
+const execute = process.argv.includes("--execute");
+
+deliverSphere2026TourRecapInbox({
+  db,
+  admin,
+  dryRun: !execute,
+  logger: console,
+})
+  .then((r) => {
+    console.log(JSON.stringify(r, null, 2));
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/functions/sphereTourRecapDelivery.js
+++ b/functions/sphereTourRecapDelivery.js
@@ -1,0 +1,287 @@
+/**
+ * Sphere 2026 inaugural tour recap → Firestore `commsInbox` delivery (#120).
+ *
+ * Aggregation mirrors `src/features/scoring/model/aggregateTourStandings.js` and
+ * `src/shared/utils/showAggregation.js` — keep copies aligned when scoring rules change.
+ *
+ * Editorial source: `content/comms/tours/sphere-2026-inaugural.md`
+ * Template ID / inbox doc id: `sphere-2026-inaugural`
+ */
+
+const SPHERE_2026_INAUGURAL_TEMPLATE_ID = "sphere-2026-inaugural";
+
+/** Doc id under `users/{uid}/commsInbox` — fixed for idempotent admin re-runs. */
+const COMMS_INBOX_DOC_ID = "sphere-2026-inaugural";
+
+/**
+ * Sphere Run dates — must stay in sync with `Sphere Run` under
+ * `src/shared/data/showDates.js` (`FALLBACK_SHOW_DATES_BY_TOUR`).
+ *
+ * @type {readonly string[]}
+ */
+const SPHERE_2026_INAUGURAL_SHOW_DATES = Object.freeze([
+  "2026-04-16",
+  "2026-04-17",
+  "2026-04-18",
+  "2026-04-23",
+  "2026-04-24",
+  "2026-04-25",
+  "2026-04-30",
+  "2026-05-01",
+  "2026-05-02",
+]);
+
+/**
+ * @param {unknown} picks
+ * @returns {boolean}
+ */
+function hasNonEmptyPicksObject(picks) {
+  if (picks == null || typeof picks !== "object" || Array.isArray(picks)) {
+    return false;
+  }
+  return Object.values(picks).some(
+    (v) => v != null && String(v).trim() !== ""
+  );
+}
+
+/**
+ * @param {Record<string, unknown> | null | undefined} pickData
+ * @returns {boolean}
+ */
+function pickCountsTowardSeason(pickData) {
+  if (!pickData || pickData.isGraded !== true) return false;
+  return hasNonEmptyPicksObject(pickData.picks);
+}
+
+/**
+ * @param {Iterable<Record<string, unknown>>} pickList
+ * @returns {{ max: number | null, winners: Record<string, unknown>[] }}
+ */
+function reduceShowWinners(pickList) {
+  let max = null;
+  /** @type {Record<string, unknown>[]} */
+  const eligible = [];
+  for (const row of pickList) {
+    if (!pickCountsTowardSeason(row)) continue;
+    eligible.push(row);
+    const score = typeof row.score === "number" ? row.score : 0;
+    if (max === null || score > max) max = score;
+  }
+  if (max === null || max <= 0) {
+    return { max: null, winners: [] };
+  }
+  const winners = eligible.filter(
+    (row) => (typeof row.score === "number" ? row.score : 0) === max
+  );
+  return { max, winners };
+}
+
+/**
+ * @typedef {{
+ *   uid: string,
+ *   handle: string,
+ *   totalPoints: number,
+ *   wins: number,
+ *   shows: number,
+ * }} TourStandingsRow
+ */
+
+/**
+ * @param {Array<{ date: string, picks: Array<Record<string, unknown>> }>} picksByDate
+ * @returns {TourStandingsRow[]}
+ */
+function aggregateTourStandings(picksByDate) {
+  /** @type {Map<string, TourStandingsRow>} */
+  const perUser = new Map();
+
+  for (const entry of picksByDate || []) {
+    const picks = Array.isArray(entry?.picks) ? entry.picks : [];
+    const { max, winners } = reduceShowWinners(picks);
+    const winnerUids = new Set(
+      winners.map((w) => String(w.userId || w.uid || "")).filter(Boolean)
+    );
+
+    for (const row of picks) {
+      if (!pickCountsTowardSeason(row)) continue;
+      const uid = String(row.userId || row.uid || "").trim();
+      if (!uid) continue;
+
+      const prev = perUser.get(uid);
+      const score = typeof row.score === "number" ? row.score : 0;
+      const handle =
+        typeof row.handle === "string" && row.handle.trim()
+          ? row.handle.trim()
+          : prev?.handle || "Anonymous";
+
+      const next = prev || {
+        uid,
+        handle,
+        totalPoints: 0,
+        wins: 0,
+        shows: 0,
+      };
+      next.handle = handle;
+      next.totalPoints += score;
+      next.shows += 1;
+      if (max != null && winnerUids.has(uid)) next.wins += 1;
+      perUser.set(uid, next);
+    }
+  }
+
+  return [...perUser.values()].sort((a, b) => {
+    if (b.totalPoints !== a.totalPoints) return b.totalPoints - a.totalPoints;
+    if (b.wins !== a.wins) return b.wins - a.wins;
+    return a.handle.localeCompare(b.handle);
+  });
+}
+
+const MAX_FIRESTORE_BATCH = 500;
+
+/**
+ * @param {import('firebase-admin').firestore.Firestore} db
+ * @returns {Promise<Array<{ date: string, picks: Record<string, unknown>[] }>>}
+ */
+async function loadPicksByDateForSphereTour(db) {
+  const snap = await db
+    .collection("picks")
+    .where("showDate", "in", [...SPHERE_2026_INAUGURAL_SHOW_DATES])
+    .get();
+
+  /** @type {Map<string, Record<string, unknown>[]>} */
+  const byDate = new Map();
+  for (const d of SPHERE_2026_INAUGURAL_SHOW_DATES) {
+    byDate.set(d, []);
+  }
+
+  for (const doc of snap.docs) {
+    const data = doc.data() || {};
+    const sd =
+      typeof data.showDate === "string" ? data.showDate.trim() : "";
+    if (!byDate.has(sd)) continue;
+    byDate.get(sd).push({ id: doc.id, ...data });
+  }
+
+  return SPHERE_2026_INAUGURAL_SHOW_DATES.map((date) => ({
+    date,
+    picks: byDate.get(date) || [],
+  }));
+}
+
+/**
+ * @param {{
+ *   db: import('firebase-admin').firestore.Firestore,
+ *   admin: typeof import('firebase-admin'),
+ *   dryRun: boolean,
+ *   logger?: { info?: Function, warn?: Function },
+ * }} params
+ */
+async function deliverSphere2026TourRecapInbox({ db, admin, dryRun, logger }) {
+  const picksByDate = await loadPicksByDateForSphereTour(db);
+  const leaders = aggregateTourStandings(picksByDate);
+  const participantCount = leaders.length;
+
+  /** @type {{ uid: string, rank: number, handle: string, payload: Record<string, number> }[]} */
+  const preview = [];
+
+  for (let i = 0; i < leaders.length; i++) {
+    const row = leaders[i];
+    const rank = i + 1;
+    const payload = {
+      rank,
+      points: row.totalPoints,
+      wins: row.wins,
+      showsPlayed: row.shows,
+      participantCount,
+    };
+    preview.push({
+      uid: row.uid,
+      rank,
+      handle: row.handle,
+      payload,
+    });
+  }
+
+  if (leaders.length === 0) {
+    return {
+      ok: true,
+      dryRun,
+      templateId: SPHERE_2026_INAUGURAL_TEMPLATE_ID,
+      inboxDocId: COMMS_INBOX_DOC_ID,
+      showDates: [...SPHERE_2026_INAUGURAL_SHOW_DATES],
+      participantCount: 0,
+      delivered: 0,
+      preview: [],
+      message:
+        "No eligible players — no graded, non-empty picks on Sphere inaugural dates.",
+    };
+  }
+
+  if (dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      templateId: SPHERE_2026_INAUGURAL_TEMPLATE_ID,
+      inboxDocId: COMMS_INBOX_DOC_ID,
+      showDates: [...SPHERE_2026_INAUGURAL_SHOW_DATES],
+      participantCount,
+      delivered: 0,
+      preview,
+    };
+  }
+
+  let batch = db.batch();
+  let opCount = 0;
+  let delivered = 0;
+
+  for (const item of preview) {
+    if (opCount >= MAX_FIRESTORE_BATCH) {
+      await batch.commit();
+      batch = db.batch();
+      opCount = 0;
+    }
+    const ref = db
+      .collection("users")
+      .doc(item.uid)
+      .collection("commsInbox")
+      .doc(COMMS_INBOX_DOC_ID);
+    batch.set(
+      ref,
+      {
+        templateId: SPHERE_2026_INAUGURAL_TEMPLATE_ID,
+        payload: item.payload,
+        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+    opCount += 1;
+    delivered += 1;
+  }
+
+  if (opCount > 0) {
+    await batch.commit();
+  }
+
+  logger?.info?.("deliverSphere2026TourRecapInbox: wrote inbox rows", {
+    delivered,
+    participantCount,
+  });
+
+  return {
+    ok: true,
+    dryRun: false,
+    templateId: SPHERE_2026_INAUGURAL_TEMPLATE_ID,
+    inboxDocId: COMMS_INBOX_DOC_ID,
+    showDates: [...SPHERE_2026_INAUGURAL_SHOW_DATES],
+    participantCount,
+    delivered,
+    preview: preview.slice(0, 50),
+  };
+}
+
+module.exports = {
+  SPHERE_2026_INAUGURAL_SHOW_DATES,
+  SPHERE_2026_INAUGURAL_TEMPLATE_ID,
+  COMMS_INBOX_DOC_ID,
+  aggregateTourStandings,
+  deliverSphere2026TourRecapInbox,
+};

--- a/functions/sphereTourRecapDelivery.test.js
+++ b/functions/sphereTourRecapDelivery.test.js
@@ -1,0 +1,75 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { aggregateTourStandings } = require("./sphereTourRecapDelivery");
+
+test("aggregateTourStandings: sums points, wins, shows like tour leaderboard", () => {
+  const picksByDate = [
+    {
+      date: "2026-04-16",
+      picks: [
+        {
+          userId: "a",
+          handle: "Alice",
+          isGraded: true,
+          picks: { opener: "Tweezer" },
+          score: 10,
+        },
+        {
+          userId: "b",
+          handle: "Bob",
+          isGraded: true,
+          picks: { opener: "Reba" },
+          score: 8,
+        },
+      ],
+    },
+    {
+      date: "2026-04-17",
+      picks: [
+        {
+          userId: "a",
+          handle: "Alice",
+          isGraded: true,
+          picks: { opener: "YEM" },
+          score: 5,
+        },
+        {
+          userId: "b",
+          handle: "Bob",
+          isGraded: true,
+          picks: { opener: "Mike's" },
+          score: 12,
+        },
+      ],
+    },
+  ];
+
+  const rows = aggregateTourStandings(picksByDate);
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].uid, "b");
+  assert.equal(rows[0].totalPoints, 20);
+  assert.equal(rows[0].wins, 1);
+  assert.equal(rows[0].shows, 2);
+  assert.equal(rows[1].uid, "a");
+  assert.equal(rows[1].totalPoints, 15);
+  assert.equal(rows[1].wins, 1);
+  assert.equal(rows[1].shows, 2);
+});
+
+test("aggregateTourStandings: skips ungraded picks", () => {
+  const rows = aggregateTourStandings([
+    {
+      date: "2026-04-16",
+      picks: [
+        {
+          userId: "a",
+          handle: "A",
+          isGraded: false,
+          picks: { opener: "X" },
+          score: 99,
+        },
+      ],
+    },
+  ]);
+  assert.equal(rows.length, 0);
+});

--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -49,6 +49,10 @@ import {
 import { PastShowLockBanner, TooEarlyBanner } from '../../features/picks';
 import { DashboardInstallEngageBanner } from '../../features/install';
 
+import {
+  CommsInboxProvider,
+  DashboardNotificationsBell,
+} from '../../features/notifications';
 import { persistDashboardPath } from '../../shared/lib/dashboardLastPath';
 import {
   BRAND_APP_CHROME_MARK_SRC,
@@ -123,6 +127,7 @@ export default function DashboardLayout() {
 
   return (
     <ScoringRulesModalProvider>
+    <CommsInboxProvider userId={user?.uid}>
     <div className="flex h-[100dvh] min-h-0 w-full bg-transparent text-white overflow-hidden md:h-screen">
       
       {/* DESKTOP SIDEBAR */}
@@ -146,6 +151,9 @@ export default function DashboardLayout() {
               </span>
             </Link>
           </h1>
+        </div>
+        <div className="mb-3 flex justify-end px-1">
+          <DashboardNotificationsBell />
         </div>
         <div className="flex flex-col gap-2 flex-1">
           {navItems.map((item) => {
@@ -328,6 +336,7 @@ export default function DashboardLayout() {
       </nav>
 
     </div>
+    </CommsInboxProvider>
     </ScoringRulesModalProvider>
   );
 }

--- a/src/app/layout/ui/DashboardMobileBrandBar.jsx
+++ b/src/app/layout/ui/DashboardMobileBrandBar.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
+import { DashboardNotificationsBell } from '../../../features/notifications';
+
 import {
   BRAND_APP_CHROME_MARK_SRC,
   brandAppChromeMarkImgClassNames,
@@ -31,8 +33,11 @@ export default function DashboardMobileBrandBar({ user }) {
           </Link>
         </h1>
 
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center self-center rounded-full border border-border-subtle/35 bg-surface-panel-strong text-xs">
-          {user?.email?.charAt(0).toUpperCase() || '👤'}
+        <div className="flex shrink-0 items-center gap-2">
+          <DashboardNotificationsBell />
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center self-center rounded-full border border-border-subtle/35 bg-surface-panel-strong text-xs">
+            {user?.email?.charAt(0).toUpperCase() || '👤'}
+          </div>
         </div>
       </BrandWordmarkBarRow>
     </div>

--- a/src/features/admin/api/sphereTourRecapDeliveryApi.js
+++ b/src/features/admin/api/sphereTourRecapDeliveryApi.js
@@ -1,0 +1,19 @@
+import { getFunctions, httpsCallable } from 'firebase/functions';
+import { app } from '../../../shared/lib/firebase';
+
+const FUNCTIONS_REGION = 'us-central1';
+
+/**
+ * Admin-only callable: Sphere ’26 inaugural recap → user `commsInbox` docs (#120).
+ *
+ * Server aggregates picks across fixed Sphere Run dates (same math as tour standings).
+ *
+ * @param {{ dryRun?: boolean }} data  Omit or `true` = no writes; pass `dryRun: false` to deliver.
+ * @returns {Promise<Record<string, unknown>>}
+ */
+export async function deliverSphere2026TourRecapInbox(data = {}) {
+  const functions = getFunctions(app, FUNCTIONS_REGION);
+  const callable = httpsCallable(functions, 'deliverSphere2026TourRecapInbox');
+  const result = await callable(data);
+  return result.data;
+}

--- a/src/features/admin/ui/AdminForm.jsx
+++ b/src/features/admin/ui/AdminForm.jsx
@@ -15,6 +15,7 @@ import AdminFinalizeAndSave from './AdminFinalizeAndSave';
 import AdminWarRoomShowDate from './AdminWarRoomShowDate';
 import AdminClaimBootstrap from './AdminClaimBootstrap';
 import { AdminTourRecapPreview } from '../../tour-recap';
+import AdminSphereTourRecapDelivery from './AdminSphereTourRecapDelivery';
 import ConfirmationModal from '../../../shared/ui/ConfirmationModal/ConfirmationModal';
 
 function normalizeDashboardShowDate(value) {
@@ -168,6 +169,12 @@ export default function AdminForm({ user, selectedDate }) {
               onOpenChange={setTourRecapPreviewOpen}
             >
               <AdminTourRecapPreview />
+              <div className="mt-6 border-t border-border-muted pt-6">
+                <p className="mb-3 text-xs font-bold uppercase tracking-widest text-content-secondary">
+                  Deliver recap to user inboxes
+                </p>
+                <AdminSphereTourRecapDelivery />
+              </div>
             </AdminActionToggle>
           </div>
         </div>

--- a/src/features/admin/ui/AdminSphereTourRecapDelivery.jsx
+++ b/src/features/admin/ui/AdminSphereTourRecapDelivery.jsx
@@ -1,0 +1,133 @@
+import React, { useCallback, useState } from 'react';
+
+import { deliverSphere2026TourRecapInbox } from '../api/sphereTourRecapDeliveryApi';
+import ConfirmationModal from '../../../shared/ui/ConfirmationModal/ConfirmationModal';
+
+/**
+ * War Room: dry-run / execute Sphere ’26 recap inbox delivery (#120).
+ * Requires admin claim; callable reads `picks` for Sphere Run dates server-side.
+ */
+export default function AdminSphereTourRecapDelivery() {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [lastResult, setLastResult] = useState(/** @type {Record<string, unknown> | null} */ (null));
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const runDryRun = useCallback(async () => {
+    setError('');
+    setBusy(true);
+    setLastResult(null);
+    try {
+      const data = await deliverSphere2026TourRecapInbox({ dryRun: true });
+      setLastResult(data && typeof data === 'object' ? data : {});
+    } catch (e) {
+      setError(e?.message || 'Dry run failed.');
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const runDeliver = useCallback(async () => {
+    setError('');
+    setBusy(true);
+    try {
+      const data = await deliverSphere2026TourRecapInbox({ dryRun: false });
+      setLastResult(data && typeof data === 'object' ? data : {});
+    } catch (e) {
+      setError(e?.message || 'Delivery failed.');
+    } finally {
+      setBusy(false);
+      setConfirmOpen(false);
+    }
+  }, []);
+
+  const previewRows = Array.isArray(lastResult?.preview) ? lastResult.preview : [];
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm font-bold leading-relaxed text-content-secondary">
+        Computes tour totals from graded picks on all nine Sphere inaugural dates (same rules as
+        Tour standings), then writes{' '}
+        <code className="rounded bg-surface-inset px-1 font-mono text-xs text-white">
+          users/&lt;uid&gt;/commsInbox/sphere-2026-inaugural
+        </code>{' '}
+        for each eligible player. Run <strong>Dry run</strong> first — default callable mode is
+        dry-run only; execute requires <code className="font-mono text-xs">dryRun: false</code>.
+      </p>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={runDryRun}
+          className="rounded-lg border border-border-muted bg-surface-inset px-4 py-2 text-xs font-black uppercase tracking-widest text-white transition-colors hover:border-brand-primary/50 disabled:opacity-50"
+        >
+          {busy ? 'Working…' : 'Dry run'}
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => {
+            setError('');
+            setConfirmOpen(true);
+          }}
+          className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-2 text-xs font-black uppercase tracking-widest text-amber-100 transition-colors hover:border-amber-400 disabled:opacity-50"
+        >
+          Deliver to inboxes
+        </button>
+      </div>
+      {error ? <p className="text-sm font-bold text-amber-300">{error}</p> : null}
+      {lastResult && typeof lastResult.participantCount === 'number' ? (
+        <div className="rounded-xl border border-border-muted/60 bg-surface-inset/40 px-4 py-3 text-sm font-bold text-content-secondary">
+          <p className="text-white">
+            Participants (eligible):{' '}
+            <span className="text-brand-primary">{lastResult.participantCount}</span>
+            {typeof lastResult.delivered === 'number' ? (
+              <>
+                {' '}
+                · Rows written:{' '}
+                <span className="text-brand-primary">{lastResult.delivered}</span>
+              </>
+            ) : null}
+            {lastResult.dryRun ? (
+              <span className="ml-2 text-xs font-black uppercase tracking-wider text-amber-200">
+                (dry run — no writes)
+              </span>
+            ) : null}
+          </p>
+          {typeof lastResult.message === 'string' && lastResult.message ? (
+            <p className="mt-2 text-xs text-amber-200">{lastResult.message}</p>
+          ) : null}
+          {previewRows.length > 0 ? (
+            <ul className="mt-3 max-h-48 list-inside list-disc space-y-1 overflow-y-auto text-xs font-bold">
+              {previewRows.slice(0, 15).map((row) => (
+                <li key={row.uid}>
+                  #{row.rank} {row.handle || row.uid}{' '}
+                  <span className="text-content-secondary">
+                    pts {row.payload?.points}, wins {row.payload?.wins}, shows{' '}
+                    {row.payload?.showsPlayed}
+                  </span>
+                </li>
+              ))}
+              {previewRows.length > 15 ? (
+                <li className="list-none text-content-secondary">
+                  …and {previewRows.length - 15} more
+                </li>
+              ) : null}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+
+      <ConfirmationModal
+        open={confirmOpen}
+        title="Deliver Sphere ’26 recap to all inboxes?"
+        message="This writes (or merges) one Firestore row per eligible player under their commsInbox. Re-running overwrites the same doc id. Run a dry run first to verify counts."
+        confirmLabel="Deliver now"
+        confirmVariant="danger"
+        busy={busy}
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={runDeliver}
+      />
+    </div>
+  );
+}

--- a/src/features/notifications/api/commsInboxApi.js
+++ b/src/features/notifications/api/commsInboxApi.js
@@ -9,6 +9,7 @@ import {
 } from 'firebase/firestore';
 
 import { db } from '../../../shared/lib/firebase';
+import { whenFirebaseReady } from '../../../shared/lib/firebaseAppCheck';
 
 /** @typedef {import('firebase/firestore').Timestamp} FirestoreTimestamp */
 
@@ -49,27 +50,42 @@ export const COMMS_INBOX_COLLECTION_ID = 'commsInbox';
  * @returns {() => void} unsubscribe
  */
 export function subscribeCommsInbox(uid, onNext, onError) {
-  const q = query(
-    collection(db, 'users', uid, COMMS_INBOX_COLLECTION_ID),
-    orderBy('createdAt', 'desc'),
-  );
-  return onSnapshot(
-    q,
-    (snap) => {
-      const list = snap.docs.map((d) => {
-        const data = d.data();
-        return {
-          id: d.id,
-          templateId: typeof data.templateId === 'string' ? data.templateId : '',
-          payload: data.payload && typeof data.payload === 'object' ? data.payload : {},
-          createdAt: data.createdAt,
-          readAt: data.readAt,
-        };
-      });
-      onNext(list);
-    },
-    onError,
-  );
+  let innerUnsub = () => {};
+  let cancelled = false;
+
+  whenFirebaseReady().then(() => {
+    if (cancelled) return;
+    const q = query(
+      collection(db, 'users', uid, COMMS_INBOX_COLLECTION_ID),
+      orderBy('createdAt', 'desc'),
+    );
+    innerUnsub = onSnapshot(
+      q,
+      (snap) => {
+        const list = snap.docs.map((d) => {
+          const data = d.data();
+          return {
+            id: d.id,
+            templateId: typeof data.templateId === 'string' ? data.templateId : '',
+            payload: data.payload && typeof data.payload === 'object' ? data.payload : {},
+            createdAt: data.createdAt,
+            readAt: data.readAt,
+          };
+        });
+        onNext(list);
+      },
+      (err) => {
+        if (onError) {
+          onError(err instanceof Error ? err : new Error(String(err)));
+        }
+      },
+    );
+  });
+
+  return () => {
+    cancelled = true;
+    innerUnsub();
+  };
 }
 
 /**
@@ -77,6 +93,7 @@ export function subscribeCommsInbox(uid, onNext, onError) {
  * @param {string} messageId
  */
 export async function markCommsInboxMessageRead(uid, messageId) {
+  await whenFirebaseReady();
   await updateDoc(doc(db, 'users', uid, COMMS_INBOX_COLLECTION_ID, messageId), {
     readAt: serverTimestamp(),
   });

--- a/src/features/notifications/api/commsInboxApi.js
+++ b/src/features/notifications/api/commsInboxApi.js
@@ -1,0 +1,83 @@
+import {
+  collection,
+  doc,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
+  updateDoc,
+} from 'firebase/firestore';
+
+import { db } from '../../../shared/lib/firebase';
+
+/** @typedef {import('firebase/firestore').Timestamp} FirestoreTimestamp */
+
+/**
+ * Per-user editorial / recap messages (in-app inbox). Written by Admin SDK /
+ * Cloud Functions; clients read and may set `readAt` only.
+ *
+ * Doc shape:
+ * - `templateId` — registry key (e.g. `sphere-2026-inaugural`)
+ * - `payload` — variables for the template renderer (numbers coerced in UI)
+ * - `createdAt` — server write time
+ * - `readAt` — optional; set when the user acknowledges the message
+ */
+export const COMMS_INBOX_COLLECTION_ID = 'commsInbox';
+
+/**
+ * @typedef {object} CommsInboxPayloadSphere2026
+ * @property {number} rank
+ * @property {number} points
+ * @property {number} wins
+ * @property {number} showsPlayed
+ * @property {number} [participantCount]
+ */
+
+/**
+ * @typedef {object} CommsInboxMessage
+ * @property {string} id
+ * @property {string} templateId
+ * @property {Record<string, unknown>} payload
+ * @property {FirestoreTimestamp | null | undefined} createdAt
+ * @property {FirestoreTimestamp | null | undefined} readAt
+ */
+
+/**
+ * @param {string} uid
+ * @param {(messages: CommsInboxMessage[]) => void} onNext
+ * @param {(err: Error) => void} [onError]
+ * @returns {() => void} unsubscribe
+ */
+export function subscribeCommsInbox(uid, onNext, onError) {
+  const q = query(
+    collection(db, 'users', uid, COMMS_INBOX_COLLECTION_ID),
+    orderBy('createdAt', 'desc'),
+  );
+  return onSnapshot(
+    q,
+    (snap) => {
+      const list = snap.docs.map((d) => {
+        const data = d.data();
+        return {
+          id: d.id,
+          templateId: typeof data.templateId === 'string' ? data.templateId : '',
+          payload: data.payload && typeof data.payload === 'object' ? data.payload : {},
+          createdAt: data.createdAt,
+          readAt: data.readAt,
+        };
+      });
+      onNext(list);
+    },
+    onError,
+  );
+}
+
+/**
+ * @param {string} uid
+ * @param {string} messageId
+ */
+export async function markCommsInboxMessageRead(uid, messageId) {
+  await updateDoc(doc(db, 'users', uid, COMMS_INBOX_COLLECTION_ID, messageId), {
+    readAt: serverTimestamp(),
+  });
+}

--- a/src/features/notifications/index.js
+++ b/src/features/notifications/index.js
@@ -1,4 +1,6 @@
 export { default as NotificationsPrototypeScreen } from './ui/NotificationsPrototypeScreen.jsx';
+export { CommsInboxProvider, useCommsInbox } from './model/commsInboxContext.jsx';
+export { default as DashboardNotificationsBell } from './ui/DashboardNotificationsBell.jsx';
 export {
   DEFAULT_NOTIFICATION_PREFS,
   mergeNotificationPrefs,

--- a/src/features/notifications/model/commsInboxContext.jsx
+++ b/src/features/notifications/model/commsInboxContext.jsx
@@ -1,0 +1,82 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+import {
+  markCommsInboxMessageRead,
+  subscribeCommsInbox,
+} from '../api/commsInboxApi.js';
+
+const CommsInboxContext = createContext(null);
+
+/**
+ * @typedef {import('../api/commsInboxApi.js').CommsInboxMessage} CommsInboxMessage
+ */
+
+/**
+ * @param {{ userId: string | undefined, children: React.ReactNode }} props
+ */
+export function CommsInboxProvider({ userId, children }) {
+  const [messages, setMessages] = useState(/** @type {CommsInboxMessage[]} */ ([]));
+  const [error, setError] = useState(/** @type {string | null} */ (null));
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!userId) {
+      setMessages([]);
+      setError(null);
+      setReady(true);
+      return undefined;
+    }
+
+    setReady(false);
+    setError(null);
+
+    const unsub = subscribeCommsInbox(
+      userId,
+      (list) => {
+        setMessages(list);
+        setReady(true);
+      },
+      (err) => {
+        console.error('commsInbox subscribe', err);
+        setError(err?.message || 'Could not load messages.');
+        setReady(true);
+      },
+    );
+
+    return () => unsub();
+  }, [userId]);
+
+  const unreadCount = useMemo(
+    () => messages.filter((m) => m.readAt == null).length,
+    [messages],
+  );
+
+  const markRead = useCallback(
+    async (messageId) => {
+      if (!userId) return;
+      await markCommsInboxMessageRead(userId, messageId);
+    },
+    [userId],
+  );
+
+  const value = useMemo(
+    () => ({
+      messages,
+      unreadCount,
+      error,
+      ready,
+      markRead,
+    }),
+    [messages, unreadCount, error, ready, markRead],
+  );
+
+  return <CommsInboxContext.Provider value={value}>{children}</CommsInboxContext.Provider>;
+}
+
+export function useCommsInbox() {
+  const ctx = useContext(CommsInboxContext);
+  if (!ctx) {
+    throw new Error('useCommsInbox must be used within CommsInboxProvider');
+  }
+  return ctx;
+}

--- a/src/features/notifications/ui/CommsInboxSection.jsx
+++ b/src/features/notifications/ui/CommsInboxSection.jsx
@@ -1,0 +1,143 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { ChevronDown, Inbox } from 'lucide-react';
+
+import { useCommsInbox } from '../model/commsInboxContext.jsx';
+import CommsRecapMessageBody from './CommsRecapMessageBody.jsx';
+
+function formatDeliveredAt(createdAt) {
+  if (!createdAt?.toDate) return '';
+  try {
+    return createdAt.toDate().toLocaleString(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    });
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * In-app inbox for editorial messages (tour recaps, etc.). Preference toggles live below.
+ */
+export default function CommsInboxSection() {
+  const { messages, unreadCount, error, ready, markRead } = useCommsInbox();
+  const [openId, setOpenId] = useState(/** @type {string | null} */ (null));
+
+  useEffect(() => {
+    if (!openId) return;
+    const stillExists = messages.some((m) => m.id === openId);
+    if (!stillExists) setOpenId(null);
+  }, [messages, openId]);
+
+  const handleToggle = useCallback(
+    async (id, nextOpen) => {
+      setOpenId(nextOpen ? id : null);
+      if (nextOpen) {
+        const row = messages.find((m) => m.id === id);
+        if (row && row.readAt == null) {
+          try {
+            await markRead(id);
+          } catch (e) {
+            console.error('markRead', e);
+          }
+        }
+      }
+    },
+    [messages, markRead],
+  );
+
+  return (
+    <section className="mb-10" aria-labelledby="comms-inbox-heading">
+      <div className="mb-4 text-left">
+        <h3
+          id="comms-inbox-heading"
+          className="font-display text-lg font-bold uppercase tracking-tight text-white"
+        >
+          Messages
+        </h3>
+        <p className="mt-2 text-sm font-bold leading-relaxed text-content-secondary">
+          Tour recaps and announcements land here first — variable copy matches your stats when we
+          deliver to your inbox.
+          {unreadCount > 0 ? (
+            <span className="ml-1 font-black text-brand-primary">
+              ({unreadCount} unread)
+            </span>
+          ) : null}
+        </p>
+      </div>
+
+      {!ready ? (
+        <p className="text-sm font-bold text-content-secondary">Loading messages…</p>
+      ) : error ? (
+        <p className="text-sm font-bold text-amber-300">{error}</p>
+      ) : messages.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 rounded-3xl border border-border-subtle bg-surface-panel/60 px-6 py-10 text-center shadow-inset-glass">
+          <Inbox className="h-10 w-10 text-content-secondary" aria-hidden />
+          <p className="max-w-sm text-sm font-bold leading-relaxed text-content-secondary">
+            No messages yet. When we publish a recap or announcement for your account, it will show up
+            here — check back after tour wrap-ups or watch for the notifications bell.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {messages.map((m) => {
+            const isOpen = openId === m.id;
+            const unread = m.readAt == null;
+            const delivered = formatDeliveredAt(m.createdAt);
+            const headerId = `comms-msg-${m.id}-hdr`;
+            const panelId = `comms-msg-${m.id}-panel`;
+
+            return (
+              <li
+                key={m.id}
+                className="overflow-hidden rounded-3xl border border-border-subtle bg-surface-panel shadow-inset-glass"
+              >
+                <button
+                  type="button"
+                  id={headerId}
+                  aria-expanded={isOpen}
+                  aria-controls={panelId}
+                  onClick={() => handleToggle(m.id, !isOpen)}
+                  className="flex w-full items-start gap-3 px-5 py-4 text-left transition-colors hover:bg-white/[0.04] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface-panel"
+                >
+                  <span className="flex min-w-0 flex-1 flex-col gap-1">
+                    <span className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-black uppercase tracking-widest text-content-secondary">
+                        Message
+                      </span>
+                      {unread ? (
+                        <span className="rounded-full bg-brand-primary/20 px-2 py-0.5 text-[10px] font-black uppercase tracking-wider text-brand-primary">
+                          New
+                        </span>
+                      ) : null}
+                    </span>
+                    <span className="text-xs font-bold text-content-secondary">
+                      Template: {m.templateId || '—'}
+                      {delivered ? ` · ${delivered}` : ''}
+                    </span>
+                  </span>
+                  <ChevronDown
+                    className={`mt-0.5 h-5 w-5 shrink-0 text-content-secondary transition-transform duration-200 ${
+                      isOpen ? 'rotate-180' : ''
+                    }`}
+                    aria-hidden
+                  />
+                </button>
+                {isOpen ? (
+                  <div
+                    id={panelId}
+                    role="region"
+                    aria-labelledby={headerId}
+                    className="border-t border-border-muted/80 px-5 pb-6 pt-4"
+                  >
+                    <CommsRecapMessageBody templateId={m.templateId} payload={m.payload} />
+                  </div>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/features/notifications/ui/CommsRecapMessageBody.jsx
+++ b/src/features/notifications/ui/CommsRecapMessageBody.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import {
+  SPHERE_2026_RECAP_ID,
+  Sphere2026TourRecapInApp,
+} from '../../tour-recap';
+
+function coerceNumber(v, fallback = 0) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * Maps persisted inbox payload → recap UI by registry template id.
+ *
+ * @param {{ templateId: string, payload: Record<string, unknown> }} props
+ */
+export default function CommsRecapMessageBody({ templateId, payload }) {
+  if (templateId === SPHERE_2026_RECAP_ID) {
+    const rank = coerceNumber(payload.rank);
+    const points = coerceNumber(payload.points);
+    const wins = coerceNumber(payload.wins);
+    const showsPlayed = coerceNumber(payload.showsPlayed);
+    const participantCount =
+      payload.participantCount != null ? coerceNumber(payload.participantCount) : undefined;
+
+    return (
+      <Sphere2026TourRecapInApp
+        rank={rank}
+        points={points}
+        wins={wins}
+        showsPlayed={showsPlayed}
+        {...(participantCount !== undefined ? { participantCount } : {})}
+      />
+    );
+  }
+
+  return (
+    <p className="text-sm font-bold text-amber-200">
+      This message uses an unsupported template ({templateId}). Contact support if it persists.
+    </p>
+  );
+}

--- a/src/features/notifications/ui/DashboardNotificationsBell.jsx
+++ b/src/features/notifications/ui/DashboardNotificationsBell.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Bell } from 'lucide-react';
+
+import { useCommsInbox } from '../model/commsInboxContext.jsx';
+
+/**
+ * Header/sidebar affordance for `/dashboard/notifications` with unread badge.
+ */
+export default function DashboardNotificationsBell() {
+  const { unreadCount, ready } = useCommsInbox();
+
+  const label =
+    unreadCount > 0
+      ? `Notifications — ${unreadCount} unread`
+      : 'Notifications';
+
+  return (
+    <Link
+      to="/dashboard/notifications"
+      className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-border-subtle/60 bg-surface-panel-strong text-content-secondary transition-colors hover:border-brand-primary/40 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary"
+      aria-label={label}
+    >
+      <Bell className="h-5 w-5" aria-hidden />
+      {ready && unreadCount > 0 ? (
+        <span className="absolute -right-0.5 -top-0.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-brand-primary px-1 text-[10px] font-black leading-none text-[rgb(var(--brand-bg-deep))]">
+          {unreadCount > 9 ? '9+' : unreadCount}
+        </span>
+      ) : null}
+    </Link>
+  );
+}

--- a/src/features/notifications/ui/NotificationsPrototypeScreen.jsx
+++ b/src/features/notifications/ui/NotificationsPrototypeScreen.jsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { Bell, ChevronDown, Mail, Smartphone } from 'lucide-react';
 
 import { dashboardPageTitleGradientClasses } from '../../../shared/config/dashboardHeadingTypography';
+import CommsInboxSection from './CommsInboxSection.jsx';
 import { useNotificationPrefs } from '../model/useNotificationPrefs';
 import { usePushTokenRegistration } from '../model/usePushTokenRegistration';
 
@@ -154,11 +155,17 @@ export default function NotificationsPrototypeScreen() {
           Notifications
         </h2>
         <p className="mt-2 text-sm font-bold leading-relaxed text-content-secondary md:mt-3">
-          Choose how we reach you about shows, scores, and recaps.
+          Read messages below, then choose how we reach you about shows, scores, and recaps.
         </p>
       </div>
 
-      <ul className="mt-8 space-y-3">
+      <CommsInboxSection />
+
+      <p className="mb-3 mt-10 text-xs font-black uppercase tracking-widest text-content-secondary">
+        Preferences
+      </p>
+
+      <ul className="mt-3 space-y-3">
         <NotificationAccordionSection
           sectionId="notif-push"
           title="Push notifications"


### PR DESCRIPTION
Refs #120
Related #272

## Summary

This PR ships an **in-app comms inbox** at `users/{uid}/commsInbox` with Security Rules (read own docs; server-only creates; owners may set `readAt`), **dashboard bell + unread badge**, **Messages** section on `/dashboard/notifications`, and variable recap rendering for **`sphere-2026-inaugural`** via existing tour-recap UI.

It adds **manual Sphere tour recap delivery**: Cloud Function **`deliverSphere2026TourRecapInbox`** (defaults to **dry run**), War Room controls under Tour recap copy, and optional CLI `functions/scripts/deliverSphere2026TourRecapInbox.js`. Aggregation matches **Tour standings** math over the nine Sphere Run dates (`functions/sphereTourRecapDelivery.js`).

**Docs:** `content/comms/README.md` (phased orchestration, manual QA), **`sphere-2026-inaugural.md`** metadata row.

**Fix:** Inbox Firestore listener waits for **`whenFirebaseReady()`** so App Check does not race on localhost / enforced environments.

## Test plan

- [ ] `npm run lint`, `npm test`, `npm run verify:dashboard-meta`, `npm run verify:dashboard-ui`
- [ ] `cd functions && npm test`
- [ ] `npm run test:rules`
- [ ] Deploy **Firestore rules** + **functions** to staging; verify Messages loads without permission errors (staging browser).
- [ ] War Room: **Dry run** recap delivery → counts match Tour standings; **Deliver** (if desired) → inbox rows + bell UX.
- [ ] Confirm inbox `readAt` updates when expanding a message.

Staging verification by PR author / reviewer in browser (agents cannot fully verify Vercel/auth flows).


Made with [Cursor](https://cursor.com)