### PR TITLE
feat(auth): partial-profile anomaly signal + rollback telemetry + guard regression tests

### DIFF
--- a/docs/AUTH_TELEMETRY_RUNBOOK.md
+++ b/docs/AUTH_TELEMETRY_RUNBOOK.md
@@ -1,0 +1,89 @@
+# Auth Telemetry Runbook
+
+Living reference for the GA4 events the splash-auth and route-guard code
+emits, plus the GA4 console configuration needed to make them queryable.
+
+Backstory: in May 2026 a 2-day regression (PR #393 → #399) silently routed
+new sign-ups directly to `/dashboard` because the consent write created a
+`users/{uid}` doc before profile setup, and the route guard tested the doc
+for mere truthiness. We had ~30 minutes of guesswork tracing it through GA4
+because the `auth_error` event's `method` and `error_code` parameters were
+sent but never registered as custom dimensions — and we had no anomaly
+signal at all for partial-profile state. This runbook keeps both gaps
+closed.
+
+## 1. Events emitted
+
+All events flow through `src/features/auth/model/authAnalytics.js` and are
+delivered via `ga4Event` in `src/shared/lib/ga4.js`. GA4 only initializes
+on `setlistpickem.com` (prod) — preview/staging/localhost stay silent.
+
+| Event | Source | Params | Meaning |
+|---|---|---|---|
+| `sign_up` | `useSplashSignUp` | `method` (`email` \| `google`) | New account created and consent recorded |
+| `login` | `useSplashSignUp`, `useSplashSignIn` | `method` (`email` \| `google`) | Returning user signed in |
+| `auth_error` | `useSplashSignUp`, `useSplashSignIn` | `method`, `error_code` (Firebase code or `unknown`) | Any auth-API throw — wrong password, popup-blocked, etc. |
+| `auth_partial_profile` | `DashboardRoute` | `has_consent` (`true`/`false`), `surface` (`dashboard_route`) | **ANOMALY** — `users/{uid}` exists but `handle` missing |
+| `auth_rollback` | `useSplashSignUp` | `method`, `stage` (`consent_write`) | Post-signup Firestore write failed; Auth account deletion initiated |
+| `auth_rollback_failed` | `useSplashSignUp` | `method`, `error_code` | The `deleteUser` rollback itself failed — phantom Auth account exists |
+
+## 2. Required GA4 console configuration
+
+`method` and `error_code` flow on every `auth_error` event but are **not
+queryable in `run_report`** until they're registered as event-scoped
+custom dimensions. Same for the params on the new events.
+
+**To register (one-time, 5 minutes):**
+
+1. GA4 → Admin → Property `set-picks` (527619709)
+2. Data display → Custom definitions → Create custom dimensions
+3. Add each row:
+
+| Dimension name (UI) | Scope | Event parameter | Description |
+|---|---|---|---|
+| `auth_method` | Event | `method` | Auth provider — `email` or `google` |
+| `auth_error_code` | Event | `error_code` | Firebase Auth error code (e.g. `auth/wrong-password`) |
+| `auth_rollback_stage` | Event | `stage` | Which post-signup write failed (`consent_write`) |
+| `auth_partial_has_consent` | Event | `has_consent` | Whether the partial doc has `termsPrivacyAcceptedAt` |
+| `auth_partial_surface` | Event | `surface` | Which route detected the partial state |
+
+Historical data is **not backfilled**. New events landing after
+registration become queryable via `run_report` with
+`customEvent:method`, `customEvent:error_code`, etc.
+
+## 3. Required alerts / conversions
+
+Mark `auth_partial_profile` and `auth_rollback_failed` as **conversions**
+in GA4 admin (Configure → Events → mark as conversion).
+
+Then in GA4 → Insights → Create insight:
+
+- **Trigger:** `auth_partial_profile` count > 0 in the past day.
+- **Frequency:** daily, with an email alert to the on-call channel.
+
+Same alert for `auth_rollback_failed`. Both should be zero in steady
+state; any non-zero is actionable.
+
+## 4. Recommended dashboard
+
+Pin in GA4 → Explore → Funnel exploration → New exploration:
+
+> Step 1: `first_visit`
+> Step 2: `sign_up` OR `login`
+> Step 3: `page_view` on `/setup`
+> Step 4: `page_view` on `/dashboard*`
+
+A regression like the May 2026 bug shows as a Step 3 dropoff to ~0% for
+new users within an hour of deploy.
+
+## 5. Repair scripts
+
+When `auth_partial_profile` or `auth_rollback_failed` fires:
+
+- `functions/scripts/diagnoseUserDoc.js <uid>` — classifies a single UID
+  as `HEALTHY` / `CONSENT_ONLY` / `NO_DOC` / `EMPTY_DOC`.
+- `functions/scripts/repairConsentOnlyUser.js <uid>` — see script header
+  for repair semantics; pre-stamps `createdAt` from
+  `auth.metadata.creationTime` for CONSENT_ONLY users.
+
+(Both ship with PR-2 of the post-mortem hardening series.)

--- a/src/app/routes/DashboardRoute.jsx
+++ b/src/app/routes/DashboardRoute.jsx
@@ -1,23 +1,38 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Navigate } from 'react-router-dom';
 
