### PR TITLE
fix(push): hydrate notification UI state, align recap copy, add forceResend (#384)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -306,10 +306,12 @@ exports.deliverSphere2026TourRecapInbox = onCall(
   async (request) => {
     assertAdminClaim(request);
     const dryRun = request.data?.dryRun !== false;
+    const forceResend = request.data?.forceResend === true;
     return deliverSphere2026TourRecapInbox({
       db,
       admin,
       dryRun,
+      forceResend,
       logger,
     });
   }

--- a/functions/sphereTourRecapDelivery.js
+++ b/functions/sphereTourRecapDelivery.js
@@ -137,6 +137,36 @@ function aggregateTourStandings(picksByDate) {
   });
 }
 
+/**
+ * Build the FCM title + body for a recap push notification.
+ *
+ * Keep in sync with `buildSphere2026PushPayload` in
+ * `src/features/tour-recap/model/sphere2026Recap.js` — that function is the
+ * authoritative preview/client copy; this is its server-side mirror.
+ *
+ * @param {{ rank: number | null, points: number, wins: number }} ctx
+ * @returns {{ title: string, body: string }}
+ */
+function buildRecapPushPayload({ rank, points, wins }) {
+  const title = "Sphere '26 recap is in";
+  if (typeof rank === "number" && rank === 1) {
+    return {
+      title,
+      body: `You took #1 with ${points} pts and ${wins} nightly wins. Open the app for the full wrap-up.`,
+    };
+  }
+  if (typeof rank === "number" && rank > 0) {
+    return {
+      title,
+      body: `You finished #${rank} (${points} pts, ${wins} wins). Open the app for your personalized recap.`,
+    };
+  }
+  return {
+    title,
+    body: "Your Sphere '26 recap is in. Open the app to read it.",
+  };
+}
+
 const MAX_FIRESTORE_BATCH = 500;
 const MAX_RECAP_PUSH_SENDS_PER_INVOCATION = 400;
 const MAX_TOKENS_PER_USER_FOR_RECAP = 5;
@@ -168,12 +198,13 @@ function userWantsRecapPush(userData) {
  *   admin: typeof import('firebase-admin'),
  *   templateId: string,
  *   preview: Array<{ uid: string, payload: Record<string, number> }>,
+ *   forceResend?: boolean,
  *   logger?: { info?: Function, warn?: Function },
  * }} params
  */
