### PR TITLE
feat(profile): self-serve delete account with Firestore audit log

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -160,5 +160,13 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
+    /**
+     * Self-serve account deletion audit (`deleteAccountWithAudit` callable).
+     * Written only via Admin SDK; no client access.
+     */
+    match /account_deletion_reports/{reportId} {
+      allow read, write: if false;
+    }
+
   }
 }

--- a/firestore.rules.test.cjs
+++ b/firestore.rules.test.cjs
@@ -484,6 +484,21 @@ test("rollup_audit: client writes always rejected (even admin)", async () => {
   );
 });
 
+// ─── account_deletion_reports/{reportId} ─────────────────────────────────────
+
+test("account_deletion_reports: no client read or write (even admin claim)", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "account_deletion_reports", "r1"), {
+      uid: "alice",
+    });
+  });
+  const db = signedInAs("mod", { admin: true });
+  await assertFails(getDoc(doc(db, "account_deletion_reports", "r1")));
+  await assertFails(
+    setDoc(doc(db, "account_deletion_reports", "r2"), { uid: "bob" })
+  );
+});
+
 // ─── cross-collection: a pool member profiles query (standings-style) ────────
 
 test("users: signed-in user may query profiles (standings/pool lookup)", async () => {

--- a/functions/accountDelete.js
+++ b/functions/accountDelete.js
@@ -1,0 +1,196 @@
+"use strict";
+
+const { HttpsError } = require("firebase-functions/v2/https");
+const { logger } = require("firebase-functions");
+
+/** Must match client copy in `DeleteAccountSection.jsx`. */
+const DELETE_ACCOUNT_CONFIRMATION_PHRASE = "DELETE MY ACCOUNT";
+
+const MAX_BATCH = 500;
+
+/**
+ * @param {unknown} data — `request.data` from callable
+ */
+function validateDeletionRequest(data) {
+  const acknowledged = data?.acknowledgedPermanentDeletion === true;
+  if (!acknowledged) {
+    throw new HttpsError(
+      "invalid-argument",
+      "Confirm that you understand account deletion is permanent."
+    );
+  }
+  const phrase =
+    typeof data?.confirmationPhrase === "string"
+      ? data.confirmationPhrase.trim()
+      : "";
+  if (phrase !== DELETE_ACCOUNT_CONFIRMATION_PHRASE) {
+    throw new HttpsError(
+      "invalid-argument",
+      `Type "${DELETE_ACCOUNT_CONFIRMATION_PHRASE}" exactly to confirm.`
+    );
+  }
+}
+
+/**
+ * Self-serve account deletion: pool membership cleanup, picks, user subcollections,
+ * audit doc, user profile doc, then Auth record (caller must match uid).
+ *
+ * @param {{
+ *   db: FirebaseFirestore.Firestore,
+ *   admin: typeof import("firebase-admin"),
+ *   callerUid: string,
+ *   requestData: unknown,
+ * }} ctx
+ * @returns {Promise<{ ok: true, reportId: string, picksDeleted: number, poolsUpdated: number }>}
+ */
+async function runAccountDeletionForCaller({
+  db,
+  admin,
+  callerUid,
+  requestData,
+}) {
+  validateDeletionRequest(requestData);
+
+  const owned = await db
+    .collection("pools")
+    .where("ownerId", "==", callerUid)
+    .limit(1)
+    .get();
+  if (!owned.empty) {
+    throw new HttpsError(
+      "failed-precondition",
+      "You still own one or more pools. Delete each pool from its admin settings first, then try again."
+    );
+  }
+
+  let userRecord;
+  try {
+    userRecord = await admin.auth().getUser(callerUid);
+  } catch (e) {
+    logger.error("deleteAccount: auth getUser failed", { callerUid, err: e });
+    throw new HttpsError("not-found", "Account not found.");
+  }
+
+  const userRef = db.collection("users").doc(callerUid);
+  const userSnap = await userRef.get();
+  const userData = userSnap.exists ? userSnap.data() || {} : {};
+
+  const memberPoolsSnap = await db
+    .collection("pools")
+    .where("members", "array-contains", callerUid)
+    .get();
+
+  const poolIdsTouched = memberPoolsSnap.docs.map((d) => d.id);
+
+  let batch = db.batch();
+  let opCount = 0;
+  let poolsUpdated = 0;
+
+  for (const poolDoc of memberPoolsSnap.docs) {
+    if (opCount >= MAX_BATCH) {
+      await batch.commit();
+      batch = db.batch();
+      opCount = 0;
+    }
+    batch.update(poolDoc.ref, {
+      members: admin.firestore.FieldValue.arrayRemove(callerUid),
+    });
+    opCount += 1;
+    poolsUpdated += 1;
+  }
+  if (opCount > 0) {
+    await batch.commit();
+    batch = db.batch();
+    opCount = 0;
+  }
+
+  let picksDeleted = 0;
+  for (;;) {
+    const picksSnap = await db
+      .collection("picks")
+      .where("userId", "==", callerUid)
+      .limit(MAX_BATCH)
+      .get();
+    if (picksSnap.empty) break;
+
+    const delBatch = db.batch();
+    for (const p of picksSnap.docs) {
+      delBatch.delete(p.ref);
+    }
+    await delBatch.commit();
+    picksDeleted += picksSnap.size;
+    if (picksSnap.size < MAX_BATCH) break;
+  }
+
+  for (const sub of ["private_fcmTokens", "commsInbox"]) {
+    for (;;) {
+      const subSnap = await userRef.collection(sub).limit(MAX_BATCH).get();
+      if (subSnap.empty) break;
+      const subBatch = db.batch();
+      for (const d of subSnap.docs) {
+        subBatch.delete(d.ref);
+      }
+      await subBatch.commit();
+      if (subSnap.size < MAX_BATCH) break;
+    }
+  }
+
+  const reportRef = db.collection("account_deletion_reports").doc();
+  const providerIds = Array.isArray(userRecord.providerData)
+    ? userRecord.providerData
+        .map((p) => (typeof p?.providerId === "string" ? p.providerId : ""))
+        .filter(Boolean)
+    : [];
+
+  await reportRef.set({
+    uid: callerUid,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    email: userRecord.email || null,
+    emailVerified: userRecord.emailVerified === true,
+    handle: typeof userData.handle === "string" ? userData.handle : null,
+    displayName:
+      typeof userRecord.displayName === "string" ? userRecord.displayName : null,
+    providerIds,
+    poolIdsMemberRemovedFrom: poolIdsTouched,
+    picksDeleted,
+    poolsUpdated,
+    source: "profile-self-serve",
+    termsPath: "docs/TERMS_OF_SERVICE.md",
+  });
+
+  await userRef.delete();
+
+  try {
+    await admin.auth().deleteUser(callerUid);
+  } catch (e) {
+    logger.error("deleteAccount: auth deleteUser failed after Firestore cleanup", {
+      callerUid,
+      reportId: reportRef.id,
+      err: e,
+    });
+    throw new HttpsError(
+      "internal",
+      "Account data was removed but sign-in could not be finalized. Contact support."
+    );
+  }
+
+  logger.info("deleteAccountWithAudit complete", {
+    uid: callerUid,
+    reportId: reportRef.id,
+    picksDeleted,
+    poolsUpdated,
+  });
+
+  return {
+    ok: true,
+    reportId: reportRef.id,
+    picksDeleted,
+    poolsUpdated,
+  };
+}
+
+module.exports = {
+  DELETE_ACCOUNT_CONFIRMATION_PHRASE,
+  validateDeletionRequest,
+  runAccountDeletionForCaller,
+};

--- a/functions/accountDelete.test.js
+++ b/functions/accountDelete.test.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { HttpsError } = require("firebase-functions/v2/https");
+
+const {
+  DELETE_ACCOUNT_CONFIRMATION_PHRASE,
+  validateDeletionRequest,
+} = require("./accountDelete");
+
+test("validateDeletionRequest: requires acknowledgment flag", () => {
+  assert.throws(
+    () =>
+      validateDeletionRequest({
+        confirmationPhrase: DELETE_ACCOUNT_CONFIRMATION_PHRASE,
+      }),
+    (e) => e instanceof HttpsError && e.code === "invalid-argument"
+  );
+});
+
+test("validateDeletionRequest: requires exact phrase", () => {
+  assert.throws(
+    () =>
+      validateDeletionRequest({
+        acknowledgedPermanentDeletion: true,
+        confirmationPhrase: "delete my account",
+      }),
+    (e) => e instanceof HttpsError && e.code === "invalid-argument"
+  );
+});
+
+test("validateDeletionRequest: accepts valid payload", () => {
+  assert.doesNotThrow(() =>
+    validateDeletionRequest({
+      acknowledgedPermanentDeletion: true,
+      confirmationPhrase: DELETE_ACCOUNT_CONFIRMATION_PHRASE,
+    })
+  );
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -41,6 +41,7 @@ const {
 const { applyRevertRollupForShow } = require("./revertRollupCore");
 const { deliverSphere2026TourRecapInbox } = require("./sphereTourRecapDelivery");
 const { evaluateManualFinalizeTimingGate } = require("./showFinalizationGate");
+const { runAccountDeletionForCaller } = require("./accountDelete");
 
 const phishnetApiKey = defineSecret("PHISHNET_API_KEY");
 
@@ -640,6 +641,30 @@ exports.deletePoolWithCleanup = onCall(
     });
 
     return { ok: true, poolId, memberUpdates };
+  }
+);
+
+/**
+ * Self-serve account deletion (Terms of Service): gated confirmation on the client;
+ * server writes `account_deletion_reports/{id}`, removes pool membership / picks /
+ * user subcollections / profile doc, then deletes the Firebase Auth user.
+ */
+exports.deleteAccountWithAudit = onCall(
+  {
+    region: PHISHNET_FUNCTIONS_REGION,
+    invoker: "public",
+    enforceAppCheck: false,
+  },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError("unauthenticated", "Sign in required.");
+    }
+    return runAccountDeletionForCaller({
+      db,
+      admin,
+      callerUid: request.auth.uid,
+      requestData: request.data,
+    });
   }
 );
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
-    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js showFinalizationGate.test.js revertRollupCore.test.js postShowRollupPush.test.js picksLockReminder.test.js fcmMessagingCore.test.js sphereTourRecapDelivery.test.js",
+    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js accountDelete.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js showFinalizationGate.test.js revertRollupCore.test.js postShowRollupPush.test.js picksLockReminder.test.js fcmMessagingCore.test.js sphereTourRecapDelivery.test.js",
     "serve": "firebase emulators:start --only functions",
     "shell": "firebase functions:shell",
     "start": "npm run shell",

