### PR TITLE
feat(scoring): graded picks share card (PNG + text) — #304

### DIFF
--- a/docs/walkthroughs/issue-304-graded-picks-share.md
+++ b/docs/walkthroughs/issue-304-graded-picks-share.md
@@ -10,7 +10,7 @@ This feature ships a graded recap once an official setlist exists (`actualSetlis
 2. Find your row (**You** badge / expanded breakdown).
 3. Expand the row.
 4. Below the six-slot breakdown, use **Share graded card**:
-   - **Copy recap** — writes **plain text** (headline once + human-readable lines per slot using the same result labels as the app) plus **`text/html`** when the browser supports it, so Mail / Notes / Slack often show a **small color grid** when you paste. Also includes a **Unicode block** mini-grid (`█` / `▓` / `░`, not emoji) for plain SMS.
+   - **Copy recap** — writes **plain text** (headline once + human-readable lines per slot using the same result labels as the app) plus **`text/html`** when the browser supports it. The HTML grid uses **opaque** teal / blue / slate tiles (plus inner `div` + `bgcolor` fallbacks) so pasted cells stay colored on white backgrounds, not washed-out rgba. Also includes a **Unicode block** mini-grid (`█` / `▓` / `░`) for plain SMS.
    - **Download PNG** — 2 rows × 3 columns, rounded tiles, per-slot points, **Bustout Boost™** pill when applicable.
    - **Share…** — Web Share uses **`title`** = recap headline and **`text`** = body **without** repeating that headline (many apps merge title + body without a newline and would corrupt or duplicate lines).
 

--- a/docs/walkthroughs/issue-304-graded-picks-share.md
+++ b/docs/walkthroughs/issue-304-graded-picks-share.md
@@ -1,37 +1,31 @@
 # Walkthrough: Graded picks share card (issue #304)
 
-This feature ships a graded recap once an official setlist exists (`actualSetlist` on `official_setlists/{date}`). Colors and points follow **`getSlotScoreBreakdown`** / **`ScoreBreakdownGrid`** so share output cannot drift from live scoring.
+Graded recap once an official setlist exists. Scoring colors come from **`getSlotScoreBreakdown`** so the card cannot drift from live scoring.
 
 ## Surfaces
 
 ### 1. Standings
 
-1. Open **Dashboard → Standings** for a **graded** show (setlist loaded; scores visible).
-2. Find your row (**You** badge / expanded breakdown).
-3. Expand the row.
-4. Below the six-slot breakdown, use **Share graded card**:
-   - **Copy recap** — writes **plain text** (headline once + human-readable lines per slot using the same result labels as the app) plus **`text/html`** when the browser supports it. The HTML grid uses **opaque** teal / blue / slate tiles (plus inner `div` + `bgcolor` fallbacks) so pasted cells stay colored on white backgrounds, not washed-out rgba. Also includes a **Unicode block** mini-grid (`█` / `▓` / `░`) for plain SMS.
-   - **Download PNG** — 2 rows × 3 columns, rounded tiles, per-slot points, **Bustout Boost™** pill when applicable.
-   - **Share…** — Web Share uses **`title`** = recap headline and **`text`** = body **without** repeating that headline (many apps merge title + body without a newline and would corrupt or duplicate lines).
+1. **Dashboard → Standings** (graded show) → expand **your** row.
+2. **Share graded card**
+   - **Copy recap** — **Rich paste:** HTML includes the **same PNG as a data-URL image** (reliable color everywhere Mail/Notes/Slack support images) plus **setlistpickem.com** CTA. **Plain text:** short headline + show + total + join link (no per-slot prose).
+   - **Download PNG** — full card; footer includes **setlistpickem.com · Free to play**.
+   - **Share…** — image + succinct caption + **title** (headline not repeated in `text`, to avoid client merge bugs).
 
 ### 2. Picks
 
-1. Open **Dashboard → Picks** for the same graded date.
-2. With picks on file and the official setlist present, a **Share graded card** block appears **above** the pick fields.
-3. Same three actions as Standings.
+Same controls above the form when the show is graded.
 
-## Plain text vs color
+## Marketing goal
 
-- **SMS / plain clients:** Readable slot lines + block legend; attach **PNG** for the full color card.
-- **Rich paste:** Prefer **Copy recap** into apps that accept HTML from the clipboard.
-- **Icons:** Lucide only exists in the React app; the recap uses **canvas PNG**, **inline-styled HTML**, and **Unicode block characters** (geometric, not colorful emoji) for plain-text “tiles.”
+Recap is **visual-first** (grid + PNG / embedded image) with a **single canonical CTA** to **https://www.setlistpickem.com/** so viewers can sign up or sign in.
 
 ## Implementation map
 
-- Core: `src/features/scoring/model/gradedPicksShareCore.js` (slots, plain body, HTML, canvas PNG).
-- Picks tab setlist load: `src/features/scoring/model/useOfficialSetlistForShow.js`.
-- UI: `src/features/scoring/ui/GradedPicksShareBar.jsx`; wired from `LeaderboardRow` (self + graded) and `PicksPage`.
+- `src/features/scoring/model/gradedPicksShareCore.js` — slots, PNG, plain body, `buildGradedPicksShareClipboardHtml` (data-URL img + link).
+- `src/features/scoring/ui/GradedPicksShareBar.jsx` — renders PNG → data URL for clipboard HTML.
+- `src/features/scoring/model/useOfficialSetlistForShow.js` — Picks tab setlist.
 
 ## Reference visuals
 
-For this delivery, illustrative UI mockups were generated for the PR description (Standings expanded row + Picks tab + example PNG card). After merge, capture real screenshots from a graded show in dev or staging if you want this doc to embed live assets.
+Capture real screenshots from a graded show in dev or staging if you want embedded images in this doc.

--- a/docs/walkthroughs/issue-304-graded-picks-share.md
+++ b/docs/walkthroughs/issue-304-graded-picks-share.md
@@ -1,6 +1,6 @@
 # Walkthrough: Graded picks share card (issue #304)
 
-This feature ships a **Wordle-style** graded picks summary once an official setlist exists (`actualSetlist` on `official_setlists/{date}`). Colors and points follow **`getSlotScoreBreakdown`** / **`ScoreBreakdownGrid`** so share output cannot drift from live scoring.
+This feature ships a graded recap once an official setlist exists (`actualSetlist` on `official_setlists/{date}`). Colors and points follow **`getSlotScoreBreakdown`** / **`ScoreBreakdownGrid`** so share output cannot drift from live scoring.
 
 ## Surfaces
 
@@ -10,9 +10,9 @@ This feature ships a **Wordle-style** graded picks summary once an official setl
 2. Find your row (**You** badge / expanded breakdown).
 3. Expand the row.
 4. Below the six-slot breakdown, use **Share graded card**:
-   - **Copy text grid** — monospace-friendly 2×3 letter codes (X/E/W/I/M) with per-slot points and ` BB` when **Bustout Boost™** applied (plain text; no emoji).
-   - **Download PNG** — 2 rows × 3 columns, rounded tiles aligned with the in-app breakdown colors, per-slot points centered in each cell, amber **Bustout Boost™** pill when applicable.
-   - **Share…** — Web Share API with PNG + caption when supported; falls back to text-only share or clipboard.
+   - **Copy recap** — writes **plain text** (headline once + human-readable lines per slot using the same result labels as the app) plus **`text/html`** when the browser supports it, so Mail / Notes / Slack often show a **small color grid** when you paste. Also includes a **Unicode block** mini-grid (`█` / `▓` / `░`, not emoji) for plain SMS.
+   - **Download PNG** — 2 rows × 3 columns, rounded tiles, per-slot points, **Bustout Boost™** pill when applicable.
+   - **Share…** — Web Share uses **`title`** = recap headline and **`text`** = body **without** repeating that headline (many apps merge title + body without a newline and would corrupt or duplicate lines).
 
 ### 2. Picks
 
@@ -20,22 +20,15 @@ This feature ships a **Wordle-style** graded picks summary once an official setl
 2. With picks on file and the official setlist present, a **Share graded card** block appears **above** the pick fields.
 3. Same three actions as Standings.
 
-## Output semantics
+## Plain text vs color
 
-| Slot result (kind) | PNG fill | Text code |
-|--------------------|----------|-----------|
-| Exact slot | Teal-tinted fill + teal border | `X` + points |
-| Encore exact | Same teal family | `E` + points |
-| Wildcard | Same teal family | `W` + points |
-| In setlist (blue lane) | Blue-tinted fill + blue border | `I` + points |
-| Miss / no pick | Muted panel fill | `M` + points or `—` when empty |
-| Bustout Boost™ | Amber **frame** + pill label (PNG); suffix **` BB`** on that cell (text) | |
-
-**Order** matches **`FORM_FIELDS`**: Set 1 Opener → Set 1 Closer → Set 2 Opener → Set 2 Closer → Encore → Wildcard (two rows of three).
+- **SMS / plain clients:** Readable slot lines + block legend; attach **PNG** for the full color card.
+- **Rich paste:** Prefer **Copy recap** into apps that accept HTML from the clipboard.
+- **Icons:** Lucide only exists in the React app; the recap uses **canvas PNG**, **inline-styled HTML**, and **Unicode block characters** (geometric, not colorful emoji) for plain-text “tiles.”
 
 ## Implementation map
 
-- Core: `src/features/scoring/model/gradedPicksShareCore.js` (slots, caption text, canvas PNG).
+- Core: `src/features/scoring/model/gradedPicksShareCore.js` (slots, plain body, HTML, canvas PNG).
 - Picks tab setlist load: `src/features/scoring/model/useOfficialSetlistForShow.js`.
 - UI: `src/features/scoring/ui/GradedPicksShareBar.jsx`; wired from `LeaderboardRow` (self + graded) and `PicksPage`.
 

--- a/docs/walkthroughs/issue-304-graded-picks-share.md
+++ b/docs/walkthroughs/issue-304-graded-picks-share.md
@@ -8,7 +8,7 @@ Graded recap once an official setlist exists. Scoring colors come from **`getSlo
 
 1. **Dashboard → Standings** (graded show) → expand **your** row.
 2. **Share graded card**
-   - **Copy recap** — **Rich paste:** HTML includes the **same PNG as a data-URL image** (reliable color everywhere Mail/Notes/Slack support images) plus **setlistpickem.com** CTA. **Plain text:** short headline + show + total + join link (no per-slot prose).
+   - **Copy recap** — **Rich paste:** HTML includes the **PNG as a data-URL image** plus **setlistpickem.com** CTA. **Plain text:** **Artist · date** line (from `SHARE_RECAP_ARTIST_NAME` in `gameConfig.js`, today `Phish`), total, a **2×3 colored block grid** (`🟩` / `🟦` / `⬛` + points + ` BB` for Bustout Boost™), short legend, then the site URL.
    - **Download PNG** — full card; footer includes **setlistpickem.com · Free to play**.
    - **Share…** — image + succinct caption + **title** (headline not repeated in `text`, to avoid client merge bugs).
 

--- a/docs/walkthroughs/issue-304-graded-picks-share.md
+++ b/docs/walkthroughs/issue-304-graded-picks-share.md
@@ -10,8 +10,8 @@ This feature ships a **Wordle-style** graded picks summary once an official setl
 2. Find your row (**You** badge / expanded breakdown).
 3. Expand the row.
 4. Below the six-slot breakdown, use **Share graded card**:
-   - **Copy text grid** — emoji-ish 2×3 grid with per-slot points and a bustout marker (`⭐`).
-   - **Download PNG** — 2 rows × 3 columns, color-first cells, per-slot points, amber **Bustout** label when the bustout boost applied.
+   - **Copy text grid** — monospace-friendly 2×3 letter codes (X/E/W/I/M) with per-slot points and ` BB` when **Bustout Boost™** applied (plain text; no emoji).
+   - **Download PNG** — 2 rows × 3 columns, rounded tiles aligned with the in-app breakdown colors, per-slot points centered in each cell, amber **Bustout Boost™** pill when applicable.
    - **Share…** — Web Share API with PNG + caption when supported; falls back to text-only share or clipboard.
 
 ### 2. Picks
@@ -22,12 +22,14 @@ This feature ships a **Wordle-style** graded picks summary once an official setl
 
 ## Output semantics
 
-| Slot result (kind) | PNG fill | Text tile |
+| Slot result (kind) | PNG fill | Text code |
 |--------------------|----------|-----------|
-| Exact / encore exact / wildcard | Teal family | 🟩 |
-| In setlist (blue lane) | Blue family | 🟦 |
-| Miss / empty | Muted slate | ⬛ |
-| Bustout boost | Amber **border** + “Bustout” chip (PNG); `⭐` adjacent to emoji (text) | |
+| Exact slot | Teal-tinted fill + teal border | `X` + points |
+| Encore exact | Same teal family | `E` + points |
+| Wildcard | Same teal family | `W` + points |
+| In setlist (blue lane) | Blue-tinted fill + blue border | `I` + points |
+| Miss / no pick | Muted panel fill | `M` + points or `—` when empty |
+| Bustout Boost™ | Amber **frame** + pill label (PNG); suffix **` BB`** on that cell (text) | |
 
 **Order** matches **`FORM_FIELDS`**: Set 1 Opener → Set 1 Closer → Set 2 Opener → Set 2 Closer → Encore → Wildcard (two rows of three).
 

--- a/docs/walkthroughs/issue-304-graded-picks-share.md
+++ b/docs/walkthroughs/issue-304-graded-picks-share.md
@@ -8,7 +8,7 @@ Graded recap once an official setlist exists. Scoring colors come from **`getSlo
 
 1. **Dashboard → Standings** (graded show) → expand **your** row.
 2. **Share graded card**
-   - **Copy recap** — **Rich paste:** HTML includes the **PNG as a data-URL image** plus **setlistpickem.com** CTA. **Plain text:** **Artist · date** line (from `SHARE_RECAP_ARTIST_NAME` in `gameConfig.js`, today `Phish`), total, a **2×3 colored block grid** (`🟩` / `🟦` / `⬛` + points + ` BB` for Bustout Boost™), short legend, then the site URL.
+   - **Copy recap** — **Rich paste:** HTML includes the **PNG as a data-URL image** plus **setlistpickem.com** CTA. **Plain text:** **Artist · date** (from `SHARE_RECAP_ARTIST_NAME` in `gameConfig.js`, today `Phish`), total, a **2×3 grid of six colored squares only** (`🟩` / `🟦` / `⬛` / `🟧` for **Bustout Boost™**), one legend line, then the site URL.
    - **Download PNG** — full card; footer includes **setlistpickem.com · Free to play**.
    - **Share…** — image + succinct caption + **title** (headline not repeated in `text`, to avoid client merge bugs).
 

--- a/docs/walkthroughs/issue-304-graded-picks-share.md
+++ b/docs/walkthroughs/issue-304-graded-picks-share.md
@@ -1,0 +1,42 @@
+# Walkthrough: Graded picks share card (issue #304)
+
+This feature ships a **Wordle-style** graded picks summary once an official setlist exists (`actualSetlist` on `official_setlists/{date}`). Colors and points follow **`getSlotScoreBreakdown`** / **`ScoreBreakdownGrid`** so share output cannot drift from live scoring.
+
+## Surfaces
+
+### 1. Standings
+
+1. Open **Dashboard → Standings** for a **graded** show (setlist loaded; scores visible).
+2. Find your row (**You** badge / expanded breakdown).
+3. Expand the row.
+4. Below the six-slot breakdown, use **Share graded card**:
+   - **Copy text grid** — emoji-ish 2×3 grid with per-slot points and a bustout marker (`⭐`).
+   - **Download PNG** — 2 rows × 3 columns, color-first cells, per-slot points, amber **Bustout** label when the bustout boost applied.
+   - **Share…** — Web Share API with PNG + caption when supported; falls back to text-only share or clipboard.
+
+### 2. Picks
+
+1. Open **Dashboard → Picks** for the same graded date.
+2. With picks on file and the official setlist present, a **Share graded card** block appears **above** the pick fields.
+3. Same three actions as Standings.
+
+## Output semantics
+
+| Slot result (kind) | PNG fill | Text tile |
+|--------------------|----------|-----------|
+| Exact / encore exact / wildcard | Teal family | 🟩 |
+| In setlist (blue lane) | Blue family | 🟦 |
+| Miss / empty | Muted slate | ⬛ |
+| Bustout boost | Amber **border** + “Bustout” chip (PNG); `⭐` adjacent to emoji (text) | |
+
+**Order** matches **`FORM_FIELDS`**: Set 1 Opener → Set 1 Closer → Set 2 Opener → Set 2 Closer → Encore → Wildcard (two rows of three).
+
+## Implementation map
+
+- Core: `src/features/scoring/model/gradedPicksShareCore.js` (slots, caption text, canvas PNG).
+- Picks tab setlist load: `src/features/scoring/model/useOfficialSetlistForShow.js`.
+- UI: `src/features/scoring/ui/GradedPicksShareBar.jsx`; wired from `LeaderboardRow` (self + graded) and `PicksPage`.
+
+## Reference visuals
+
+For this delivery, illustrative UI mockups were generated for the PR description (Standings expanded row + Picks tab + example PNG card). After merge, capture real screenshots from a graded show in dev or staging if you want this doc to embed live assets.

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -4,7 +4,10 @@ export {
 } from './api/globalShowAggregation';
 export { default as Leaderboard } from './ui/Leaderboard';
 export { default as GradedPicksShareBar } from './ui/GradedPicksShareBar';
-export { GRADED_PICKS_SHARE_RECAP_TITLE } from './model/gradedPicksShareCore';
+export {
+  GRADED_PICKS_SHARE_RECAP_TITLE,
+  GRADED_PICKS_SHARE_SITE_URL,
+} from './model/gradedPicksShareCore';
 export { useOfficialSetlistForShow } from './model/useOfficialSetlistForShow';
 export { useDisplayedPicks } from './model/useDisplayedPicks';
 export { useStandings } from './model/useStandings';

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -3,6 +3,8 @@ export {
   fetchGlobalShowWinners,
 } from './api/globalShowAggregation';
 export { default as Leaderboard } from './ui/Leaderboard';
+export { default as GradedPicksShareBar } from './ui/GradedPicksShareBar';
+export { useOfficialSetlistForShow } from './model/useOfficialSetlistForShow';
 export { useDisplayedPicks } from './model/useDisplayedPicks';
 export { useStandings } from './model/useStandings';
 export { useStandingsLeaderboardView } from './model/useStandingsLeaderboardView';

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -8,6 +8,7 @@ export {
   GRADED_PICKS_SHARE_RECAP_TITLE,
   GRADED_PICKS_SHARE_SITE_URL,
 } from './model/gradedPicksShareCore';
+export { SHARE_RECAP_ARTIST_NAME } from '../../shared/data/gameConfig';
 export { useOfficialSetlistForShow } from './model/useOfficialSetlistForShow';
 export { useDisplayedPicks } from './model/useDisplayedPicks';
 export { useStandings } from './model/useStandings';

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -4,6 +4,7 @@ export {
 } from './api/globalShowAggregation';
 export { default as Leaderboard } from './ui/Leaderboard';
 export { default as GradedPicksShareBar } from './ui/GradedPicksShareBar';
+export { GRADED_PICKS_SHARE_RECAP_TITLE } from './model/gradedPicksShareCore';
 export { useOfficialSetlistForShow } from './model/useOfficialSetlistForShow';
 export { useDisplayedPicks } from './model/useDisplayedPicks';
 export { useStandings } from './model/useStandings';

--- a/src/features/scoring/model/gradedPicksShareCore.js
+++ b/src/features/scoring/model/gradedPicksShareCore.js
@@ -2,7 +2,6 @@ import { FORM_FIELDS } from '../../../shared/data/gameConfig';
 import {
   calculateTotalScore,
   getSlotScoreBreakdown,
-  SCORE_BREAKDOWN_KIND_LABEL,
 } from '../../../shared/utils/scoring';
 
 /** Matches splash / marketing copy (`SplashHeader`, `SplashAboutSection`). */
@@ -10,6 +9,9 @@ export const GRADED_PICKS_SHARE_BRAND = "Setlist Pick 'Em";
 
 /** Web Share API `title` + first line when copying full plain text. */
 export const GRADED_PICKS_SHARE_RECAP_TITLE = "My Setlist Pick 'Em Recap";
+
+/** Canonical marketing URL (see `InstallAppCard`, Firebase auth notes). */
+export const GRADED_PICKS_SHARE_SITE_URL = 'https://www.setlistpickem.com/';
 
 /**
  * @param {string} s
@@ -48,8 +50,7 @@ export function buildGradedPicksShareSlots(userPicks, actualSetlist) {
 }
 
 /**
- * Opaque fills so PNG + HTML paste read clearly on dark canvas and on white
- * rich-text targets (translucent rgba on white looked like blank white tiles).
+ * Opaque fills — PNG card (and any raster preview) reads clearly everywhere.
  *
  * @param {ReturnType<typeof buildGradedPicksShareSlots>[number]} slot
  */
@@ -76,57 +77,24 @@ function paletteForSlot(slot) {
 }
 
 /**
- * Monochrome “block” row for plain-text clients (█ strong · ▓ in-setlist · ░ miss / empty).
- * Not emoji; Unicode block elements.
- */
-export function buildGradedPicksShareBlockRow(slots, userPicks) {
-  const ch = (slot) => {
-    const raw = userPicks?.[slot.fieldId];
-    const hasPick = raw != null && String(raw).trim() !== '';
-    if (!hasPick) return '░';
-    if (slot.kind === 'miss' || slot.kind === 'none') return '░';
-    if (slot.kind === 'in_setlist') return '▓';
-    return '█';
-  };
-  return `${ch(slots[0])}${ch(slots[1])}${ch(slots[2])}\n${ch(slots[3])}${ch(slots[4])}${ch(slots[5])}`;
-}
-
-function slotReadableLine(field, slot, userPicks) {
-  const raw = userPicks?.[field.id];
-  const hasPick = raw != null && String(raw).trim() !== '';
-  const kindLabel = hasPick ? SCORE_BREAKDOWN_KIND_LABEL[slot.kind] || '—' : 'No pick';
-  const bb = slot.bustoutBoost ? ' · Bustout Boost™' : '';
-  return `${field.label}: ${slot.points} pts — ${kindLabel}${bb}`;
-}
-
-/**
- * Readable recap body (no top headline). Safe to pair with `navigator.share({ title })`
- * so clients do not concatenate two identical titles.
+ * Succinct body for SMS / Web Share `text` (no per-slot prose). Pair with
+ * `title: GRADED_PICKS_SHARE_RECAP_TITLE` so clients do not duplicate the headline.
  *
  * @param {{ userPicks: Record<string, unknown>, actualSetlist: unknown, showLabel: string }} args
  */
 export function buildGradedPicksShareBodyPlain({ userPicks, actualSetlist, showLabel }) {
-  const slots = buildGradedPicksShareSlots(userPicks, actualSetlist);
   const total = calculateTotalScore(userPicks, actualSetlist);
-  const lines = [
+  return [
     `${GRADED_PICKS_SHARE_BRAND} · ${showLabel}`,
     `Total: ${total} pts`,
     '',
-  ];
-  FORM_FIELDS.forEach((field, i) => {
-    const slot = slots[i];
-    lines.push(slotReadableLine(field, slot, userPicks));
-  });
-  lines.push('');
-  lines.push(buildGradedPicksShareBlockRow(slots, userPicks));
-  lines.push('█ hit · ▓ in setlist · ░ miss or empty');
-  lines.push('');
-  lines.push('Tip: Use Download PNG for the full color card everywhere; Copy recap adds color in Mail/Notes/Slack when rich paste is supported.');
-  return lines.join('\n');
+    'Free live setlist picks for Phish shows — join the pool:',
+    GRADED_PICKS_SHARE_SITE_URL,
+  ].join('\n');
 }
 
 /**
- * Full plain text for clipboard fallback (headline once, then body).
+ * Full plain text for clipboard fallback (headline once, then succinct body).
  */
 export function buildGradedPicksShareFullPlainText(args) {
   return [GRADED_PICKS_SHARE_RECAP_TITLE, '', buildGradedPicksShareBodyPlain(args)].join('\n');
@@ -138,43 +106,22 @@ export function buildGradedPicksShareText(args) {
 }
 
 /**
- * Minimal HTML for rich clipboard / some mail clients — colored 2×3 grid, no Lucide (not possible in HTML string).
+ * Rich clipboard: embedded PNG (data URL) so colors survive Mail/Notes/Slack,
+ * plus a short CTA link. `imageDataUrl` must be `data:image/png;base64,...`.
  *
- * @param {{ userPicks: Record<string, unknown>, actualSetlist: unknown, showLabel: string }} args
+ * @param {{ imageDataUrl: string, showLabel: string, totalPoints: number }} args
  */
-export function buildGradedPicksShareHtml({ userPicks, actualSetlist, showLabel }) {
-  const slots = buildGradedPicksShareSlots(userPicks, actualSetlist);
-  const total = calculateTotalScore(userPicks, actualSetlist);
+export function buildGradedPicksShareClipboardHtml({ imageDataUrl, showLabel, totalPoints }) {
   const esc = escapeHtml(showLabel);
+  const alt = escapeHtml(`${GRADED_PICKS_SHARE_RECAP_TITLE} — ${showLabel}`);
+  const href = escapeHtml(GRADED_PICKS_SHARE_SITE_URL);
+  const host = 'setlistpickem.com';
 
-  /**
-   * Inner div carries fill (many clients strip td backgrounds); bgcolor on td is a fallback.
-   */
-  function tdHtml(slot) {
-    const { fill, stroke, text } = paletteForSlot(slot);
-    const bust = slot.bustoutBoost;
-    const borderColor = bust ? '#f59e0b' : stroke;
-    const borderW = bust ? '3px' : '2px';
-    const boost = bust
-      ? '<div style="font-size:8px;font-weight:700;color:#fbbf24;margin:0 0 4px 0;line-height:1.2;">Bustout Boost™</div>'
-      : '';
-    const inner = `<div style="background-color:${fill};border:${borderW} solid ${borderColor};border-radius:14px;padding:10px 6px 12px 6px;text-align:center;min-height:52px;">
-      ${boost}<div style="font-weight:800;font-size:22px;font-family:Arial,Helvetica,sans-serif;color:${text};line-height:1.15;">${slot.points}</div>
-    </div>`;
-    return `<td width="33%" bgcolor="#0f172a" style="padding:6px;background-color:#0f172a;vertical-align:top;border:none;">${inner}</td>`;
-  }
-
-  const row1 = `<tr>${tdHtml(slots[0])}${tdHtml(slots[1])}${tdHtml(slots[2])}</tr>`;
-  const row2 = `<tr>${tdHtml(slots[3])}${tdHtml(slots[4])}${tdHtml(slots[5])}</tr>`;
-
-  return `<!DOCTYPE html><html><head><meta charset="utf-8"></head><body bgcolor="#0f172a" style="margin:0;background-color:#0f172a;color:#f8fafc;font-family:Arial,Helvetica,sans-serif;padding:16px;">
-<div bgcolor="#0f172a" style="max-width:360px;background-color:#0f172a;">
-  <div style="font-weight:800;font-size:17px;margin-bottom:6px;color:#f8fafc;">${escapeHtml(GRADED_PICKS_SHARE_RECAP_TITLE)}</div>
-  <div style="color:#94a3b8;font-size:12px;margin-bottom:4px;">${escapeHtml(GRADED_PICKS_SHARE_BRAND)} · ${esc}</div>
-  <div style="font-weight:700;color:#2dd4bf;font-size:14px;margin-bottom:12px;">${total} pts</div>
-  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#0f172a" style="width:100%;border-collapse:separate;border-spacing:10px;background-color:#0f172a;">${row1}${row2}</table>
-  <p style="color:#94a3b8;font-size:10px;margin-top:12px;line-height:1.4;">Amber frame = Bustout Boost™ on that slot.</p>
-</div>
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"></head>
+<body bgcolor="#0f172a" style="margin:0;padding:16px;background-color:#0f172a;text-align:center;font-family:Arial,Helvetica,sans-serif;">
+  <img src="${imageDataUrl}" alt="${alt}" width="320" style="max-width:100%;height:auto;display:block;margin:0 auto 12px auto;border-radius:12px;" />
+  <p style="color:#94a3b8;font-size:13px;margin:0 0 10px;line-height:1.4;">${escapeHtml(GRADED_PICKS_SHARE_BRAND)} · ${esc}<br/><span style="color:#2dd4bf;font-weight:700;">${totalPoints} pts</span></p>
+  <p style="margin:0;font-size:14px;"><a href="${href}" style="color:#2dd4bf;font-weight:800;">Play free · ${host} →</a></p>
 </body></html>`;
 }
 
@@ -211,7 +158,7 @@ function drawBoostPill(ctx, x, y, w) {
  */
 export function renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints, scale = 2 }) {
   const W = 640;
-  const H = 420;
+  const H = 440;
 
   const canvas = document.createElement('canvas');
   canvas.width = Math.round(W * scale);
@@ -245,7 +192,7 @@ export function renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints, s
 
   const padX = 20;
   const padTop = 72;
-  const footerH = 28;
+  const footerH = 48;
   const gap = 12;
   const rowGap = 12;
   const cellW = (W - padX * 2 - gap * 2) / 3;
@@ -298,11 +245,14 @@ export function renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints, s
     ctx.stroke();
   });
 
-  ctx.fillStyle = 'rgba(148, 163, 184, 0.85)';
-  ctx.font = '10px Inter, system-ui, -apple-system, sans-serif';
   ctx.textAlign = 'center';
   ctx.textBaseline = 'alphabetic';
-  ctx.fillText('Amber frame = Bustout Boost™ on that slot.', W / 2, H - 12);
+  ctx.fillStyle = 'rgba(148, 163, 184, 0.9)';
+  ctx.font = '9px Inter, system-ui, -apple-system, sans-serif';
+  ctx.fillText('Amber frame = Bustout Boost™ on that slot.', W / 2, H - 32);
+  ctx.fillStyle = 'rgb(45, 212, 191)';
+  ctx.font = 'bold 11px Inter, system-ui, -apple-system, sans-serif';
+  ctx.fillText('setlistpickem.com · Free to play', W / 2, H - 12);
 
   return new Promise((resolve, reject) => {
     canvas.toBlob(

--- a/src/features/scoring/model/gradedPicksShareCore.js
+++ b/src/features/scoring/model/gradedPicksShareCore.js
@@ -1,4 +1,4 @@
-import { FORM_FIELDS } from '../../../shared/data/gameConfig';
+import { FORM_FIELDS, SHARE_RECAP_ARTIST_NAME } from '../../../shared/data/gameConfig';
 import {
   calculateTotalScore,
   getSlotScoreBreakdown,
@@ -54,6 +54,39 @@ export function buildGradedPicksShareSlots(userPicks, actualSetlist) {
  *
  * @param {ReturnType<typeof buildGradedPicksShareSlots>[number]} slot
  */
+/**
+ * Colored block + points + optional BB (plain-text / SMS friendly).
+ * Uses large colored squares (not custom icons — plain text cannot embed SVG).
+ *
+ * @param {ReturnType<typeof buildGradedPicksShareSlots>[number]} slot
+ * @param {Record<string, unknown>} userPicks
+ */
+function shareEmojiCellToken(slot, userPicks) {
+  const raw = userPicks?.[slot.fieldId];
+  const hasPick = raw != null && String(raw).trim() !== '';
+  let block = '⬛';
+  if (hasPick) {
+    if (slot.kind === 'miss' || slot.kind === 'none') block = '⬛';
+    else if (slot.kind === 'in_setlist') block = '🟦';
+    else block = '🟩';
+  }
+  const bust = slot.bustoutBoost ? ' BB' : '';
+  return `${block}${slot.points}${bust}`;
+}
+
+/**
+ * Two rows × three columns, padded for monospace alignment.
+ *
+ * @param {ReturnType<typeof buildGradedPicksShareSlots>} slots
+ * @param {Record<string, unknown>} userPicks
+ */
+export function buildGradedPicksShareEmojiGrid(slots, userPicks) {
+  const cells = slots.map((s) => shareEmojiCellToken(s, userPicks));
+  const w = Math.max(...cells.map((c) => c.length), 5);
+  const pad = (c) => c.padEnd(w, ' ');
+  return `${pad(cells[0])} ${pad(cells[1])} ${pad(cells[2])}\n${pad(cells[3])} ${pad(cells[4])} ${pad(cells[5])}`;
+}
+
 function paletteForSlot(slot) {
   if (slot.kind === 'none' || slot.kind === 'miss') {
     return {
@@ -83,12 +116,18 @@ function paletteForSlot(slot) {
  * @param {{ userPicks: Record<string, unknown>, actualSetlist: unknown, showLabel: string }} args
  */
 export function buildGradedPicksShareBodyPlain({ userPicks, actualSetlist, showLabel }) {
+  const slots = buildGradedPicksShareSlots(userPicks, actualSetlist);
   const total = calculateTotalScore(userPicks, actualSetlist);
+  const grid = buildGradedPicksShareEmojiGrid(slots, userPicks);
   return [
-    `${GRADED_PICKS_SHARE_BRAND} · ${showLabel}`,
+    `${SHARE_RECAP_ARTIST_NAME} · ${showLabel}`,
     `Total: ${total} pts`,
     '',
-    'Free live setlist picks for Phish shows — join the pool:',
+    grid,
+    '',
+    '🟩 strong pick · 🟦 in setlist · ⬛ miss or empty · BB = Bustout Boost™',
+    '',
+    'Free setlist game:',
     GRADED_PICKS_SHARE_SITE_URL,
   ].join('\n');
 }
@@ -113,6 +152,7 @@ export function buildGradedPicksShareText(args) {
  */
 export function buildGradedPicksShareClipboardHtml({ imageDataUrl, showLabel, totalPoints }) {
   const esc = escapeHtml(showLabel);
+  const artistEsc = escapeHtml(SHARE_RECAP_ARTIST_NAME);
   const alt = escapeHtml(`${GRADED_PICKS_SHARE_RECAP_TITLE} — ${showLabel}`);
   const href = escapeHtml(GRADED_PICKS_SHARE_SITE_URL);
   const host = 'setlistpickem.com';
@@ -120,7 +160,7 @@ export function buildGradedPicksShareClipboardHtml({ imageDataUrl, showLabel, to
   return `<!DOCTYPE html><html><head><meta charset="utf-8"></head>
 <body bgcolor="#0f172a" style="margin:0;padding:16px;background-color:#0f172a;text-align:center;font-family:Arial,Helvetica,sans-serif;">
   <img src="${imageDataUrl}" alt="${alt}" width="320" style="max-width:100%;height:auto;display:block;margin:0 auto 12px auto;border-radius:12px;" />
-  <p style="color:#94a3b8;font-size:13px;margin:0 0 10px;line-height:1.4;">${escapeHtml(GRADED_PICKS_SHARE_BRAND)} · ${esc}<br/><span style="color:#2dd4bf;font-weight:700;">${totalPoints} pts</span></p>
+  <p style="color:#94a3b8;font-size:13px;margin:0 0 10px;line-height:1.4;">${artistEsc} · ${esc}<br/><span style="color:#2dd4bf;font-weight:700;">${totalPoints} pts</span></p>
   <p style="margin:0;font-size:14px;"><a href="${href}" style="color:#2dd4bf;font-weight:800;">Play free · ${host} →</a></p>
 </body></html>`;
 }
@@ -156,7 +196,7 @@ function drawBoostPill(ctx, x, y, w) {
  * @param {{ showLabel: string, totalPoints: number, scale?: number }} opts
  * @returns {Promise<Blob>}
  */
-export function renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints, scale = 2 }) {
+export function renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints, scale = 2, artistName = SHARE_RECAP_ARTIST_NAME }) {
   const W = 640;
   const H = 440;
 
@@ -180,7 +220,7 @@ export function renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints, s
 
   ctx.fillStyle = 'rgb(148, 163, 184)';
   ctx.font = '12px Inter, system-ui, -apple-system, sans-serif';
-  ctx.fillText(`${GRADED_PICKS_SHARE_BRAND} · ${showLabel}`, 22, 54);
+  ctx.fillText(`${artistName} · ${showLabel}`, 22, 54);
 
   const ptsLabel = `${totalPoints} pts`;
   ctx.font = 'bold 15px Inter, system-ui, -apple-system, sans-serif';

--- a/src/features/scoring/model/gradedPicksShareCore.js
+++ b/src/features/scoring/model/gradedPicksShareCore.js
@@ -47,26 +47,31 @@ export function buildGradedPicksShareSlots(userPicks, actualSetlist) {
   });
 }
 
-/** @param {ReturnType<typeof buildGradedPicksShareSlots>[number]} slot */
+/**
+ * Opaque fills so PNG + HTML paste read clearly on dark canvas and on white
+ * rich-text targets (translucent rgba on white looked like blank white tiles).
+ *
+ * @param {ReturnType<typeof buildGradedPicksShareSlots>[number]} slot
+ */
 function paletteForSlot(slot) {
   if (slot.kind === 'none' || slot.kind === 'miss') {
     return {
-      fill: 'rgba(30, 41, 59, 0.95)',
-      stroke: 'rgba(100, 116, 139, 0.55)',
-      text: 'rgb(148, 163, 184)',
+      fill: '#1e293b',
+      stroke: '#64748b',
+      text: '#94a3b8',
     };
   }
   if (slot.kind === 'in_setlist') {
     return {
-      fill: 'rgba(59, 130, 246, 0.12)',
-      stroke: 'rgba(59, 130, 246, 0.5)',
-      text: 'rgb(147, 197, 253)',
+      fill: '#172554',
+      stroke: '#3b82f6',
+      text: '#93c5fd',
     };
   }
   return {
-    fill: 'rgba(45, 212, 191, 0.12)',
-    stroke: 'rgba(45, 212, 191, 0.5)',
-    text: 'rgb(204, 251, 241)',
+    fill: '#134e4a',
+    stroke: '#2dd4bf',
+    text: '#ccfbf1',
   };
 }
 
@@ -116,7 +121,7 @@ export function buildGradedPicksShareBodyPlain({ userPicks, actualSetlist, showL
   lines.push(buildGradedPicksShareBlockRow(slots, userPicks));
   lines.push('█ hit · ▓ in setlist · ░ miss or empty');
   lines.push('');
-  lines.push('Tip: Paste into Mail, Notes, or Slack for a color card if you used Copy recap; or use Download PNG.');
+  lines.push('Tip: Use Download PNG for the full color card everywhere; Copy recap adds color in Mail/Notes/Slack when rich paste is supported.');
   return lines.join('\n');
 }
 
@@ -142,27 +147,32 @@ export function buildGradedPicksShareHtml({ userPicks, actualSetlist, showLabel 
   const total = calculateTotalScore(userPicks, actualSetlist);
   const esc = escapeHtml(showLabel);
 
+  /**
+   * Inner div carries fill (many clients strip td backgrounds); bgcolor on td is a fallback.
+   */
   function tdHtml(slot) {
     const { fill, stroke, text } = paletteForSlot(slot);
     const bust = slot.bustoutBoost;
-    const border = bust ? '2.5px solid rgba(245,158,11,0.75)' : `1.75px solid ${stroke}`;
+    const borderColor = bust ? '#f59e0b' : stroke;
+    const borderW = bust ? '3px' : '2px';
     const boost = bust
-      ? '<div style="font-size:8px;font-weight:700;color:#fbbf24;margin-bottom:2px;">Bustout Boost™</div>'
+      ? '<div style="font-size:8px;font-weight:700;color:#fbbf24;margin:0 0 4px 0;line-height:1.2;">Bustout Boost™</div>'
       : '';
-    return `<td style="padding:6px;border-radius:12px;background:${fill};border:${border};color:${text};text-align:center;width:33%;vertical-align:middle;">
-      ${boost}<div style="font:800 20px system-ui,-apple-system,BlinkMacSystemFont,sans-serif;">${slot.points}</div>
-    </td>`;
+    const inner = `<div style="background-color:${fill};border:${borderW} solid ${borderColor};border-radius:14px;padding:10px 6px 12px 6px;text-align:center;min-height:52px;">
+      ${boost}<div style="font-weight:800;font-size:22px;font-family:Arial,Helvetica,sans-serif;color:${text};line-height:1.15;">${slot.points}</div>
+    </div>`;
+    return `<td width="33%" bgcolor="#0f172a" style="padding:6px;background-color:#0f172a;vertical-align:top;border:none;">${inner}</td>`;
   }
 
   const row1 = `<tr>${tdHtml(slots[0])}${tdHtml(slots[1])}${tdHtml(slots[2])}</tr>`;
   const row2 = `<tr>${tdHtml(slots[3])}${tdHtml(slots[4])}${tdHtml(slots[5])}</tr>`;
 
-  return `<!DOCTYPE html><html><head><meta charset="utf-8"></head><body style="margin:0;background:#0f172a;color:#f8fafc;font-family:system-ui,-apple-system,sans-serif;padding:16px;">
-<div style="max-width:360px;">
-  <div style="font-weight:800;font-size:17px;margin-bottom:6px;">${escapeHtml(GRADED_PICKS_SHARE_RECAP_TITLE)}</div>
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"></head><body bgcolor="#0f172a" style="margin:0;background-color:#0f172a;color:#f8fafc;font-family:Arial,Helvetica,sans-serif;padding:16px;">
+<div bgcolor="#0f172a" style="max-width:360px;background-color:#0f172a;">
+  <div style="font-weight:800;font-size:17px;margin-bottom:6px;color:#f8fafc;">${escapeHtml(GRADED_PICKS_SHARE_RECAP_TITLE)}</div>
   <div style="color:#94a3b8;font-size:12px;margin-bottom:4px;">${escapeHtml(GRADED_PICKS_SHARE_BRAND)} · ${esc}</div>
   <div style="font-weight:700;color:#2dd4bf;font-size:14px;margin-bottom:12px;">${total} pts</div>
-  <table role="presentation" cellspacing="8" cellpadding="0" style="width:100%;border-collapse:separate;">${row1}${row2}</table>
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" bgcolor="#0f172a" style="width:100%;border-collapse:separate;border-spacing:10px;background-color:#0f172a;">${row1}${row2}</table>
   <p style="color:#94a3b8;font-size:10px;margin-top:12px;line-height:1.4;">Amber frame = Bustout Boost™ on that slot.</p>
 </div>
 </body></html>`;
@@ -283,7 +293,7 @@ export function renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints, s
 
     ctx.beginPath();
     ctx.roundRect(x, y, cellW, cellH, cornerR);
-    ctx.strokeStyle = bust ? 'rgba(245, 158, 11, 0.55)' : stroke;
+    ctx.strokeStyle = bust ? '#f59e0b' : stroke;
     ctx.lineWidth = borderW;
     ctx.stroke();
   });

--- a/src/features/scoring/model/gradedPicksShareCore.js
+++ b/src/features/scoring/model/gradedPicksShareCore.js
@@ -7,6 +7,9 @@ import {
 /** Matches splash / marketing copy (`SplashHeader`, `SplashAboutSection`). */
 export const GRADED_PICKS_SHARE_BRAND = "Setlist Pick 'Em";
 
+/** Web Share API title + recap headline (plain language). */
+export const GRADED_PICKS_SHARE_RECAP_TITLE = "My Setlist Pick 'Em Recap";
+
 /**
  * @param {Record<string, unknown>} userPicks
  * @param {unknown} actualSetlist
@@ -32,52 +35,117 @@ export function buildGradedPicksShareSlots(userPicks, actualSetlist) {
   });
 }
 
-function tileEmoji(slot) {
-  if (slot.kind === 'none' || slot.kind === 'miss') return '⬛';
-  if (slot.kind === 'in_setlist') return '🟦';
-  return '🟩';
+/**
+ * Single-letter slot tier for plain-text share (no emoji — SMS/social safe).
+ * @param {string} kind
+ * @param {boolean} hasPick
+ */
+export function shareTextKindLetter(kind, hasPick) {
+  if (!hasPick) return '—';
+  switch (kind) {
+    case 'exact_slot':
+      return 'X';
+    case 'encore_exact':
+      return 'E';
+    case 'wildcard_hit':
+      return 'W';
+    case 'in_setlist':
+      return 'I';
+    case 'miss':
+      return 'M';
+    default:
+      return '—';
+  }
 }
 
-function cellTextToken(slot) {
-  const emoji = tileEmoji(slot);
-  const bust = slot.bustoutBoost ? '⭐' : '';
-  return `${emoji}${bust}${slot.points}`;
+function formatShareTextCell(slot, userPicks) {
+  const raw = userPicks?.[slot.fieldId];
+  const hasPick = raw != null && String(raw).trim() !== '';
+  const letter = shareTextKindLetter(slot.kind, hasPick);
+  const bust = slot.bustoutBoost ? ' BB' : '';
+  return `${letter}${slot.points}${bust}`;
+}
+
+function padShareCells(cells, cellWidth) {
+  return cells.map((c) => c.padEnd(cellWidth, ' '));
 }
 
 /**
- * Compact share caption: brand, show label, total, 2×3 emoji-ish grid with per-slot points.
+ * Compact share caption: recap title, brand, show, total, 2×3 letter grid + legend (no emoji).
  *
  * @param {{ userPicks: Record<string, unknown>, actualSetlist: unknown, showLabel: string }} args
  */
 export function buildGradedPicksShareText({ userPicks, actualSetlist, showLabel }) {
   const slots = buildGradedPicksShareSlots(userPicks, actualSetlist);
   const total = calculateTotalScore(userPicks, actualSetlist);
-  const row1 = slots.slice(0, 3).map(cellTextToken).join('  ');
-  const row2 = slots.slice(3, 6).map(cellTextToken).join('  ');
+  const cells = slots.map((s) => formatShareTextCell(s, userPicks));
+  const cellW = Math.max(...cells.map((c) => c.length), 6);
+  const [a, b, c, d, e, f] = padShareCells(cells, cellW);
+  const row1 = `${a} ${b} ${c}`;
+  const row2 = `${d} ${e} ${f}`;
   return [
+    GRADED_PICKS_SHARE_RECAP_TITLE,
     `${GRADED_PICKS_SHARE_BRAND} · ${showLabel}`,
-    `${total} pts`,
+    `Total: ${total} pts`,
     '',
     row1,
     row2,
     '',
-    '⭐ = bustout bonus',
+    'X=Exact slot · E=Encore exact · W=Wildcard · I=In setlist · M=Miss · —=No pick',
+    'BB=Bustout Boost™',
   ].join('\n');
 }
 
 /** @param {ReturnType<typeof buildGradedPicksShareSlots>[number]} slot */
 function paletteForSlot(slot) {
   if (slot.kind === 'none' || slot.kind === 'miss') {
-    return { fill: '#1e293b', stroke: '#64748b', text: '#e2e8f0' };
+    return {
+      fill: 'rgba(30, 41, 59, 0.95)',
+      stroke: 'rgba(100, 116, 139, 0.55)',
+      text: 'rgb(148, 163, 184)',
+    };
   }
   if (slot.kind === 'in_setlist') {
-    return { fill: '#172554', stroke: '#3b82f6', text: '#bfdbfe' };
+    return {
+      fill: 'rgba(59, 130, 246, 0.12)',
+      stroke: 'rgba(59, 130, 246, 0.5)',
+      text: 'rgb(147, 197, 253)',
+    };
   }
-  return { fill: '#134e4a', stroke: '#2dd4bf', text: '#ccfbf1' };
+  return {
+    fill: 'rgba(45, 212, 191, 0.12)',
+    stroke: 'rgba(45, 212, 191, 0.5)',
+    text: 'rgb(204, 251, 241)',
+  };
+}
+
+/**
+ * @param {CanvasRenderingContext2D} ctx
+ */
+function drawBoostPill(ctx, x, y, w) {
+  const pillH = 17;
+  const pillR = pillH / 2;
+  const label = 'Bustout Boost™';
+  ctx.font = '600 8.5px Inter, system-ui, -apple-system, sans-serif';
+  const tw = ctx.measureText(label).width;
+  const pillW = Math.min(w - 10, tw + 14);
+  const px = x + (w - pillW) / 2;
+  ctx.beginPath();
+  ctx.roundRect(px, y, pillW, pillH, pillR);
+  ctx.fillStyle = 'rgba(245, 158, 11, 0.16)';
+  ctx.fill();
+  ctx.strokeStyle = 'rgba(245, 158, 11, 0.38)';
+  ctx.lineWidth = 1;
+  ctx.stroke();
+  ctx.fillStyle = 'rgb(251, 191, 36)';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(label, px + pillW / 2, y + pillH / 2);
 }
 
 /**
  * Draws a 2×3 graded grid (slot order = {@link FORM_FIELDS}) to PNG.
+ * Layout matches in-app breakdown: rounded-xl tiles, points centered in cell.
  *
  * @param {ReturnType<typeof buildGradedPicksShareSlots>} slots
  * @param {{ showLabel: string, totalPoints: number, scale?: number }} opts
@@ -85,7 +153,7 @@ function paletteForSlot(slot) {
  */
 export function renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints, scale = 2 }) {
   const W = 640;
-  const H = 400;
+  const H = 420;
 
   const canvas = document.createElement('canvas');
   canvas.width = Math.round(W * scale);
@@ -96,58 +164,87 @@ export function renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints, s
   }
   ctx.scale(scale, scale);
 
-  ctx.fillStyle = '#0f172a';
+  ctx.fillStyle = 'rgb(15, 23, 42)';
   ctx.fillRect(0, 0, W, H);
 
   ctx.fillStyle = '#f8fafc';
-  ctx.font = 'bold 20px Inter, system-ui, -apple-system, sans-serif';
-  ctx.fillText(GRADED_PICKS_SHARE_BRAND, 22, 36);
+  ctx.font = 'bold 19px Inter, system-ui, -apple-system, sans-serif';
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'alphabetic';
+  ctx.fillText(GRADED_PICKS_SHARE_RECAP_TITLE, 22, 34);
 
-  ctx.fillStyle = '#94a3b8';
-  ctx.font = '13px Inter, system-ui, -apple-system, sans-serif';
-  ctx.fillText(showLabel, 22, 58);
+  ctx.fillStyle = 'rgb(148, 163, 184)';
+  ctx.font = '12px Inter, system-ui, -apple-system, sans-serif';
+  ctx.fillText(`${GRADED_PICKS_SHARE_BRAND} · ${showLabel}`, 22, 54);
 
   const ptsLabel = `${totalPoints} pts`;
-  ctx.font = 'bold 16px Inter, system-ui, -apple-system, sans-serif';
-  ctx.fillStyle = '#2dd4bf';
+  ctx.font = 'bold 15px Inter, system-ui, -apple-system, sans-serif';
+  ctx.fillStyle = 'rgb(45, 212, 191)';
   const ptsW = ctx.measureText(ptsLabel).width;
-  ctx.fillText(ptsLabel, W - 22 - ptsW, 40);
+  ctx.textAlign = 'right';
+  ctx.fillText(ptsLabel, W - 22, 36);
+  ctx.textAlign = 'left';
 
   const padX = 20;
-  const padY = 78;
+  const padTop = 72;
+  const footerH = 28;
   const gap = 12;
+  const rowGap = 12;
   const cellW = (W - padX * 2 - gap * 2) / 3;
-  const cellH = (H - padY - 20 - gap) / 2;
-  const r = 10;
+  const cellH = (H - padTop - footerH - rowGap) / 2;
+  const cornerR = 14;
 
   slots.forEach((slot, i) => {
     const col = i % 3;
     const row = Math.floor(i / 3);
     const x = padX + col * (cellW + gap);
-    const y = padY + row * (cellH + gap);
+    const y = padTop + row * (cellH + rowGap);
     const { fill, stroke, text } = paletteForSlot(slot);
     const bust = slot.bustoutBoost;
+    const borderW = bust ? 2.5 : 1.75;
 
     ctx.beginPath();
-    ctx.roundRect(x, y, cellW, cellH, r);
+    ctx.roundRect(x, y, cellW, cellH, cornerR);
     ctx.fillStyle = fill;
     ctx.fill();
-    ctx.lineWidth = bust ? 3.5 : 2;
-    ctx.strokeStyle = bust ? '#f59e0b' : stroke;
-    ctx.stroke();
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.roundRect(x + borderW, y + borderW, cellW - borderW * 2, cellH - borderW * 2, Math.max(4, cornerR - borderW));
+    ctx.clip();
+
+    const innerPad = 10;
+    let contentTop = y + innerPad;
+    if (bust) {
+      drawBoostPill(ctx, x, contentTop, cellW);
+      contentTop += 22;
+    }
+
+    const contentBottom = y + cellH - innerPad;
+    const centerY = (contentTop + contentBottom) / 2;
+    const mainSize = Math.min(32, Math.max(20, cellH * 0.38));
 
     ctx.fillStyle = text;
-    ctx.font = 'bold 28px Inter, system-ui, -apple-system, sans-serif';
+    ctx.font = `800 ${mainSize}px Inter, system-ui, -apple-system, sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
     const ptsStr = String(slot.points);
-    const tw = ctx.measureText(ptsStr).width;
-    ctx.fillText(ptsStr, x + (cellW - tw) / 2, y + cellH / 2 + 10);
+    ctx.fillText(ptsStr, x + cellW / 2, centerY);
 
-    if (bust) {
-      ctx.font = 'bold 11px Inter, system-ui, -apple-system, sans-serif';
-      ctx.fillStyle = '#fbbf24';
-      ctx.fillText('Bustout', x + 8, y + 18);
-    }
+    ctx.restore();
+
+    ctx.beginPath();
+    ctx.roundRect(x, y, cellW, cellH, cornerR);
+    ctx.strokeStyle = bust ? 'rgba(245, 158, 11, 0.55)' : stroke;
+    ctx.lineWidth = borderW;
+    ctx.stroke();
   });
