### PR TITLE
fix(auth): splash Google modal block-new-user UX and sign-in errors

### DIFF
--- a/src/app/routes/HomeRoute.jsx
+++ b/src/app/routes/HomeRoute.jsx
@@ -1,7 +1,11 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Navigate } from 'react-router-dom';
 
-import { useAuth } from '../../features/auth';
+import {
+  isSplashGoogleModalInflight,
+  SPLASH_GOOGLE_MODAL_STORAGE_EVENT,
+  useAuth,
+} from '../../features/auth';
 import { getDashboardEntryHref } from '../../shared/lib/dashboardLastPath';
 
 import LandingPage from '../../pages/landing/LandingPage';
@@ -11,8 +15,17 @@ import LandingPage from '../../pages/landing/LandingPage';
  */
 export default function HomeRoute() {
   const { user, isAdmin: isAdminUser } = useAuth();
+  const [, bump] = useState(0);
 
-  if (user) {
+  useEffect(() => {
+    const onInflight = () => bump((n) => n + 1);
+    window.addEventListener(SPLASH_GOOGLE_MODAL_STORAGE_EVENT, onInflight);
+    return () => window.removeEventListener(SPLASH_GOOGLE_MODAL_STORAGE_EVENT, onInflight);
+  }, []);
+
+  // Stay on landing while a splash Google popup is finishing — otherwise
+  // `HomeRoute` redirects before sign-in-modal block-new-user can setError.
+  if (user && !isSplashGoogleModalInflight()) {
     return <Navigate to={getDashboardEntryHref({ isAdminUser })} replace />;
   }
 

--- a/src/features/auth/index.js
+++ b/src/features/auth/index.js
@@ -18,3 +18,7 @@ export {
   stashSplashResumeAuthModal,
   consumeSplashResumeAuthModal,
 } from './utils/splashAuthResumeStorage';
+export {
+  isSplashGoogleModalInflight,
+  SPLASH_GOOGLE_MODAL_STORAGE_EVENT,
+} from './utils/splashGoogleModalInflight';

--- a/src/features/auth/model/useSplashSignIn.js
+++ b/src/features/auth/model/useSplashSignIn.js
@@ -9,6 +9,10 @@ import {
   signInWithEmail,
   signInWithGoogle,
 } from '../api/splashAuthApi';
+import {
+  clearSplashGoogleModalInflight,
+  setSplashGoogleModalInflight,
+} from '../utils/splashGoogleModalInflight';
 import { trackAuthError, trackAuthLogin } from './authAnalytics';
 import { decideSignInModalGoogleAction } from './signInModalGuard';
 
@@ -51,6 +55,7 @@ export function useSplashSignIn(isOpen, onClose) {
   const handleGoogle = useCallback(async () => {
     setError('');
     setBusy(true);
+    setSplashGoogleModalInflight();
     try {
       const { isNewUser } = await signInWithGoogle(auth);
       const action = decideSignInModalGoogleAction(isNewUser);
@@ -81,6 +86,7 @@ export function useSplashSignIn(isOpen, onClose) {
       trackAuthError({ method: 'google', error_code: err.code });
       setError(getFirebaseAuthErrorMessage(err.code));
     } finally {
+      clearSplashGoogleModalInflight();
       setBusy(false);
     }
   }, [closeModal]);

--- a/src/features/auth/model/useSplashSignUp.js
+++ b/src/features/auth/model/useSplashSignUp.js
@@ -9,6 +9,10 @@ import {
   signInWithGoogle,
 } from '../api/splashAuthApi';
 import {
+  clearSplashGoogleModalInflight,
+  setSplashGoogleModalInflight,
+} from '../utils/splashGoogleModalInflight';
+import {
   trackAuthError,
   trackAuthLogin,
   trackAuthRollback,
@@ -61,6 +65,7 @@ export function useSplashSignUp(isOpen, onClose) {
       return;
     }
     setBusy(true);
+    setSplashGoogleModalInflight();
     try {
       const { isNewUser } = await signInWithGoogle(auth);
       if (isNewUser) {
@@ -93,6 +98,7 @@ export function useSplashSignUp(isOpen, onClose) {
       trackAuthError({ method: 'google', error_code: err.code });
       setError(getFirebaseAuthErrorMessage(err.code));
     } finally {
+      clearSplashGoogleModalInflight();
       setBusy(false);
     }
   }, [closeModal, legalAccepted]);

--- a/src/features/auth/ui/SplashAuthModalShell.jsx
+++ b/src/features/auth/ui/SplashAuthModalShell.jsx
@@ -14,6 +14,12 @@ export default function SplashAuthModalShell({
   prependContent,
   googleFootnote,
   children,
+  /**
+   * When false, clicking the dimmed backdrop does not close the dialog.
+   * OAuth popups can leave a stray click that would otherwise dismiss the
+   * modal before the user reads post-Google error copy (sign-in modal).
+   */
+  closeOnBackdropClick = true,
 }) {
   if (!isOpen) return null;
 
@@ -26,7 +32,10 @@ export default function SplashAuthModalShell({
       role="dialog"
       aria-modal="true"
       aria-label={title}
-      onClick={(e) => e.target === e.currentTarget && onClose()}
+      onClick={(e) => {
+        if (!closeOnBackdropClick) return;
+        if (e.target === e.currentTarget) onClose();
+      }}
     >
       <div
         className="max-h-[90vh] w-full max-w-md overflow-y-auto rounded-[2rem] border border-border-subtle bg-surface-panel-strong p-8 shadow-inset-glass ring-1 ring-border-glass/20"

--- a/src/features/auth/ui/SplashSignInModal.jsx
+++ b/src/features/auth/ui/SplashSignInModal.jsx
@@ -30,6 +30,12 @@ export default function SplashSignInModal({ isOpen, onClose }) {
       title="Sign in"
       handleGoogle={handleGoogle}
       busy={busy}
+      prependContent={
+        error ? (
+          <StatusBanner type="error" message={error} className="text-left" />
+        ) : null
+      }
+      closeOnBackdropClick={false}
     >
         <form onSubmit={handleEmailSignIn} className="space-y-4 text-left">
           <div>
@@ -139,7 +145,6 @@ export default function SplashSignInModal({ isOpen, onClose }) {
               />
             ) : null}
           </div>
-          {error ? <StatusBanner type="error" message={error} /> : null}
           <Button
             variant="secondary"
             type="submit"

--- a/src/features/auth/ui/SplashSignUpModal.jsx
+++ b/src/features/auth/ui/SplashSignUpModal.jsx
@@ -72,6 +72,7 @@ export default function SplashSignUpModal({ isOpen, onClose }) {
       googleDisabled={busy || !legalAccepted}
       prependContent={consentBlock}
       googleFootnote="You'll set your username/handle on the next page. Your email address is never shared or visible to other users."
+      closeOnBackdropClick={false}
     >
         <form onSubmit={handleEmailSignUp} className="space-y-4 text-left">
           <div>

--- a/src/features/auth/utils/firebaseAuthMessages.js
+++ b/src/features/auth/utils/firebaseAuthMessages.js
@@ -10,7 +10,12 @@ export function getFirebaseAuthErrorMessage(code) {
     case 'auth/user-not-found':
     case 'auth/wrong-password':
     case 'auth/invalid-credential':
-      return 'Incorrect email or password. If you recently updated your password, Chrome/autofill may still use an old password—try typing it manually or use Google.';
+      return [
+        'Sign-in failed: either the password is wrong, or there is no account for this email',
+        '(Firebase uses one message for both so addresses cannot be guessed).',
+        'New here? Use Create account on the splash page—this form is for returning users.',
+        'If you do have an account and recently changed your password, autofill may still use an old one—try typing it manually or use Google.',
+      ].join(' ');
     case 'auth/too-many-requests':
       return 'Too many attempts. Wait a moment and try again.';
     case 'auth/popup-closed-by-user':

--- a/src/features/auth/utils/splashGoogleModalInflight.js
+++ b/src/features/auth/utils/splashGoogleModalInflight.js
@@ -1,0 +1,44 @@
+/**
+ * While a splash auth modal is resolving `signInWithPopup`, Firebase briefly
+ * sets `auth.currentUser`. `HomeRoute` would otherwise `<Navigate>` to the
+ * dashboard immediately, unmounting the modal before sign-in-modal new-user
+ * block logic can run `deleteUser` + `setError` (PR #406).
+ *
+ * Set this flag synchronously before awaiting `signInWithGoogle`, clear in
+ * `finally` when the handler completes.
+ */
+const KEY = 'setlistpickem_splash_google_modal_inflight';
+
+/** Same-tab signal so `HomeRoute` re-renders after storage changes (sessionStorage does not notify). */
+export const SPLASH_GOOGLE_MODAL_STORAGE_EVENT = 'setlistpickem:splash-google-modal-inflight';
+
+function notifyInflightChanged() {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(SPLASH_GOOGLE_MODAL_STORAGE_EVENT));
+}
+
+export function setSplashGoogleModalInflight() {
+  try {
+    sessionStorage.setItem(KEY, '1');
+  } catch {
+    /* ignore quota / private mode */
+  }
+  notifyInflightChanged();
+}
+
+export function clearSplashGoogleModalInflight() {
+  try {
+    sessionStorage.removeItem(KEY);
+  } catch {
+    /* ignore */
+  }
+  notifyInflightChanged();
+}
+
+export function isSplashGoogleModalInflight() {
+  try {
+    return sessionStorage.getItem(KEY) === '1';
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to PR #406 testing: new Google users blocked from the **Sign in** modal never saw the explanatory message because `HomeRoute` redirected to the dashboard as soon as `signInWithPopup` set `user`, unmounting the splash before `deleteUser` / `setError` ran.

- **`splashGoogleModalInflight`**: set synchronously before `await signInWithGoogle`, cleared in `finally`; `HomeRoute` skips dashboard redirect while the flag is set and listens for a same-tab event so we re-render after a successful Google login when the flag clears.
- **Sign-in modal**: error banner moved to `prependContent` (above **Continue with Google**); `SplashAuthModalShell` supports `closeOnBackdropClick={false}` on splash modals to reduce stray dismiss from OAuth popup teardown.
- **`firebaseAuthMessages`**: clearer copy for `invalid-credential` / wrong password vs no account, pointing new users to **Create account**.

## Test plan

- [x] Vercel preview: Sign in modal → Google with a **new** Google account → expect block message to stay visible on the modal (no flash to dashboard then back to `/`).
- [x] Sign in modal → Google **returning** user → still lands on dashboard as before.
- [x] Create account modal → Google (new + returning) → consent path unchanged.
- [x] Sign in modal → wrong email/password → message visible above Google CTA.
- [x] `npm run lint` / `npm test` (pass locally on branch).

Made with [Cursor](https://cursor.com)