### PR TITLE
feat(auth): block new-user Google sign-up via the sign-in modal

### DIFF
--- a/src/features/auth/model/signInModalGuard.js
+++ b/src/features/auth/model/signInModalGuard.js
@@ -1,0 +1,30 @@
+/**
+ * Returns the action a sign-in-modal Google flow should take given the
+ * resolved `isNewUser` flag from `signInWithGoogle`.
+ *
+ * Lifted out of `useSplashSignIn.handleGoogle` so the regression — the
+ * sign-in modal must NOT register new accounts because it never showed
+ * the Terms/Privacy clickwrap — can be pinned by a node-env test without
+ * mocking Firebase Auth.
+ *
+ * @param {boolean} isNewUser
+ * @returns {
+ *   | { kind: 'allow-login' }
+ *   | {
+ *       kind: 'block-new-user',
+ *       errorMessage: string,
+ *       telemetryErrorCode: string,
+ *     }
+ * }
+ */
+export function decideSignInModalGoogleAction(isNewUser) {
+  if (isNewUser === true) {
+    return {
+      kind: 'block-new-user',
+      errorMessage:
+        "That Google account isn't registered yet. Tap “Create account” to sign up and accept the Terms.",
+      telemetryErrorCode: 'signin_modal_new_user_blocked',
+    };
+  }
+  return { kind: 'allow-login' };
+}

--- a/src/features/auth/model/signInModalGuard.test.js
+++ b/src/features/auth/model/signInModalGuard.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { decideSignInModalGoogleAction } from './signInModalGuard';
+
+describe('decideSignInModalGoogleAction', () => {
+  it('allows login for returning users', () => {
+    expect(decideSignInModalGoogleAction(false)).toEqual({ kind: 'allow-login' });
+  });
+
+  it('blocks new users (compliance hole closed by PR-3)', () => {
+    // Sign-in modal does not present the Terms/Privacy clickwrap.
+    // Allowing a brand-new Google account through would create a Firebase
+    // Auth user with no `termsPrivacyAcceptedAt` and (pre-PR #399) drop
+    // them directly on /dashboard — the same hole that masked the
+    // May 2026 orphan-doc bug for two days.
+    const action = decideSignInModalGoogleAction(true);
+    expect(action.kind).toBe('block-new-user');
+    expect(action.telemetryErrorCode).toBe('signin_modal_new_user_blocked');
+    expect(action.errorMessage).toMatch(/Create account/i);
+    expect(action.errorMessage).toMatch(/Terms/i);
+  });
+
+  it('treats undefined as "allow login" (defensive — signInWithGoogle should always return a boolean)', () => {
+    expect(decideSignInModalGoogleAction(undefined)).toEqual({ kind: 'allow-login' });
+  });
+
+  it('does not silently block on truthy-but-not-true values', () => {
+    // signInWithGoogle returns `Boolean(extra?.isNewUser)` so the only
+    // truthy-true case is `true`. Anything else means we shouldn't be
+    // making a destructive decision against the caller.
+    expect(decideSignInModalGoogleAction(1)).toEqual({ kind: 'allow-login' });
+    expect(decideSignInModalGoogleAction('true')).toEqual({ kind: 'allow-login' });
+  });
+});

--- a/src/features/auth/model/useSplashSignIn.js
+++ b/src/features/auth/model/useSplashSignIn.js
@@ -1,9 +1,16 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { auth } from '../../../shared/lib/firebase';
+import { signOutUser } from '../api/authApi';
 import { getFirebaseAuthErrorMessage } from '../utils/firebaseAuthMessages';
-import { sendResetEmail, signInWithEmail, signInWithGoogle } from '../api/splashAuthApi';
+import {
+  deleteAuthUserIfPresent,
+  sendResetEmail,
+  signInWithEmail,
+  signInWithGoogle,
+} from '../api/splashAuthApi';
 import { trackAuthError, trackAuthLogin } from './authAnalytics';