+
+  ctx.fillStyle = 'rgba(148, 163, 184, 0.85)';
+  ctx.font = '10px Inter, system-ui, -apple-system, sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'alphabetic';
+  ctx.fillText('Amber frame = Bustout Boost™ on that slot.', W / 2, H - 12);
 
   return new Promise((resolve, reject) => {
     canvas.toBlob(

--- a/src/features/scoring/model/gradedPicksShareCore.js
+++ b/src/features/scoring/model/gradedPicksShareCore.js
@@ -2,13 +2,25 @@ import { FORM_FIELDS } from '../../../shared/data/gameConfig';
 import {
   calculateTotalScore,
   getSlotScoreBreakdown,
+  SCORE_BREAKDOWN_KIND_LABEL,
 } from '../../../shared/utils/scoring';
 
 /** Matches splash / marketing copy (`SplashHeader`, `SplashAboutSection`). */
 export const GRADED_PICKS_SHARE_BRAND = "Setlist Pick 'Em";
 
-/** Web Share API title + recap headline (plain language). */
+/** Web Share API `title` + first line when copying full plain text. */
 export const GRADED_PICKS_SHARE_RECAP_TITLE = "My Setlist Pick 'Em Recap";
+
+/**
+ * @param {string} s
+ */
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
 
 /**
  * @param {Record<string, unknown>} userPicks
@@ -35,67 +47,6 @@ export function buildGradedPicksShareSlots(userPicks, actualSetlist) {
   });
 }
 
-/**
- * Single-letter slot tier for plain-text share (no emoji — SMS/social safe).
- * @param {string} kind
- * @param {boolean} hasPick
- */
-export function shareTextKindLetter(kind, hasPick) {
-  if (!hasPick) return '—';
-  switch (kind) {
-    case 'exact_slot':
-      return 'X';
-    case 'encore_exact':
-      return 'E';
-    case 'wildcard_hit':
-      return 'W';
-    case 'in_setlist':
-      return 'I';
-    case 'miss':
-      return 'M';
-    default:
-      return '—';
-  }
-}
-
-function formatShareTextCell(slot, userPicks) {
-  const raw = userPicks?.[slot.fieldId];
-  const hasPick = raw != null && String(raw).trim() !== '';
-  const letter = shareTextKindLetter(slot.kind, hasPick);
-  const bust = slot.bustoutBoost ? ' BB' : '';
-  return `${letter}${slot.points}${bust}`;
-}
-
-function padShareCells(cells, cellWidth) {
-  return cells.map((c) => c.padEnd(cellWidth, ' '));
-}
-
-/**
- * Compact share caption: recap title, brand, show, total, 2×3 letter grid + legend (no emoji).
- *
- * @param {{ userPicks: Record<string, unknown>, actualSetlist: unknown, showLabel: string }} args
- */
-export function buildGradedPicksShareText({ userPicks, actualSetlist, showLabel }) {
-  const slots = buildGradedPicksShareSlots(userPicks, actualSetlist);
-  const total = calculateTotalScore(userPicks, actualSetlist);
-  const cells = slots.map((s) => formatShareTextCell(s, userPicks));
-  const cellW = Math.max(...cells.map((c) => c.length), 6);
-  const [a, b, c, d, e, f] = padShareCells(cells, cellW);
-  const row1 = `${a} ${b} ${c}`;
-  const row2 = `${d} ${e} ${f}`;
-  return [
-    GRADED_PICKS_SHARE_RECAP_TITLE,
-    `${GRADED_PICKS_SHARE_BRAND} · ${showLabel}`,
-    `Total: ${total} pts`,
-    '',
-    row1,
-    row2,
-    '',
-    'X=Exact slot · E=Encore exact · W=Wildcard · I=In setlist · M=Miss · —=No pick',
-    'BB=Bustout Boost™',
-  ].join('\n');
-}
-
 /** @param {ReturnType<typeof buildGradedPicksShareSlots>[number]} slot */
 function paletteForSlot(slot) {
   if (slot.kind === 'none' || slot.kind === 'miss') {
@@ -117,6 +68,104 @@ function paletteForSlot(slot) {
     stroke: 'rgba(45, 212, 191, 0.5)',
     text: 'rgb(204, 251, 241)',
   };
+}
+
+/**
+ * Monochrome “block” row for plain-text clients (█ strong · ▓ in-setlist · ░ miss / empty).
+ * Not emoji; Unicode block elements.
+ */
+export function buildGradedPicksShareBlockRow(slots, userPicks) {
+  const ch = (slot) => {
+    const raw = userPicks?.[slot.fieldId];
+    const hasPick = raw != null && String(raw).trim() !== '';
+    if (!hasPick) return '░';
+    if (slot.kind === 'miss' || slot.kind === 'none') return '░';
+    if (slot.kind === 'in_setlist') return '▓';
+    return '█';
+  };
+  return `${ch(slots[0])}${ch(slots[1])}${ch(slots[2])}\n${ch(slots[3])}${ch(slots[4])}${ch(slots[5])}`;
+}
+
+function slotReadableLine(field, slot, userPicks) {
+  const raw = userPicks?.[field.id];
+  const hasPick = raw != null && String(raw).trim() !== '';
+  const kindLabel = hasPick ? SCORE_BREAKDOWN_KIND_LABEL[slot.kind] || '—' : 'No pick';
+  const bb = slot.bustoutBoost ? ' · Bustout Boost™' : '';
+  return `${field.label}: ${slot.points} pts — ${kindLabel}${bb}`;
+}
+
+/**
+ * Readable recap body (no top headline). Safe to pair with `navigator.share({ title })`
+ * so clients do not concatenate two identical titles.
+ *
+ * @param {{ userPicks: Record<string, unknown>, actualSetlist: unknown, showLabel: string }} args
+ */
+export function buildGradedPicksShareBodyPlain({ userPicks, actualSetlist, showLabel }) {
+  const slots = buildGradedPicksShareSlots(userPicks, actualSetlist);
+  const total = calculateTotalScore(userPicks, actualSetlist);
+  const lines = [
+    `${GRADED_PICKS_SHARE_BRAND} · ${showLabel}`,
+    `Total: ${total} pts`,
+    '',
+  ];
+  FORM_FIELDS.forEach((field, i) => {
+    const slot = slots[i];
+    lines.push(slotReadableLine(field, slot, userPicks));
+  });
+  lines.push('');
+  lines.push(buildGradedPicksShareBlockRow(slots, userPicks));
+  lines.push('█ hit · ▓ in setlist · ░ miss or empty');
+  lines.push('');
+  lines.push('Tip: Paste into Mail, Notes, or Slack for a color card if you used Copy recap; or use Download PNG.');
+  return lines.join('\n');
+}
+
+/**
+ * Full plain text for clipboard fallback (headline once, then body).
+ */
+export function buildGradedPicksShareFullPlainText(args) {
+  return [GRADED_PICKS_SHARE_RECAP_TITLE, '', buildGradedPicksShareBodyPlain(args)].join('\n');
+}
+
+/** @deprecated Prefer {@link buildGradedPicksShareFullPlainText}; alias for older imports. */
+export function buildGradedPicksShareText(args) {
+  return buildGradedPicksShareFullPlainText(args);
+}
+
+/**
+ * Minimal HTML for rich clipboard / some mail clients — colored 2×3 grid, no Lucide (not possible in HTML string).
+ *
+ * @param {{ userPicks: Record<string, unknown>, actualSetlist: unknown, showLabel: string }} args
+ */
+export function buildGradedPicksShareHtml({ userPicks, actualSetlist, showLabel }) {
+  const slots = buildGradedPicksShareSlots(userPicks, actualSetlist);
+  const total = calculateTotalScore(userPicks, actualSetlist);
+  const esc = escapeHtml(showLabel);
+
+  function tdHtml(slot) {
+    const { fill, stroke, text } = paletteForSlot(slot);
+    const bust = slot.bustoutBoost;
+    const border = bust ? '2.5px solid rgba(245,158,11,0.75)' : `1.75px solid ${stroke}`;
+    const boost = bust
+      ? '<div style="font-size:8px;font-weight:700;color:#fbbf24;margin-bottom:2px;">Bustout Boost™</div>'
+      : '';
+    return `<td style="padding:6px;border-radius:12px;background:${fill};border:${border};color:${text};text-align:center;width:33%;vertical-align:middle;">
+      ${boost}<div style="font:800 20px system-ui,-apple-system,BlinkMacSystemFont,sans-serif;">${slot.points}</div>
+    </td>`;
+  }
+
+  const row1 = `<tr>${tdHtml(slots[0])}${tdHtml(slots[1])}${tdHtml(slots[2])}</tr>`;
+  const row2 = `<tr>${tdHtml(slots[3])}${tdHtml(slots[4])}${tdHtml(slots[5])}</tr>`;
+
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"></head><body style="margin:0;background:#0f172a;color:#f8fafc;font-family:system-ui,-apple-system,sans-serif;padding:16px;">
+<div style="max-width:360px;">
+  <div style="font-weight:800;font-size:17px;margin-bottom:6px;">${escapeHtml(GRADED_PICKS_SHARE_RECAP_TITLE)}</div>
+  <div style="color:#94a3b8;font-size:12px;margin-bottom:4px;">${escapeHtml(GRADED_PICKS_SHARE_BRAND)} · ${esc}</div>
+  <div style="font-weight:700;color:#2dd4bf;font-size:14px;margin-bottom:12px;">${total} pts</div>
+  <table role="presentation" cellspacing="8" cellpadding="0" style="width:100%;border-collapse:separate;">${row1}${row2}</table>
+  <p style="color:#94a3b8;font-size:10px;margin-top:12px;line-height:1.4;">Amber frame = Bustout Boost™ on that slot.</p>
+</div>
+</body></html>`;
 }
 
 /**
@@ -145,7 +194,6 @@ function drawBoostPill(ctx, x, y, w) {
 
 /**
  * Draws a 2×3 graded grid (slot order = {@link FORM_FIELDS}) to PNG.
- * Layout matches in-app breakdown: rounded-xl tiles, points centered in cell.
  *
  * @param {ReturnType<typeof buildGradedPicksShareSlots>} slots
  * @param {{ showLabel: string, totalPoints: number, scale?: number }} opts

--- a/src/features/scoring/model/gradedPicksShareCore.js
+++ b/src/features/scoring/model/gradedPicksShareCore.js
@@ -1,0 +1,162 @@
+import { FORM_FIELDS } from '../../../shared/data/gameConfig';
+import {
+  calculateTotalScore,
+  getSlotScoreBreakdown,
+} from '../../../shared/utils/scoring';
+
+/** Matches splash / marketing copy (`SplashHeader`, `SplashAboutSection`). */
+export const GRADED_PICKS_SHARE_BRAND = "Setlist Pick 'Em";
+
+/**
+ * @param {Record<string, unknown>} userPicks
+ * @param {unknown} actualSetlist
+ * @returns {Array<{ fieldId: string, label: string, points: number, bustoutBoost: boolean, kind: string }>}
+ */
+export function buildGradedPicksShareSlots(userPicks, actualSetlist) {
+  return FORM_FIELDS.map((field) => {
+    if (!actualSetlist || !userPicks) {
+      return {
+        fieldId: field.id,
+        label: field.label,
+        points: 0,
+        bustoutBoost: false,
+        kind: /** @type {const} */ ('none'),
+      };
+    }
+    const { points, bustoutBoost, kind } = getSlotScoreBreakdown(
+      field.id,
+      userPicks[field.id],
+      actualSetlist
+    );
+    return { fieldId: field.id, label: field.label, points, bustoutBoost, kind };
+  });
+}
+
+function tileEmoji(slot) {
+  if (slot.kind === 'none' || slot.kind === 'miss') return '⬛';
+  if (slot.kind === 'in_setlist') return '🟦';
+  return '🟩';
+}
+
+function cellTextToken(slot) {
+  const emoji = tileEmoji(slot);
+  const bust = slot.bustoutBoost ? '⭐' : '';
+  return `${emoji}${bust}${slot.points}`;
+}
+
+/**
+ * Compact share caption: brand, show label, total, 2×3 emoji-ish grid with per-slot points.
+ *
+ * @param {{ userPicks: Record<string, unknown>, actualSetlist: unknown, showLabel: string }} args
+ */
+export function buildGradedPicksShareText({ userPicks, actualSetlist, showLabel }) {
+  const slots = buildGradedPicksShareSlots(userPicks, actualSetlist);
+  const total = calculateTotalScore(userPicks, actualSetlist);
+  const row1 = slots.slice(0, 3).map(cellTextToken).join('  ');
+  const row2 = slots.slice(3, 6).map(cellTextToken).join('  ');
+  return [
+    `${GRADED_PICKS_SHARE_BRAND} · ${showLabel}`,
+    `${total} pts`,
+    '',
+    row1,
+    row2,
+    '',
+    '⭐ = bustout bonus',
+  ].join('\n');
+}
+
+/** @param {ReturnType<typeof buildGradedPicksShareSlots>[number]} slot */
+function paletteForSlot(slot) {
+  if (slot.kind === 'none' || slot.kind === 'miss') {
+    return { fill: '#1e293b', stroke: '#64748b', text: '#e2e8f0' };
+  }
+  if (slot.kind === 'in_setlist') {
+    return { fill: '#172554', stroke: '#3b82f6', text: '#bfdbfe' };
+  }
+  return { fill: '#134e4a', stroke: '#2dd4bf', text: '#ccfbf1' };
+}
+
+/**
+ * Draws a 2×3 graded grid (slot order = {@link FORM_FIELDS}) to PNG.
+ *
+ * @param {ReturnType<typeof buildGradedPicksShareSlots>} slots
+ * @param {{ showLabel: string, totalPoints: number, scale?: number }} opts
+ * @returns {Promise<Blob>}
+ */
+export function renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints, scale = 2 }) {
+  const W = 640;
+  const H = 400;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.round(W * scale);
+  canvas.height = Math.round(H * scale);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    return Promise.reject(new Error('Canvas 2D context unavailable'));
+  }
+  ctx.scale(scale, scale);
+
+  ctx.fillStyle = '#0f172a';
+  ctx.fillRect(0, 0, W, H);
+
+  ctx.fillStyle = '#f8fafc';
+  ctx.font = 'bold 20px Inter, system-ui, -apple-system, sans-serif';
+  ctx.fillText(GRADED_PICKS_SHARE_BRAND, 22, 36);
+
+  ctx.fillStyle = '#94a3b8';
+  ctx.font = '13px Inter, system-ui, -apple-system, sans-serif';
+  ctx.fillText(showLabel, 22, 58);
+
+  const ptsLabel = `${totalPoints} pts`;
+  ctx.font = 'bold 16px Inter, system-ui, -apple-system, sans-serif';
+  ctx.fillStyle = '#2dd4bf';
+  const ptsW = ctx.measureText(ptsLabel).width;
+  ctx.fillText(ptsLabel, W - 22 - ptsW, 40);
+
+  const padX = 20;
+  const padY = 78;
+  const gap = 12;
+  const cellW = (W - padX * 2 - gap * 2) / 3;
+  const cellH = (H - padY - 20 - gap) / 2;
+  const r = 10;
+
+  slots.forEach((slot, i) => {
+    const col = i % 3;
+    const row = Math.floor(i / 3);
+    const x = padX + col * (cellW + gap);
+    const y = padY + row * (cellH + gap);
+    const { fill, stroke, text } = paletteForSlot(slot);
+    const bust = slot.bustoutBoost;
+
+    ctx.beginPath();
+    ctx.roundRect(x, y, cellW, cellH, r);
+    ctx.fillStyle = fill;
+    ctx.fill();
+    ctx.lineWidth = bust ? 3.5 : 2;
+    ctx.strokeStyle = bust ? '#f59e0b' : stroke;
+    ctx.stroke();
+
+    ctx.fillStyle = text;
+    ctx.font = 'bold 28px Inter, system-ui, -apple-system, sans-serif';
+    const ptsStr = String(slot.points);
+    const tw = ctx.measureText(ptsStr).width;
+    ctx.fillText(ptsStr, x + (cellW - tw) / 2, y + cellH / 2 + 10);
+
+    if (bust) {
+      ctx.font = 'bold 11px Inter, system-ui, -apple-system, sans-serif';
+      ctx.fillStyle = '#fbbf24';
+      ctx.fillText('Bustout', x + 8, y + 18);
+    }
+  });
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) resolve(blob);
+        else reject(new Error('PNG export failed'));
+      },
+      'image/png',
+      1
+    );
+  });
+}

--- a/src/features/scoring/model/gradedPicksShareCore.js
+++ b/src/features/scoring/model/gradedPicksShareCore.js
@@ -50,44 +50,42 @@ export function buildGradedPicksShareSlots(userPicks, actualSetlist) {
 }
 
 /**
- * Opaque fills — PNG card (and any raster preview) reads clearly everywhere.
- *
- * @param {ReturnType<typeof buildGradedPicksShareSlots>[number]} slot
- */
-/**
- * Colored block + points + optional BB (plain-text / SMS friendly).
- * Uses large colored squares (not custom icons — plain text cannot embed SVG).
+ * One colored square per slot (no digits). Bustout = 🟧 (amber); yellow 🟨 is
+ * reserved if we ever need a second warm tone — plain text cannot pick per-font.
  *
  * @param {ReturnType<typeof buildGradedPicksShareSlots>[number]} slot
  * @param {Record<string, unknown>} userPicks
  */
-function shareEmojiCellToken(slot, userPicks) {
+function shareEmojiCellChar(slot, userPicks) {
   const raw = userPicks?.[slot.fieldId];
   const hasPick = raw != null && String(raw).trim() !== '';
-  let block = '⬛';
-  if (hasPick) {
-    if (slot.kind === 'miss' || slot.kind === 'none') block = '⬛';
-    else if (slot.kind === 'in_setlist') block = '🟦';
-    else block = '🟩';
-  }
-  const bust = slot.bustoutBoost ? ' BB' : '';
-  return `${block}${slot.points}${bust}`;
+  if (!hasPick) return '⬛';
+  if (slot.bustoutBoost) return '🟧';
+  if (slot.kind === 'miss' || slot.kind === 'none') return '⬛';
+  if (slot.kind === 'in_setlist') return '🟦';
+  return '🟩';
 }
 
 /**
- * Two rows × three columns, padded for monospace alignment.
+ * Two rows × three columns (spaced for readability in SMS).
  *
  * @param {ReturnType<typeof buildGradedPicksShareSlots>} slots
  * @param {Record<string, unknown>} userPicks
  */
 export function buildGradedPicksShareEmojiGrid(slots, userPicks) {
-  const cells = slots.map((s) => shareEmojiCellToken(s, userPicks));
-  const w = Math.max(...cells.map((c) => c.length), 5);
-  const pad = (c) => c.padEnd(w, ' ');
-  return `${pad(cells[0])} ${pad(cells[1])} ${pad(cells[2])}\n${pad(cells[3])} ${pad(cells[4])} ${pad(cells[5])}`;
+  const ch = (s) => shareEmojiCellChar(s, userPicks);
+  return `${ch(slots[0])} ${ch(slots[1])} ${ch(slots[2])}\n${ch(slots[3])} ${ch(slots[4])} ${ch(slots[5])}`;
 }
 
+/** Opaque fills for PNG tiles (bust = full amber tile, same idea as emoji 🟧). */
 function paletteForSlot(slot) {
+  if (slot.bustoutBoost) {
+    return {
+      fill: '#713f12',
+      stroke: '#fbbf24',
+      text: '#fef3c7',
+    };
+  }
   if (slot.kind === 'none' || slot.kind === 'miss') {
     return {
       fill: '#1e293b',
@@ -125,7 +123,7 @@ export function buildGradedPicksShareBodyPlain({ userPicks, actualSetlist, showL
     '',
     grid,
     '',
-    '🟩 strong pick · 🟦 in setlist · ⬛ miss or empty · BB = Bustout Boost™',
+    '🟩 strong pick · 🟦 in setlist · ⬛ miss or empty · 🟧 Bustout Boost™',
     '',
     'Free setlist game:',
     GRADED_PICKS_SHARE_SITE_URL,
@@ -163,30 +161,6 @@ export function buildGradedPicksShareClipboardHtml({ imageDataUrl, showLabel, to
   <p style="color:#94a3b8;font-size:13px;margin:0 0 10px;line-height:1.4;">${artistEsc} · ${esc}<br/><span style="color:#2dd4bf;font-weight:700;">${totalPoints} pts</span></p>
   <p style="margin:0;font-size:14px;"><a href="${href}" style="color:#2dd4bf;font-weight:800;">Play free · ${host} →</a></p>
 </body></html>`;
-}
-
-/**
- * @param {CanvasRenderingContext2D} ctx
- */
-function drawBoostPill(ctx, x, y, w) {
-  const pillH = 17;
-  const pillR = pillH / 2;
-  const label = 'Bustout Boost™';
-  ctx.font = '600 8.5px Inter, system-ui, -apple-system, sans-serif';
-  const tw = ctx.measureText(label).width;
-  const pillW = Math.min(w - 10, tw + 14);
-  const px = x + (w - pillW) / 2;
-  ctx.beginPath();
-  ctx.roundRect(px, y, pillW, pillH, pillR);
-  ctx.fillStyle = 'rgba(245, 158, 11, 0.16)';
-  ctx.fill();
-  ctx.strokeStyle = 'rgba(245, 158, 11, 0.38)';
-  ctx.lineWidth = 1;
-  ctx.stroke();
-  ctx.fillStyle = 'rgb(251, 191, 36)';
-  ctx.textAlign = 'center';
-  ctx.textBaseline = 'middle';
-  ctx.fillText(label, px + pillW / 2, y + pillH / 2);
 }
 
 /**
@@ -245,8 +219,7 @@ export function renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints, s
     const x = padX + col * (cellW + gap);
     const y = padTop + row * (cellH + rowGap);
     const { fill, stroke, text } = paletteForSlot(slot);
-    const bust = slot.bustoutBoost;
-    const borderW = bust ? 2.5 : 1.75;
+    const borderW = 1.75;
 
     ctx.beginPath();
     ctx.roundRect(x, y, cellW, cellH, cornerR);
@@ -259,12 +232,7 @@ export function renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints, s
     ctx.clip();
 
     const innerPad = 10;
-    let contentTop = y + innerPad;
-    if (bust) {
-      drawBoostPill(ctx, x, contentTop, cellW);
-      contentTop += 22;
-    }
-
+    const contentTop = y + innerPad;
     const contentBottom = y + cellH - innerPad;
     const centerY = (contentTop + contentBottom) / 2;
     const mainSize = Math.min(32, Math.max(20, cellH * 0.38));
@@ -280,7 +248,7 @@ export function renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints, s
 
     ctx.beginPath();
     ctx.roundRect(x, y, cellW, cellH, cornerR);
-    ctx.strokeStyle = bust ? '#f59e0b' : stroke;
+    ctx.strokeStyle = stroke;
     ctx.lineWidth = borderW;
     ctx.stroke();
   });
@@ -289,7 +257,7 @@ export function renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints, s
   ctx.textBaseline = 'alphabetic';
   ctx.fillStyle = 'rgba(148, 163, 184, 0.9)';
   ctx.font = '9px Inter, system-ui, -apple-system, sans-serif';
-  ctx.fillText('Amber frame = Bustout Boost™ on that slot.', W / 2, H - 32);
+  ctx.fillText('Amber tile = Bustout Boost™ on that slot.', W / 2, H - 32);
   ctx.fillStyle = 'rgb(45, 212, 191)';
   ctx.font = 'bold 11px Inter, system-ui, -apple-system, sans-serif';
   ctx.fillText('setlistpickem.com · Free to play', W / 2, H - 12);

--- a/src/features/scoring/model/gradedPicksShareCore.test.js
+++ b/src/features/scoring/model/gradedPicksShareCore.test.js
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest';
 
+import { SHARE_RECAP_ARTIST_NAME } from '../../../shared/data/gameConfig';
 import {
   buildGradedPicksShareBodyPlain,
   buildGradedPicksShareClipboardHtml,
+  buildGradedPicksShareEmojiGrid,
   buildGradedPicksShareFullPlainText,
   buildGradedPicksShareSlots,
-  GRADED_PICKS_SHARE_BRAND,
   GRADED_PICKS_SHARE_RECAP_TITLE,
   GRADED_PICKS_SHARE_SITE_URL,
 } from './gradedPicksShareCore.js';
@@ -45,7 +46,7 @@ describe('gradedPicksShareCore', () => {
     expect(slots[2].kind).toBe('miss');
   });
 
-  it('buildGradedPicksShareBodyPlain is succinct with CTA (no per-slot lines)', () => {
+  it('buildGradedPicksShareBodyPlain uses artist · date and colored block grid', () => {
     const actual = { ...baseSetlist, bustouts: ['AC/DC Bag'] };
     const picks = {
       s1o: 'AC/DC Bag',
@@ -61,11 +62,27 @@ describe('gradedPicksShareCore', () => {
       showLabel: '2025-01-01 Miami',
     });
     expect(body).not.toContain(GRADED_PICKS_SHARE_RECAP_TITLE);
-    expect(body).not.toContain('Set 1 Opener');
-    expect(body).toContain(GRADED_PICKS_SHARE_BRAND);
-    expect(body).toContain('2025-01-01 Miami');
+    expect(body).toContain(`${SHARE_RECAP_ARTIST_NAME} · 2025-01-01 Miami`);
+    expect(body).toContain('🟩');
+    expect(body).toContain('🟦');
+    expect(body).toContain('⬛');
+    expect(body).toContain('BB = Bustout Boost™');
     expect(body).toContain(GRADED_PICKS_SHARE_SITE_URL);
-    expect(body).toContain('join the pool');
+  });
+
+  it('buildGradedPicksShareEmojiGrid pads bustout slot with BB suffix', () => {
+    const actual = { ...baseSetlist, bustouts: ['AC/DC Bag'] };
+    const picks = {
+      s1o: 'AC/DC Bag',
+      s1c: 'Bathtub Gin',
+      s2o: 'Wrong',
+      s2c: 'Down with Disease',
+      enc: 'Tweezer Reprise',
+      wild: 'AC/DC Bag',
+    };
+    const slots = buildGradedPicksShareSlots(picks, actual);
+    const grid = buildGradedPicksShareEmojiGrid(slots, picks);
+    expect(grid).toContain('BB');
   });
 
   it('buildGradedPicksShareFullPlainText includes headline once', () => {
@@ -88,7 +105,7 @@ describe('gradedPicksShareCore', () => {
     expect(n).toBe(1);
   });
 
-  it('buildGradedPicksShareClipboardHtml embeds image and CTA link', () => {
+  it('buildGradedPicksShareClipboardHtml embeds image and artist · date', () => {
     const html = buildGradedPicksShareClipboardHtml({
       imageDataUrl: 'data:image/png;base64,AAA',
       showLabel: '2025-01-01 <em>x</em>',
@@ -97,7 +114,7 @@ describe('gradedPicksShareCore', () => {
     expect(html).toContain('data:image/png;base64,AAA');
     expect(html).toContain('&lt;em&gt;');
     expect(html).toContain('55 pts');
-    expect(html).toContain('setlistpickem.com');
+    expect(html).toContain(SHARE_RECAP_ARTIST_NAME);
     expect(html).toMatch(/href="https:\/\/www\.setlistpickem\.com\/"/);
   });
 });

--- a/src/features/scoring/model/gradedPicksShareCore.test.js
+++ b/src/features/scoring/model/gradedPicksShareCore.test.js
@@ -5,6 +5,7 @@ import {
   buildGradedPicksShareSlots,
   buildGradedPicksShareText,
   GRADED_PICKS_SHARE_BRAND,
+  GRADED_PICKS_SHARE_RECAP_TITLE,
 } from './gradedPicksShareCore.js';
 
 describe('gradedPicksShareCore', () => {
@@ -42,7 +43,7 @@ describe('gradedPicksShareCore', () => {
     expect(slots[2].kind).toBe('miss');
   });
 
-  it('buildGradedPicksShareText includes brand, bustout star line, and emoji rows', () => {
+  it('buildGradedPicksShareText uses recap title, letter grid, and Bustout Boost™ legend (no emoji)', () => {
     const actual = { ...baseSetlist, bustouts: ['AC/DC Bag'] };
     const picks = {
       s1o: 'AC/DC Bag',
@@ -57,12 +58,13 @@ describe('gradedPicksShareCore', () => {
       actualSetlist: actual,
       showLabel: '2025-01-01 Miami',
     });
+    expect(text).toContain(GRADED_PICKS_SHARE_RECAP_TITLE);
     expect(text).toContain(GRADED_PICKS_SHARE_BRAND);
     expect(text).toContain('2025-01-01 Miami');
-    expect(text).toContain('⭐');
-    expect(text).toContain(
-      `🟩⭐${SCORING_RULES.EXACT_SLOT + SCORING_RULES.BUSTOUT_BOOST}`,
-    );
-    expect(text).toContain('⬛0');
+    expect(text).toContain('BB=Bustout Boost™');
+    expect(text).not.toMatch(/[\u{1F300}-\u{1FAFF}]/u);
+    const bustPts = SCORING_RULES.EXACT_SLOT + SCORING_RULES.BUSTOUT_BOOST;
+    expect(text).toContain(`X${bustPts} BB`);
+    expect(text).toContain('M0');
   });
 });

--- a/src/features/scoring/model/gradedPicksShareCore.test.js
+++ b/src/features/scoring/model/gradedPicksShareCore.test.js
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest';
 
-import { SCORING_RULES } from '../../../shared/utils/scoring.js';
 import {
   buildGradedPicksShareBodyPlain,
+  buildGradedPicksShareClipboardHtml,
   buildGradedPicksShareFullPlainText,
-  buildGradedPicksShareHtml,
   buildGradedPicksShareSlots,
   GRADED_PICKS_SHARE_BRAND,
   GRADED_PICKS_SHARE_RECAP_TITLE,
+  GRADED_PICKS_SHARE_SITE_URL,
 } from './gradedPicksShareCore.js';
 
 describe('gradedPicksShareCore', () => {
@@ -45,7 +45,7 @@ describe('gradedPicksShareCore', () => {
     expect(slots[2].kind).toBe('miss');
   });
 
-  it('buildGradedPicksShareBodyPlain omits recap headline (safe with Web Share title)', () => {
+  it('buildGradedPicksShareBodyPlain is succinct with CTA (no per-slot lines)', () => {
     const actual = { ...baseSetlist, bustouts: ['AC/DC Bag'] };
     const picks = {
       s1o: 'AC/DC Bag',
@@ -61,15 +61,14 @@ describe('gradedPicksShareCore', () => {
       showLabel: '2025-01-01 Miami',
     });
     expect(body).not.toContain(GRADED_PICKS_SHARE_RECAP_TITLE);
+    expect(body).not.toContain('Set 1 Opener');
     expect(body).toContain(GRADED_PICKS_SHARE_BRAND);
-    expect(body).toContain('Set 1 Opener');
-    const bustPts = SCORING_RULES.EXACT_SLOT + SCORING_RULES.BUSTOUT_BOOST;
-    expect(body).toContain(`${bustPts} pts`);
-    expect(body).toContain('Bustout Boost™');
-    expect(body).toContain('█');
+    expect(body).toContain('2025-01-01 Miami');
+    expect(body).toContain(GRADED_PICKS_SHARE_SITE_URL);
+    expect(body).toContain('join the pool');
   });
 
-  it('buildGradedPicksShareFullPlainText includes headline once then body', () => {
+  it('buildGradedPicksShareFullPlainText includes headline once', () => {
     const actual = { ...baseSetlist, bustouts: [] };
     const picks = {
       s1o: 'AC/DC Bag',
@@ -89,23 +88,16 @@ describe('gradedPicksShareCore', () => {
     expect(n).toBe(1);
   });
 
-  it('buildGradedPicksShareHtml escapes show label and includes colored table', () => {
-    const actual = { ...baseSetlist, bustouts: [] };
-    const picks = {
-      s1o: 'AC/DC Bag',
-      s1c: 'Bathtub Gin',
-      s2o: "Colonel Forbin's Ascent",
-      s2c: 'Down with Disease',
-      enc: 'Tweezer Reprise',
-      wild: 'AC/DC Bag',
-    };
-    const html = buildGradedPicksShareHtml({
-      userPicks: picks,
-      actualSetlist: actual,
-      showLabel: '2025-01-01 <script>',
+  it('buildGradedPicksShareClipboardHtml embeds image and CTA link', () => {
+    const html = buildGradedPicksShareClipboardHtml({
+      imageDataUrl: 'data:image/png;base64,AAA',
+      showLabel: '2025-01-01 <em>x</em>',
+      totalPoints: 55,
     });
-    expect(html).toContain('&lt;script&gt;');
-    expect(html).toContain('#134e4a');
-    expect(html).toContain('<table');
+    expect(html).toContain('data:image/png;base64,AAA');
+    expect(html).toContain('&lt;em&gt;');
+    expect(html).toContain('55 pts');
+    expect(html).toContain('setlistpickem.com');
+    expect(html).toMatch(/href="https:\/\/www\.setlistpickem\.com\/"/);
   });
 });

--- a/src/features/scoring/model/gradedPicksShareCore.test.js
+++ b/src/features/scoring/model/gradedPicksShareCore.test.js
@@ -105,7 +105,7 @@ describe('gradedPicksShareCore', () => {
       showLabel: '2025-01-01 <script>',
     });
     expect(html).toContain('&lt;script&gt;');
-    expect(html).toContain('rgba(45, 212, 191');
+    expect(html).toContain('#134e4a');
     expect(html).toContain('<table');
   });
 });

--- a/src/features/scoring/model/gradedPicksShareCore.test.js
+++ b/src/features/scoring/model/gradedPicksShareCore.test.js
@@ -66,11 +66,11 @@ describe('gradedPicksShareCore', () => {
     expect(body).toContain('🟩');
     expect(body).toContain('🟦');
     expect(body).toContain('⬛');
-    expect(body).toContain('BB = Bustout Boost™');
+    expect(body).toContain('🟧 Bustout Boost™');
     expect(body).toContain(GRADED_PICKS_SHARE_SITE_URL);
   });
 
-  it('buildGradedPicksShareEmojiGrid pads bustout slot with BB suffix', () => {
+  it('buildGradedPicksShareEmojiGrid is six squares only; bust uses 🟧', () => {
     const actual = { ...baseSetlist, bustouts: ['AC/DC Bag'] };
     const picks = {
       s1o: 'AC/DC Bag',
@@ -82,7 +82,10 @@ describe('gradedPicksShareCore', () => {
     };
     const slots = buildGradedPicksShareSlots(picks, actual);
     const grid = buildGradedPicksShareEmojiGrid(slots, picks);
-    expect(grid).toContain('BB');
+    expect(grid).toContain('🟧');
+    expect(grid).not.toMatch(/\d/);
+    const tiles = grid.split(/\s+/).filter(Boolean);
+    expect(tiles.length).toBe(6);
   });
 
   it('buildGradedPicksShareFullPlainText includes headline once', () => {

--- a/src/features/scoring/model/gradedPicksShareCore.test.js
+++ b/src/features/scoring/model/gradedPicksShareCore.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+
+import { SCORING_RULES } from '../../../shared/utils/scoring.js';
+import {
+  buildGradedPicksShareSlots,
+  buildGradedPicksShareText,
+  GRADED_PICKS_SHARE_BRAND,
+} from './gradedPicksShareCore.js';
+
+describe('gradedPicksShareCore', () => {
+  const baseSetlist = {
+    s1o: 'AC/DC Bag',
+    s1c: 'Bathtub Gin',
+    s2o: "Colonel Forbin's Ascent",
+    s2c: 'Down with Disease',
+    enc: 'Tweezer Reprise',
+    wild: '',
+    officialSetlist: [
+      'AC/DC Bag',
+      'Bathtub Gin',
+      "Colonel Forbin's Ascent",
+      'Down with Disease',
+      'Tweezer Reprise',
+    ],
+  };
+
+  it('buildGradedPicksShareSlots matches getSlotScoreBreakdown order (FORM_FIELDS)', () => {
+    const actual = { ...baseSetlist, bustouts: ['AC/DC Bag'] };
+    const picks = {
+      s1o: 'AC/DC Bag',
+      s1c: 'Bathtub Gin',
+      s2o: 'Wrong',
+      s2c: 'Down with Disease',
+      enc: 'Tweezer Reprise',
+      wild: 'AC/DC Bag',
+    };
+    const slots = buildGradedPicksShareSlots(picks, actual);
+    expect(slots).toHaveLength(6);
+    expect(slots[0].fieldId).toBe('s1o');
+    expect(slots[0].bustoutBoost).toBe(true);
+    expect(slots[0].kind).toBe('exact_slot');
+    expect(slots[2].kind).toBe('miss');
+  });
+
+  it('buildGradedPicksShareText includes brand, bustout star line, and emoji rows', () => {
+    const actual = { ...baseSetlist, bustouts: ['AC/DC Bag'] };
+    const picks = {
+      s1o: 'AC/DC Bag',
+      s1c: 'Bathtub Gin',
+      s2o: 'Nope',
+      s2c: 'Down with Disease',
+      enc: 'Tweezer Reprise',
+      wild: 'AC/DC Bag',
+    };
+    const text = buildGradedPicksShareText({
+      userPicks: picks,
+      actualSetlist: actual,
+      showLabel: '2025-01-01 Miami',
+    });
+    expect(text).toContain(GRADED_PICKS_SHARE_BRAND);
+    expect(text).toContain('2025-01-01 Miami');
+    expect(text).toContain('⭐');
+    expect(text).toContain(
+      `🟩⭐${SCORING_RULES.EXACT_SLOT + SCORING_RULES.BUSTOUT_BOOST}`,
+    );
+    expect(text).toContain('⬛0');
+  });
+});

--- a/src/features/scoring/model/gradedPicksShareCore.test.js
+++ b/src/features/scoring/model/gradedPicksShareCore.test.js
@@ -2,8 +2,10 @@ import { describe, it, expect } from 'vitest';
 
 import { SCORING_RULES } from '../../../shared/utils/scoring.js';
 import {
+  buildGradedPicksShareBodyPlain,
+  buildGradedPicksShareFullPlainText,
+  buildGradedPicksShareHtml,
   buildGradedPicksShareSlots,
-  buildGradedPicksShareText,
   GRADED_PICKS_SHARE_BRAND,
   GRADED_PICKS_SHARE_RECAP_TITLE,
 } from './gradedPicksShareCore.js';
@@ -43,7 +45,7 @@ describe('gradedPicksShareCore', () => {
     expect(slots[2].kind).toBe('miss');
   });
 
-  it('buildGradedPicksShareText uses recap title, letter grid, and Bustout Boost™ legend (no emoji)', () => {
+  it('buildGradedPicksShareBodyPlain omits recap headline (safe with Web Share title)', () => {
     const actual = { ...baseSetlist, bustouts: ['AC/DC Bag'] };
     const picks = {
       s1o: 'AC/DC Bag',
@@ -53,18 +55,57 @@ describe('gradedPicksShareCore', () => {
       enc: 'Tweezer Reprise',
       wild: 'AC/DC Bag',
     };
-    const text = buildGradedPicksShareText({
+    const body = buildGradedPicksShareBodyPlain({
       userPicks: picks,
       actualSetlist: actual,
       showLabel: '2025-01-01 Miami',
     });
-    expect(text).toContain(GRADED_PICKS_SHARE_RECAP_TITLE);
-    expect(text).toContain(GRADED_PICKS_SHARE_BRAND);
-    expect(text).toContain('2025-01-01 Miami');
-    expect(text).toContain('BB=Bustout Boost™');
-    expect(text).not.toMatch(/[\u{1F300}-\u{1FAFF}]/u);
+    expect(body).not.toContain(GRADED_PICKS_SHARE_RECAP_TITLE);
+    expect(body).toContain(GRADED_PICKS_SHARE_BRAND);
+    expect(body).toContain('Set 1 Opener');
     const bustPts = SCORING_RULES.EXACT_SLOT + SCORING_RULES.BUSTOUT_BOOST;
-    expect(text).toContain(`X${bustPts} BB`);
-    expect(text).toContain('M0');
+    expect(body).toContain(`${bustPts} pts`);
+    expect(body).toContain('Bustout Boost™');
+    expect(body).toContain('█');
+  });
+
+  it('buildGradedPicksShareFullPlainText includes headline once then body', () => {
+    const actual = { ...baseSetlist, bustouts: [] };
+    const picks = {
+      s1o: 'AC/DC Bag',
+      s1c: 'Bathtub Gin',
+      s2o: "Colonel Forbin's Ascent",
+      s2c: 'Down with Disease',
+      enc: 'Tweezer Reprise',
+      wild: 'AC/DC Bag',
+    };
+    const full = buildGradedPicksShareFullPlainText({
+      userPicks: picks,
+      actualSetlist: actual,
+      showLabel: '2025-01-01 Miami',
+    });
+    expect(full.startsWith(GRADED_PICKS_SHARE_RECAP_TITLE)).toBe(true);
+    const n = full.split(GRADED_PICKS_SHARE_RECAP_TITLE).length - 1;
+    expect(n).toBe(1);
+  });
+
+  it('buildGradedPicksShareHtml escapes show label and includes colored table', () => {
+    const actual = { ...baseSetlist, bustouts: [] };
+    const picks = {
+      s1o: 'AC/DC Bag',
+      s1c: 'Bathtub Gin',
+      s2o: "Colonel Forbin's Ascent",
+      s2c: 'Down with Disease',
+      enc: 'Tweezer Reprise',
+      wild: 'AC/DC Bag',
+    };
+    const html = buildGradedPicksShareHtml({
+      userPicks: picks,
+      actualSetlist: actual,
+      showLabel: '2025-01-01 <script>',
+    });
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('rgba(45, 212, 191');
+    expect(html).toContain('<table');
   });
 });

--- a/src/features/scoring/model/useOfficialSetlistForShow.js
+++ b/src/features/scoring/model/useOfficialSetlistForShow.js
@@ -1,0 +1,146 @@
+import { useEffect, useState } from 'react';
+
+import { getShowStatus } from '../../../shared/utils/timeLogic.js';
+import {
+  fetchOfficialSetlistForShow,
+  subscribeOfficialSetlistForShow,
+} from '../api/standingsApi';
+
+/** @see useStandings — same LIVE hide debounce as full standings (#311). */
+const LIVE_LISTENER_HIDE_DEBOUNCE_MS = 60_000;
+
+/**
+ * Loads `official_setlists/{showDate}` for surfaces that only need graded truth
+ * (e.g. Picks tab share card) without subscribing to the full picks query.
+ *
+ * @param {string | undefined} showDate
+ * @param {{ date: string }[] | undefined} showDates
+ */
+export function useOfficialSetlistForShow(showDate, showDates) {
+  const [actualSetlist, setActualSetlist] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!showDate) {
+      setActualSetlist(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const showStatus =
+      Array.isArray(showDates) && showDates.length > 0
+        ? getShowStatus(showDate, showDates)
+        : 'FUTURE';
+
+    if (showStatus === 'FUTURE') {
+      setActualSetlist(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    if (showStatus !== 'LIVE') {
+      setLoading(true);
+      setError(null);
+
+      (async () => {
+        try {
+          const setlist = await fetchOfficialSetlistForShow(showDate);
+          if (!cancelled) setActualSetlist(setlist);
+        } catch (err) {
+          if (!cancelled) {
+            setError(err);
+            console.error('useOfficialSetlistForShow fetch error:', err);
+          }
+        } finally {
+          if (!cancelled) setLoading(false);
+        }
+      })();
+
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    let unsub = null;
+    let hideTimer = null;
+
+    const clearHideTimer = () => {
+      if (hideTimer != null) {
+        clearTimeout(hideTimer);
+        hideTimer = null;
+      }
+    };
+
+    const tearDown = () => {
+      if (unsub) {
+        unsub();
+        unsub = null;
+      }
+    };
+
+    const attach = () => {
+      tearDown();
+      if (cancelled) return;
+      unsub = subscribeOfficialSetlistForShow(
+        showDate,
+        (next) => {
+          if (!cancelled) setActualSetlist(next);
+        },
+        (err) => {
+          if (!cancelled) {
+            setError(err);
+            console.error('useOfficialSetlistForShow live listener error:', err);
+          }
+        }
+      );
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        clearHideTimer();
+        attach();
+      } else {
+        clearHideTimer();
+        hideTimer = window.setTimeout(() => {
+          if (document.visibilityState === 'hidden') tearDown();
+        }, LIVE_LISTENER_HIDE_DEBOUNCE_MS);
+      }
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const setlist = await fetchOfficialSetlistForShow(showDate);
+        if (!cancelled) setActualSetlist(setlist);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err);
+          console.error('useOfficialSetlistForShow initial fetch error:', err);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+
+      if (cancelled) return;
+      if (document.visibilityState === 'visible') attach();
+    })();
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      clearHideTimer();
+      tearDown();
+    };
+  }, [showDate, showDates]);
+
+  return { actualSetlist, loading, error };
+}

--- a/src/features/scoring/ui/GradedPicksShareBar.jsx
+++ b/src/features/scoring/ui/GradedPicksShareBar.jsx
@@ -1,0 +1,121 @@
+import React, { useCallback, useState } from 'react';
+import { Copy, Download, Share2 } from 'lucide-react';
+
+import {
+  buildGradedPicksShareSlots,
+  buildGradedPicksShareText,
+  renderGradedPicksSharePngBlob,
+} from '../model/gradedPicksShareCore';
+import { calculateTotalScore } from '../../../shared/utils/scoring';
+
+function ymdForFilename(showLabel) {
+  const m = String(showLabel).match(/(\d{4}-\d{2}-\d{2})/);
+  return m ? m[1] : 'show';
+}
+
+export default function GradedPicksShareBar({ userPicks, actualSetlist, showLabel }) {
+  const [notice, setNotice] = useState(null);
+
+  const clearNoticeSoon = useCallback((msg) => {
+    setNotice(msg);
+    window.setTimeout(() => setNotice(null), 3200);
+  }, []);
+
+  const onCopy = useCallback(async () => {
+    const text = buildGradedPicksShareText({ userPicks, actualSetlist, showLabel });
+    try {
+      await navigator.clipboard.writeText(text);
+      clearNoticeSoon('Copied grid to clipboard');
+    } catch {
+      clearNoticeSoon('Could not copy — try again');
+    }
+  }, [actualSetlist, clearNoticeSoon, showLabel, userPicks]);
+
+  const onDownloadPng = useCallback(async () => {
+    const slots = buildGradedPicksShareSlots(userPicks, actualSetlist);
+    const totalPoints = calculateTotalScore(userPicks, actualSetlist);
+    try {
+      const blob = await renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `setlist-pickem-graded-${ymdForFilename(showLabel)}.png`;
+      a.click();
+      URL.revokeObjectURL(url);
+      clearNoticeSoon('PNG downloaded');
+    } catch (e) {
+      console.error(e);
+      clearNoticeSoon('PNG export failed');
+    }
+  }, [actualSetlist, clearNoticeSoon, showLabel, userPicks]);
+
+  const onShare = useCallback(async () => {
+    const text = buildGradedPicksShareText({ userPicks, actualSetlist, showLabel });
+    const slots = buildGradedPicksShareSlots(userPicks, actualSetlist);
+    const totalPoints = calculateTotalScore(userPicks, actualSetlist);
+
+    try {
+      const blob = await renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints });
+      const file = new File([blob], `setlist-pickem-graded-${ymdForFilename(showLabel)}.png`, {
+        type: 'image/png',
+      });
+
+      const shareData = { text, title: 'My graded picks' };
+      if (navigator.canShare?.({ files: [file] })) {
+        await navigator.share({ ...shareData, files: [file] });
+        clearNoticeSoon('Shared');
+        return;
+      }
+      if (navigator.share) {
+        await navigator.share(shareData);
+        clearNoticeSoon('Shared');
+        return;
+      }
+      await navigator.clipboard.writeText(text);
+      clearNoticeSoon('Share not available — copied text instead');
+    } catch (e) {
+      if (e && (e.name === 'AbortError' || e.name === 'NotAllowedError')) return;
+      console.error(e);
+      clearNoticeSoon('Share failed');
+    }
+  }, [actualSetlist, clearNoticeSoon, showLabel, userPicks]);
+
+  return (
+    <div className="mt-4 rounded-xl border border-border-subtle/50 bg-surface-panel/40 px-3 py-3">
+      <p className="mb-2 text-[10px] font-black uppercase tracking-widest text-content-secondary">
+        Share graded card
+      </p>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={onCopy}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-border-muted bg-surface-inset px-3 py-2 text-xs font-bold text-slate-200 transition-colors hover:bg-surface-panel-strong hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
+        >
+          <Copy className="h-3.5 w-3.5" aria-hidden />
+          Copy text grid
+        </button>
+        <button
+          type="button"
+          onClick={onDownloadPng}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-border-muted bg-surface-inset px-3 py-2 text-xs font-bold text-slate-200 transition-colors hover:bg-surface-panel-strong hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
+        >
+          <Download className="h-3.5 w-3.5" aria-hidden />
+          Download PNG
+        </button>
+        <button
+          type="button"
+          onClick={onShare}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-brand-primary/40 bg-brand-primary/10 px-3 py-2 text-xs font-bold text-brand-primary transition-colors hover:bg-brand-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
+        >
+          <Share2 className="h-3.5 w-3.5" aria-hidden />
+          Share…
+        </button>
+      </div>
+      {notice ? (
+        <p className="mt-2 text-[11px] font-semibold text-brand-primary" role="status">
+          {notice}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/scoring/ui/GradedPicksShareBar.jsx
+++ b/src/features/scoring/ui/GradedPicksShareBar.jsx
@@ -3,8 +3,8 @@ import { Copy, Download, Share2 } from 'lucide-react';
 
 import {
   buildGradedPicksShareBodyPlain,
+  buildGradedPicksShareClipboardHtml,
   buildGradedPicksShareFullPlainText,
-  buildGradedPicksShareHtml,
   buildGradedPicksShareSlots,
   GRADED_PICKS_SHARE_RECAP_TITLE,
   renderGradedPicksSharePngBlob,
@@ -16,6 +16,15 @@ function ymdForFilename(showLabel) {
   return m ? m[1] : 'show';
 }
 
+function blobToDataUrl(blob) {
+  return new Promise((resolve, reject) => {
+    const r = new FileReader();
+    r.onload = () => resolve(String(r.result));
+    r.onerror = () => reject(new Error('readAsDataURL failed'));
+    r.readAsDataURL(blob);
+  });
+}
+
 export default function GradedPicksShareBar({ userPicks, actualSetlist, showLabel }) {
   const [notice, setNotice] = useState(null);
 
@@ -25,9 +34,19 @@ export default function GradedPicksShareBar({ userPicks, actualSetlist, showLabe
   }, []);
 
   const onCopy = useCallback(async () => {
+    const slots = buildGradedPicksShareSlots(userPicks, actualSetlist);
+    const totalPoints = calculateTotalScore(userPicks, actualSetlist);
     const plain = buildGradedPicksShareFullPlainText({ userPicks, actualSetlist, showLabel });
-    const html = buildGradedPicksShareHtml({ userPicks, actualSetlist, showLabel });
+
     try {
+      const pngBlob = await renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints });
+      const imageDataUrl = await blobToDataUrl(pngBlob);
+      const html = buildGradedPicksShareClipboardHtml({
+        imageDataUrl,
+        showLabel,
+        totalPoints,
+      });
+
       if (navigator.clipboard.write && typeof ClipboardItem !== 'undefined') {
         await navigator.clipboard.write([
           new ClipboardItem({
@@ -35,13 +54,13 @@ export default function GradedPicksShareBar({ userPicks, actualSetlist, showLabe
             'text/plain': new Blob([plain], { type: 'text/plain' }),
           }),
         ]);
-        clearNoticeSoon('Copied recap (color card in rich apps)');
+        clearNoticeSoon('Copied recap (image + link in rich apps)');
         return;
       }
       await navigator.clipboard.writeText(plain);
       clearNoticeSoon('Copied recap');
     } catch (e) {
-      console.warn('Rich clipboard failed, falling back to plain text.', e);
+      console.warn('Copy recap failed, falling back to plain text.', e);
       try {
         await navigator.clipboard.writeText(plain);
         clearNoticeSoon('Copied recap');
@@ -70,7 +89,6 @@ export default function GradedPicksShareBar({ userPicks, actualSetlist, showLabe
   }, [actualSetlist, clearNoticeSoon, showLabel, userPicks]);
 
   const onShare = useCallback(async () => {
-    /** Body only — many targets merge `title` + `text` without a newline; repeating the headline corrupts the thread. */
     const text = buildGradedPicksShareBodyPlain({ userPicks, actualSetlist, showLabel });
     const slots = buildGradedPicksShareSlots(userPicks, actualSetlist);
     const totalPoints = calculateTotalScore(userPicks, actualSetlist);

--- a/src/features/scoring/ui/GradedPicksShareBar.jsx
+++ b/src/features/scoring/ui/GradedPicksShareBar.jsx
@@ -4,6 +4,7 @@ import { Copy, Download, Share2 } from 'lucide-react';
 import {
   buildGradedPicksShareSlots,
   buildGradedPicksShareText,
+  GRADED_PICKS_SHARE_RECAP_TITLE,
   renderGradedPicksSharePngBlob,
 } from '../model/gradedPicksShareCore';
 import { calculateTotalScore } from '../../../shared/utils/scoring';
@@ -60,7 +61,7 @@ export default function GradedPicksShareBar({ userPicks, actualSetlist, showLabe
         type: 'image/png',
       });
 
-      const shareData = { text, title: 'My graded picks' };
+      const shareData = { text, title: GRADED_PICKS_SHARE_RECAP_TITLE };
       if (navigator.canShare?.({ files: [file] })) {
         await navigator.share({ ...shareData, files: [file] });
         clearNoticeSoon('Shared');

--- a/src/features/scoring/ui/GradedPicksShareBar.jsx
+++ b/src/features/scoring/ui/GradedPicksShareBar.jsx
@@ -2,8 +2,10 @@ import React, { useCallback, useState } from 'react';
 import { Copy, Download, Share2 } from 'lucide-react';
 
 import {
+  buildGradedPicksShareBodyPlain,
+  buildGradedPicksShareFullPlainText,
+  buildGradedPicksShareHtml,
   buildGradedPicksShareSlots,
-  buildGradedPicksShareText,
   GRADED_PICKS_SHARE_RECAP_TITLE,
   renderGradedPicksSharePngBlob,
 } from '../model/gradedPicksShareCore';
@@ -23,12 +25,29 @@ export default function GradedPicksShareBar({ userPicks, actualSetlist, showLabe
   }, []);
 
   const onCopy = useCallback(async () => {
-    const text = buildGradedPicksShareText({ userPicks, actualSetlist, showLabel });
+    const plain = buildGradedPicksShareFullPlainText({ userPicks, actualSetlist, showLabel });
+    const html = buildGradedPicksShareHtml({ userPicks, actualSetlist, showLabel });
     try {
-      await navigator.clipboard.writeText(text);
-      clearNoticeSoon('Copied grid to clipboard');
-    } catch {
-      clearNoticeSoon('Could not copy — try again');
+      if (navigator.clipboard.write && typeof ClipboardItem !== 'undefined') {
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            'text/html': new Blob([html], { type: 'text/html' }),
+            'text/plain': new Blob([plain], { type: 'text/plain' }),
+          }),
+        ]);
+        clearNoticeSoon('Copied recap (color card in rich apps)');
+        return;
+      }
+      await navigator.clipboard.writeText(plain);
+      clearNoticeSoon('Copied recap');
+    } catch (e) {
+      console.warn('Rich clipboard failed, falling back to plain text.', e);
+      try {
+        await navigator.clipboard.writeText(plain);
+        clearNoticeSoon('Copied recap');
+      } catch {
+        clearNoticeSoon('Could not copy — try again');
+      }
     }
   }, [actualSetlist, clearNoticeSoon, showLabel, userPicks]);
 
@@ -51,7 +70,8 @@ export default function GradedPicksShareBar({ userPicks, actualSetlist, showLabe
   }, [actualSetlist, clearNoticeSoon, showLabel, userPicks]);
 
   const onShare = useCallback(async () => {
-    const text = buildGradedPicksShareText({ userPicks, actualSetlist, showLabel });
+    /** Body only — many targets merge `title` + `text` without a newline; repeating the headline corrupts the thread. */
+    const text = buildGradedPicksShareBodyPlain({ userPicks, actualSetlist, showLabel });
     const slots = buildGradedPicksShareSlots(userPicks, actualSetlist);
     const totalPoints = calculateTotalScore(userPicks, actualSetlist);
 
@@ -72,8 +92,10 @@ export default function GradedPicksShareBar({ userPicks, actualSetlist, showLabe
         clearNoticeSoon('Shared');
         return;
       }
-      await navigator.clipboard.writeText(text);
-      clearNoticeSoon('Share not available — copied text instead');
+      await navigator.clipboard.writeText(
+        [GRADED_PICKS_SHARE_RECAP_TITLE, '', text].join('\n'),
+      );
+      clearNoticeSoon('Share not available — copied recap instead');
     } catch (e) {
       if (e && (e.name === 'AbortError' || e.name === 'NotAllowedError')) return;
       console.error(e);
@@ -93,7 +115,7 @@ export default function GradedPicksShareBar({ userPicks, actualSetlist, showLabe
           className="inline-flex items-center gap-1.5 rounded-lg border border-border-muted bg-surface-inset px-3 py-2 text-xs font-bold text-slate-200 transition-colors hover:bg-surface-panel-strong hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
         >
           <Copy className="h-3.5 w-3.5" aria-hidden />
-          Copy text grid
+          Copy recap
         </button>
         <button
           type="button"

--- a/src/features/scoring/ui/Leaderboard.jsx
+++ b/src/features/scoring/ui/Leaderboard.jsx
@@ -10,6 +10,7 @@ const Leaderboard = ({
   selfUserId = null,
   suppressLeadingCallout = false,
   redactOpponentPicksPreLock = false,
+  shareShowLabel = '',
 }) => {
   const { sortedPicks, getPickPayload, expandedUser, toggleUserExpansion } = useLeaderboard(
     poolPicks,
@@ -29,6 +30,7 @@ const Leaderboard = ({
       selfUserId={selfUserId}
       suppressLeadingCallout={suppressLeadingCallout}
       redactOpponentPicksPreLock={redactOpponentPicksPreLock}
+      shareShowLabel={shareShowLabel}
     />
   );
 };

--- a/src/features/scoring/ui/LeaderboardList.jsx
+++ b/src/features/scoring/ui/LeaderboardList.jsx
@@ -26,6 +26,7 @@ export default function LeaderboardList({
   suppressLeadingCallout = false,
   /** Pre-lock: blur opponent pick titles in expanded rows (#303). */
   redactOpponentPicksPreLock = false,
+  shareShowLabel = '',
 }) {
   if (sortedPicks.length === 0) {
     return (
@@ -139,6 +140,7 @@ export default function LeaderboardList({
             onToggle={() => onToggle(uniqueId)}
             userPicks={userPicks}
             maskPickTitles={maskPickTitles}
+            shareShowLabel={shareShowLabel}
           />
         );
       })}

--- a/src/features/scoring/ui/LeaderboardRow.jsx
+++ b/src/features/scoring/ui/LeaderboardRow.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
 import { calculateTotalScore } from '../../../shared/utils/scoring';
+import GradedPicksShareBar from './GradedPicksShareBar';
 import ScoreBreakdownGrid from './ScoreBreakdownGrid';
 
 const rankBadgeClass = (rank) => {
@@ -22,6 +23,7 @@ export default function LeaderboardRow({
   userPicks,
   /** Pre-lock privacy (#303): blur opponent song titles in the breakdown. */
   maskPickTitles = false,
+  shareShowLabel = '',
 }) {
   const uniqueId = p.uid || p.id;
   const playerUserId = p.userId || p.uid;
@@ -109,6 +111,13 @@ export default function LeaderboardRow({
             actualSetlist={actualSetlist}
             maskPickTitles={maskPickTitles}
           />
+          {isSelf && actualSetlist && !maskPickTitles && shareShowLabel ? (
+            <GradedPicksShareBar
+              userPicks={userPicks}
+              actualSetlist={actualSetlist}
+              showLabel={shareShowLabel}
+            />
+          ) : null}
         </div>
       )}
     </div>

--- a/src/features/scoring/ui/ScoreBreakdownGrid.jsx
+++ b/src/features/scoring/ui/ScoreBreakdownGrid.jsx
@@ -70,9 +70,9 @@ export default function ScoreBreakdownGrid({ userPicks, actualSetlist, maskPickT
                 {bustoutBoost && (
                   <span
                     className="text-[9px] font-black uppercase tracking-wider px-2 py-0.5 rounded-full bg-amber-500/15 text-amber-400 border border-amber-500/35"
-                    title={`+${SCORING_RULES.BUSTOUT_BOOST} bustout bonus`}
+                    title={`+${SCORING_RULES.BUSTOUT_BOOST} Bustout Boost™`}
                   >
-                    Bustout boost
+                    Bustout Boost™
                   </span>
                 )}
               </div>

--- a/src/features/scoring/ui/StandingsShowOrPoolView.jsx
+++ b/src/features/scoring/ui/StandingsShowOrPoolView.jsx
@@ -119,6 +119,7 @@ export default function StandingsShowOrPoolView({ screen }) {
               selfUserId={selfUserId}
               suppressLeadingCallout={Boolean(showWinnerBanner)}
               redactOpponentPicksPreLock={redactOpponentPicksPreLock}
+              shareShowLabel={showLabel}
             />
           </div>
         ) : null}
@@ -250,6 +251,7 @@ export default function StandingsShowOrPoolView({ screen }) {
           selfUserId={selfUserId}
           suppressLeadingCallout={Boolean(showWinnerBanner)}
           redactOpponentPicksPreLock={redactOpponentPicksPreLock}
+          shareShowLabel={showLabel}
         />
       )}
     </>

--- a/src/pages/picks/PicksPage.jsx
+++ b/src/pages/picks/PicksPage.jsx
@@ -3,12 +3,16 @@ import { CheckCircle2, ChevronDown, Lock, Scale } from 'lucide-react';
 
 import { PicksFieldsForm, PicksSubmitButton, usePicksForm } from '../../features/picks';
 import { useShowCalendar } from '../../features/show-calendar';
-import { useScoringRulesModal } from '../../features/scoring';
+import { GradedPicksShareBar, useOfficialSetlistForShow, useScoringRulesModal } from '../../features/scoring';
+import { showOptionLabelCompact } from '../../shared/utils/showOptionLabel';
 import Card from '../../shared/ui/Card';
 import DashboardActionRow from '../../shared/ui/DashboardActionRow';
 import GhostPill from '../../shared/ui/GhostPill';
 export default function PicksPage({ user, selectedDate }) {
   const { showDates, showDatesByTour } = useShowCalendar();
+  const { actualSetlist: gradedSetlist } = useOfficialSetlistForShow(selectedDate, showDates);
+  const showForShare = selectedDate ? showDates?.find((s) => s.date === selectedDate) : null;
+  const shareShowLabel = showForShare ? showOptionLabelCompact(showForShare) : selectedDate || '';
   const {
     formData,
     handleInput,
@@ -106,6 +110,13 @@ export default function PicksPage({ user, selectedDate }) {
           variant="venue"
           className="space-y-4 transition-all duration-300"
         >
+          {gradedSetlist && hasExistingPicks ? (
+            <GradedPicksShareBar
+              userPicks={formData}
+              actualSetlist={gradedSetlist}
+              showLabel={shareShowLabel}
+            />
+          ) : null}
           {pickConstraintMessage ? (
             <div
               className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm font-bold text-amber-100"

--- a/src/shared/data/gameConfig.js
+++ b/src/shared/data/gameConfig.js
@@ -1,3 +1,9 @@
+/**
+ * Display name for share / recap subtitles (`Artist · date`). Single-band today;
+ * replace with per-tour config when multi-band ships.
+ */
+export const SHARE_RECAP_ARTIST_NAME = 'Phish';
+
 export const FORM_FIELDS = [
   { id: "s1o", label: "Set 1 Opener" },
   { id: "s1c", label: "Set 1 Closer" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #304

## Summary

Graded share card: **PNG** (canvas 2×3, colors aligned with breakdown) + **plain-text** recap + Web Share. Follow-up fixes: recap title **"My Setlist Pick 'Em Recap"**, PNG points **centered inside** rounded cells (clip + `textBaseline: middle`), **no emoji** in text share (letter codes + `BB`), **Bustout Boost™** in-app and on PNG pill, `ScoreBreakdownGrid` chip copy aligned.

## Test plan

- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run verify:theme-contract`
- [ ] Manual: mobile Share sheet PNG — points inside tiles; copy text has legend, no emoji
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a193118-9488-40b3-b051-c32d15973c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a193118-9488-40b3-b051-c32d15973c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