--- a/src/features/profile/api/deleteAccountCallable.js
+++ b/src/features/profile/api/deleteAccountCallable.js
@@ -1,0 +1,66 @@
+import { getFunctions, httpsCallable } from 'firebase/functions';
+
+import { app } from '../../../shared/lib/firebase';
+
+const FUNCTIONS_REGION = 'us-central1';
+
+/** Keep in sync with `DELETE_ACCOUNT_CONFIRMATION_PHRASE` in `functions/accountDelete.js`. */
+export const DELETE_ACCOUNT_CONFIRMATION_PHRASE = 'DELETE MY ACCOUNT';
+
+/**
+ * Self-serve account deletion (callable `deleteAccountWithAudit`).
+ *
+ * @param {{ acknowledgedPermanentDeletion: boolean, confirmationPhrase: string }} params
+ * @returns {Promise<{ ok: boolean, reportId: string, picksDeleted: number, poolsUpdated: number }>}
+ */
+export async function deleteAccountWithAudit(params) {
+  const functions = getFunctions(app, FUNCTIONS_REGION);
+  const callable = httpsCallable(functions, 'deleteAccountWithAudit');
+  try {
+    const result = await callable({
+      acknowledgedPermanentDeletion: params.acknowledgedPermanentDeletion === true,
+      confirmationPhrase:
+        typeof params.confirmationPhrase === 'string' ? params.confirmationPhrase : '',
+    });
+    const data = /** @type {any} */ (result?.data ?? {});
+    return {
+      ok: data.ok === true,
+      reportId: typeof data.reportId === 'string' ? data.reportId : '',
+      picksDeleted: typeof data.picksDeleted === 'number' ? data.picksDeleted : 0,
+      poolsUpdated: typeof data.poolsUpdated === 'number' ? data.poolsUpdated : 0,
+    };
+  } catch (e) {
+    throw normalizeDeleteAccountError(e);
+  }
+}
+
+/**
+ * @param {unknown} e
+ * @returns {Error & { code?: string }}
+ */
+function normalizeDeleteAccountError(e) {
+  const rawMessage =
+    e instanceof Error ? e.message : 'Could not delete your account. Try again.';
+  const rawCode =
+    e && typeof e === 'object' && 'code' in e
+      ? String(/** @type {any} */ (e).code)
+      : '';
+  const code = rawCode.includes('/') ? rawCode.split('/').pop() : rawCode;
+
+  /** @type {Error & { code?: string }} */
+  const err = new Error(rawMessage);
+  if (code === 'failed-precondition') {
+    err.code = 'owns-pools';
+  } else if (code === 'invalid-argument') {
+    err.code = 'invalid-argument';
+  } else if (code === 'unauthenticated') {
+    err.code = 'unauthenticated';
+  } else if (code === 'not-found') {
+    err.code = 'not-found';
+  } else if (code === 'internal') {
+    err.code = 'internal';
+  } else {
+    err.code = code || 'unknown';
+  }
+  return err;
+}