+import { decideSignInModalGoogleAction } from './signInModalGuard';
 
 export function useSplashSignIn(isOpen, onClose) {
   const [email, setEmail] = useState('');
@@ -45,7 +52,28 @@ export function useSplashSignIn(isOpen, onClose) {
     setError('');
     setBusy(true);
     try {
-      await signInWithGoogle(auth);
+      const { isNewUser } = await signInWithGoogle(auth);
+      const action = decideSignInModalGoogleAction(isNewUser);
+      if (action.kind === 'block-new-user') {
+        // Sign-in modal is for returning users only — it never presented
+        // the Terms/Privacy clickwrap. Roll back the auth account
+        // (best-effort) and force a sign-out so a partially-rolled-back
+        // account can't sit in a signed-in but unconsented state. Route
+        // them to the Create Account modal where the consent checkbox is
+        // enforced.
+        await deleteAuthUserIfPresent(auth.currentUser);
+        try {
+          await signOutUser();
+        } catch (signOutErr) {
+          console.error('signOut after sign-in modal block:', signOutErr);
+        }
+        trackAuthError({
+          method: 'google',
+          error_code: action.telemetryErrorCode,
+        });
+        setError(action.errorMessage);
+        return;
+      }
       trackAuthLogin('google');
       closeModal();
     } catch (err) {


### PR DESCRIPTION
## Summary

Closes a compliance hole exposed (not introduced) by PR #399. The sign-in modal never presented the Terms/Privacy clickwrap, so any new Google account routed through it landed in Firebase Auth with no \`termsPrivacyAcceptedAt\` record and no \`users/{uid}\` doc — the same gap that masked the May 2026 orphan-doc bug for two days.

**Returning Google users (\`isNewUser === false\`) are unaffected** — that code path is byte-equivalent to before.

- \`useSplashSignIn.handleGoogle\` captures \`isNewUser\` from \`signInWithGoogle\` and, when true: rolls back the Auth account via \`deleteAuthUserIfPresent\`, force-signs-out as belt-and-braces in case \`deleteUser\` fails, fires \`auth_error\` with \`error_code: signin_modal_new_user_blocked\`, and shows an error message routing the user to Create Account.
- Extracted a tiny pure helper \`decideSignInModalGoogleAction\` so the branching is testable without mocking Firebase Auth. +4 vitest cases lock the error message + telemetry code.

Closes #405

## Risk

- **Returning Google users:** unaffected. The non-new-user branch is identical to before.
- **Email sign-in / sign-up:** unaffected. Only the Google branch of \`useSplashSignIn\` is touched.
- **Splash Sign Up modal (\`useSplashSignUp\`):** unaffected. The Google new-user path there has always recorded consent and emits \`sign_up\`.
- **Edge case — \`deleteUser\` fails after a new-user block:** we still call \`signOutUser()\` as a fallback, so the user is at minimum signed out locally. If \`deleteUser\` itself fails (network blip / session invalidated), a Firebase Auth account with their Google email will remain. They'll try Create Account next and hit \`auth/email-already-in-use\` from Google's perspective is not a thing (Google signs you in regardless) — they'll signal success again and hit our consent gate via \`useSplashSignUp\`, which records consent and creates the profile doc correctly. So the net effect is one extra round-trip but no compliance gap.

## Test plan

- [x] \`npm run lint\` — passes
- [x] \`npm test\` — 29 files, 185 tests pass (was 181 before this PR; +4)
- [ ] **Manual against Vercel preview, Pat:**
  - Sign in with an existing Google account → should still sign in normally and route to dashboard.
  - Sign in with a brand-new Google account (use a fresh Google identity / different browser profile) → should show the "That Google account isn't registered" error and route nowhere. After dismissing, Create Account → Google with the same identity should complete normally with consent recorded.
- [ ] Verify GA4 picks up the new \`error_code: signin_modal_new_user_blocked\` once the custom dimension from PR-1 is registered.

Made with [Cursor](https://cursor.com)