-import { AuthLoadingScreen, useAuth } from '../../features/auth';
+import {
+  AuthLoadingScreen,
+  trackAuthPartialProfile,
+  useAuth,
+} from '../../features/auth';
 
 import { ShowCalendarProvider } from '../../features/show-calendar';
 import DashboardLayout from '../layout/DashboardLayout';
+import { decideDashboardRoute } from './profileGuardDecision';
 
 export default function DashboardRoute() {
   const { user, userProfile, loading } = useAuth();
+  const decision = decideDashboardRoute({ loading, user, userProfile });
 
-  if (loading) {
-    return <AuthLoadingScreen />;
-  }
+  // Anomaly signal for the consent-only orphan regression (May 2026).
+  // Keyed on uid so a single mount fires once per user, even across
+  // StrictMode double-invokes (GA4 helper additionally dedupes within
+  // 120ms). See `docs/AUTH_TELEMETRY_RUNBOOK.md`.
+  const partialProfile =
+    decision.kind === 'redirect-setup' && decision.telemetry === 'partial_profile';
+  const hasConsent = Boolean(userProfile?.termsPrivacyAcceptedAt);
+  useEffect(() => {
+    if (!partialProfile) return;
+    trackAuthPartialProfile({
+      has_consent: hasConsent,
+      surface: 'dashboard_route',
+    });
+  }, [partialProfile, hasConsent, user?.uid]);
 
-  if (!user) {
-    return <Navigate to="/" replace />;
-  }
-
-  if (!userProfile?.handle) {
+  if (decision.kind === 'loading') return <AuthLoadingScreen />;
+  if (decision.kind === 'redirect-home') return <Navigate to="/" replace />;
+  if (decision.kind === 'redirect-setup') {
     return <Navigate to="/setup" replace />;
   }
 

--- a/src/app/routes/SetupRoute.jsx
+++ b/src/app/routes/SetupRoute.jsx
@@ -5,21 +5,16 @@ import { AuthLoadingScreen, useAuth } from '../../features/auth';
 import { getDashboardEntryHref } from '../../shared/lib/dashboardLastPath';
 
 import ProfileSetupPage from '../../pages/auth/ProfileSetupPage';
+import { decideSetupRoute } from './profileGuardDecision';
 
 export default function SetupRoute() {
   const { user, userProfile, loading, isAdmin: isAdminUser } = useAuth();
+  const decision = decideSetupRoute({ loading, user, userProfile });
 
-  if (loading) {
-    return <AuthLoadingScreen />;
-  }
-
-  if (!user) {
-    return <Navigate to="/" replace />;
-  }
-
-  if (userProfile?.handle) {
+  if (decision.kind === 'loading') return <AuthLoadingScreen />;
+  if (decision.kind === 'redirect-home') return <Navigate to="/" replace />;
+  if (decision.kind === 'redirect-dashboard') {
     return <Navigate to={getDashboardEntryHref({ isAdminUser })} replace />;
   }
-
   return <ProfileSetupPage user={user} />;
 }

--- a/src/app/routes/profileGuardDecision.js
+++ b/src/app/routes/profileGuardDecision.js
@@ -1,0 +1,66 @@
+/**
+ * Pure decision functions for the auth route guards. Extracted so the
+ * consent-only doc regression (May 2026 — PR #399) can be exercised by a
+ * plain `*.test.js` against the `node` vitest environment without spinning
+ * up a DOM.
+ *
+ * `handle` is the sentinel for "profile setup completed" — only written by
+ * `createInitialUserProfile`, never by the consent write or any server-side
+ * users-doc updater. See `docs/AUTH_TELEMETRY_RUNBOOK.md` for the matching
+ * GA4 anomaly signal (`auth_partial_profile`).
+ */
+
+/**
+ * @typedef {{ kind: 'loading' }
+ *   | { kind: 'redirect-home' }
+ *   | { kind: 'redirect-dashboard' }
+ *   | { kind: 'render-setup' }} SetupDecision
+ */
+
+/**
+ * @param {{
+ *   loading: boolean,
+ *   user: { uid: string } | null | undefined,
+ *   userProfile: { handle?: string } | null | undefined,
+ * }} params
+ * @returns {SetupDecision}
+ */
+export function decideSetupRoute({ loading, user, userProfile }) {
+  if (loading) return { kind: 'loading' };
+  if (!user) return { kind: 'redirect-home' };
+  if (userProfile?.handle) return { kind: 'redirect-dashboard' };
+  return { kind: 'render-setup' };
+}
+
+/**
+ * @typedef {{ kind: 'loading' }
+ *   | { kind: 'redirect-home' }
+ *   | { kind: 'redirect-setup', telemetry: 'partial_profile' | null }
+ *   | { kind: 'render-dashboard' }} DashboardDecision
+ */
+
+/**
+ * `telemetry: 'partial_profile'` fires when a `users/{uid}` doc exists for
+ * the caller but is missing `handle`. That's the exact fingerprint of the
+ * consent-only orphan bug — if it ever surfaces again, the GA4
+ * `auth_partial_profile` event will catch it within seconds rather than
+ * the two days it took us to spot the original regression.
+ *
+ * @param {{
+ *   loading: boolean,
+ *   user: { uid: string } | null | undefined,
+ *   userProfile: { handle?: string } | null | undefined,
+ * }} params
+ * @returns {DashboardDecision}
+ */
+export function decideDashboardRoute({ loading, user, userProfile }) {
+  if (loading) return { kind: 'loading' };
+  if (!user) return { kind: 'redirect-home' };
+  if (!userProfile?.handle) {
+    return {
+      kind: 'redirect-setup',
+      telemetry: userProfile ? 'partial_profile' : null,
+    };
+  }
+  return { kind: 'render-dashboard' };
+}

--- a/src/app/routes/profileGuardDecision.test.js
+++ b/src/app/routes/profileGuardDecision.test.js
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  decideDashboardRoute,
+  decideSetupRoute,
+} from './profileGuardDecision';
+
+const user = { uid: 'u-1' };
+
+describe('decideSetupRoute', () => {
+  it('shows loading while auth resolves', () => {
+    expect(decideSetupRoute({ loading: true, user: null, userProfile: null }))
+      .toEqual({ kind: 'loading' });
+  });
+
+  it('redirects unsigned-in visitors to the splash', () => {
+    expect(decideSetupRoute({ loading: false, user: null, userProfile: null }))
+      .toEqual({ kind: 'redirect-home' });
+  });
+
+  it('renders setup when no users doc exists yet', () => {
+    expect(decideSetupRoute({ loading: false, user, userProfile: null }))
+      .toEqual({ kind: 'render-setup' });
+  });
+
+  it('renders setup for a consent-only doc (regression: PR #399)', () => {
+    // This is the exact bug shape from May 2026: doc exists with
+    // `termsPrivacyAcceptedAt` written by `recordTermsPrivacyConsent`, but
+    // `handle` is missing because `createInitialUserProfile` never ran.
+    // Pre-PR #399 the guard treated this as "profile complete" and
+    // redirected to dashboard, skipping onboarding entirely.
+    const consentOnlyProfile = {
+      termsPrivacyAcceptedAt: { seconds: 1715000000, nanoseconds: 0 },
+    };
+    expect(
+      decideSetupRoute({ loading: false, user, userProfile: consentOnlyProfile })
+    ).toEqual({ kind: 'render-setup' });
+  });
+
+  it('redirects completed profiles to the dashboard', () => {
+    expect(
+      decideSetupRoute({
+        loading: false,
+        user,
+        userProfile: { handle: 'pat', termsPrivacyAcceptedAt: {} },
+      })
+    ).toEqual({ kind: 'redirect-dashboard' });
+  });
+
+  it('treats empty-string handle as not-yet-set (defensive)', () => {
+    expect(
+      decideSetupRoute({ loading: false, user, userProfile: { handle: '' } })
+    ).toEqual({ kind: 'render-setup' });
+  });
+});
+
+describe('decideDashboardRoute', () => {
+  it('shows loading while auth resolves', () => {
+    expect(decideDashboardRoute({ loading: true, user: null, userProfile: null }))
+      .toEqual({ kind: 'loading' });
+  });
+
+  it('redirects unsigned-in visitors to the splash', () => {
+    expect(decideDashboardRoute({ loading: false, user: null, userProfile: null }))
+      .toEqual({ kind: 'redirect-home' });
+  });
+
+  it('redirects to setup with no telemetry when no doc exists', () => {
+    expect(decideDashboardRoute({ loading: false, user, userProfile: null }))
+      .toEqual({ kind: 'redirect-setup', telemetry: null });
+  });
+
+  it('redirects to setup AND flags partial_profile for consent-only docs', () => {
+    // The anomaly signal. If this ever fires in GA4, the consent-only
+    // regression is back. Wire `auth_partial_profile` to a custom alert.
+    expect(
+      decideDashboardRoute({
+        loading: false,
+        user,
+        userProfile: {
+          termsPrivacyAcceptedAt: { seconds: 1715000000, nanoseconds: 0 },
+        },
+      })
+    ).toEqual({ kind: 'redirect-setup', telemetry: 'partial_profile' });
+  });
+
+  it('renders dashboard for completed profiles', () => {
+    expect(
+      decideDashboardRoute({
+        loading: false,
+        user,
+        userProfile: { handle: 'pat' },
+      })
+    ).toEqual({ kind: 'render-dashboard' });
+  });
+
+  it('flags partial_profile when only a non-handle field is present', () => {
+    // Belt-and-braces: any future field that lands before `handle` (e.g.,
+    // a marketing-prefs row written from outside the setup flow) would
+    // also fire the anomaly signal. That's intentional — it forces us to
+    // notice unexpected partial states.
+    expect(
+      decideDashboardRoute({
+        loading: false,
+        user,
+        userProfile: { totalPoints: 0 },
+      })
+    ).toEqual({ kind: 'redirect-setup', telemetry: 'partial_profile' });
+  });
+});

--- a/src/features/auth/api/splashAuthApi.js
+++ b/src/features/auth/api/splashAuthApi.js
@@ -43,14 +43,20 @@ export function registerWithEmail(auth, email, password) {
 
 /**
  * Best-effort rollback when post-sign-up Firestore writes fail (e.g. legal consent).
+ * Returns a status object so the caller can fire `auth_rollback_failed`
+ * telemetry when the delete itself fails — historically the bare `catch`
+ * here swallowed phantom-Auth-account creation entirely.
+ *
  * @param {import('firebase/auth').User | null} user
+ * @returns {Promise<{ deleted: boolean, errorCode?: string }>}
  */
 export async function deleteAuthUserIfPresent(user) {
-  if (!user) return;
+  if (!user) return { deleted: false };
   try {
     await deleteUser(user);
-  } catch {
-    // Caller logs; deletion may fail if session already invalidated.
+    return { deleted: true };
+  } catch (err) {
+    return { deleted: false, errorCode: err?.code || 'unknown' };
   }
 }
 

--- a/src/features/auth/index.js
+++ b/src/features/auth/index.js
@@ -7,6 +7,7 @@ export { default as PasswordResetForm } from './ui/PasswordResetForm';
 export { default as ProfileSetupForm } from './ui/ProfileSetupForm';
 export { useAuth } from './model/useAuth';
 export { useAuthSession } from './model/useAuthSession';
+export { trackAuthPartialProfile } from './model/authAnalytics';
 export { usePasswordReset } from './model/usePasswordReset';
 export { usePasswordResetCompleteState } from './model/usePasswordResetCompleteState';
 export { useProfileSetup } from './model/useProfileSetup';

--- a/src/features/auth/model/authAnalytics.js
+++ b/src/features/auth/model/authAnalytics.js
@@ -17,3 +17,51 @@ export function trackAuthError(payload) {
     error_code: payload.error_code ?? 'unknown',
   });
 }
+
+/**
+ * Anomaly signal: a `users/{uid}` doc exists for the signed-in caller but
+ * is missing `handle` (the sentinel for completed profile setup). The
+ * canonical case is the May 2026 consent-only orphan bug (PR #399). Wire
+ * this event as a custom alert in GA4 — a non-zero daily count should page
+ * the on-call.
+ *
+ * @param {{ has_consent: boolean, surface: 'dashboard_route' }} payload
+ */
+export function trackAuthPartialProfile(payload) {
+  ga4Event('auth_partial_profile', {
+    has_consent: payload.has_consent ? 'true' : 'false',
+    surface: payload.surface,
+  });
+}
+
+/**
+ * Fires when post-sign-up Firestore writes fail and we initiate an Auth
+ * rollback (`deleteAuthUserIfPresent`). Gives us a numerator for
+ * "signup attempts that failed after Auth account creation" without
+ * conflating with normal `auth_error` cases (wrong-password etc.).
+ *
+ * @param {{ method: 'email' | 'google', stage: 'consent_write' }} payload
+ */
+export function trackAuthRollback(payload) {
+  ga4Event('auth_rollback', {
+    method: payload.method,
+    stage: payload.stage,
+  });
+}
+
+/**
+ * Fires when the rollback `deleteUser` call itself fails — historically
+ * swallowed by a bare `catch {}` and effectively invisible. A non-zero
+ * count means we have phantom Firebase Auth accounts (no Firestore doc,
+ * no consent record) accumulating. Pair with the
+ * `repairConsentOnlyUser` / `diagnoseUserDoc` scripts under
+ * `functions/scripts/` to clean up.
+ *
+ * @param {{ method: 'email' | 'google', error_code: string }} payload
+ */
+export function trackAuthRollbackFailed(payload) {
+  ga4Event('auth_rollback_failed', {
+    method: payload.method,
+    error_code: payload.error_code,
+  });
+}

--- a/src/features/auth/model/useSplashSignUp.js
+++ b/src/features/auth/model/useSplashSignUp.js
@@ -8,7 +8,13 @@ import {
   registerWithEmail,
   signInWithGoogle,
 } from '../api/splashAuthApi';
-import { trackAuthError, trackAuthLogin, trackAuthSignUp } from './authAnalytics';
+import {
+  trackAuthError,
+  trackAuthLogin,
+  trackAuthRollback,
+  trackAuthRollbackFailed,
+  trackAuthSignUp,
+} from './authAnalytics';
 
 export function useSplashSignUp(isOpen, onClose) {
   const [email, setEmail] = useState('');
@@ -62,7 +68,18 @@ export function useSplashSignUp(isOpen, onClose) {
           await recordTermsPrivacyConsent(auth.currentUser.uid);
         } catch (consentErr) {
           console.error('Consent write after Google sign-up:', consentErr);
-          await deleteAuthUserIfPresent(auth.currentUser);
+          trackAuthRollback({ method: 'google', stage: 'consent_write' });
+          const rollback = await deleteAuthUserIfPresent(auth.currentUser);
+          if (!rollback.deleted) {
+            trackAuthRollbackFailed({
+              method: 'google',
+              error_code: rollback.errorCode || 'unknown',
+            });
+            console.error(
+              'Auth rollback delete failed after Google sign-up:',
+              rollback.errorCode
+            );
+          }
           setError('Could not finish creating your account. Please try again.');
           return;
         }
@@ -103,7 +120,18 @@ export function useSplashSignUp(isOpen, onClose) {
           await recordTermsPrivacyConsent(cred.user.uid);
         } catch (consentErr) {
           console.error('Consent write after email sign-up:', consentErr);
-          await deleteAuthUserIfPresent(cred.user);
+          trackAuthRollback({ method: 'email', stage: 'consent_write' });
+          const rollback = await deleteAuthUserIfPresent(cred.user);
+          if (!rollback.deleted) {
+            trackAuthRollbackFailed({
+              method: 'email',
+              error_code: rollback.errorCode || 'unknown',
+            });
+            console.error(
+              'Auth rollback delete failed after email sign-up:',
+              rollback.errorCode
+            );
+          }
           setError('Could not finish creating your account. Please try again.');
           return;
         }


### PR DESCRIPTION
## Summary

Forward-looking observability hardening after the consent-only doc bug fixed in PR #399. No existing flow changes — guards resolve to the same decisions for every input we tested.

- **Pure guard helpers** (\`src/app/routes/profileGuardDecision.js\`) — extracted decision logic from \`SetupRoute\` and \`DashboardRoute\` so we can regression-test the exact bug shape from May 2026.
- **+12 vitest cases** (181 → 193). The key one asserts that a \`userProfile = { termsPrivacyAcceptedAt }\` value resolves to \`render-setup\` rather than \`redirect-dashboard\` — pinning PR #399 against accidental revert.
- **3 new GA4 events**:
  - \`auth_partial_profile\` fires from \`DashboardRoute\` when a \`users/{uid}\` doc exists but \`handle\` is missing. Wire this as a daily-count > 0 alert in GA4 (see runbook).
  - \`auth_rollback\` fires when the post-signup consent write fails and we initiate the Auth rollback.
  - \`auth_rollback_failed\` fires when the rollback \`deleteUser\` itself throws — previously swallowed by a bare \`catch {}\`, so phantom Firebase Auth accounts were invisible.
- **\`deleteAuthUserIfPresent\` return contract**: now \`{ deleted, errorCode? }\`. Non-breaking — old call sites that ignore the return value still work.
- **\`docs/AUTH_TELEMETRY_RUNBOOK.md\`** documents every event, required GA4 console actions (\`method\` and \`error_code\` are sent today but not registered as custom dimensions — that's why we couldn't drill into the 5 errors from 2026-05-09), and the funnel exploration that would have caught the original bug.

Closes #401

## Risk

- **No existing user flow is affected.** The pure helpers return the same decisions as the previous inline branching for every state we tested (verified in test cases).
- **Telemetry-only additions** are silent on non-prod hostnames (GA4 only initializes on \`setlistpickem.com\`).
- The \`deleteAuthUserIfPresent\` return value is additive; only callers that opt into reading it see the new fields.

## Test plan

- [x] \`npm run lint\` — passes
- [x] \`npm test\` — 29 files, 193 tests pass (was 28/181 before this PR)
- [x] \`npm run verify:dashboard-meta\` — 12 cases OK
- [x] \`npm run verify:dashboard-ui\` — OK
- [ ] Manual: confirm guard tests cover (\`userProfile = null\`, \`userProfile = { termsPrivacyAcceptedAt }\`, \`userProfile = { handle: 'x' }\`)
- [ ] **Post-merge (manual, Pat):** register the 5 custom dimensions in GA4 admin per \`docs/AUTH_TELEMETRY_RUNBOOK.md\` §2, mark \`auth_partial_profile\` + \`auth_rollback_failed\` as conversions, create the daily alerts.

## Follow-up PRs (sequenced)

This is PR-1 of 4 closing out the post-mortem:
- PR-2: \`createdAt\` resilience + orphan diagnostic/repair scripts
- PR-3: block sign-in modal new-user Google bypass (compliance hole)
- PR-4: replace one-shot \`fetchUserProfile\` with \`onSnapshot\` (architectural cleanup that removes the \`window.location.href\` hack in \`useProfileSetup\`)

Made with [Cursor](https://cursor.com)