### PR TITLE
feat(notifications): send recap push alerts with inbox delivery

### DIFF
--- a/content/comms/README.md
+++ b/content/comms/README.md
@@ -25,10 +25,12 @@ Once that doc exists, variable recap copy **renders in the app** from the same b
 
 | Phase | Who triggers | Mechanism |
 |-------|----------------|-----------|
-| **1 — Ship today** | Admin / PM (War Room) | HTTPS callable **`deliverSphere2026TourRecapInbox`** (`functions/index.js`): **`dryRun`** defaults to **true**; pass **`dryRun: false`** to write rows. Aggregates **graded** picks on the nine **Sphere Run** dates (same math as dashboard Tour standings) and writes **`users/{uid}/commsInbox/sphere-2026-inaugural`**. UI: **War Room → Tour recap copy → Deliver recap to user inboxes** (`AdminSphereTourRecapDelivery`). CLI (ADC): `functions/scripts/deliverSphere2026TourRecapInbox.js` — omit flag for dry run, **`--execute`** to write. |
+| **1 — Ship today** | Admin / PM (War Room) | HTTPS callable **`deliverSphere2026TourRecapInbox`** (`functions/index.js`): **`dryRun`** defaults to **true**; pass **`dryRun: false`** to write rows. Aggregates **graded** picks on the nine **Sphere Run** dates (same math as dashboard Tour standings) and writes **`users/{uid}/commsInbox/sphere-2026-inaugural`**. On execute mode it also sends a concise push alert (when the user has push tokens + `notificationPrefs.results !== false`) pointing users to Notifications for the full in-app message. UI: **War Room → Tour recap copy → Deliver recap to user inboxes** (`AdminSphereTourRecapDelivery`). CLI (ADC): `functions/scripts/deliverSphere2026TourRecapInbox.js` — omit flag for dry run, **`--execute`** to write. Re-runs are idempotent for inbox docs and push fan-out is deduped per `templateId + uid` via `fcm_notification_log`. |
 | **2** | Automation | Scheduled or rollup-triggered job calling the same delivery helper (extend **`sphereTourRecapDelivery.js`** or add registry-driven modules). Tracked in **#370** / epic **#272**. |
 
 Sphere inaugural **show-date list** in code must stay aligned with **`src/shared/data/showDates.js`** (`Sphere Run`). Follow-up runbook: **#371**.
+
+**Rollout gotcha (rules vs functions):** If delivery writes succeed but `/dashboard/notifications` still shows **"Missing or insufficient permissions"**, deploy Firestore rules (`firebase deploy --only firestore:rules`). Callable/Admin-SDK writes can succeed before the client read rule for `users/{uid}/commsInbox/{messageId}` is deployed.
 
 ---
 

--- a/functions/sphereTourRecapDelivery.js
+++ b/functions/sphereTourRecapDelivery.js
@@ -8,6 +8,8 @@
  * Template ID / inbox doc id: `sphere-2026-inaugural`
  */
 
+const { sendWebPushToToken } = require("./fcmMessagingCore");
+
 const SPHERE_2026_INAUGURAL_TEMPLATE_ID = "sphere-2026-inaugural";
 
 /** Doc id under `users/{uid}/commsInbox` — fixed for idempotent admin re-runs. */
@@ -136,6 +138,151 @@ function aggregateTourStandings(picksByDate) {
 }
 
 const MAX_FIRESTORE_BATCH = 500;
