### PR TITLE
feat(scoring): promote share bar to top of standings view

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -52,6 +52,28 @@ Implemented as CSS variables in `src/index.css` and mapped in `tailwind.config.j
 - **Rank 1 Gold**: `#d97706` (or standard `text-amber-500`/`bg-amber-500`) — Used exclusively for 1st place leaderboard indicators.
 - **Success/Score Teal**: `text-brand-primary` — Used to highlight user scores (e.g., "45 PTS").
 
+### Tertiary+ accents & dashboard “slices”
+
+As each **menu tab** (Standings, Picks, Pools, Profile, etc.) gains more **card stacks**—recaps, banners, list rows, and tool-specific panels—the palette needs **roles beyond primary + secondary** so every block does not collapse into the same teal ring or the same meta gray.
+
+**Role ladder (conceptual — implement as Tailwind today, promote to CSS tokens when a pattern repeats):**
+
+| Tier | Role | Examples (non-exhaustive) | Guardrails |
+|------|------|---------------------------|------------|
+| **Primary** | Money path, scores, main CTA | `brand-primary`, `shadow-glow-brand` | One dominant teal action per dense viewport when possible. |
+| **Secondary** | Labels, helpers, inactive meta | `text-content-secondary`, `border-border-subtle` | Default for uppercase eyebrows and hint copy. |
+| **Tertiary** | **Card identity / wayfinding** — “this slice is different from its neighbor” without competing with CTAs | Muted violet/slate/blue **borders or text** at low saturation; optional **named** ring (e.g. recap card) | Must not read as “click me” like primary teal; avoid amber/gold except true 1st-place badges. |
+| **Quaternary+** | Rare emphasis inside a tertiary card (badges, inline status) | Chip fills, icon tint | Prefer **semantic names** in code (`status-live`, `recap-border`) even if mapped to Tailwind for now; **promote to `index.css` + `tailwind.config.js`** once the same pairing appears in **two or more** tabs or features. |
+
+**When to introduce a new color token (checklist):**
+
+1. The same accent pairing (border + text + background) appears in **two or more** surfaces or tabs.  
+2. It **cannot** be expressed with existing `brand-*`, `surface-*`, `content-secondary`, or Rank 1 gold without breaking the roles above.  
+3. It passes **contrast** on the intended surface (`surface-panel`, `surface-inset`, or `brand-bg`).  
+4. It is documented here with a **one-line role** so agents and humans do not reuse it for a conflicting meaning later.
+
+**Tab-specific card variation:** Prefer **surface elevation + border weight + typography** first; add a **tertiary accent** only when those are not enough to separate stacked modules (e.g. “your rank” recap above a frosted leaderboard list). Do not let tertiary colors multiply into a rainbow per screen—**one tertiary family per major column** is a good default.
+
 ## 3. Typography Rules
 
 ### Font Families
@@ -115,6 +137,7 @@ Because the app uses a dark theme, traditional black drop-shadows do not work. D
 - Use `font-display` exclusively for large headings, keeping `font-sans` for dense UI to ensure readability.
 - Rely on `surface-panel` with opacity for cards so the underlying `brand-bg` bleeds through slightly.
 - Use `brand-primary` for scores and ranks to draw the user's eye immediately to the gamification elements.
+- Use **tertiary** accents (see **§2 Tertiary+ accents**) for dense dashboard **slices**—recaps, anchors, tab-specific modules—when teal would over-compete or meta gray would under-differentiate.
 - Strictly adhere to the shape rules: `rounded-xl` for CTAs and inputs, `rounded-full` for chips and filters.
 
 ### Don't
