### PR TITLE
feat(auth): subscribe to users/{uid} via onSnapshot in useAuth

### DIFF
--- a/src/features/auth/api/authApi.js
+++ b/src/features/auth/api/authApi.js
@@ -1,5 +1,5 @@
 import { onAuthStateChanged, onIdTokenChanged, signOut } from 'firebase/auth';
-import { doc, getDoc } from 'firebase/firestore';
+import { doc, getDoc, onSnapshot } from 'firebase/firestore';
 
 import { auth, db } from '../../../shared/lib/firebase';
 import { whenFirebaseReady } from '../../../shared/lib/firebaseAppCheck';
@@ -45,6 +45,35 @@ export async function fetchUserProfile(uid) {
   const userRef = doc(db, 'users', uid);
   const userSnap = await getDoc(userRef);
   return userSnap.exists() ? userSnap.data() : null;
+}
+
+/**
+ * Real-time subscription to `users/{uid}`. Use instead of `fetchUserProfile`
+ * when the caller needs the profile to live-update — for example, the
+ * splash → setup → dashboard flow, where the route guard needs to react
+ * to the user completing setup without forcing a full page reload.
+ *
+ * Waits for App Check before attaching the listener so an unwarmed App
+ * Check token can't cause a permission-denied snapshot error on first
+ * render.
+ *
+ * @param {string} uid
+ * @param {(profile: object | null) => void} onNext  Receives `data()` or null.
+ * @param {(err: unknown) => void} [onError]
+ * @returns {Promise<() => void>}  Resolves to an unsubscribe function once
+ *   Firebase / App Check are ready. The caller MUST invoke the returned
+ *   function when the subscription is no longer needed.
+ */
+export async function subscribeToUserProfile(uid, onNext, onError) {
+  await whenFirebaseReady();
+  const userRef = doc(db, 'users', uid);
+  return onSnapshot(
+    userRef,
+    (snap) => onNext(snap.exists() ? snap.data() : null),
+    (err) => {
+      if (onError) onError(err);
+    }
+  );
 }
 
 export async function signOutUser() {

--- a/src/features/auth/model/useAuth.js
+++ b/src/features/auth/model/useAuth.js
@@ -1,18 +1,25 @@
 import { useState, useEffect } from 'react';
 
 import {
-  fetchUserProfile,
   resolveIsAdmin,
   subscribeToAuthState,
   subscribeToIdTokenChanges,
+  subscribeToUserProfile,
 } from '../api/authApi';
 
 /**
- * Session-scoped auth hook. Exposes the Firebase user, the Firestore profile
- * doc, a loading flag, and `isAdmin` — resolved from the `admin: true` custom
- * claim (issue #139; PR B made the claim the sole signal). `isAdmin` refreshes
- * whenever the ID token refreshes, so `setAdminClaim` callable writes
- * propagate into the UI without a full re-login (after `getIdTokenResult(true)`).
+ * Session-scoped auth hook. Exposes the Firebase user, the Firestore
+ * profile doc, a loading flag, and `isAdmin` — resolved from the
+ * `admin: true` custom claim (issue #139; PR B made the claim the sole
+ * signal). `isAdmin` refreshes whenever the ID token refreshes, so
+ * `setAdminClaim` callable writes propagate into the UI without a full
+ * re-login (after `getIdTokenResult(true)`).
+ *
+ * The profile doc is **subscribed via `onSnapshot`**, not one-shot read
+ * (PR-4 of the May 2026 post-mortem). That makes the route guards
+ * self-healing — `SetupRoute` now redirects to dashboard automatically
+ * the moment `createInitialUserProfile` writes the `handle` field, with
+ * no full-page reload required.
  */
 export function useAuth() {
   const [user, setUser] = useState(null);
@@ -21,24 +28,91 @@ export function useAuth() {
   const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
-    const unsubscribe = subscribeToAuthState(async (u) => {
-      if (u) {
-        setUser(u);
-        const [profile, adminFlag] = await Promise.all([
-          fetchUserProfile(u.uid),
-          resolveIsAdmin(u),
-        ]);
-        setUserProfile(profile);
-        setIsAdmin(adminFlag);
-      } else {
+    let cancelled = false;
+    let detachProfile = null;
+
+    const stopProfileListener = () => {
+      if (typeof detachProfile === 'function') {
+        try {
+          detachProfile();
+        } catch {
+          // Best-effort teardown; SDK occasionally throws on double-unsub.
+        }
+      }
+      detachProfile = null;
+    };
+
+    const unsubscribeAuth = subscribeToAuthState(async (u) => {
+      // Always detach the previous listener before reacting to a new
+      // auth state. Otherwise sign-out / account-switch would leak a
+      // snapshot listener pointed at the prior uid.
+      stopProfileListener();
+
+      if (cancelled) return;
+
+      if (!u) {
         setUser(null);
         setUserProfile(null);
         setIsAdmin(false);
+        setLoading(false);
+        return;
       }
-      setLoading(false);
+
+      setUser(u);
+
+      // Admin claim resolves independently of profile doc; fire in
+      // parallel so a slow Firestore subscription doesn't delay the
+      // initial admin-flag flip.
+      resolveIsAdmin(u)
+        .then((flag) => {
+          if (!cancelled) setIsAdmin(flag);
+        })
+        .catch(() => {
+          if (!cancelled) setIsAdmin(false);
+        });
+
+      try {
+        const unsub = await subscribeToUserProfile(
+          u.uid,
+          (profile) => {
+            if (cancelled) return;
+            setUserProfile(profile);
+            setLoading(false);
+          },
+          (err) => {
+            console.error('useAuth profile subscription error:', err);
+            if (cancelled) return;
+            // Drop to null so guards route to /setup or /; do not leave a
+            // stale profile around after a permission / network fault.
+            setUserProfile(null);
+            setLoading(false);
+          }
+        );
+
+        if (cancelled) {
+          try {
+            unsub();
+          } catch {
+            // ignore
+          }
+          return;
+        }
+
+        detachProfile = unsub;
+      } catch (err) {
+        console.error('useAuth profile subscribe failed:', err);
+        if (!cancelled) {
+          setUserProfile(null);
+          setLoading(false);
+        }
+      }
     });
 
-    return () => unsubscribe();
+    return () => {
+      cancelled = true;
+      stopProfileListener();
+      unsubscribeAuth();
+    };
   }, []);
 
   useEffect(() => {

--- a/src/features/auth/model/useProfileSetup.js
+++ b/src/features/auth/model/useProfileSetup.js
@@ -1,8 +1,6 @@
 import { useCallback, useState } from 'react';
 
 import { fetchPublicProfileByHandle } from '../../profile';
-import { getDashboardEntryHref } from '../../../shared/lib/dashboardLastPath';
-import { resolveIsAdmin } from '../api/authApi';
 import { createInitialUserProfile } from '../api/profileSetupApi';
 
 export function useProfileSetup(user) {
@@ -24,6 +22,7 @@ export function useProfileSetup(user) {
         const existing = await fetchPublicProfileByHandle(trimmed);
         if (existing && existing.uid !== user.uid) {
           setError('That handle is already taken. Pick another.');
+          setIsSaving(false);
           return;
         }
 
@@ -32,18 +31,17 @@ export function useProfileSetup(user) {
           favoriteSong,
           email: user.email,
         });
-
-        // Force a reload so `useAuth` re-reads the Firestore users doc.
-        // Otherwise `/dashboard/*` can redirect back to `/setup` because `userProfile`
-        // is not live-updated after the write.
-        const isAdminUser = await resolveIsAdmin(user);
-        window.location.href = getDashboardEntryHref({ isAdminUser });
+        // No explicit navigation: `useAuth` now subscribes to `users/{uid}`
+        // via `onSnapshot`, so the moment Firestore acks the local write
+        // the snapshot delivers a profile with `handle`, `SetupRoute`'s
+        // decision flips to `redirect-dashboard`, and the route system
+        // takes care of the rest. Keeping `isSaving` true after the
+        // successful write means the form stays disabled until the route
+        // change unmounts this component, preventing a double-submit
+        // window.
       } catch (err) {
         console.error(err);
         setError('Failed to create profile. Try again.');
-      } finally {
-        // If navigation is redirected back to `/setup` (e.g., userProfile gatekeeper),
-        // we still need the form to unlock.
         setIsSaving(false);
       }
     },


### PR DESCRIPTION
## Summary

Final architectural cleanup of the May 2026 post-mortem series. Removes the \`window.location.href\` full-page reload from \`useProfileSetup.saveProfile\` by giving \`useAuth\` a reactive subscription to the user's Firestore doc. This is the property that would have made the original consent-only bug self-healing — when the guard derives off live state, "partial doc" states naturally resolve as soon as setup completes.

## Changes

- **\`subscribeToUserProfile(uid, onNext, onError)\`** in \`authApi\` — wraps \`onSnapshot\` and awaits \`whenFirebaseReady()\` before attaching, matching the App Check warm-up posture of the original \`fetchUserProfile\`.
- **\`useAuth\`** now subscribes when auth state delivers a user. Listener detaches cleanly on:
  - sign-out (auth state delivers \`null\`)
  - account-switch (re-subscribes against the new uid)
  - hook unmount (component teardown)
  - cancellation race (a \`cancelled\` flag prevents the async \`subscribeToUserProfile\` setup from attaching a listener after teardown)
- Snapshot \`onError\` (rules denial, network blip) drops \`userProfile\` to null and resolves \`loading\`, so guards route to \`/setup\` or \`/\` rather than holding a stale profile.
- **\`useProfileSetup.saveProfile\`** drops the \`window.location.href\` hack. \`isSaving\` stays \`true\` after successful write so the form is locked until the route change unmounts — no double-submit window. Same destination as before (the snapshot's local-cache update fires synchronously off \`setDoc\`'s ack, \`SetupRoute\`'s decision flips to \`redirect-dashboard\`, React Router takes care of the rest).
- Removed now-unused \`resolveIsAdmin\` and \`getDashboardEntryHref\` imports from \`useProfileSetup\`.

Closes #407

## Risk

The most invasive change in the series. Spelling out each scenario explicitly:

| Scenario | Pre-PR | Post-PR | Δ |
|---|---|---|---|
| Returning user sign-in | one-shot read fires once, \`loading\` flips false | snapshot's initial delivery fires once, \`loading\` flips false | none observable |
| Profile completion (signup → setup) | \`window.location.href\` reload to dashboard | snapshot delivers new \`handle\`, SetupRoute redirects | **no full reload** (better UX) |
| Profile edit (existing user changes handle) | one-shot read is stale; UI shows old data until refresh | snapshot delivers new handle live | improved (was a known limitation) |
| Sign out | listener was a one-shot, nothing to detach | listener explicitly detached | safer (no leaked listeners) |
| Account switch (sign out → sign in different user) | one-shot for new uid | old listener detaches, new listener attaches | safer |
| App Check warm-up race | \`whenFirebaseReady()\` await in \`fetchUserProfile\` | \`whenFirebaseReady()\` await in \`subscribeToUserProfile\` | byte-equivalent |
| Firestore rules denial | exception; \`userProfile = null\` and \`loading = false\` | \`onError\`; same outcome | byte-equivalent |

## Test plan

- [x] \`npm run lint\` — passes
- [x] \`npm test\` — 28 files, 181 tests pass (baseline; PR-1's tests not on this branch)
- [x] \`npm run verify:dashboard-meta\` — 12 cases OK
- [x] \`npm run verify:dashboard-ui\` — OK
- [x] \`npm run build\` — passes; DashboardRoute chunk slightly smaller after \`useProfileSetup\` dropped two unused imports
- [ ] **Manual against Vercel preview, Pat — critical:**
  - Existing user signs in → routes to dashboard normally
  - New user: splash → Create Account → email signup → /setup → submits handle → arrives on dashboard **with no full-page reload** (you'll see route-level loading skeletons rather than the white "Initializing..." flash)
  - Sign out from dashboard → no console errors about Firestore permission denied on a detached listener
  - Sign in again as same user → snapshot re-subscribes; profile loads
  - Sign in as a *different* user (different uid) → old listener detaches, new profile loads
  - Open DevTools → Application → Storage → IndexedDB → Firestore: confirm exactly one snapshot listener for \`users/{currentUid}\`, not multiple

## Why this is PR-4 of the series

This is the largest change and the only one that meaningfully alters runtime behavior beyond telemetry / data quality. Sequencing it last lets PR-1, PR-2, PR-3 land independently first; if anything goes sideways with the snapshot listener post-merge, this can be reverted in isolation without losing the telemetry/data-quality work.

Made with [Cursor](https://cursor.com)