--- a/src/features/profile/index.js
+++ b/src/features/profile/index.js
@@ -1,5 +1,6 @@
 export { fetchPublicProfileByHandle } from './api/publicProfileApi';
 export { default as AccountSecurity } from './ui/AccountSecurity';
+export { default as DeleteAccountSection } from './ui/DeleteAccountSection';
 export { default as ProfileEditForm } from './ui/ProfileEditForm';
 export { default as PublicProfileView } from './ui/PublicProfileView';
 export { usePublicProfile } from './model/usePublicProfile';

--- a/src/features/profile/model/useDeleteAccount.js
+++ b/src/features/profile/model/useDeleteAccount.js
@@ -1,0 +1,63 @@
+import { useCallback, useState } from 'react';
+
+import { useSignOut } from '../../auth';
+import { deleteAccountWithAudit } from '../api/deleteAccountCallable';
+
+/**
+ * Orchestrates self-serve account deletion (callable + local sign-out).
+ */
+export function useDeleteAccount({ onAfterDelete }) {
+  const signOut = useSignOut();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState('');
+
+  const clearError = useCallback(() => setError(''), []);
+
+  const requestDelete = useCallback(
+    async ({ acknowledgedPermanentDeletion, confirmationPhrase }) => {
+      setError('');
+      setIsDeleting(true);
+      try {
+        await deleteAccountWithAudit({
+          acknowledgedPermanentDeletion,
+          confirmationPhrase,
+        });
+        try {
+          await signOut();
+        } catch {
+          // Auth record may already be gone; still navigate away.
+        }
+        onAfterDelete?.();
+      } catch (e) {
+        const code =
+          e && typeof e === 'object' && 'code' in e
+            ? String(/** @type {any} */ (e).code)
+            : '';
+        const msg = e instanceof Error ? e.message : 'Something went wrong.';
+        if (code === 'owns-pools') {
+          setError(
+            'You still own one or more pools. Open each pool you manage, delete it from admin settings (when allowed), then try again.'
+          );
+        } else if (code === 'invalid-argument') {
+          setError(msg || 'Confirm the checkbox and type the phrase exactly.');
+        } else if (code === 'unauthenticated') {
+          setError('Sign in again, then retry.');
+        } else if (code === 'internal') {
+          setError(msg);
+        } else {
+          setError(msg);
+        }
+      } finally {
+        setIsDeleting(false);
+      }
+    },
+    [onAfterDelete, signOut]
+  );
+
+  return {
+    isDeleting,
+    error,
+    clearError,
+    requestDelete,
+  };
+}

