### PR TITLE
feat(notifications): collapsible messages container + new-message indicators

### DIFF
--- a/src/features/notifications/ui/CommsInboxSection.jsx
+++ b/src/features/notifications/ui/CommsInboxSection.jsx
@@ -22,6 +22,7 @@ function formatDeliveredAt(createdAt) {
 export default function CommsInboxSection() {
   const { messages, unreadCount, error, ready, markRead } = useCommsInbox();
   const [openId, setOpenId] = useState(/** @type {string | null} */ (null));
+  const [isSectionOpen, setIsSectionOpen] = useState(true);
 
   useEffect(() => {
     if (!openId) return;
@@ -46,98 +47,151 @@ export default function CommsInboxSection() {
     [messages, markRead],
   );
 
+  const handleDismiss = useCallback(
+    async (id) => {
+      const row = messages.find((m) => m.id === id);
+      if (row && row.readAt == null) {
+        try {
+          await markRead(id);
+        } catch (e) {
+          console.error('dismiss message', e);
+        }
+      }
+      setOpenId((prev) => (prev === id ? null : prev));
+    },
+    [messages, markRead],
+  );
+
   return (
-    <section className="mb-10" aria-labelledby="comms-inbox-heading">
-      <div className="mb-4 text-left">
-        <h3
-          id="comms-inbox-heading"
-          className="font-display text-lg font-bold uppercase tracking-tight text-white"
-        >
-          Messages
-        </h3>
-        <p className="mt-2 text-sm font-bold leading-relaxed text-content-secondary">
-          Tour recaps and announcements land here first — variable copy matches your stats when we
-          deliver to your inbox.
-          {unreadCount > 0 ? (
-            <span className="ml-1 font-black text-brand-primary">
-              ({unreadCount} unread)
-            </span>
-          ) : null}
-        </p>
-      </div>
+    <section
+      className="mb-10 rounded-3xl border border-border-subtle bg-surface-panel/60 p-5 shadow-inset-glass"
+      aria-labelledby="comms-inbox-heading"
+    >
+      <button
+        type="button"
+        onClick={() => setIsSectionOpen((prev) => !prev)}
+        aria-expanded={isSectionOpen}
+        aria-controls="comms-inbox-panel"
+        className="flex w-full items-start gap-3 text-left transition-colors hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary"
+      >
+        <span className="min-w-0 flex-1">
+          <span
+            id="comms-inbox-heading"
+            className="font-display text-lg font-bold uppercase tracking-tight text-white"
+          >
+            Messages
+          </span>
+          <span className="mt-2 block text-sm font-bold leading-relaxed text-content-secondary">
+            Actionable updates land here first, including score changes, nightly recaps, and key
+            announcements for your picks.
+            {unreadCount > 0 ? (
+              <span className="ml-2 inline-flex items-center gap-1 rounded-full border border-brand-primary/40 bg-brand-primary/10 px-2 py-0.5 text-[10px] font-black uppercase tracking-wider text-brand-primary">
+                <span className="h-1.5 w-1.5 rounded-full bg-brand-primary" aria-hidden />
+                New message waiting
+              </span>
+            ) : null}
+          </span>
+        </span>
+        <ChevronDown
+          className={`mt-0.5 h-5 w-5 shrink-0 text-content-secondary transition-transform duration-200 ${
+            isSectionOpen ? 'rotate-180' : ''
+          }`}
+          aria-hidden
+        />
+      </button>
 
-      {!ready ? (
-        <p className="text-sm font-bold text-content-secondary">Loading messages…</p>
-      ) : error ? (
-        <p className="text-sm font-bold text-amber-300">{error}</p>
-      ) : messages.length === 0 ? (
-        <div className="flex flex-col items-center gap-3 rounded-3xl border border-border-subtle bg-surface-panel/60 px-6 py-10 text-center shadow-inset-glass">
-          <Inbox className="h-10 w-10 text-content-secondary" aria-hidden />
-          <p className="max-w-sm text-sm font-bold leading-relaxed text-content-secondary">
-            No messages yet. When we publish a recap or announcement for your account, it will show up
-            here — check back after tour wrap-ups or watch for the notifications bell.
-          </p>
-        </div>
-      ) : (
-        <ul className="space-y-3">
-          {messages.map((m) => {
-            const isOpen = openId === m.id;
-            const unread = m.readAt == null;
-            const delivered = formatDeliveredAt(m.createdAt);
-            const headerId = `comms-msg-${m.id}-hdr`;
-            const panelId = `comms-msg-${m.id}-panel`;
+      {isSectionOpen ? (
+        <div id="comms-inbox-panel" className="mt-4">
+          {!ready ? (
+            <p className="text-sm font-bold text-content-secondary">Loading messages…</p>
+          ) : error ? (
+            <p className="text-sm font-bold text-amber-300">{error}</p>
+          ) : messages.length === 0 ? (
+            <div className="flex flex-col items-center gap-3 rounded-3xl border border-border-subtle bg-surface-panel px-6 py-10 text-center shadow-inset-glass">
+              <Inbox className="h-10 w-10 text-content-secondary" aria-hidden />
+              <p className="max-w-sm text-sm font-bold leading-relaxed text-content-secondary">
+                No messages yet. New scoring updates, nightly recaps, and important announcements
+                will appear here as soon as they are available.
+              </p>
+            </div>
+          ) : (
+            <ul className="space-y-3">
+              {messages.map((m) => {
+                const isOpen = openId === m.id;
+                const unread = m.readAt == null;
+                const delivered = formatDeliveredAt(m.createdAt);
+                const headerId = `comms-msg-${m.id}-hdr`;
+                const panelId = `comms-msg-${m.id}-panel`;
 
-            return (
-              <li
-                key={m.id}
-                className="overflow-hidden rounded-3xl border border-border-subtle bg-surface-panel shadow-inset-glass"
-              >
-                <button
-                  type="button"
-                  id={headerId}
-                  aria-expanded={isOpen}
-                  aria-controls={panelId}
-                  onClick={() => handleToggle(m.id, !isOpen)}
-                  className="flex w-full items-start gap-3 px-5 py-4 text-left transition-colors hover:bg-white/[0.04] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface-panel"
-                >
-                  <span className="flex min-w-0 flex-1 flex-col gap-1">
-                    <span className="flex flex-wrap items-center gap-2">
-                      <span className="text-sm font-black uppercase tracking-widest text-content-secondary">
-                        Message
-                      </span>
-                      {unread ? (
-                        <span className="rounded-full bg-brand-primary/20 px-2 py-0.5 text-[10px] font-black uppercase tracking-wider text-brand-primary">
-                          New
-                        </span>
-                      ) : null}
-                    </span>
-                    <span className="text-xs font-bold text-content-secondary">
-                      Template: {m.templateId || '—'}
-                      {delivered ? ` · ${delivered}` : ''}
-                    </span>
-                  </span>
-                  <ChevronDown
-                    className={`mt-0.5 h-5 w-5 shrink-0 text-content-secondary transition-transform duration-200 ${
-                      isOpen ? 'rotate-180' : ''
-                    }`}
-                    aria-hidden
-                  />
-                </button>
-                {isOpen ? (
-                  <div
-                    id={panelId}
-                    role="region"
-                    aria-labelledby={headerId}
-                    className="border-t border-border-muted/80 px-5 pb-6 pt-4"
+                return (
+                  <li
+                    key={m.id}
+                    className="overflow-hidden rounded-3xl border border-border-subtle bg-surface-panel shadow-inset-glass"
                   >
-                    <CommsRecapMessageBody templateId={m.templateId} payload={m.payload} />
-                  </div>
-                ) : null}
-              </li>
-            );
-          })}
-        </ul>
-      )}
+                    <button
+                      type="button"
+                      id={headerId}
+                      aria-expanded={isOpen}
+                      aria-controls={panelId}
+                      onClick={() => handleToggle(m.id, !isOpen)}
+                      className="flex w-full items-start gap-3 px-5 py-4 text-left transition-colors hover:bg-white/[0.04] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface-panel"
+                    >
+                      <span className="flex min-w-0 flex-1 flex-col gap-1">
+                        <span className="flex flex-wrap items-center gap-2">
+                          <span className="text-sm font-black uppercase tracking-widest text-content-secondary">
+                            Message
+                          </span>
+                          {unread ? (
+                            <span className="rounded-full bg-brand-primary/20 px-2 py-0.5 text-[10px] font-black uppercase tracking-wider text-brand-primary">
+                              New
+                            </span>
+                          ) : null}
+                        </span>
+                        <span className="text-xs font-bold text-content-secondary">
+                          Template: {m.templateId || '—'}
+                          {delivered ? ` · ${delivered}` : ''}
+                        </span>
+                      </span>
+                      <ChevronDown
+                        className={`mt-0.5 h-5 w-5 shrink-0 text-content-secondary transition-transform duration-200 ${
+                          isOpen ? 'rotate-180' : ''
+                        }`}
+                        aria-hidden
+                      />
+                    </button>
+                    {isOpen ? (
+                      <div
+                        id={panelId}
+                        role="region"
+                        aria-labelledby={headerId}
+                        className="border-t border-border-muted/80 px-5 pb-6 pt-4"
+                      >
+                        <CommsRecapMessageBody templateId={m.templateId} payload={m.payload} />
+                        <div className="mt-4 flex items-center justify-end gap-2">
+                          <button
+                            type="button"
+                            onClick={() => handleToggle(m.id, false)}
+                            className="rounded-lg border border-border-muted bg-surface-inset px-3 py-1.5 text-xs font-black uppercase tracking-widest text-content-secondary transition-colors hover:border-brand-primary/40 hover:text-white"
+                          >
+                            Collapse
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleDismiss(m.id)}
+                            className="rounded-lg border border-border-muted bg-surface-inset px-3 py-1.5 text-xs font-black uppercase tracking-widest text-content-secondary transition-colors hover:border-brand-primary/40 hover:text-white"
+                          >
+                            Dismiss
+                          </button>
+                        </div>
+                      </div>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/src/features/notifications/ui/DashboardNotificationsBell.jsx
+++ b/src/features/notifications/ui/DashboardNotificationsBell.jsx
@@ -12,7 +12,7 @@ export default function DashboardNotificationsBell() {
 
   const label =
     unreadCount > 0
-      ? `Notifications — ${unreadCount} unread`
+      ? `Notifications — new message waiting (${unreadCount} unread)`
       : 'Notifications';
 
   return (
@@ -22,6 +22,9 @@ export default function DashboardNotificationsBell() {
       aria-label={label}
     >
       <Bell className="h-5 w-5" aria-hidden />
+      {ready && unreadCount > 0 ? (
+        <span className="absolute -left-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-brand-primary ring-2 ring-surface-panel-strong" />
+      ) : null}
       {ready && unreadCount > 0 ? (
         <span className="absolute -right-0.5 -top-0.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-brand-primary px-1 text-[10px] font-black leading-none text-[rgb(var(--brand-bg-deep))]">
           {unreadCount > 9 ? '9+' : unreadCount}


### PR DESCRIPTION
Closes #374

## Summary
- make the Notifications `Messages` section an accordion-style collapsible container
- replace technical copy with user-friendly actionable update language (scoring updates, nightly recaps, announcements)
- add unread/new-message signaling in both the Messages header and `DashboardNotificationsBell`
- keep per-message expand/collapse and dismiss behavior intact

## Test plan
- [x] `ReadLints` on touched files reports no errors
- [ ] Open `/dashboard/notifications` and confirm Messages section toggles open/closed
- [ ] With unread inbox docs, confirm "New message waiting" pill appears in Messages header
- [ ] Confirm dashboard bell shows unread badge/new indicator and updated accessibility label
- [ ] Expand a message, verify content renders and Collapse/Dismiss actions still work

Made with [Cursor](https://cursor.com)