### PR TITLE
feat(comms): in-app toasts for setlist lock and profile update

### DIFF
--- a/docs/FIREBASE_AUTH_EMAIL_TEMPLATES.md
+++ b/docs/FIREBASE_AUTH_EMAIL_TEMPLATES.md
@@ -1,0 +1,155 @@
+# Firebase Auth Email Templates — Manual Configuration Runbook
+
+Firebase Authentication sends several transactional emails automatically (password reset, email address verification, email change). These templates **must be customized in the Firebase Console** — they cannot be configured via code or the Firebase CLI.
+
+## Why This Is Manual
+
+Firebase Auth email templates are project-level settings stored in the Firebase backend. There is no Terraform/CLI path for the web-app email body or subject line. Branding updates require a human to open the Console and save the template.
+
+Related issue: [#120 — Custom communications for in-app actions](https://github.com/your-org/set-picks/issues/120)
+
+---
+
+## Firebase Console Location
+
+1. Go to [Firebase Console](https://console.firebase.google.com/)
+2. Select project **`set-picks`**
+3. Navigate to **Authentication → Templates** (left sidebar, under "Build")
+
+You will see four template types:
+- **Password reset**
+- **Email address verification**
+- **Email address change**
+- **SMS verification** (not applicable — SMS not enabled)
+
+---
+
+## Templates to Customize
+
+### 1. Password Reset
+
+**Trigger:** User clicks "Forgot password?" on the splash screen or in Account Security settings.
+
+| Field | Recommended value |
+|-------|------------------|
+| **Sender name** | `Setlist Pick 'Em` |
+| **From address** | `noreply@set-picks.firebaseapp.com` (or custom domain — see below) |
+| **Reply-to** | Leave empty or `support@<yourdomain>.com` |
+| **Subject** | `Reset your Setlist Pick 'Em password` |
+| **Message body** | See template text below |
+
+**Suggested body:**
+
+```
+Hi,
+
+We received a request to reset the password for your Setlist Pick 'Em account.
+
+Click the link below to choose a new password. This link expires in 1 hour.
+
+%LINK%
+
+If you didn't request a password reset, you can ignore this email — your account is still secure.
+
+— The Setlist Pick 'Em team
+```
+
+> `%LINK%` is a Firebase placeholder that gets replaced with the actual reset URL.
+
+**Action URL:** By default this redirects to `set-picks.firebaseapp.com`. The app uses `handleCodeInApp: true` with `url: window.location.origin + '/password-reset-complete'`, so the link should deep-link back into the app. Verify this is set correctly under **"Action URL"** in the template editor — it should reflect the production domain (e.g., `https://setlistpickem.com/password-reset-complete`).
+
+---
+
+### 2. Email Address Verification
+
+**Trigger:** After new account creation (if email verification is enabled).
+
+| Field | Recommended value |
+|-------|------------------|
+| **Subject** | `Verify your Setlist Pick 'Em email` |
+
+**Suggested body:**
+
+```
+Hi,
+
+Welcome to Setlist Pick 'Em! Please verify your email address to complete your account setup.
+
+%LINK%
+
+If you didn't create this account, you can safely ignore this email.
+
+— The Setlist Pick 'Em team
+```
+
+---
+
+### 3. Email Address Change
+
+**Trigger:** When a user changes their email in Account Security settings (revocation email sent to the old address).
+
+| Field | Recommended value |
+|-------|------------------|
+| **Subject** | `Your Setlist Pick 'Em email address was changed` |
+
+**Suggested body:**
+
+```
+Hi,
+
+The email address for your Setlist Pick 'Em account was recently changed.
+
+If you made this change, no further action is needed.
+
+If you did not make this change, click the link below to revoke it and secure your account:
+
+%LINK%
+
+— The Setlist Pick 'Em team
+```
+
+---
+
+## Custom Send Domain (Optional)
+
+By default Firebase sends from `noreply@<project-id>.firebaseapp.com`. To send from a branded domain (e.g., `noreply@setlistpickem.com`):
+
+1. In the Firebase Console, go to **Authentication → Templates → Edit** (top of page)
+2. Click **"Customize domain"**
+3. Add a verified sending domain and configure the required DNS records (SPF, DKIM, DMARC)
+4. This requires ownership of the domain and access to DNS settings
+
+> Note: Custom domains for Firebase Auth emails are distinct from the app's custom `authDomain` setting configured in `src/shared/lib/firebase.js` (that affects the OAuth redirect domain, not email sending).
+
+---
+
+## Logo / Branding
+
+To add a logo to Auth emails:
+
+1. In the Firebase Console, go to **Authentication → Templates**
+2. Click the **pencil icon** next to "Customize Action URL" near the top
+3. Under **"Customize"**, upload a logo image (PNG/JPG, recommended: 120×30 px on a transparent or white background)
+4. The logo appears at the top of all Firebase Auth emails
+
+---
+
+## Verification Checklist (after updating templates)
+
+- [ ] Trigger a password reset from the splash page and confirm the email arrives with correct sender name, subject, and body
+- [ ] Confirm `%LINK%` deep-links back to `https://setlistpickem.com/password-reset-complete` (or staging equivalent) and not to `set-picks.firebaseapp.com`
+- [ ] Check spam folder — SPF/DKIM records may need to be verified if using a custom domain
+- [ ] Test on mobile email clients (Gmail app, Apple Mail) for rendering
+
+---
+
+## What Is NOT In Scope Here
+
+The following require a separate transactional email provider (e.g., SendGrid) and backend Cloud Functions — deferred to a future sprint per issue #120:
+
+- Branded HTML email for pick confirmation
+- Post-show recap email
+- Welcome email series
+- Setlist lock reminder email
+
+See [docs/IN_APP_ADS_EPIC.md](./IN_APP_ADS_EPIC.md) and the comms backlog for the full email roadmap.

--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -46,7 +46,7 @@ import {
   showOptionLabelDesktop,
   showOptionTitle,
 } from '../../shared/utils/showOptionLabel.js';
-import { PastShowLockBanner, TooEarlyBanner } from '../../features/picks';
+import { PastShowLockBanner, TooEarlyBanner, useSetlistLockToast } from '../../features/picks';
 import { DashboardInstallEngageBanner } from '../../features/install';
 
 import {
@@ -116,6 +116,7 @@ export default function DashboardLayout() {
 
   const meta = getDashboardPageMeta(location.pathname, location.search);
   const datePickerStatus = getShowStatus(selectedDate, showDates);
+  useSetlistLockToast(datePickerStatus);
   const priorShowForTooEarly = getShowBeforeDate(selectedDate, showDates);
   const tooEarlyPriorLabel =
     priorShowForTooEarly != null ? showOptionLabelCompact(priorShowForTooEarly) : null;

--- a/src/features/picks/index.js
+++ b/src/features/picks/index.js
@@ -7,3 +7,4 @@ export { default as PicksSelfRecapSection } from './ui/PicksSelfRecapSection';
 export { default as usePicksForm } from './model/usePicksForm';
 export { usePicksSelfRecap } from './model/usePicksSelfRecap';
 export { useNextShowPicksStatus } from './model/useNextShowPicksStatus';
+export { useSetlistLockToast } from './model/useSetlistLockToast';

--- a/src/features/picks/model/useSetlistLockToast.js
+++ b/src/features/picks/model/useSetlistLockToast.js
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react';
+
+import { showSuccessToast } from '../../../shared/ui/toast';
+
+/**
+ * Fires a toast notification exactly once when the active show transitions
+ * from the open-picks state ('NEXT') to the locked state ('LIVE').
+ *
+ * Handles the common case where the user has the dashboard open around show
+ * time: without a page reload, the status changes live and the toast fires
+ * when 7:55 pm local arrives.  A hard reload after lock (initial status
+ * already 'LIVE') does not re-fire the toast.
+ *
+ * @param {string|null} showStatus - Result of getShowStatus() for the active
+ *   show date: 'NEXT' | 'LIVE' | 'PAST' | 'FUTURE' | null
+ */
+export function useSetlistLockToast(showStatus) {
+  const prevStatusRef = useRef(showStatus);
+
+  useEffect(() => {
+    const prev = prevStatusRef.current;
+    prevStatusRef.current = showStatus;
+
+    if (prev === 'NEXT' && showStatus === 'LIVE') {
+      showSuccessToast("Picks are locked — show time! 🎸");
+    }
+  }, [showStatus]);
+}

--- a/src/features/profile/model/useUserProfile.js
+++ b/src/features/profile/model/useUserProfile.js
@@ -5,6 +5,7 @@ import {
   fetchUserProfileDocument,
   updateUserProfileWithPickHandles,
 } from '../api/profileApi';
+import { showSuccessToast } from '../../../shared/ui/toast';
 
 /**
  * Loads the signed-in user's profile, holds edit form state, and persists updates.
@@ -84,6 +85,7 @@ export function useUserProfile(user) {
           favoriteSong,
         });
         setMessage({ text: 'Profile updated successfully! 🎸', type: 'success' });
+        showSuccessToast('Profile updated! 🎸');
         return true;
       } catch (error) {
         console.error('Error updating profile:', error);


### PR DESCRIPTION
## Summary

Partially addresses #120 — implements the bounded, high-value comms items from the sprint scope.

- **Setlist lock toast** — `useSetlistLockToast` hook detects when the active show transitions from `NEXT` → `LIVE` (client-side 7:55 pm lock) and fires an in-app toast via the existing `showSuccessToast` helper. Wired into `DashboardLayout` using the already-computed `datePickerStatus`. A hard reload after lock (initial status already `LIVE`) does not re-fire the toast.
- **Profile update toast** — `useUserProfile.saveProfile` now calls `showSuccessToast('Profile updated! 🎸')` on success, complementing the existing inline `message` state (which is kept for accessibility/fallback).
- **Firebase Auth email templates runbook** — `docs/FIREBASE_AUTH_EMAIL_TEMPLATES.md` documents all manual steps to configure branded password-reset, email-verification, and email-change templates in the Firebase Console, including custom send domain setup and a post-deploy verification checklist.

## What is deferred (too large for this sprint)

- Full branded transactional email system (SendGrid/Mailgun)
- Cloud Functions triggered emails for every in-app action
- Firestore-triggered `commsInbox` writes for lock events (server-side delivery)
- Welcome email series / pick-reminder emails

These are tracked in the comms backlog and `docs/IN_APP_ADS_EPIC.md`.

## Test plan

- [ ] Lint passes: `npm run lint`
- [ ] Unit tests pass: `npm test` (226 tests, 33 files)
- [ ] Manually: open dashboard around show time — toast fires once when clock hits 7:55 pm
- [ ] Manually: update profile handle — toast appears alongside inline success message
- [ ] Review `docs/FIREBASE_AUTH_EMAIL_TEMPLATES.md` for accuracy against the Firebase Console

Made with [Cursor](https://cursor.com)