--- a/src/features/profile/ui/DeleteAccountSection.jsx
+++ b/src/features/profile/ui/DeleteAccountSection.jsx
@@ -1,0 +1,132 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+
+import { useDeleteAccount } from '../model/useDeleteAccount';
+import { DELETE_ACCOUNT_CONFIRMATION_PHRASE } from '../api/deleteAccountCallable';
+import Button from '../../../shared/ui/Button';
+
+/**
+ * Last-resort account deletion: collapsed by default; checkbox + exact phrase + confirm.
+ */
+export default function DeleteAccountSection() {
+  const navigate = useNavigate();
+  const [expanded, setExpanded] = useState(false);
+  const [ack, setAck] = useState(false);
+  const [phrase, setPhrase] = useState('');
+
+  const { isDeleting, error, clearError, requestDelete } = useDeleteAccount({
+    onAfterDelete: () => navigate('/'),
+  });
+
+  const phraseOk = phrase.trim() === DELETE_ACCOUNT_CONFIRMATION_PHRASE;
+  const canSubmit = ack && phraseOk && !isDeleting;
+
+  return (
+    <div className="mt-10 rounded-3xl border border-red-500/25 bg-red-950/20 p-6 shadow-inset-glass">
+      <h3 className="text-sm font-black uppercase tracking-widest text-red-300/90">
+        Delete account
+      </h3>
+      <p className="mt-2 text-sm leading-relaxed text-content-secondary">
+        This permanently removes your sign-in, profile, picks, and pool memberships, as described in
+        the{' '}
+        <Link
+          to="/terms"
+          className="font-semibold text-red-200 underline decoration-red-400/50 underline-offset-2 hover:text-white"
+        >
+          Terms of Service
+        </Link>
+        . You cannot undo this. If you own any pools, delete them from each pool&apos;s settings
+        first.
+      </p>
+
+      {!expanded ? (
+        <button
+          type="button"
+          onClick={() => {
+            setExpanded(true);
+            clearError();
+          }}
+          className="mt-4 w-full rounded-xl border-2 border-red-500/40 bg-transparent py-3.5 text-sm font-black uppercase tracking-widest text-red-300 transition-colors hover:border-red-400 hover:bg-red-500/10 hover:text-white"
+        >
+          I need to delete my account
+        </button>
+      ) : (
+        <div className="mt-4 space-y-4">
+          <label className="flex cursor-pointer items-start gap-3 text-sm leading-snug text-content-secondary">
+            <input
+              type="checkbox"
+              className="mt-1 h-4 w-4 shrink-0 rounded border-red-500/50 bg-surface-field text-red-500 focus-visible:ring-2 focus-visible:ring-red-400"
+              checked={ack}
+              onChange={(e) => {
+                setAck(e.target.checked);
+                clearError();
+              }}
+            />
+            <span>
+              I understand this is permanent and I still want to delete my account and related
+              data.
+            </span>
+          </label>
+
+          <div>
+            <label
+              htmlFor="delete-account-phrase"
+              className="text-xs font-bold uppercase tracking-widest text-content-secondary"
+            >
+              Type{' '}
+              <span className="font-mono text-red-200">{DELETE_ACCOUNT_CONFIRMATION_PHRASE}</span>{' '}
+              to confirm
+            </label>
+            <input
+              id="delete-account-phrase"
+              type="text"
+              autoComplete="off"
+              value={phrase}
+              onChange={(e) => {
+                setPhrase(e.target.value);
+                clearError();
+              }}
+              className="mt-2 w-full rounded-xl border-2 border-border-subtle bg-surface-field px-4 py-3 text-sm text-white placeholder:text-content-secondary/60 focus:border-red-400/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400/40"
+              placeholder={DELETE_ACCOUNT_CONFIRMATION_PHRASE}
+              disabled={isDeleting}
+            />
+          </div>
+
+          {error ? (
+            <p className="text-sm font-medium text-red-300" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              variant="glass"
+              size="sm"
+              className="w-full border-border-subtle sm:w-auto"
+              disabled={isDeleting}
+              onClick={() => {
+                setExpanded(false);
+                setAck(false);
+                setPhrase('');
+                clearError();
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="danger"
+              size="sm"
+              className="w-full sm:w-auto"
+              disabled={!canSubmit}
+              onClick={() => requestDelete({ acknowledgedPermanentDeletion: ack, confirmationPhrase: phrase })}
+            >
+              {isDeleting ? 'Deleting…' : 'Delete my account forever'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -4,7 +4,7 @@ import { Bell, ExternalLink } from 'lucide-react';
 
 import { useSignOut } from '../../features/auth';
 import { InstallAppCard } from '../../features/install';
-import { ProfileEditForm, useUserProfile } from '../../features/profile';
+import { DeleteAccountSection, ProfileEditForm, useUserProfile } from '../../features/profile';
 import { dashboardPageTitleGradientClasses } from '../../shared/config/dashboardHeadingTypography';
 import Button from '../../shared/ui/Button';
 import DashboardActionRow from '../../shared/ui/DashboardActionRow';
@@ -119,6 +119,8 @@ export default function Profile({ user }) {
           Log Out
         </Button>
       </div>
+
+      <DeleteAccountSection />
     </div>
   );
 }


### PR DESCRIPTION
Closes #388

## Summary

Adds a gated **Delete account** flow on the dashboard Profile page (checkbox + exact phrase), backed by callable **`deleteAccountWithAudit`**, which removes pool membership, picks, user subcollections, the profile doc, and the Auth user, and writes **`account_deletion_reports`** for audit. Firestore rules deny all client access to that collection. Deletion is blocked while the user still owns any pool.

## Test plan

- [ ] `npm run lint` && `npm test`
- [ ] `cd functions && npm test`
- [ ] Deploy `firestore:rules` and `functions:deleteAccountWithAudit`, then exercise Profile delete flow (including owned-pool block)
- [ ] `npm run test:rules` (emulator) for new `account_deletion_reports` rules case

Made with [Cursor](https://cursor.com)