### PR TITLE
feat(auth): signup consent, legal UX, profile-only dashboard links

### DIFF
--- a/src/app/ScrollToTop.jsx
+++ b/src/app/ScrollToTop.jsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Reset window scroll on client-side navigation so deep-linked legal pages and
+ * other routes always open at the top (React Router does not do this by default).
+ */
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -290,14 +290,6 @@ export default function DashboardLayout() {
               <Route path="pool/:poolId" element={<PoolHubPage user={user} />} />
             </Routes>
           </Suspense>
-
-          <footer className="mt-12 border-t border-border-muted/40 pb-2 pt-4 text-center text-[11px] font-medium text-content-secondary/60">
-            <span className="space-x-2">
-              <Link to="/privacy" className="underline decoration-border-muted underline-offset-2 transition-colors hover:text-white">Privacy</Link>
-              <span aria-hidden>&middot;</span>
-              <Link to="/terms" className="underline decoration-border-muted underline-offset-2 transition-colors hover:text-white">Terms</Link>
-            </span>
-          </footer>
         </div>
       </main>
 

--- a/src/features/auth/api/legalConsentApi.js
+++ b/src/features/auth/api/legalConsentApi.js
@@ -1,0 +1,22 @@
+import { doc, serverTimestamp, setDoc } from 'firebase/firestore';
+
+import { db } from '../../../shared/lib/firebase';
+
+/**
+ * Records affirmative Terms + Privacy consent at account creation (sign-up).
+ * Uses merge so a later `createInitialUserProfile` write does not overwrite this field.
+ *
+ * @param {string} uid
+ */
+export async function recordTermsPrivacyConsent(uid) {
+  if (!uid?.trim()) {
+    throw new Error('Missing uid.');
+  }
+  await setDoc(
+    doc(db, 'users', uid.trim()),
+    {
+      termsPrivacyAcceptedAt: serverTimestamp(),
+    },
+    { merge: true }
+  );
+}

--- a/src/features/auth/api/profileSetupApi.js
+++ b/src/features/auth/api/profileSetupApi.js
@@ -7,11 +7,15 @@ import { db } from '../../../shared/lib/firebase';
  * `createdAt` is a server timestamp so public profiles and date formatting stay consistent.
  */
 export async function createInitialUserProfile(uid, { handle, favoriteSong, email }) {
-  await setDoc(doc(db, 'users', uid), {
-    handle: handle.trim(),
-    email: email ?? null,
-    favoriteSong: (favoriteSong || '').trim() || 'Unknown',
-    createdAt: serverTimestamp(),
-    totalPoints: 0,
-  });
+  await setDoc(
+    doc(db, 'users', uid),
+    {
+      handle: handle.trim(),
+      email: email ?? null,
+      favoriteSong: (favoriteSong || '').trim() || 'Unknown',
+      createdAt: serverTimestamp(),
+      totalPoints: 0,
+    },
+    { merge: true }
+  );
 }

--- a/src/features/auth/api/splashAuthApi.js
+++ b/src/features/auth/api/splashAuthApi.js
@@ -1,5 +1,6 @@
 import {
   createUserWithEmailAndPassword,
+  deleteUser,
   getAdditionalUserInfo,
   GoogleAuthProvider,
   sendPasswordResetEmail,
@@ -38,6 +39,19 @@ export async function signInWithGoogle(auth) {
 
 export function registerWithEmail(auth, email, password) {
   return createUserWithEmailAndPassword(auth, email.trim(), password);
+}
+
+/**
+ * Best-effort rollback when post-sign-up Firestore writes fail (e.g. legal consent).
+ * @param {import('firebase/auth').User | null} user
+ */
+export async function deleteAuthUserIfPresent(user) {
+  if (!user) return;
+  try {
+    await deleteUser(user);
+  } catch {
+    // Caller logs; deletion may fail if session already invalidated.
+  }
 }
 
 export function signInWithEmail(auth, email, password) {

--- a/src/features/auth/index.js
+++ b/src/features/auth/index.js
@@ -13,3 +13,7 @@ export { useProfileSetup } from './model/useProfileSetup';
 export { useSignOut } from './model/useSignOut';
 export { getFirebaseAuthErrorMessage } from './utils/firebaseAuthMessages';
 export { getPasswordResetActionCodeSettings } from './utils/passwordResetActionSettings';
+export {
+  stashSplashResumeAuthModal,
+  consumeSplashResumeAuthModal,
+} from './utils/splashAuthResumeStorage';

--- a/src/features/auth/model/useSplashSignUp.js
+++ b/src/features/auth/model/useSplashSignUp.js
@@ -1,14 +1,20 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { auth } from '../../../shared/lib/firebase';
+import { recordTermsPrivacyConsent } from '../api/legalConsentApi';
 import { getFirebaseAuthErrorMessage } from '../utils/firebaseAuthMessages';
-import { registerWithEmail, signInWithGoogle } from '../api/splashAuthApi';
+import {
+  deleteAuthUserIfPresent,
+  registerWithEmail,
+  signInWithGoogle,
+} from '../api/splashAuthApi';
 import { trackAuthError, trackAuthLogin, trackAuthSignUp } from './authAnalytics';
 
 export function useSplashSignUp(isOpen, onClose) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
+  const [legalAccepted, setLegalAccepted] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
 
@@ -16,6 +22,7 @@ export function useSplashSignUp(isOpen, onClose) {
     setEmail('');
     setPassword('');
     setConfirmPassword('');
+    setLegalAccepted(false);
     setError('');
   }, []);
 
@@ -43,10 +50,22 @@ export function useSplashSignUp(isOpen, onClose) {
 
   const handleGoogle = useCallback(async () => {
     setError('');
+    if (!legalAccepted) {
+      setError('Confirm you agree to the Terms of Service and Privacy Policy to continue.');
+      return;
+    }
     setBusy(true);
     try {
       const { isNewUser } = await signInWithGoogle(auth);
       if (isNewUser) {
+        try {
+          await recordTermsPrivacyConsent(auth.currentUser.uid);
+        } catch (consentErr) {
+          console.error('Consent write after Google sign-up:', consentErr);
+          await deleteAuthUserIfPresent(auth.currentUser);
+          setError('Could not finish creating your account. Please try again.');
+          return;
+        }
         trackAuthSignUp('google');
       } else {
         trackAuthLogin('google');
@@ -59,12 +78,16 @@ export function useSplashSignUp(isOpen, onClose) {
     } finally {
       setBusy(false);
     }
-  }, [closeModal]);
+  }, [closeModal, legalAccepted]);
 
   const handleEmailSignUp = useCallback(
     async (e) => {
       e.preventDefault();
       setError('');
+      if (!legalAccepted) {
+        setError('Confirm you agree to the Terms of Service and Privacy Policy to continue.');
+        return;
+      }
       if (password !== confirmPassword) {
         setError('Passwords do not match.');
         return;
@@ -75,7 +98,15 @@ export function useSplashSignUp(isOpen, onClose) {
       }
       setBusy(true);
       try {
-        await registerWithEmail(auth, email, password);
+        const cred = await registerWithEmail(auth, email, password);
+        try {
+          await recordTermsPrivacyConsent(cred.user.uid);
+        } catch (consentErr) {
+          console.error('Consent write after email sign-up:', consentErr);
+          await deleteAuthUserIfPresent(cred.user);
+          setError('Could not finish creating your account. Please try again.');
+          return;
+        }
         trackAuthSignUp('email');
         closeModal();
       } catch (err) {
@@ -86,7 +117,7 @@ export function useSplashSignUp(isOpen, onClose) {
         setBusy(false);
       }
     },
-    [closeModal, confirmPassword, email, password]
+    [closeModal, confirmPassword, email, legalAccepted, password]
   );
 
   return {
@@ -96,6 +127,8 @@ export function useSplashSignUp(isOpen, onClose) {
     setPassword,
     confirmPassword,
     setConfirmPassword,
+    legalAccepted,
+    setLegalAccepted,
     busy,
     error,
     closeModal,

--- a/src/features/auth/ui/SplashAuthModalShell.jsx
+++ b/src/features/auth/ui/SplashAuthModalShell.jsx
@@ -8,10 +8,17 @@ export default function SplashAuthModalShell({
   title,
   handleGoogle,
   busy,
+  /** When set, overrides default Google disabled state (`busy` only). */
+  googleDisabled,
+  /** Rendered after the title row and before “Continue with Google” (e.g. sign-up legal consent). */
+  prependContent,
   googleFootnote,
   children,
 }) {
   if (!isOpen) return null;
+
+  const isGoogleDisabled =
+    typeof googleDisabled === 'boolean' ? googleDisabled : busy;
 
   return (
     <div
@@ -38,11 +45,13 @@ export default function SplashAuthModalShell({
           </Button>
         </div>
 
+        {prependContent ? <div className="mb-6">{prependContent}</div> : null}
+
         <Button
           variant="text"
           type="button"
           onClick={handleGoogle}
-          disabled={busy}
+          disabled={isGoogleDisabled}
           className="w-full bg-white text-slate-900 py-3.5 rounded-xl gap-3 shadow-[0_8px_24px_-12px_rgba(255,255,255,0.35)] ring-1 ring-white/20 transition-all duration-200 hover:-translate-y-0.5 hover:bg-slate-50 hover:shadow-[0_12px_28px_-12px_rgba(255,255,255,0.45)]"
         >
           <img src="https://www.google.com/favicon.ico" alt="" className="w-5 h-5" />

--- a/src/features/auth/ui/SplashSignUpModal.jsx
+++ b/src/features/auth/ui/SplashSignUpModal.jsx
@@ -6,6 +6,7 @@ import Input from '../../../shared/ui/Input';
 import { StatusBanner } from '../../../shared';
 import SplashAuthModalShell from './SplashAuthModalShell';
 import { useSplashSignUp } from '../model/useSplashSignUp';
+import { stashSplashResumeAuthModal } from '../utils/splashAuthResumeStorage';
 
 export default function SplashSignUpModal({ isOpen, onClose }) {
   const {
@@ -15,12 +16,51 @@ export default function SplashSignUpModal({ isOpen, onClose }) {
     setPassword,
     confirmPassword,
     setConfirmPassword,
+    legalAccepted,
+    setLegalAccepted,
     busy,
     error,
     closeModal,
     handleGoogle,
     handleEmailSignUp,
   } = useSplashSignUp(isOpen, onClose);
+
+  const consentBlock = (
+    <label className="flex cursor-pointer items-start gap-3 rounded-2xl border border-border-subtle bg-surface-field/80 p-4 text-left text-sm font-semibold leading-snug text-slate-200">
+      <input
+        type="checkbox"
+        checked={legalAccepted}
+        onChange={(e) => setLegalAccepted(e.target.checked)}
+        className="mt-1 h-4 w-4 shrink-0 rounded border-slate-500 bg-surface-panel text-brand-primary focus-visible:ring-2 focus-visible:ring-brand"
+        aria-describedby="signup-legal-hint"
+      />
+      <span id="signup-legal-hint">
+        I agree to the{' '}
+        <Link
+          to="/terms"
+          className="text-teal-300 underline decoration-teal-500/60 underline-offset-2 hover:text-white"
+          onClick={(e) => {
+            e.stopPropagation();
+            stashSplashResumeAuthModal('signup');
+          }}
+        >
+          Terms of Service
+        </Link>{' '}
+        and{' '}
+        <Link
+          to="/privacy"
+          className="text-teal-300 underline decoration-teal-500/60 underline-offset-2 hover:text-white"
+          onClick={(e) => {
+            e.stopPropagation();
+            stashSplashResumeAuthModal('signup');
+          }}
+        >
+          Privacy Policy
+        </Link>
+        .
+      </span>
+    </label>
+  );
 
   return (
     <SplashAuthModalShell
@@ -29,7 +69,9 @@ export default function SplashSignUpModal({ isOpen, onClose }) {
       title="Create account"
       handleGoogle={handleGoogle}
       busy={busy}
-      googleFootnote="You'll set your handle on the next page. Your personal info will never be shared with users."
+      googleDisabled={busy || !legalAccepted}
+      prependContent={consentBlock}
+      googleFootnote="You'll set your username/handle on the next page. Your email address is never shared or visible to other users."
     >
         <form onSubmit={handleEmailSignUp} className="space-y-4 text-left">
           <div>
@@ -79,21 +121,10 @@ export default function SplashSignUpModal({ isOpen, onClose }) {
             />
           </div>
           {error ? <StatusBanner type="error" message={error} /> : null}
-          <p className="text-center text-[11px] font-semibold leading-relaxed text-slate-400">
-            By creating an account you agree to our{' '}
-            <Link to="/terms" className="text-slate-300 underline decoration-slate-500 underline-offset-2 hover:text-white hover:decoration-slate-300">
-              Terms of Service
-            </Link>{' '}
-            and{' '}
-            <Link to="/privacy" className="text-slate-300 underline decoration-slate-500 underline-offset-2 hover:text-white hover:decoration-slate-300">
-              Privacy Policy
-            </Link>
-            .
-          </p>
           <Button
             variant="secondary"
             type="submit"
-            disabled={busy}
+            disabled={busy || !legalAccepted}
             className="w-full py-3.5 rounded-xl uppercase tracking-widest"
           >
             {busy ? 'Creating…' : 'Create account'}

--- a/src/features/auth/utils/splashAuthResumeStorage.js
+++ b/src/features/auth/utils/splashAuthResumeStorage.js
@@ -1,0 +1,29 @@
+const STORAGE_KEY = 'splashResumeAuthModal';
+
+/**
+ * Call before navigating away from the splash auth modal to Terms/Privacy so
+ * browser Back can reopen the same modal (session-only).
+ * @param {'signup' | 'signin'} kind
+ */
+export function stashSplashResumeAuthModal(kind) {
+  if (kind !== 'signup' && kind !== 'signin') return;
+  try {
+    sessionStorage.setItem(STORAGE_KEY, kind);
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+/**
+ * @returns {'signup' | 'signin' | null}
+ */
+export function consumeSplashResumeAuthModal() {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    sessionStorage.removeItem(STORAGE_KEY);
+    if (raw === 'signup' || raw === 'signin') return raw;
+  } catch {
+    // ignore
+  }
+  return null;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './app/App.jsx'
 import Ga4RouteListener from './app/Ga4RouteListener.jsx'
+import ScrollToTop from './app/ScrollToTop.jsx'
 import { initGa4 } from './shared/lib/ga4'
 import { initializeAppCheckDeferred } from './shared/lib/firebaseAppCheck'
 import { registerMessagingServiceWorker } from './shared/lib/firebaseMessaging'
@@ -32,6 +33,7 @@ root.render(
     <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <QueryClientProvider client={queryClient}>
         <HelmetProvider>
+          <ScrollToTop />
           <Ga4RouteListener />
           <App />
         </HelmetProvider>

--- a/src/pages/landing/SplashPage.jsx
+++ b/src/pages/landing/SplashPage.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
+import { consumeSplashResumeAuthModal } from '../../features/auth';
 import {
   SplashAuthModals,
   SplashPageShell,
@@ -23,6 +24,8 @@ export default function Splash() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const didHandleLoginFlagRef = useRef(false);
+  /** One-shot bootstrap for resume-from-legal + pool-invite (Strict Mode safe). */
+  const splashResumeAndInviteRef = useRef(false);
   const {
     howItWorksSectionRef,
     howItWorksHeadingRef,
@@ -48,6 +51,15 @@ export default function Splash() {
   }, [navigate, openSignInModal, searchParams]);
 
   useEffect(() => {
+    if (splashResumeAndInviteRef.current) return;
+    splashResumeAndInviteRef.current = true;
+
+    const resume = consumeSplashResumeAuthModal();
+    if (resume) {
+      setAuthModal(resume);
+      return;
+    }
+
     const pending = getLocalStorageItem(POOL_INVITE_STORAGE_KEY)?.trim();
     if (!pending) return;
     const now = Date.now();

--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -121,6 +121,26 @@ export default function Profile({ user }) {
       </div>
 
       <DeleteAccountSection />
+
+      {user?.uid ? (
+        <footer className="mt-10 border-t border-border-muted/40 pb-2 pt-6 text-center text-[11px] font-medium text-content-secondary/70">
+          <span className="space-x-2">
+            <Link
+              to="/privacy"
+              className="underline decoration-border-muted underline-offset-2 transition-colors hover:text-white"
+            >
+              Privacy
+            </Link>
+            <span aria-hidden>&middot;</span>
+            <Link
+              to="/terms"
+              className="underline decoration-border-muted underline-offset-2 transition-colors hover:text-white"
+            >
+              Terms
+            </Link>
+          </span>
+        </footer>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Closes #392

## Summary

- Sign-up modal: shared Terms/Privacy clickwrap above Google and email; both actions disabled until checked; `termsPrivacyAcceptedAt` written for new accounts; Auth rollback if consent write fails; profile `setDoc` merge preserves consent.
- Google footnote copy updated (username/handle + email not visible to others).
- `ScrollToTop` on pathname change so legal pages open at the top.
- Session resume reopens the sign-up modal after visiting Terms/Privacy from the checkbox.
- Dashboard: remove global Privacy/Terms footer; add the same links at the bottom of **Profile** only.

## Test plan

- [ ] `npm run lint` && `npm test`
- [ ] Sign-up: checkbox gates Google + email; new user has `termsPrivacyAcceptedAt` in Firestore
- [ ] From sign-up, open Terms → Back → modal still open
- [ ] Dashboard: Privacy/Terms on Profile only; absent on Picks / Standings / Pools

Made with [Cursor](https://cursor.com)