-async function sendRecapPushFanout({ db, admin, templateId, preview, logger }) {
+async function sendRecapPushFanout({ db, admin, templateId, preview, forceResend = false, logger }) {
   if (!Array.isArray(preview) || preview.length === 0) {
-    return { sent: 0, skipped: 0 };
+    return { sent: 0, skipped: 0, pushSent: false, pushSkipReason: "no_candidates" };
   }
 
   let sent = 0;
@@ -215,10 +246,13 @@ async function sendRecapPushFanout({ db, admin, templateId, preview, logger }) {
 
     const logId = recapPushLogDocId(templateId, item.uid);
     const logRef = db.collection(FCM_LOG_COLLECTION).doc(logId);
-    const existing = await logRef.get();
-    if (existing.exists) {
-      skipped += 1;
-      continue;
+
+    if (!forceResend) {
+      const existing = await logRef.get();
+      if (existing.exists) {
+        skipped += 1;
+        continue;
+      }
     }
 
     const userData = await loadUser(item.uid);
@@ -234,11 +268,9 @@ async function sendRecapPushFanout({ db, admin, templateId, preview, logger }) {
     }
 
     const rank = Number.isFinite(item?.payload?.rank) ? item.payload.rank : null;
-    const title = "New tour recap in Messages";
-    const body =
-      typeof rank === "number" && rank > 0
-        ? `Your Sphere '26 recap is ready. Current rank: #${rank}.`
-        : "Your Sphere '26 recap is ready. Open Notifications to read it.";
+    const points = typeof item?.payload?.points === "number" ? item.payload.points : 0;
+    const wins = typeof item?.payload?.wins === "number" ? item.payload.wins : 0;
+    const { title, body } = buildRecapPushPayload({ rank, points, wins });
 
     let anyDelivered = false;
     for (const token of tokens) {
@@ -265,6 +297,7 @@ async function sendRecapPushFanout({ db, admin, templateId, preview, logger }) {
           templateId,
           userId: item.uid,
           delivered: true,
+          forceResend: forceResend || false,
           decidedAt: admin.firestore.FieldValue.serverTimestamp(),
         },
         { merge: true }
@@ -275,13 +308,23 @@ async function sendRecapPushFanout({ db, admin, templateId, preview, logger }) {
     }
   }
 
+  const pushSent = sent > 0;
+  const pushSkipReason = pushSent
+    ? null
+    : skipped > 0
+      ? "all_skipped"
+      : "no_tokens_or_prefs";
+
   logger?.info?.("sendRecapPushFanout complete", {
     templateId,
     sent,
     skipped,
     candidates: preview.length,
+    forceResend,
+    pushSent,
+    pushSkipReason,
   });
-  return { sent, skipped };
+  return { sent, skipped, pushSent, pushSkipReason };
 }
 
 /**
@@ -319,10 +362,11 @@ async function loadPicksByDateForSphereTour(db) {
  *   db: import('firebase-admin').firestore.Firestore,
  *   admin: typeof import('firebase-admin'),
  *   dryRun: boolean,
+ *   forceResend?: boolean,
  *   logger?: { info?: Function, warn?: Function },
  * }} params
  */
-async function deliverSphere2026TourRecapInbox({ db, admin, dryRun, logger }) {
+async function deliverSphere2026TourRecapInbox({ db, admin, dryRun, forceResend = false, logger }) {
   const picksByDate = await loadPicksByDateForSphereTour(db);
   const leaders = aggregateTourStandings(picksByDate);
   const participantCount = leaders.length;
@@ -420,6 +464,7 @@ async function deliverSphere2026TourRecapInbox({ db, admin, dryRun, logger }) {
     admin,
     templateId: SPHERE_2026_INAUGURAL_TEMPLATE_ID,
     preview,
+    forceResend,
     logger,
   });
 
@@ -431,8 +476,11 @@ async function deliverSphere2026TourRecapInbox({ db, admin, dryRun, logger }) {
     showDates: [...SPHERE_2026_INAUGURAL_SHOW_DATES],
     participantCount,
     delivered,
-    pushSent: pushResult.sent,
+    pushSent: pushResult.pushSent,
+    pushSentCount: pushResult.sent,
     pushSkipped: pushResult.skipped,
+    pushSkipReason: pushResult.pushSkipReason,
+    forceResend,
     preview: preview.slice(0, 50),
   };
 }

--- a/src/features/notifications/api/fcmTokenApi.js
+++ b/src/features/notifications/api/fcmTokenApi.js
@@ -1,4 +1,14 @@
-import { deleteDoc, doc, serverTimestamp, setDoc, updateDoc } from 'firebase/firestore';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDocs,
+  limit,
+  query,
+  serverTimestamp,
+  setDoc,
+  updateDoc,
+} from 'firebase/firestore';
 
 import { db } from '../../../shared/lib/firebase';
 
@@ -59,4 +69,17 @@ export async function deleteFcmTokenForUser({ userId, token }) {
   if (!token) return;
   const tokenId = await deriveTokenId(token);
   await deleteDoc(tokenDocRef(userId, tokenId));
+}
+
+/**
+ * Returns the first registered FCM token string for `userId`, or `null` if none exist.
+ * Used to hydrate UI state on mount without requiring the user to re-tap Enable.
+ */
+export async function getFirstFcmTokenForUser(userId) {
+  if (!userId) return null;
+  const colRef = collection(db, 'users', userId, 'private_fcmTokens');
+  const snap = await getDocs(query(colRef, limit(1)));
+  if (snap.empty) return null;
+  const token = snap.docs[0].data()?.token;
+  return typeof token === 'string' && token.trim() ? token.trim() : null;
 }

--- a/src/features/notifications/model/usePushTokenRegistration.js
+++ b/src/features/notifications/model/usePushTokenRegistration.js
@@ -7,7 +7,7 @@ import {
   revokeFcmDeviceToken,
   subscribeForegroundFcmMessages,
 } from '../../../shared/lib/firebaseMessaging';
-import { deleteFcmTokenForUser, upsertFcmTokenForUser } from '../api/fcmTokenApi';
+import { deleteFcmTokenForUser, getFirstFcmTokenForUser, upsertFcmTokenForUser } from '../api/fcmTokenApi';
 import { sendPushCanary } from '../api/pushCanaryApi';
 
 function browserPermissionState() {
@@ -49,6 +49,31 @@ export function usePushTokenRegistration() {
 
     return () => unsubscribe();
   }, []);
+
+  // Hydrate enabled state from Firestore on mount so the UI reflects "On"
+  // immediately when the browser already has notification permission and a
+  // token was previously registered (without requiring another Enable tap).
+  useEffect(() => {
+    if (!user?.uid) return;
+    if (browserPermissionState() !== 'granted') return;
+
+    let cancelled = false;
+    getFirstFcmTokenForUser(user.uid)
+      .then((token) => {
+        if (cancelled) return;
+        if (token) {
+          setCurrentFcmToken(token);
+          setStatus('enabled');
+        }
+      })
+      .catch(() => {
+        // Silent failure — user can still tap Enable to re-register.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.uid]);
 
   const enablePush = useCallback(async () => {
     if (!user?.uid) {


### PR DESCRIPTION
## Summary

Fixes three issues from #384 with targeted, minimal changes across the push notification system.

### Problem 1 — Session-only "enabled" state (UI shows Off after navigation)

`usePushTokenRegistration` started with `status: 'idle'` (→ **Off**) every page load, even when the browser already had `Notification.permission === 'granted'` and a token was registered.

**Fix:** Added `getFirstFcmTokenForUser` to `fcmTokenApi.js` that queries `users/{uid}/private_fcmTokens` (limit 1). A new mount effect in `usePushTokenRegistration` calls it when permission is already `'granted'`; if a token is found, `status` is set to `'enabled'` and `currentFcmToken` is hydrated — no tap required.

### Problem 2 — Recap push copy mismatch (prod vs preview)

Production `sendRecapPushFanout` was sending a generic `"New tour recap in Messages"` / `"Your Sphere '26 recap is ready. Current rank: #N."` copy, while the UI preview helper `buildSphere2026PushPayload` sends personalized champion/ranked copy with a different title.

**Fix:** Added a local `buildRecapPushPayload` function in `sphereTourRecapDelivery.js` that mirrors `buildSphere2026PushPayload` exactly — same `"Sphere '26 recap is in"` title and champion/ranked body variants. A comment points to the frontend source for alignment. `sendRecapPushFanout` now uses this builder.

### Problem 3 — Recap resend + dedupe + canary confusion

The callable response didn't distinguish between "FCM sent" vs. "deduplicated by log". Admins had no way to force a resend without manual Firestore edits.

**Fix:**
- `sendRecapPushFanout` now returns `pushSent: boolean` (true if ≥1 FCM delivery) and `pushSkipReason` string (`null | "all_skipped" | "no_tokens_or_prefs" | "no_candidates"`).
- Added `forceResend: boolean` parameter (defaults `false`) — when `true`, skips the `fcm_notification_log` dedupe check so admins can resend without clearing log docs.
- `deliverSphere2026TourRecapInbox` surfaces `pushSent`, `pushSentCount`, `pushSkipReason`, and `forceResend` in its response.
- The `deliverSphere2026TourRecapInbox` callable in `index.js` reads `request.data.forceResend` and passes it through.

## Files changed

| File | Change |
|------|--------|
| `src/features/notifications/api/fcmTokenApi.js` | Add `getFirstFcmTokenForUser` |
| `src/features/notifications/model/usePushTokenRegistration.js` | Mount hydration effect |
| `functions/sphereTourRecapDelivery.js` | `buildRecapPushPayload`, aligned copy, `forceResend`, `pushSent`/`pushSkipReason` |
| `functions/index.js` | Pass `forceResend` from callable request data |

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 209 frontend tests pass
- [x] `cd functions && npm test` — 161 functions tests pass (including `aggregateTourStandings`, `recapPushLogDocId`, `userWantsRecapPush`)

Fixes #384

Made with [Cursor](https://cursor.com)