@@ -154,6 +177,7 @@ Do **not** hardcode `/branding/…` paths in components; import from **`shared/c
 ### Quick Tailwind Class Reference
 - **Brand wordmark (img):** import `BRAND_WORDMARK_SRC`, `brandWordmarkImgClassNames`, and the matching scale wrapper from `src/shared/config/branding.js` — do not duplicate `/branding/…` paths in feature or layout files.
 - **Background:** `bg-brand-bg`
+- **Tertiary slice (conceptual):** differentiate stacked cards with border/ring + `text-content-secondary` eyebrows first; add a dedicated token only after the pattern repeats (see **§2 Tertiary+ accents**).
 - **Standard Card:** `bg-surface-panel border border-border-subtle rounded-xl`
 - **Frosted list card:** `Card` `variant="frosted"` — teal border + blur + inset glass
 - **Primary Text:** `text-white font-sans`

--- a/src/features/picks/index.js
+++ b/src/features/picks/index.js
@@ -3,5 +3,7 @@ export { default as PastShowLockBanner } from './ui/PastShowLockBanner';
 export { default as TooEarlyBanner } from './ui/TooEarlyBanner';
 export { default as PicksFieldsForm } from './ui/PicksFieldsForm';
 export { default as PicksSubmitButton } from './ui/PicksSubmitButton';
+export { default as PicksSelfRecapSection } from './ui/PicksSelfRecapSection';
 export { default as usePicksForm } from './model/usePicksForm';
+export { usePicksSelfRecap } from './model/usePicksSelfRecap';
 export { useNextShowPicksStatus } from './model/useNextShowPicksStatus';

--- a/src/features/picks/model/usePicksSelfRecap.js
+++ b/src/features/picks/model/usePicksSelfRecap.js
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+
+import { FORM_FIELDS } from '../../../shared/data/gameConfig';
+import {
+  computeShowWinnerOfTheNight,
+  computeStandingsSelfRecap,
+  useStandings,
+} from '../../scoring';
+
+function formHasPicks(formData) {
+  if (!formData || typeof formData !== 'object') return false;
+  return FORM_FIELDS.some((f) => {
+    const v = formData[f.id];
+    return v != null && String(v).trim() !== '';
+  });
+}
+
+/**
+ * Global-show rank snapshot for the Picks tab (same ordering as Standings).
+ *
+ * @param {{ user: { uid?: string } | null | undefined, selectedDate: string | undefined, showDates: unknown[], formData: Record<string, unknown> }} args
+ */
+export function usePicksSelfRecap({ user, selectedDate, showDates, formData }) {
+  const { picks, actualSetlist } = useStandings(selectedDate, showDates);
+
+  const recap = useMemo(
+    () => computeStandingsSelfRecap(picks, actualSetlist, user?.uid),
+    [picks, actualSetlist, user?.uid],
+  );
+
+  const shareGradedRecapAllowed = useMemo(() => {
+    if (!actualSetlist || !formHasPicks(formData)) return false;
+    return !computeShowWinnerOfTheNight(picks).hasUngradedNonEmptyPick;
+  }, [actualSetlist, formData, picks]);
+
+  return { recap, shareGradedRecapAllowed, actualSetlist };
+}

--- a/src/features/picks/ui/PicksSelfRecapSection.jsx
+++ b/src/features/picks/ui/PicksSelfRecapSection.jsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { ChevronDown } from 'lucide-react';
+
+import {
+  PICKS_SELF_RECAP_STANDINGS_LINK,
+  STANDINGS_SELF_RECAP_EYEBROW,
+} from '../../../shared/config/dashboardVocabulary';
+import { StandingsSelfRecapCard } from '../../scoring';
+
+/** Compact stats for `<details>` summary: `#n/total · pts` with full phrase in `aria-label`. */
+function recapSummaryCompactStats(recap) {
+  const playerWord = recap.totalPlayers === 1 ? 'player' : 'players';
+
+  if (recap.displayRank != null) {
+    const score = recap.totalScore != null ? recap.totalScore : '—';
+    const ariaLabel = `Rank ${recap.displayRank} of ${recap.totalPlayers} ${playerWord}, ${
+      score === '—' ? 'points pending' : `${score} points`
+    }`;
+    return (
+      <p
+        className="mt-0.5 flex flex-wrap items-baseline gap-x-1.5 text-sm font-semibold tabular-nums leading-snug sm:text-base"
+        aria-label={ariaLabel}
+      >
+        <span className="font-bold text-white">#{recap.displayRank}</span>
+        <span className="text-content-secondary" aria-hidden>
+          /
+        </span>
+        <span className="font-bold text-white">{recap.totalPlayers}</span>
+        <span className="font-bold text-content-secondary">·</span>
+        <span className="font-bold text-brand-primary">{score}</span>
+        <span className="text-[10px] font-bold uppercase tracking-widest text-content-secondary">
+          pts
+        </span>
+      </p>
+    );
+  }
+
+  const score = recap.totalScore != null ? recap.totalScore : '—';
+  return (
+    <p
+      className="mt-0.5 text-sm font-bold leading-snug text-content-secondary"
+      aria-label="Rank updates after the setlist is posted. Current points if any."
+    >
+      <span className="text-brand-primary">You</span>
+      <span className="mx-1 font-semibold">·</span>
+      <span className="tabular-nums text-brand-primary">{score}</span>
+      <span className="ml-1 text-[10px] font-bold uppercase tracking-widest">pts</span>
+    </p>
+  );
+}
+
+/**
+ * Picks-tab wrapper: full self-recap on `md+`. On small screens, a `<details>` summary
+ * shows label + handle (wraps, not truncated) + compact `#n/total · pts`; the open body
+ * reuses {@link StandingsSelfRecapCard} in `bodyOnly` mode so rank/name are not repeated.
+ */
+export default function PicksSelfRecapSection({
+  recap,
+  shareGradedRecapAllowed,
+  showLabel,
+  formData,
+  actualSetlist,
+  standingsTo,
+}) {
+  if (!recap) return null;
+
+  const routerJump = { to: standingsTo, label: PICKS_SELF_RECAP_STANDINGS_LINK };
+
+  const cardProps = {
+    recap,
+    showLabel,
+    poolLabel: null,
+    userPicks: formData,
+    actualSetlist,
+    shareGradedRecapAllowed,
+    routerJump,
+  };
+
+  return (
+    <div className="mb-4 mt-2">
+      <div className="hidden md:block">
+        <StandingsSelfRecapCard {...cardProps} showEyebrow />
+      </div>
+
+      <details className="group rounded-xl border border-border-subtle/55 bg-surface-panel/55 shadow-inset-glass ring-1 ring-brand-primary/15 md:hidden">
+        <summary className="flex list-none cursor-pointer items-center gap-2 px-3 py-2.5 text-left [&::-webkit-details-marker]:hidden">
+          <div className="min-w-0 flex-1">
+            <p className="text-xs font-black uppercase tracking-widest text-amber-200/90">
+              {STANDINGS_SELF_RECAP_EYEBROW}
+            </p>
+            <p
+              className="mt-1 break-words text-base font-bold leading-snug text-slate-100"
+              title={recap.handle}
+            >
+              {recap.handle}
+            </p>
+            {recapSummaryCompactStats(recap)}
+          </div>
+          <ChevronDown
+            className="h-4 w-4 shrink-0 text-content-secondary opacity-80 transition-transform duration-200 ease-out group-open:rotate-180"
+            aria-hidden
+          />
+        </summary>
+        <div className="border-t border-border-subtle/40 px-3 pb-3 pt-1">
+          <StandingsSelfRecapCard
+            {...cardProps}
+            bodyOnly
+            showEyebrow={false}
+            className="border-0 bg-transparent p-0 shadow-none ring-0"
+          />
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -4,6 +4,9 @@ export {
 } from './api/globalShowAggregation';
 export { default as Leaderboard } from './ui/Leaderboard';
 export { default as GradedPicksShareBar } from './ui/GradedPicksShareBar';
+export { default as StandingsSelfRecapCard } from './ui/StandingsSelfRecapCard';
+export { computeStandingsSelfRecap } from './model/standingsSelfRecap';
+export { computeShowWinnerOfTheNight } from './model/useShowWinnerOfTheNight';
 export {
   GRADED_PICKS_SHARE_DOMAIN,
   GRADED_PICKS_SHARE_INTRO,

--- a/src/features/scoring/model/gradedPicksShareCore.js
+++ b/src/features/scoring/model/gradedPicksShareCore.js
@@ -73,6 +73,16 @@ function shareEmojiCellChar(slot, userPicks) {
 }
 
 /**
+ * One Wordle-style cell emoji (same as {@link buildGradedPicksShareEmojiGrid}).
+ *
+ * @param {ReturnType<typeof buildGradedPicksShareSlots>[number]} slot
+ * @param {Record<string, unknown>} userPicks
+ */
+export function getGradedPicksShareEmojiCell(slot, userPicks) {
+  return shareEmojiCellChar(slot, userPicks);
+}
+
+/**
  * Count slots where the user's pick was found in the setlist (hit).
  * A hit = has a pick AND kind is not miss/none.
  */
@@ -98,8 +108,13 @@ export function buildGradedPicksShareEmojiGrid(slots, userPicks) {
   return `${ch(slots[0])}${ch(slots[1])}${ch(slots[2])}\n${ch(slots[3])}${ch(slots[4])}${ch(slots[5])}`;
 }
 
-/** Opaque fills for PNG tiles (bust = full amber tile, same idea as emoji 🟧). */
-function paletteForSlot(slot) {
+/**
+ * Opaque fills for PNG tiles and in-app share preview (bust = full amber tile, same idea
+ * as emoji 🟧).
+ *
+ * @param {ReturnType<typeof buildGradedPicksShareSlots>[number]} slot
+ */
+export function getGradedShareSlotPreviewColors(slot) {
   if (slot.bustoutBoost) {
     return {
       fill: '#713f12',
@@ -245,7 +260,7 @@ export function renderGradedPicksSharePngBlob(slots, { showLabel, totalPoints, s
     const row = Math.floor(i / 3);
     const x = padX + col * (cellW + gap);
     const y = padTop + row * (cellH + rowGap);
-    const { fill, stroke, text } = paletteForSlot(slot);
+    const { fill, stroke, text } = getGradedShareSlotPreviewColors(slot);
     const borderW = 1.75;
 
     ctx.beginPath();

--- a/src/features/scoring/model/standingsSelfRecap.js
+++ b/src/features/scoring/model/standingsSelfRecap.js
@@ -1,0 +1,46 @@
+import { calculateTotalScore } from '../../../shared/utils/scoring';
+
+import { getPickPayloadFromEntry, sortPicksForLeaderboard } from './useLeaderboard';
+
+/**
+ * Live leaderboard snapshot for the signed-in user (same sort + rank rules as
+ * {@link LeaderboardList} / {@link LeaderboardRow}).
+ *
+ * @param {Array<Record<string, unknown>> | null | undefined} displayedPicks
+ * @param {unknown[] | null} actualSetlist
+ * @param {string | null | undefined} selfUserId
+ * @returns {{
+ *   handle: string,
+ *   userId: string,
+ *   displayRank: number | null,
+ *   rankNumber: number,
+ *   totalPlayers: number,
+ *   totalScore: number | null,
+ *   selfAnchorId: string,
+ * } | null}
+ */
+export function computeStandingsSelfRecap(displayedPicks, actualSetlist, selfUserId) {
+  if (!selfUserId || !Array.isArray(displayedPicks) || displayedPicks.length === 0) {
+    return null;
+  }
+  const sorted = sortPicksForLeaderboard(displayedPicks, actualSetlist, selfUserId);
+  const idx = sorted.findIndex((p) => (p.userId || p.uid) === selfUserId);
+  if (idx < 0) return null;
+
+  const entry = sorted[idx];
+  const picksPayload = getPickPayloadFromEntry(entry);
+  const rankNumber = idx + 1;
+  const isSelf = (entry.userId || entry.uid) === selfUserId;
+  const displayRank = isSelf && !actualSetlist ? null : rankNumber;
+  const totalScore = actualSetlist ? calculateTotalScore(picksPayload, actualSetlist) : null;
+
+  return {
+    handle: entry.handle || 'Anonymous',
+    userId: selfUserId,
+    displayRank,
+    rankNumber,
+    totalPlayers: sorted.length,
+    totalScore,
+    selfAnchorId: `standings-player-${selfUserId}`,
+  };
+}

--- a/src/features/scoring/model/standingsSelfRecap.test.js
+++ b/src/features/scoring/model/standingsSelfRecap.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+
+import { computeStandingsSelfRecap } from './standingsSelfRecap';
+
+describe('computeStandingsSelfRecap', () => {
+  const setlist = [{ title: 'Song A' }];
+
+  it('returns null when selfUserId or picks missing', () => {
+    expect(computeStandingsSelfRecap([], setlist, 'u1')).toBeNull();
+    expect(computeStandingsSelfRecap([{ userId: 'u1' }], setlist, null)).toBeNull();
+  });
+
+  it('uses natural rank and score when setlist exists', () => {
+    const picks = [
+      { userId: 'a', handle: 'Top', picks: {} },
+      { userId: 'me', handle: 'Self', picks: {} },
+    ];
+    const r = computeStandingsSelfRecap(picks, setlist, 'me');
+    expect(r?.displayRank).toBe(2);
+    expect(r?.rankNumber).toBe(2);
+    expect(r?.totalPlayers).toBe(2);
+    expect(r?.handle).toBe('Self');
+    expect(r?.selfAnchorId).toBe('standings-player-me');
+  });
+
+  it('hides numeric rank for self pre-grade (pinned row) but keeps rankNumber', () => {
+    const picks = [
+      { userId: 'a', handle: 'Other', picks: {} },
+      { userId: 'me', handle: 'Self', picks: {} },
+    ];
+    const r = computeStandingsSelfRecap(picks, null, 'me');
+    expect(r?.displayRank).toBeNull();
+    expect(r?.rankNumber).toBe(1);
+    expect(r?.totalScore).toBeNull();
+  });
+});

--- a/src/features/scoring/model/useLeaderboard.js
+++ b/src/features/scoring/model/useLeaderboard.js
@@ -3,6 +3,21 @@ import { FORM_FIELDS } from '../../../shared/data/gameConfig';
 import { calculateTotalScore } from '../../../shared/utils/scoring';
 
 /**
+ * @param {Record<string, unknown> | null | undefined} pickEntry
+ * @returns {Record<string, unknown>}
+ */
+export function getPickPayloadFromEntry(pickEntry) {
+  if (pickEntry?.picks && typeof pickEntry.picks === 'object') {
+    return pickEntry.picks;
+  }
+
+  return FORM_FIELDS.reduce((acc, field) => {
+    acc[field.id] = pickEntry?.[field.id] || '';
+    return acc;
+  }, {});
+}
+
+/**
  * Pull the signed-in user's row to rank 1 pre-grade (#255). Once
  * `actualSetlist` arrives, scores drive ordering and the row falls into
  * its natural rank. Non-mutating; leaves relative order of the rest.
@@ -23,6 +38,27 @@ export function pinSelfToTop(rows, selfUserId) {
 }
 
 /**
+ * Same ordering as the Standings leaderboard (score sort + pre-grade self pin).
+ *
+ * @template {{ userId?: string, uid?: string }} T
+ * @param {T[]} poolPicks
+ * @param {unknown[] | null} actualSetlist
+ * @param {string | null | undefined} selfUserId
+ * @returns {T[]}
+ */
+export function sortPicksForLeaderboard(poolPicks, actualSetlist, selfUserId) {
+  const byScore = [...poolPicks].sort((a, b) => {
+    const scoreA = calculateTotalScore(getPickPayloadFromEntry(a), actualSetlist);
+    const scoreB = calculateTotalScore(getPickPayloadFromEntry(b), actualSetlist);
+    return scoreB - scoreA;
+  });
+  if (!actualSetlist && selfUserId) {
+    return pinSelfToTop(byScore, selfUserId);
+  }
+  return byScore;
+}
+
+/**
  * @param {Array<Record<string, unknown>>} poolPicks
  * @param {unknown[] | null} actualSetlist
  * @param {{ selfUserId?: string | null }} [options]
@@ -31,31 +67,12 @@ export function useLeaderboard(poolPicks = [], actualSetlist = null, options = {
   const { selfUserId = null } = options;
   const [expandedUser, setExpandedUser] = useState(null);
 
-  const getPickPayload = (pickEntry) => {
-    if (pickEntry?.picks && typeof pickEntry.picks === 'object') {
-      return pickEntry.picks;
-    }
+  const getPickPayload = getPickPayloadFromEntry;
 
-    // Backward compatibility for legacy docs where picks lived at the root.
-    return FORM_FIELDS.reduce((acc, field) => {
-      acc[field.id] = pickEntry?.[field.id] || '';
-      return acc;
-    }, {});
-  };
-
-  const sortedPicks = useMemo(() => {
-    const byScore = [...poolPicks].sort((a, b) => {
-      const scoreA = calculateTotalScore(getPickPayload(a), actualSetlist);
-      const scoreB = calculateTotalScore(getPickPayload(b), actualSetlist);
-      return scoreB - scoreA;
-    });
-    // Pre-grade: pin self to the top so the user can see their locked-in
-    // picks at a glance while waiting for the setlist to finalize.
-    if (!actualSetlist && selfUserId) {
-      return pinSelfToTop(byScore, selfUserId);
-    }
-    return byScore;
-  }, [poolPicks, actualSetlist, selfUserId]);
+  const sortedPicks = useMemo(
+    () => sortPicksForLeaderboard(poolPicks, actualSetlist, selfUserId),
+    [poolPicks, actualSetlist, selfUserId]
+  );
 
   const toggleUserExpansion = (userId) => {
     setExpandedUser((prev) => (prev === userId ? null : userId));

--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -5,6 +5,7 @@ import { useAuth } from '../../auth';
 import { useNextShowPicksStatus } from '../../picks';
 import { useUserPools } from '../../pools';
 import { useShowCalendar } from '../../show-calendar';
+import { FORM_FIELDS } from '../../../shared/data/gameConfig';
 import { todayYmd } from '../../../shared/utils/dateUtils';
 import {
   getShowBeforeDate,
@@ -157,6 +158,17 @@ export function useStandingsScreen(selectedDate, options = {}) {
     return userPools?.find((p) => p.id === poolId)?.name ?? null;
   }, [view, poolId, userPools]);
 
+  const selfUserPicks = useMemo(() => {
+    if (!user?.uid || !displayedPicks?.length) return null;
+    const entry = displayedPicks.find((p) => (p.userId || p.uid) === user.uid);
+    if (!entry) return null;
+    if (entry.picks && typeof entry.picks === 'object') return entry.picks;
+    return FORM_FIELDS.reduce((acc, f) => {
+      acc[f.id] = entry[f.id] || '';
+      return acc;
+    }, {});
+  }, [user?.uid, displayedPicks]);
+
   const leaderboardTitle =
     view === 'pools' ? activePoolName || 'This pool' : 'Everyone';
 
@@ -196,6 +208,7 @@ export function useStandingsScreen(selectedDate, options = {}) {
     leaderboardTitle,
     activePoolName,
     selfUserId: user?.uid || null,
+    selfUserPicks,
     isSecured: hasSubmittedPicksForNextShow,
     picksStatusLoading,
 

--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -17,8 +17,12 @@ import { showOptionLabelCompact } from '../../../shared/utils/showOptionLabel';
 import { resolveCurrentTour } from './resolveCurrentTour';
 import { useDisplayedPicks } from './useDisplayedPicks';
 import { usePreviousShowNightWinner } from './usePreviousShowNightWinner';
-import { useShowWinnerOfTheNight } from './useShowWinnerOfTheNight';
+import {
+  computeShowWinnerOfTheNight,
+  useShowWinnerOfTheNight,
+} from './useShowWinnerOfTheNight';
 import { useStandings } from './useStandings';
+import { computeStandingsSelfRecap } from './standingsSelfRecap';
 import { useStandingsLeaderboardView } from './useStandingsLeaderboardView';
 import { useStandingsView } from './useStandingsView';
 import { useTourStandings } from './useTourStandings';
@@ -169,6 +173,17 @@ export function useStandingsScreen(selectedDate, options = {}) {
     }, {});
   }, [user?.uid, displayedPicks]);
 
+  const selfStandingsRecap = useMemo(
+    () => computeStandingsSelfRecap(displayedPicks, actualSetlist, user?.uid),
+    [displayedPicks, actualSetlist, user?.uid],
+  );
+
+  /** Same rule as the “winner of the night” banner: no share until global finalize. */
+  const shareGradedRecapAllowed = useMemo(() => {
+    if (!actualSetlist || !selfUserPicks) return false;
+    return !computeShowWinnerOfTheNight(picks).hasUngradedNonEmptyPick;
+  }, [actualSetlist, selfUserPicks, picks]);
+
   const leaderboardTitle =
     view === 'pools' ? activePoolName || 'This pool' : 'Everyone';
 
@@ -209,6 +224,8 @@ export function useStandingsScreen(selectedDate, options = {}) {
     activePoolName,
     selfUserId: user?.uid || null,
     selfUserPicks,
+    selfStandingsRecap,
+    shareGradedRecapAllowed,
     isSecured: hasSubmittedPicksForNextShow,
     picksStatusLoading,
 

--- a/src/features/scoring/ui/GradedPicksShareBar.jsx
+++ b/src/features/scoring/ui/GradedPicksShareBar.jsx
@@ -4,10 +4,53 @@ import { Copy, Share2 } from 'lucide-react';
 import {
   buildGradedPicksShareBodyPlain,
   buildGradedPicksShareFullPlainText,
-  GRADED_PICKS_SHARE_RECAP_TITLE,
+  buildGradedPicksShareSlots,
+  getGradedPicksShareEmojiCell,
 } from '../model/gradedPicksShareCore';
 
-export default function GradedPicksShareBar({ userPicks, actualSetlist, showLabel, className = '' }) {
+/** Same 2×3 emoji grid as SMS / Web Share body; each cell in a bordered tile so ⬜ reads as separate blocks. */
+function GradedPicksShareEmojiPreview({ userPicks, actualSetlist }) {
+  if (!userPicks || !actualSetlist) return null;
+  const slots = buildGradedPicksShareSlots(userPicks, actualSetlist);
+  const rowClass = 'flex gap-0.5';
+  const tileClass =
+    'inline-flex h-[1.35rem] w-[1.35rem] shrink-0 items-center justify-center rounded border border-slate-500/55 bg-slate-950/70 sm:h-7 sm:w-7';
+
+  return (
+    <div
+      className="flex shrink-0 select-none flex-col gap-0.5"
+      role="img"
+      aria-label="Preview: same colored squares as in your Copy / Share message"
+    >
+      <div className={rowClass} aria-hidden>
+        {slots.slice(0, 3).map((slot) => (
+          <span key={slot.fieldId} className={tileClass}>
+            <span className="text-[13px] leading-none sm:text-[15px]">
+              {getGradedPicksShareEmojiCell(slot, userPicks)}
+            </span>
+          </span>
+        ))}
+      </div>
+      <div className={rowClass} aria-hidden>
+        {slots.slice(3, 6).map((slot) => (
+          <span key={slot.fieldId} className={tileClass}>
+            <span className="text-[13px] leading-none sm:text-[15px]">
+              {getGradedPicksShareEmojiCell(slot, userPicks)}
+            </span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function GradedPicksShareBar({
+  userPicks,
+  actualSetlist,
+  showLabel,
+  className = '',
+  variant = 'default',
+}) {
   const [notice, setNotice] = useState(null);
 
   const clearNoticeSoon = useCallback((msg) => {
@@ -30,8 +73,9 @@ export default function GradedPicksShareBar({ userPicks, actualSetlist, showLabe
 
     try {
       if (navigator.share) {
-        await navigator.share({ text, title: GRADED_PICKS_SHARE_RECAP_TITLE });
-        clearNoticeSoon('Shared');
+        // Do not call setNotice here: a React re-render while the system share sheet
+        // or Messages handoff is active can dismiss the sheet / break recipient flow on iOS.
+        await navigator.share({ text });
         return;
       }
       await navigator.clipboard.writeText(text);
@@ -43,34 +87,52 @@ export default function GradedPicksShareBar({ userPicks, actualSetlist, showLabe
     }
   }, [actualSetlist, clearNoticeSoon, showLabel, userPicks]);
 
-  return (
-    <div className={`rounded-xl border border-border-subtle/50 bg-surface-panel/40 px-3 py-3 ${className}`}>
-      <p className="mb-2 text-[10px] font-black uppercase tracking-widest text-content-secondary">
-        Share your score
-      </p>
-      <div className="flex flex-wrap gap-2">
-        <button
-          type="button"
-          onClick={onCopy}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-border-muted bg-surface-inset px-3 py-2 text-xs font-bold text-slate-200 transition-colors hover:bg-surface-panel-strong hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
-        >
-          <Copy className="h-3.5 w-3.5" aria-hidden />
-          Copy
-        </button>
-        <button
-          type="button"
-          onClick={onShare}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-brand-primary/40 bg-brand-primary/10 px-3 py-2 text-xs font-bold text-brand-primary transition-colors hover:bg-brand-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
-        >
-          <Share2 className="h-3.5 w-3.5" aria-hidden />
-          Share…
-        </button>
+  const emojiPreview =
+    userPicks && actualSetlist ? (
+      <GradedPicksShareEmojiPreview userPicks={userPicks} actualSetlist={actualSetlist} />
+    ) : null;
+
+  const actions = (
+    <>
+      <div className="flex w-full min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={onCopy}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-border-muted bg-surface-inset px-3 py-2 text-xs font-bold text-slate-200 transition-colors hover:bg-surface-panel-strong hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
+          >
+            <Copy className="h-3.5 w-3.5" aria-hidden />
+            Copy
+          </button>
+          <button
+            type="button"
+            onClick={onShare}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-brand-primary/40 bg-brand-primary/10 px-3 py-2 text-xs font-bold text-brand-primary transition-colors hover:bg-brand-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
+          >
+            <Share2 className="h-3.5 w-3.5" aria-hidden />
+            Share…
+          </button>
+        </div>
+        {emojiPreview ? <div className="ml-auto shrink-0">{emojiPreview}</div> : null}
       </div>
       {notice ? (
         <p className="mt-2 text-[11px] font-semibold text-brand-primary" role="status">
           {notice}
         </p>
       ) : null}
+    </>
+  );
+
+  if (variant === 'actionsOnly') {
+    return <div className={className}>{actions}</div>;
+  }
+
+  return (
+    <div className={`rounded-xl border border-border-subtle/50 bg-surface-panel/40 px-3 py-3 ${className}`}>
+      <p className="mb-2 text-[10px] font-black uppercase tracking-widest text-content-secondary">
+        Share your score
+      </p>
+      {actions}
     </div>
   );
 }

--- a/src/features/scoring/ui/GradedPicksShareBar.jsx
+++ b/src/features/scoring/ui/GradedPicksShareBar.jsx
@@ -7,7 +7,7 @@ import {
   GRADED_PICKS_SHARE_RECAP_TITLE,
 } from '../model/gradedPicksShareCore';
 
-export default function GradedPicksShareBar({ userPicks, actualSetlist, showLabel }) {
+export default function GradedPicksShareBar({ userPicks, actualSetlist, showLabel, className = '' }) {
   const [notice, setNotice] = useState(null);
 
   const clearNoticeSoon = useCallback((msg) => {
@@ -44,7 +44,7 @@ export default function GradedPicksShareBar({ userPicks, actualSetlist, showLabe
   }, [actualSetlist, clearNoticeSoon, showLabel, userPicks]);
 
   return (
-    <div className="mt-4 rounded-xl border border-border-subtle/50 bg-surface-panel/40 px-3 py-3">
+    <div className={`rounded-xl border border-border-subtle/50 bg-surface-panel/40 px-3 py-3 ${className}`}>
       <p className="mb-2 text-[10px] font-black uppercase tracking-widest text-content-secondary">
         Share your score
       </p>

--- a/src/features/scoring/ui/Leaderboard.jsx
+++ b/src/features/scoring/ui/Leaderboard.jsx
@@ -10,7 +10,6 @@ const Leaderboard = ({
   selfUserId = null,
   suppressLeadingCallout = false,
   redactOpponentPicksPreLock = false,
-  shareShowLabel = '',
 }) => {
   const { sortedPicks, getPickPayload, expandedUser, toggleUserExpansion } = useLeaderboard(
     poolPicks,
@@ -30,7 +29,6 @@ const Leaderboard = ({
       selfUserId={selfUserId}
       suppressLeadingCallout={suppressLeadingCallout}
       redactOpponentPicksPreLock={redactOpponentPicksPreLock}
-      shareShowLabel={shareShowLabel}
     />
   );
 };

--- a/src/features/scoring/ui/LeaderboardList.jsx
+++ b/src/features/scoring/ui/LeaderboardList.jsx
@@ -139,6 +139,9 @@ export default function LeaderboardList({
             onToggle={() => onToggle(uniqueId)}
             userPicks={userPicks}
             maskPickTitles={maskPickTitles}
+            anchorId={
+              isSelf && selfUserId ? `standings-player-${selfUserId}` : undefined
+            }
           />
         );
       })}

--- a/src/features/scoring/ui/LeaderboardList.jsx
+++ b/src/features/scoring/ui/LeaderboardList.jsx
@@ -26,7 +26,6 @@ export default function LeaderboardList({
   suppressLeadingCallout = false,
   /** Pre-lock: blur opponent pick titles in expanded rows (#303). */
   redactOpponentPicksPreLock = false,
-  shareShowLabel = '',
 }) {
   if (sortedPicks.length === 0) {
     return (
@@ -140,7 +139,6 @@ export default function LeaderboardList({
             onToggle={() => onToggle(uniqueId)}
             userPicks={userPicks}
             maskPickTitles={maskPickTitles}
-            shareShowLabel={shareShowLabel}
           />
         );
       })}

--- a/src/features/scoring/ui/LeaderboardRow.jsx
+++ b/src/features/scoring/ui/LeaderboardRow.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
 import { calculateTotalScore } from '../../../shared/utils/scoring';
-import GradedPicksShareBar from './GradedPicksShareBar';
 import ScoreBreakdownGrid from './ScoreBreakdownGrid';
 
 const rankBadgeClass = (rank) => {
@@ -23,7 +22,6 @@ export default function LeaderboardRow({
   userPicks,
   /** Pre-lock privacy (#303): blur opponent song titles in the breakdown. */
   maskPickTitles = false,
-  shareShowLabel = '',
 }) {
   const uniqueId = p.uid || p.id;
   const playerUserId = p.userId || p.uid;
@@ -111,13 +109,6 @@ export default function LeaderboardRow({
             actualSetlist={actualSetlist}
             maskPickTitles={maskPickTitles}
           />
-          {isSelf && actualSetlist && !maskPickTitles && shareShowLabel ? (
-            <GradedPicksShareBar
-              userPicks={userPicks}
-              actualSetlist={actualSetlist}
-              showLabel={shareShowLabel}
-            />
-          ) : null}
         </div>
       )}
     </div>

--- a/src/features/scoring/ui/LeaderboardRow.jsx
+++ b/src/features/scoring/ui/LeaderboardRow.jsx
@@ -3,13 +3,13 @@ import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
 import { calculateTotalScore } from '../../../shared/utils/scoring';
 import ScoreBreakdownGrid from './ScoreBreakdownGrid';
 
-const rankBadgeClass = (rank) => {
+export function rankBadgeClass(rank) {
   if (rank === 1) return 'bg-amber-500/20 text-amber-300 ring-1 ring-amber-500/40';
   if (rank === 2)
     return 'bg-brand-accent-blue/15 text-blue-200 ring-1 ring-brand-accent-blue/35';
   if (rank === 3) return 'bg-orange-900/40 text-orange-200 ring-1 ring-orange-700/40';
   return 'bg-surface-inset text-slate-300 ring-1 ring-border-muted';
-};
+}
 
 export default function LeaderboardRow({
   rank,
@@ -22,6 +22,8 @@ export default function LeaderboardRow({
   userPicks,
   /** Pre-lock privacy (#303): blur opponent song titles in the breakdown. */
   maskPickTitles = false,
+  /** In-page anchor for “jump to your card” from StandingsSelfRecapCard. */
+  anchorId = null,
 }) {
   const uniqueId = p.uid || p.id;
   const playerUserId = p.userId || p.uid;
@@ -37,7 +39,8 @@ export default function LeaderboardRow({
 
   return (
     <div
-      className={`bg-surface-panel rounded-2xl border overflow-hidden shadow-inset-glass transition-all ${borderTone}`}
+      id={anchorId || undefined}
+      className={`bg-surface-panel rounded-2xl border overflow-hidden shadow-inset-glass transition-all scroll-mt-24 md:scroll-mt-28 ${borderTone}`}
     >
       <div
         role="button"

--- a/src/features/scoring/ui/StandingsSelfRecapCard.jsx
+++ b/src/features/scoring/ui/StandingsSelfRecapCard.jsx
@@ -1,0 +1,241 @@
+import React, { useCallback } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import {
+  STANDINGS_SELF_RECAP_EYEBROW,
+  STANDINGS_SELF_RECAP_JUMP_LINK,
+  STANDINGS_SHARE_AFTER_FINALIZE_INLINE,
+} from '../../../shared/config/dashboardVocabulary';
+import GradedPicksShareBar from './GradedPicksShareBar';
+
+/**
+ * Self recap: rank + points (no handle — user is always “you” here), share after finalize,
+ * optional in-page scroll or router link (e.g. Picks → Standings).
+ *
+ * @param {{ to: string, label: string } | null} [routerJump]
+ * @param {boolean} [bodyOnly] When true, skip the primary handle/rank row (e.g. Picks
+ *   `<details>` body where the summary already showed identity + score).
+ * @param {boolean} [collapsible] When true (standings only), wrap meta + actions in
+ *   `<details>` with a summary chevron; primary rank row stays visible when collapsed.
+ */
+export default function StandingsSelfRecapCard({
+  recap,
+  showLabel,
+  poolLabel = null,
+  userPicks,
+  actualSetlist,
+  shareGradedRecapAllowed = false,
+  className = '',
+  routerJump = null,
+  showEyebrow = true,
+  bodyOnly = false,
+  collapsible = false,
+}) {
+  const hasSetlistAndPicks = Boolean(actualSetlist && userPicks);
+  const useCollapsible = collapsible && !bodyOnly;
+
+  const onJumpToCard = useCallback(
+    (e) => {
+      e.preventDefault();
+      document.getElementById(recap.selfAnchorId)?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
+    },
+    [recap.selfAnchorId],
+  );
+
+  const scopeLine = [showLabel, poolLabel].filter(Boolean).join(' · ');
+  const playerWord = recap.totalPlayers === 1 ? 'player' : 'players';
+  const rankLine =
+    recap.displayRank != null
+      ? `${recap.totalPlayers} ${playerWord}`
+      : 'Waiting for setlist · rank updates after grading';
+
+  const metaLine =
+    recap.displayRank != null
+      ? scopeLine
+      : scopeLine.length > 0
+        ? `${scopeLine} · ${rankLine}`
+        : rankLine;
+
+  const rowLeading = 'leading-none';
+  const rowType = `text-base font-bold ${rowLeading} sm:text-lg`;
+
+  const rankOfTotalCluster =
+    recap.displayRank != null ? (
+      <span
+        className={`inline-flex max-w-full flex-wrap items-center gap-x-1 ${rowType}`}
+        aria-label={`Rank ${recap.displayRank} of ${recap.totalPlayers} ${playerWord}`}
+      >
+        <span className="tabular-nums text-white">#{recap.displayRank}</span>
+        <span className="font-bold text-content-secondary">of</span>
+        <span className="tabular-nums text-white">{recap.totalPlayers}</span>
+        <span className="font-bold text-content-secondary">{playerWord}</span>
+      </span>
+    ) : (
+      <span className={`text-brand-primary ${rowType}`}>You</span>
+    );
+
+  const dotSep = (
+    <span className={`shrink-0 text-content-secondary ${rowType}`}>·</span>
+  );
+  const ptsSuffix = (
+    <span
+      className={`shrink-0 text-xs font-bold uppercase tracking-widest text-content-secondary sm:text-sm ${rowLeading}`}
+    >
+      pts
+    </span>
+  );
+
+  const scoreText = recap.totalScore != null ? recap.totalScore : '—';
+
+  const rankPtsCluster = (
+    <>
+      {rankOfTotalCluster}
+      {dotSep}
+      <span className={`shrink-0 tabular-nums text-brand-primary ${rowType}`}>
+        {scoreText}
+      </span>
+      {ptsSuffix}
+    </>
+  );
+
+  const rankPtsWrapClass = `inline-flex max-w-full min-w-0 flex-wrap items-center justify-end gap-x-1.5 gap-y-0.5 ${rowType}`;
+
+  const primaryRow = (
+    <div
+      className={`flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 ${useCollapsible ? 'flex-1' : 'w-full'} ${showEyebrow ? 'justify-between' : 'justify-end'} ${rowLeading}`}
+    >
+      {showEyebrow ? (
+        <span className="shrink-0 text-xs font-black uppercase tracking-widest text-amber-200/90">
+          {STANDINGS_SELF_RECAP_EYEBROW}
+        </span>
+      ) : null}
+      {routerJump ? (
+        <Link
+          to={routerJump.to}
+          aria-label={routerJump.label}
+          title={routerJump.label}
+          className={`group/score ${rankPtsWrapClass} rounded underline-offset-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg`}
+        >
+          {rankOfTotalCluster}
+          {dotSep}
+          <span
+            className={`shrink-0 tabular-nums text-brand-primary transition-colors group-hover/score:text-white group-hover/score:underline ${rowType}`}
+          >
+            {scoreText}
+          </span>
+          {ptsSuffix}
+        </Link>
+      ) : (
+        <span className={rankPtsWrapClass}>{rankPtsCluster}</span>
+      )}
+    </div>
+  );
+
+  const chevronToggle = useCollapsible ? (
+    <ChevronDown
+      className="h-4 w-4 shrink-0 text-content-secondary opacity-80 transition-transform duration-200 ease-out group-open:rotate-180"
+      aria-hidden
+    />
+  ) : null;
+
+  const metaBlock =
+    !bodyOnly && metaLine ? (
+      <p
+        className={`truncate text-xs font-semibold leading-snug text-content-secondary ${useCollapsible ? 'mt-0' : 'mt-1.5'}`}
+      >
+        {metaLine}
+      </p>
+    ) : bodyOnly && metaLine ? (
+      <p className="truncate text-xs font-semibold leading-snug text-content-secondary">
+        {metaLine}
+      </p>
+    ) : null;
+
+  const jumpBlock =
+    routerJump ? null : (
+      <div
+        className={`${bodyOnly ? 'mt-2' : 'mt-3'} border-t border-border-subtle/35 pt-2.5`}
+      >
+        <a
+          href={`#${recap.selfAnchorId}`}
+          onClick={onJumpToCard}
+          className="inline-flex items-center gap-1 text-xs font-bold text-slate-200 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg rounded"
+        >
+          <span>{STANDINGS_SELF_RECAP_JUMP_LINK}</span>
+          <ChevronDown className="h-3.5 w-3.5 opacity-90" aria-hidden />
+        </a>
+      </div>
+    );
+
+  const shareAllowedBlock =
+    hasSetlistAndPicks && shareGradedRecapAllowed ? (
+      <div
+        className={`${bodyOnly ? 'mt-2' : 'mt-3'} border-t border-border-subtle/35 pt-3`}
+      >
+        {bodyOnly ? null : (
+          <p className="mb-2 text-[10px] font-black uppercase tracking-widest text-content-secondary">
+            Share your score
+          </p>
+        )}
+        <GradedPicksShareBar
+          variant="actionsOnly"
+          userPicks={userPicks}
+          actualSetlist={actualSetlist}
+          showLabel={showLabel}
+        />
+      </div>
+    ) : null;
+
+  const shareBlockedMessage =
+    hasSetlistAndPicks && !shareGradedRecapAllowed ? (
+      <p
+        className={`${bodyOnly ? 'mt-2' : 'mt-3'} border-t border-border-subtle/35 pt-3 text-[11px] font-semibold leading-snug text-content-secondary`}
+      >
+        {STANDINGS_SHARE_AFTER_FINALIZE_INLINE}
+      </p>
+    ) : null;
+
+  const shellClass = `rounded-xl border border-border-subtle/55 bg-surface-panel/55 px-4 py-2.5 shadow-inset-glass ring-1 ring-brand-primary/15 ${className}`;
+
+  if (useCollapsible) {
+    return (
+      <details
+        className={`group ${shellClass}`}
+        defaultOpen
+        aria-label="Your rank and score. Expand for show details, jump link, and share."
+      >
+        <summary className="flex list-none cursor-pointer items-center gap-2 text-left [&::-webkit-details-marker]:hidden">
+          {primaryRow}
+          {chevronToggle}
+        </summary>
+        <div className="mt-2">
+          {metaBlock}
+          {jumpBlock}
+          {shareAllowedBlock}
+          {shareBlockedMessage}
+        </div>
+      </details>
+    );
+  }
+
+  return (
+    <div className={shellClass}>
+      {!bodyOnly ? (
+        <>
+          {primaryRow}
+          {metaBlock}
+        </>
+      ) : (
+        metaBlock
+      )}
+
+      {jumpBlock}
+      {shareAllowedBlock}
+      {shareBlockedMessage}
+    </div>
+  );
+}

--- a/src/features/scoring/ui/StandingsShowOrPoolView.jsx
+++ b/src/features/scoring/ui/StandingsShowOrPoolView.jsx
@@ -3,7 +3,7 @@ import { Inbox, Loader2, Music } from 'lucide-react';
 
 import Card from '../../../shared/ui/Card';
 import PageTitle from '../../../shared/ui/PageTitle';
-import GradedPicksShareBar from './GradedPicksShareBar';
+import StandingsSelfRecapCard from './StandingsSelfRecapCard';
 import Leaderboard from './Leaderboard';
 import StandingsActiveShowCard from './StandingsActiveShowCard';
 import StandingsBannerWaitingSetlist from './StandingsBannerWaitingSetlist';
@@ -40,6 +40,8 @@ export default function StandingsShowOrPoolView({ screen }) {
     activePoolName,
     selfUserId,
     selfUserPicks,
+    selfStandingsRecap,
+    shareGradedRecapAllowed,
     isSecured,
     picksStatusLoading,
     showLastShowWinnerBanner,
@@ -113,6 +115,18 @@ export default function StandingsShowOrPoolView({ screen }) {
           <div className="mt-4 md:mt-6">
             {!actualSetlist && picks.length > 0 ? (
               <StandingsBannerWaitingSetlist />
+            ) : null}
+            {selfStandingsRecap ? (
+              <StandingsSelfRecapCard
+                recap={selfStandingsRecap}
+                showLabel={showLabel}
+                poolLabel={isPoolsView ? activePoolName : null}
+                userPicks={selfUserPicks}
+                actualSetlist={actualSetlist}
+                shareGradedRecapAllowed={shareGradedRecapAllowed}
+                collapsible
+                className="mb-3"
+              />
             ) : null}
             <Leaderboard
               poolPicks={displayedPicks}
@@ -200,11 +214,15 @@ export default function StandingsShowOrPoolView({ screen }) {
         />
       ) : null}
 
-      {actualSetlist && selfUserPicks ? (
-        <GradedPicksShareBar
+      {selfStandingsRecap ? (
+        <StandingsSelfRecapCard
+          recap={selfStandingsRecap}
+          showLabel={showLabel}
+          poolLabel={isPoolsView ? activePoolName : null}
           userPicks={selfUserPicks}
           actualSetlist={actualSetlist}
-          showLabel={showLabel}
+          shareGradedRecapAllowed={shareGradedRecapAllowed}
+          collapsible
           className="mb-2"
         />
       ) : null}

--- a/src/features/scoring/ui/StandingsShowOrPoolView.jsx
+++ b/src/features/scoring/ui/StandingsShowOrPoolView.jsx
@@ -3,6 +3,7 @@ import { Inbox, Loader2, Music } from 'lucide-react';
 
 import Card from '../../../shared/ui/Card';
 import PageTitle from '../../../shared/ui/PageTitle';
+import GradedPicksShareBar from './GradedPicksShareBar';
 import Leaderboard from './Leaderboard';
 import StandingsActiveShowCard from './StandingsActiveShowCard';
 import StandingsBannerWaitingSetlist from './StandingsBannerWaitingSetlist';
@@ -38,6 +39,7 @@ export default function StandingsShowOrPoolView({ screen }) {
     winnerOfTheNight,
     activePoolName,
     selfUserId,
+    selfUserPicks,
     isSecured,
     picksStatusLoading,
     showLastShowWinnerBanner,
@@ -119,7 +121,6 @@ export default function StandingsShowOrPoolView({ screen }) {
               selfUserId={selfUserId}
               suppressLeadingCallout={Boolean(showWinnerBanner)}
               redactOpponentPicksPreLock={redactOpponentPicksPreLock}
-              shareShowLabel={showLabel}
             />
           </div>
         ) : null}
@@ -199,6 +200,15 @@ export default function StandingsShowOrPoolView({ screen }) {
         />
       ) : null}
 
+      {actualSetlist && selfUserPicks ? (
+        <GradedPicksShareBar
+          userPicks={selfUserPicks}
+          actualSetlist={actualSetlist}
+          showLabel={showLabel}
+          className="mb-2"
+        />
+      ) : null}
+
       {!actualSetlist && picks.length > 0 ? (
         <StandingsBannerWaitingSetlist />
       ) : null}
@@ -251,7 +261,6 @@ export default function StandingsShowOrPoolView({ screen }) {
           selfUserId={selfUserId}
           suppressLeadingCallout={Boolean(showWinnerBanner)}
           redactOpponentPicksPreLock={redactOpponentPicksPreLock}
-          shareShowLabel={showLabel}
         />
       )}
     </>

--- a/src/pages/picks/PicksPage.jsx
+++ b/src/pages/picks/PicksPage.jsx
@@ -115,6 +115,7 @@ export default function PicksPage({ user, selectedDate }) {
               userPicks={formData}
               actualSetlist={gradedSetlist}
               showLabel={shareShowLabel}
+              className="mt-4"
             />
           ) : null}
           {pickConstraintMessage ? (

--- a/src/pages/picks/PicksPage.jsx
+++ b/src/pages/picks/PicksPage.jsx
@@ -1,16 +1,21 @@
 import React, { useEffect, useId, useState } from 'react';
 import { CheckCircle2, ChevronDown, Lock, Scale } from 'lucide-react';
 
-import { PicksFieldsForm, PicksSubmitButton, usePicksForm } from '../../features/picks';
+import {
+  PicksFieldsForm,
+  PicksSelfRecapSection,
+  PicksSubmitButton,
+  usePicksForm,
+  usePicksSelfRecap,
+} from '../../features/picks';
 import { useShowCalendar } from '../../features/show-calendar';
-import { GradedPicksShareBar, useOfficialSetlistForShow, useScoringRulesModal } from '../../features/scoring';
+import { useScoringRulesModal } from '../../features/scoring';
 import { showOptionLabelCompact } from '../../shared/utils/showOptionLabel';
 import Card from '../../shared/ui/Card';
 import DashboardActionRow from '../../shared/ui/DashboardActionRow';
 import GhostPill from '../../shared/ui/GhostPill';
 export default function PicksPage({ user, selectedDate }) {
   const { showDates, showDatesByTour } = useShowCalendar();
-  const { actualSetlist: gradedSetlist } = useOfficialSetlistForShow(selectedDate, showDates);
   const showForShare = selectedDate ? showDates?.find((s) => s.date === selectedDate) : null;
   const shareShowLabel = showForShare ? showOptionLabelCompact(showForShare) : selectedDate || '';
   const {
@@ -24,6 +29,8 @@ export default function PicksPage({ user, selectedDate }) {
     saveFeedback,
     pickConstraintMessage,
   } = usePicksForm({ user, selectedDate, showDates, showDatesByTour });
+
+  const picksRecap = usePicksSelfRecap({ user, selectedDate, showDates, formData });
 
   const { openScoringRules } = useScoringRulesModal();
   const statusContentId = useId();
@@ -104,20 +111,26 @@ export default function PicksPage({ user, selectedDate }) {
             </div>
           </>
         ) : null}
+        {!isLoadingPicks && picksRecap.recap ? (
+          <PicksSelfRecapSection
+            recap={picksRecap.recap}
+            shareGradedRecapAllowed={picksRecap.shareGradedRecapAllowed}
+            showLabel={shareShowLabel}
+            formData={formData}
+            actualSetlist={picksRecap.actualSetlist}
+            standingsTo={
+              selectedDate
+                ? `/dashboard/standings?showDate=${encodeURIComponent(selectedDate)}`
+                : '/dashboard/standings'
+            }
+          />
+        ) : null}
         <Card
           as="form"
           onSubmit={handleSave}
           variant="venue"
           className="space-y-4 transition-all duration-300"
         >
-          {gradedSetlist && hasExistingPicks ? (
-            <GradedPicksShareBar
-              userPicks={formData}
-              actualSetlist={gradedSetlist}
-              showLabel={shareShowLabel}
-              className="mt-4"
-            />
-          ) : null}
           {pickConstraintMessage ? (
             <div
               className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm font-bold text-amber-100"

--- a/src/shared/config/dashboardVocabulary.js
+++ b/src/shared/config/dashboardVocabulary.js
@@ -135,3 +135,19 @@ export const STANDINGS_PICK_PRIVACY_INFO_LABEL = 'About hidden picks';
 /** Full detail: disclosure panel + optional native `title` on summary (#303). */
 export const STANDINGS_PICK_PRIVACY_TOOLTIP =
   "We've made a key change our users have asked for: hiding other players' picks until showtime. You'll still see players and their picks, but those picks are now blurred to improve competition!";
+
+/** Standings self-recap card eyebrow (rank + points snapshot). */
+export const STANDINGS_SELF_RECAP_EYEBROW = 'Your rank';
+
+/** Scroll target from self-recap card to the user’s leaderboard row. */
+export const STANDINGS_SELF_RECAP_JUMP_LINK = 'Jump to your score card';
+
+/**
+ * Shown under the recap when the official setlist exists but share is gated
+ * until every non-empty pick for the show has been finalized (`isGraded`).
+ */
+export const STANDINGS_SHARE_AFTER_FINALIZE_INLINE =
+  'Share unlocks after this show is fully finalized (every submitted pick graded).';
+
+/** Picks tab self-recap: link to global standings for the same show date. */
+export const PICKS_SELF_RECAP_STANDINGS_LINK = 'View standings';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #304 (follow-up UX enhancement)

## Summary

Moves the "Share your score" bar from inside the user's expanded leaderboard row to a **prominent position at the top of the standings view**, directly after any winner banners and before the leaderboard. Previously, users had to find themselves in the leaderboard, tap to expand their row, scroll past the score breakdown grid, and only then see the share buttons. This was too much friction for a feature designed to drive sharing/virality.

### Changes

- **`useStandingsScreen`** — computes `selfUserPicks` from `displayedPicks` (finds the entry matching the signed-in user and extracts the picks payload), exposed via the screen hook return.
- **`StandingsShowOrPoolView`** — renders `GradedPicksShareBar` at the top of the default standings branch (graded shows), after winner banners and before the leaderboard. Only shown when `actualSetlist` exists and the user has picks.
- **`LeaderboardRow`** — removed `GradedPicksShareBar` from the expanded row, since it's now surfaced at the top level.
- **`Leaderboard` / `LeaderboardList` / `LeaderboardRow`** — cleaned up the `shareShowLabel` prop that was threaded through the entire chain.
- **`GradedPicksShareBar`** — accepts `className` prop for flexible spacing; removed baked-in `mt-4`.
- **`PicksPage`** — preserved existing share bar placement (separate surface) with explicit `className="mt-4"`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 181/181 pass
- [x] `npm run verify:dashboard-meta` — 12 cases OK
- [x] `npm run verify:dashboard-ui` — OK
- [x] `npm run build` — compiles cleanly
- [ ] Visual verification on Vercel preview (requires auth — user must verify in browser)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://road2-media.slack.com/archives/D0B2RMVCGSD/p1778297099568849?thread_ts=1778297099.568849&cid=D0B2RMVCGSD)

<div><a href="https://cursor.com/agents/bc-b6069b53-028c-575f-a8e5-584c5126b94e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6069b53-028c-575f-a8e5-584c5126b94e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