+const MAX_RECAP_PUSH_SENDS_PER_INVOCATION = 400;
+const MAX_TOKENS_PER_USER_FOR_RECAP = 5;
+const FCM_LOG_COLLECTION = "fcm_notification_log";
+
+/**
+ * @param {string} templateId
+ * @param {string} uid
+ * @returns {string}
+ */
+function recapPushLogDocId(templateId, uid) {
+  return `recap_${templateId}_${uid}`;
+}
+
+/**
+ * Reuses existing prefs posture: recap alerts count as results-style updates.
+ * @param {import("firebase-admin").firestore.DocumentData | null | undefined} userData
+ * @returns {boolean}
+ */
+function userWantsRecapPush(userData) {
+  const prefs = userData?.notificationPrefs;
+  if (!prefs || typeof prefs !== "object") return true;
+  return prefs.results !== false;
+}
+
+/**
+ * @param {{
+ *   db: import('firebase-admin').firestore.Firestore,
+ *   admin: typeof import('firebase-admin'),
+ *   templateId: string,
+ *   preview: Array<{ uid: string, payload: Record<string, number> }>,
+ *   logger?: { info?: Function, warn?: Function },
+ * }} params
+ */
+async function sendRecapPushFanout({ db, admin, templateId, preview, logger }) {
+  if (!Array.isArray(preview) || preview.length === 0) {
+    return { sent: 0, skipped: 0 };
+  }
+
+  let sent = 0;
+  let skipped = 0;
+  const userCache = new Map();
+
+  async function loadUser(uid) {
+    if (userCache.has(uid)) return userCache.get(uid);
+    const snap = await db.collection("users").doc(uid).get();
+    const data = snap.exists ? snap.data() || {} : {};
+    userCache.set(uid, data);
+    return data;
+  }
+
+  async function latestTokensForUser(uid) {
+    const snap = await db
+      .collection("users")
+      .doc(uid)
+      .collection("private_fcmTokens")
+      .limit(MAX_TOKENS_PER_USER_FOR_RECAP)
+      .get();
+    return snap.docs
+      .map((d) => {
+        const token = d.data()?.token;
+        return typeof token === "string" && token.trim() ? token.trim() : "";
+      })
+      .filter(Boolean);
+  }
+
+  for (const item of preview) {
+    if (sent >= MAX_RECAP_PUSH_SENDS_PER_INVOCATION) {
+      logger?.warn?.("sendRecapPushFanout: cap reached", {
+        templateId,
+        sent,
+        cap: MAX_RECAP_PUSH_SENDS_PER_INVOCATION,
+      });
+      break;
+    }
+
+    const logId = recapPushLogDocId(templateId, item.uid);
+    const logRef = db.collection(FCM_LOG_COLLECTION).doc(logId);
+    const existing = await logRef.get();
+    if (existing.exists) {
+      skipped += 1;
+      continue;
+    }
+
+    const userData = await loadUser(item.uid);
+    if (!userWantsRecapPush(userData)) {
+      skipped += 1;
+      continue;
+    }
+
+    const tokens = await latestTokensForUser(item.uid);
+    if (tokens.length === 0) {
+      skipped += 1;
+      continue;
+    }
+
+    const rank = Number.isFinite(item?.payload?.rank) ? item.payload.rank : null;
+    const title = "New tour recap in Messages";
+    const body =
+      typeof rank === "number" && rank > 0
+        ? `Your Sphere '26 recap is ready. Current rank: #${rank}.`
+        : "Your Sphere '26 recap is ready. Open Notifications to read it.";
+
+    let anyDelivered = false;
+    for (const token of tokens) {
+      const res = await sendWebPushToToken({
+        admin,
+        db,
+        token,
+        userId: item.uid,
+        title,
+        body,
+        data: {
+          kind: "tourRecap",
+          templateId,
+        },
+        logger,
+      });
+      if (res.ok) anyDelivered = true;
+    }
+
+    if (anyDelivered) {
+      await logRef.set(
+        {
+          kind: "tourRecap",
+          templateId,
+          userId: item.uid,
+          delivered: true,
+          decidedAt: admin.firestore.FieldValue.serverTimestamp(),
+        },
+        { merge: true }
+      );
+      sent += 1;
+    } else {
+      skipped += 1;
+    }
+  }
+
+  logger?.info?.("sendRecapPushFanout complete", {
+    templateId,
+    sent,
+    skipped,
+    candidates: preview.length,
+  });
+  return { sent, skipped };
+}
 
 /**
  * @param {import('firebase-admin').firestore.Firestore} db
@@ -225,6 +372,8 @@ async function deliverSphere2026TourRecapInbox({ db, admin, dryRun, logger }) {
       showDates: [...SPHERE_2026_INAUGURAL_SHOW_DATES],
       participantCount,
       delivered: 0,
+      pushSent: 0,
+      pushSkipped: 0,
       preview,
     };
   }
@@ -266,6 +415,14 @@ async function deliverSphere2026TourRecapInbox({ db, admin, dryRun, logger }) {
     participantCount,
   });
 
+  const pushResult = await sendRecapPushFanout({
+    db,
+    admin,
+    templateId: SPHERE_2026_INAUGURAL_TEMPLATE_ID,
+    preview,
+    logger,
+  });
+
   return {
     ok: true,
     dryRun: false,
@@ -274,6 +431,8 @@ async function deliverSphere2026TourRecapInbox({ db, admin, dryRun, logger }) {
     showDates: [...SPHERE_2026_INAUGURAL_SHOW_DATES],
     participantCount,
     delivered,
+    pushSent: pushResult.sent,
+    pushSkipped: pushResult.skipped,
     preview: preview.slice(0, 50),
   };
 }
@@ -282,6 +441,8 @@ module.exports = {
   SPHERE_2026_INAUGURAL_SHOW_DATES,
   SPHERE_2026_INAUGURAL_TEMPLATE_ID,
   COMMS_INBOX_DOC_ID,
+  recapPushLogDocId,
+  userWantsRecapPush,
   aggregateTourStandings,
   deliverSphere2026TourRecapInbox,
 };

--- a/functions/sphereTourRecapDelivery.test.js
+++ b/functions/sphereTourRecapDelivery.test.js
@@ -1,6 +1,10 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { aggregateTourStandings } = require("./sphereTourRecapDelivery");
+const {
+  aggregateTourStandings,
+  recapPushLogDocId,
+  userWantsRecapPush,
+} = require("./sphereTourRecapDelivery");
 
 test("aggregateTourStandings: sums points, wins, shows like tour leaderboard", () => {
   const picksByDate = [
@@ -72,4 +76,21 @@ test("aggregateTourStandings: skips ungraded picks", () => {
     },
   ]);
   assert.equal(rows.length, 0);
+});
+
+test("recapPushLogDocId: deterministic by template + user", () => {
+  assert.equal(
+    recapPushLogDocId("sphere-2026-inaugural", "uid_123"),
+    "recap_sphere-2026-inaugural_uid_123"
+  );
+});
+
+test("userWantsRecapPush: defaults on, honors results=false", () => {
+  assert.equal(userWantsRecapPush(undefined), true);
+  assert.equal(userWantsRecapPush({}), true);
+  assert.equal(userWantsRecapPush({ notificationPrefs: {} }), true);
+  assert.equal(
+    userWantsRecapPush({ notificationPrefs: { results: false } }),
+    false
+  );
 });

--- a/src/features/notifications/ui/CommsInboxSection.jsx
+++ b/src/features/notifications/ui/CommsInboxSection.jsx
@@ -147,9 +147,8 @@ export default function CommsInboxSection() {
                             </span>
                           ) : null}
                         </span>
-                        <span className="text-xs font-bold text-content-secondary">
-                          Template: {m.templateId || '—'}
-                          {delivered ? ` · ${delivered}` : ''}
+                        <span className="text-xs font-medium text-content-secondary">
+                          {delivered ? `Delivered ${delivered}` : 'Delivered recently'}
                         </span>
                       </span>
                       <ChevronDown

--- a/src/features/tour-recap/ui/Sphere2026TourRecapInApp.jsx
+++ b/src/features/tour-recap/ui/Sphere2026TourRecapInApp.jsx
@@ -44,7 +44,7 @@ export default function Sphere2026TourRecapInApp({
   });
 
   return (
-    <article className="space-y-3 text-sm font-bold leading-relaxed text-content-secondary">
+    <article className="space-y-3 text-sm font-normal leading-relaxed text-content-secondary">
       <header className="space-y-2 border-b border-border-muted/40 pb-6">
         <p className="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-teal-400/90">
           <Globe2 className="h-4 w-4 shrink-0" aria-hidden />


### PR DESCRIPTION
## Summary
- extend `deliverSphere2026TourRecapInbox` to fan out concise push alerts for users with registered tokens who have not disabled results notifications
- dedupe recap push sends per template+user in `fcm_notification_log`, and include push sent/skipped counts in callable results
- polish notifications message presentation by removing template id text, using a user-friendly delivered label, and reducing recap body font weight
- document two rollout runbook gotchas: deploy firestore rules for client inbox reads and recap delivery now includes concise push alerts

## Test plan
- [x] `cd functions && node --test "sphereTourRecapDelivery.test.js"`
- [x] Deploy callable: `firebase deploy --only functions:deliverSphere2026TourRecapInbox`
- [ ] In admin war room, run dry run then execute recap delivery and confirm `pushSent`/`pushSkipped` are returned
- [ ] Verify a push-enabled user receives a concise recap push and lands on `/dashboard/notifications`

Made with [Cursor](https://cursor.com)