### PR TITLE
feat(standings): "Past tours" picker for tour-scoped standings (global + pool)

### DIFF
--- a/src/features/pools/model/usePoolStandingsSection.js
+++ b/src/features/pools/model/usePoolStandingsSection.js
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
-import { resolveCurrentTour } from '../../scoring';
+import { getTourByKey, resolveSelectableTours } from '../../scoring';
 import { useShowCalendar } from '../../show-calendar';
 import { todayYmd } from '../../../shared/utils/dateUtils';
 import { floorShowsAtGameLaunch } from '../../../shared/config/gameLaunch';
@@ -49,23 +49,32 @@ import { emitPoolStandingsTelemetry } from './poolStandingsTelemetry';
 export function usePoolStandingsSection(poolId, pool, memberProfiles) {
   const { showDates, showDatesByTour } = useShowCalendar();
 
-  const currentTour = useMemo(
-    () => resolveCurrentTour(null, todayYmd(), showDatesByTour),
-    [showDatesByTour]
+  const selectableTours = useMemo(
+    () => resolveSelectableTours(showDatesByTour, todayYmd()),
+    [showDatesByTour],
   );
 
   const [scope, setScope] = useState(/** @type {PoolStandingsScope} */ ('all-time'));
+  const [selectedTourKey, setTourKey] = useState(/** @type {string | null} */ (null));
 
-  const tourKey = scope === 'tour' && currentTour ? currentTour.tour : null;
+  const selectedTour = useMemo(
+    () =>
+      (selectedTourKey ? getTourByKey(selectableTours, selectedTourKey) : null) ??
+      selectableTours[0] ??
+      null,
+    [selectableTours, selectedTourKey],
+  );
+
+  const tourKey = scope === 'tour' && selectedTour ? selectedTour.tour : null;
 
   const effectiveShowDates = useMemo(() => {
-    if (scope === 'tour' && currentTour) {
+    if (scope === 'tour' && selectedTour) {
       return floorShowsAtGameLaunch(
-        currentTour.shows.map((s) => ({ date: s.date }))
+        selectedTour.shows.map((s) => ({ date: s.date }))
       );
     }
     return floorShowsAtGameLaunch(showDates);
-  }, [scope, currentTour, showDates]);
+  }, [scope, selectedTour, showDates]);
 
   const memberIds = useMemo(
     () => (Array.isArray(pool?.members) ? pool.members.filter(Boolean) : []),
@@ -220,8 +229,6 @@ export function usePoolStandingsSection(poolId, pool, memberProfiles) {
     return rows;
   }, [memberProfiles, totalsByUser]);
 
-  // Public shape stays identical to the pre-#254 hook so the page and UI
-  // consumers don't need updates.
   const loading =
     enabled && (query.isPending || query.isFetching) && !query.isSuccess;
   const error = query.isError
@@ -233,8 +240,11 @@ export function usePoolStandingsSection(poolId, pool, memberProfiles) {
   return {
     scope,
     setScope,
-    tourName: currentTour?.tour ?? null,
-    tourAvailable: Boolean(currentTour),
+    selectableTours,
+    selectedTourKey: selectedTour?.tour ?? null,
+    setTourKey,
+    tourName: selectedTour?.tour ?? null,
+    tourAvailable: selectableTours.length > 0,
     leaderboardMembers,
     loading,
     error,

--- a/src/features/pools/ui/PoolHubStandingsSection.jsx
+++ b/src/features/pools/ui/PoolHubStandingsSection.jsx
@@ -7,6 +7,7 @@ import {
   POOL_TOUR_STANDINGS_DESCRIPTION,
   POOL_TOUR_STANDINGS_HEADING,
 } from '../../../shared/config/dashboardVocabulary';
+import { TourPicker } from '../../scoring';
 import PoolHubLeaderboard from './PoolHubLeaderboard';
 
 /**
@@ -27,6 +28,9 @@ import PoolHubLeaderboard from './PoolHubLeaderboard';
  *   onScopeChange: (scope: 'all-time' | 'tour') => void,
  *   tourName?: string | null,
  *   tourAvailable?: boolean,
+ *   selectableTours?: Array<{ tour: string }>,
+ *   selectedTourKey?: string | null,
+ *   onSelectTour?: (tourKey: string) => void,
  * }} props
  */
 export default function PoolHubStandingsSection({
@@ -36,6 +40,9 @@ export default function PoolHubStandingsSection({
   onScopeChange,
   tourName,
   tourAvailable = false,
+  selectableTours,
+  selectedTourKey,
+  onSelectTour,
 }) {
   const heading =
     scope === 'tour' ? POOL_TOUR_STANDINGS_HEADING : POOL_ALL_TIME_STANDINGS_HEADING;
@@ -61,6 +68,14 @@ export default function PoolHubStandingsSection({
           tourAvailable={tourAvailable}
         />
       </div>
+      {scope === 'tour' && (
+        <TourPicker
+          tours={selectableTours ?? []}
+          selectedTourKey={selectedTourKey}
+          onSelect={onSelectTour ?? (() => {})}
+          className="mb-3"
+        />
+      )}
       {loading ? (
         <div className="flex flex-col items-center justify-center gap-2 rounded-2xl border border-border-subtle bg-surface-panel py-10 font-bold text-content-secondary shadow-inset-glass">
           <Loader2 className="h-8 w-8 animate-spin text-brand-primary" aria-hidden />

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -39,6 +39,12 @@ export { default as StandingsViewToggle } from './ui/StandingsViewToggle';
 export { default as StandingsWinnerOfTheNightBanner } from './ui/StandingsWinnerOfTheNightBanner';
 export { default as TourStandingsSection } from './ui/TourStandingsSection';
 export { resolveCurrentTour } from './model/resolveCurrentTour';
+export {
+  resolveSelectableTours,
+  getTourByKey,
+} from './model/resolveSelectableTours';
+export { useStandingsTourSelection } from './model/useStandingsTourSelection';
 export { useShowWinnerOfTheNight } from './model/useShowWinnerOfTheNight';
 export { usePreviousShowNightWinner } from './model/usePreviousShowNightWinner';
 export { useTourStandings } from './model/useTourStandings';
+export { default as TourPicker } from './ui/TourPicker';

--- a/src/features/scoring/model/resolveSelectableTours.js
+++ b/src/features/scoring/model/resolveSelectableTours.js
@@ -1,0 +1,59 @@
+import { GAME_LAUNCH_SHOW_DATE } from '../../../shared/config/gameLaunch';
+
+/**
+ * @typedef {{ tour: string, shows: Array<{ date: string, venue?: string }> }} TourGroup
+ */
+
+/**
+ * Filter `showDatesByTour` to tours that have at least one show on or after
+ * {@link GAME_LAUNCH_SHOW_DATE} and on or before `today`, then sort newest
+ * last-show-date first so the current (most recent) tour leads the list.
+ *
+ * Used by the "Past tours" picker (#295) to populate the tour selector on
+ * both the global standings Tour view and the pool hub standings section.
+ *
+ * @param {TourGroup[] | null | undefined} showDatesByTour
+ * @param {string} today - YYYY-MM-DD lexicographic comparison
+ * @returns {TourGroup[]}
+ */
+export function resolveSelectableTours(showDatesByTour, today) {
+  if (!Array.isArray(showDatesByTour) || !today) return [];
+
+  /** @type {Array<{ group: TourGroup, lastDate: string }>} */
+  const scored = [];
+  for (const group of showDatesByTour) {
+    if (!group || !Array.isArray(group.shows)) continue;
+    const eligible = group.shows.filter(
+      (s) =>
+        typeof s.date === 'string' &&
+        s.date >= GAME_LAUNCH_SHOW_DATE &&
+        s.date <= today,
+    );
+    if (eligible.length === 0) continue;
+    const lastDate = eligible.reduce((a, b) => (a.date > b.date ? a : b)).date;
+    scored.push({ group, lastDate });
+  }
+
+  scored.sort((a, b) => (a.lastDate > b.lastDate ? -1 : 1));
+  return scored.map((r) => r.group);
+}
+
+/**
+ * Look up a tour from `showDatesByTour` by its `tour` name/key. Trims
+ * whitespace on both sides (normalization fallback) so minor differences
+ * don't cause a miss.
+ *
+ * @param {TourGroup[] | null | undefined} showDatesByTour
+ * @param {string | null | undefined} tourKey
+ * @returns {TourGroup | null}
+ */
+export function getTourByKey(showDatesByTour, tourKey) {
+  if (!Array.isArray(showDatesByTour) || typeof tourKey !== 'string') return null;
+  const key = tourKey.trim();
+  if (!key) return null;
+  return (
+    showDatesByTour.find(
+      (g) => g && typeof g.tour === 'string' && g.tour.trim() === key,
+    ) ?? null
+  );
+}

--- a/src/features/scoring/model/resolveSelectableTours.test.js
+++ b/src/features/scoring/model/resolveSelectableTours.test.js
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import { getTourByKey, resolveSelectableTours } from './resolveSelectableTours';
+
+// GAME_LAUNCH_SHOW_DATE = '2026-04-16'
+const TOURS = [
+  {
+    tour: 'Sphere Run',
+    shows: [
+      { date: '2024-04-20', venue: 'Sphere' },
+      { date: '2024-04-26', venue: 'Sphere' },
+    ],
+  },
+  {
+    tour: 'Spring Tour 2026',
+    shows: [
+      { date: '2026-04-16', venue: 'A' },
+      { date: '2026-04-18', venue: 'B' },
+      { date: '2026-04-20', venue: 'C' },
+    ],
+  },
+  {
+    tour: 'Summer Tour 2026',
+    shows: [
+      { date: '2026-07-01', venue: 'D' },
+      { date: '2026-07-02', venue: 'E' },
+    ],
+  },
+  {
+    tour: 'Fall Tour 2026',
+    shows: [{ date: '2026-10-01', venue: 'F' }],
+  },
+];
+
+describe('resolveSelectableTours', () => {
+  it('returns only tours with post-launch shows on or before today', () => {
+    const result = resolveSelectableTours(TOURS, '2026-07-15');
+    const names = result.map((t) => t.tour);
+    expect(names).toContain('Spring Tour 2026');
+    expect(names).toContain('Summer Tour 2026');
+    expect(names).not.toContain('Sphere Run');
+    expect(names).not.toContain('Fall Tour 2026');
+  });
+
+  it('sorts by newest last-show-date first', () => {
+    const result = resolveSelectableTours(TOURS, '2026-07-15');
+    expect(result[0].tour).toBe('Summer Tour 2026');
+    expect(result[1].tour).toBe('Spring Tour 2026');
+  });
+
+  it('includes a tour whose only qualifying show is exactly today', () => {
+    const result = resolveSelectableTours(TOURS, '2026-07-01');
+    expect(result.map((t) => t.tour)).toContain('Summer Tour 2026');
+  });
+
+  it('excludes a tour whose qualifying shows are all in the future', () => {
+    const result = resolveSelectableTours(TOURS, '2026-06-30');
+    expect(result.map((t) => t.tour)).not.toContain('Summer Tour 2026');
+  });
+
+  it('excludes pre-launch tours even when their shows are before today', () => {
+    const result = resolveSelectableTours(TOURS, '2026-07-15');
+    expect(result.map((t) => t.tour)).not.toContain('Sphere Run');
+  });
+
+  it('uses the last qualifying show date for sort ordering, not the overall last show', () => {
+    const tours = [
+      {
+        tour: 'Tour A',
+        shows: [
+          { date: '2026-05-01', venue: 'X' },
+          { date: '2026-08-01', venue: 'Y' },
+        ],
+      },
+      {
+        tour: 'Tour B',
+        shows: [{ date: '2026-06-01', venue: 'Z' }],
+      },
+    ];
+    // today = 2026-07-01 → Tour A's qualifying shows go up to 2026-05-01;
+    // Tour B's qualifying shows go up to 2026-06-01 → Tour B should lead.
+    const result = resolveSelectableTours(tours, '2026-07-01');
+    expect(result[0].tour).toBe('Tour B');
+    expect(result[1].tour).toBe('Tour A');
+  });
+
+  it('returns empty array for null input', () => {
+    expect(resolveSelectableTours(null, '2026-07-15')).toEqual([]);
+  });
+
+  it('returns empty array for empty showDatesByTour', () => {
+    expect(resolveSelectableTours([], '2026-07-15')).toEqual([]);
+  });
+
+  it('returns empty array when today is empty', () => {
+    expect(resolveSelectableTours(TOURS, '')).toEqual([]);
+  });
+
+  it('returns empty array when no tours have qualifying shows', () => {
+    expect(resolveSelectableTours(TOURS, '2026-04-15')).toEqual([]);
+  });
+});
+
+describe('getTourByKey', () => {
+  it('finds a tour by exact name', () => {
+    const result = getTourByKey(TOURS, 'Spring Tour 2026');
+    expect(result?.tour).toBe('Spring Tour 2026');
+  });
+
+  it('normalizes surrounding whitespace', () => {
+    const result = getTourByKey(TOURS, '  Spring Tour 2026  ');
+    expect(result?.tour).toBe('Spring Tour 2026');
+  });
+
+  it('returns null for an unknown key', () => {
+    expect(getTourByKey(TOURS, 'Unknown Tour')).toBeNull();
+  });
+
+  it('returns null for null showDatesByTour', () => {
+    expect(getTourByKey(null, 'Spring Tour 2026')).toBeNull();
+  });
+
+  it('returns null for null tourKey', () => {
+    expect(getTourByKey(TOURS, null)).toBeNull();
+  });
+
+  it('returns null for empty string tourKey', () => {
+    expect(getTourByKey(TOURS, '')).toBeNull();
+  });
+
+  it('returns null for whitespace-only tourKey', () => {
+    expect(getTourByKey(TOURS, '   ')).toBeNull();
+  });
+});

--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -24,6 +24,7 @@ import {
 import { useStandings } from './useStandings';
 import { computeStandingsSelfRecap } from './standingsSelfRecap';
 import { useStandingsLeaderboardView } from './useStandingsLeaderboardView';
+import { useStandingsTourSelection } from './useStandingsTourSelection';
 import { useStandingsView } from './useStandingsView';
 import { useTourStandings } from './useTourStandings';
 import { useScoringRulesModal } from '../ui/ScoringRulesModalProvider';
@@ -146,11 +147,15 @@ export function useStandingsScreen(selectedDate, options = {}) {
     () => resolveCurrentTour(selectedDate, todayYmd(), showDatesByTour),
     [selectedDate, showDatesByTour],
   );
+
+  const { selectedTour, setTourKey, selectableTours } =
+    useStandingsTourSelection(showDatesByTour);
+
   const {
     leaders: tourLeaders,
     loading: tourLoading,
     error: tourError,
-  } = useTourStandings(view === 'tour' ? currentTour?.shows : null);
+  } = useTourStandings(view === 'tour' ? (selectedTour?.shows ?? null) : null);
 
   const showLabel = useMemo(() => {
     const show = showDates.find((s) => s.date === selectedDate);
@@ -209,6 +214,9 @@ export function useStandingsScreen(selectedDate, options = {}) {
     openScoringRules,
 
     currentTour,
+    selectedTour,
+    setTourKey,
+    selectableTours,
     tourLeaders,
     tourLoading,
     tourError,

--- a/src/features/scoring/model/useStandingsTourSelection.js
+++ b/src/features/scoring/model/useStandingsTourSelection.js
@@ -1,0 +1,78 @@
+import { useCallback, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import { todayYmd } from '../../../shared/utils/dateUtils';
+import { getTourByKey, resolveSelectableTours } from './resolveSelectableTours';
+
+/**
+ * URL-synced tour selection for the standings Tour view (#295).
+ *
+ * Owns the `?tour=<tourKey>` query param so the selected past tour survives
+ * navigation and browser refresh. Mirrors the pattern of {@link useStandingsView}:
+ *
+ *   1. Derive selectable tours via {@link resolveSelectableTours} (post-launch
+ *      shows on or before today, sorted newest last-show-date first).
+ *   2. Resolve the selected tour from `?tour=` — defaults to the first
+ *      selectable tour (current / most-recent) when the param is absent.
+ *   3. Self-heal: if `?tour=` holds a key that no longer matches any
+ *      selectable tour, drop the param so the URL always reflects reality.
+ *
+ * The default (first) tour deliberately omits the `?tour=` param from the
+ * URL to keep canonical URLs clean — same convention as `?view=show` for
+ * {@link useStandingsView}.
+ *
+ * @param {Array<{ tour: string, shows: Array<{ date: string }> }> | null | undefined} showDatesByTour
+ * @returns {{
+ *   selectedTour: { tour: string, shows: Array<{ date: string }> } | null,
+ *   setTourKey: (tourKey: string) => void,
+ *   selectableTours: Array<{ tour: string, shows: Array<{ date: string }> }>,
+ * }}
+ */
+export function useStandingsTourSelection(showDatesByTour) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const rawTour = searchParams.get('tour') || '';
+
+  const selectableTours = resolveSelectableTours(showDatesByTour, todayYmd());
+
+  const found = rawTour ? getTourByKey(selectableTours, rawTour) : null;
+  const selectedTour = found ?? selectableTours[0] ?? null;
+
+  // Self-heal: unknown ?tour= key → drop the param
+  useEffect(() => {
+    if (!rawTour) return;
+    const match = getTourByKey(selectableTours, rawTour);
+    if (match) return;
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete('tour');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [rawTour, selectableTours, setSearchParams]);
+
+  const setTourKey = useCallback(
+    (tourKey) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          // Omit the param when selecting the default (first selectable) tour
+          // so canonical URLs stay clean — mirrors how ?view= is omitted for
+          // the DEFAULT_STANDINGS_VIEW in useStandingsView.
+          const defaultKey = selectableTours[0]?.tour ?? '';
+          if (!tourKey || tourKey === defaultKey) {
+            next.delete('tour');
+          } else {
+            next.set('tour', tourKey);
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams, selectableTours],
+  );
+
+  return { selectedTour, setTourKey, selectableTours };
+}

--- a/src/features/scoring/ui/StandingsTourView.jsx
+++ b/src/features/scoring/ui/StandingsTourView.jsx
@@ -2,12 +2,15 @@ import React from 'react';
 
 import Card from '../../../shared/ui/Card';
 import PageTitle from '../../../shared/ui/PageTitle';
+import TourPicker from './TourPicker';
 import TourStandingsSection from './TourStandingsSection';
 
 /**
- * Standings tour-view composition. Renders either an empty state (no
- * tour scheduled yet) or the tour-standings section. Pure presentational
- * — all state comes from `useStandingsScreen`.
+ * Standings tour-view composition. Renders either an empty state (no tours
+ * with graded data yet) or the tour-standings section, optionally preceded by
+ * the "Past tours" picker when multiple tours are selectable (#295).
+ *
+ * Pure presentational — all state comes from `useStandingsScreen`.
  */
 export default function StandingsTourView({
   tourName,
@@ -15,6 +18,9 @@ export default function StandingsTourView({
   loading,
   error,
   hasCurrentTour,
+  selectableTours,
+  selectedTourKey,
+  onSelectTour,
 }) {
   if (!hasCurrentTour) {
     return (
@@ -30,11 +36,18 @@ export default function StandingsTourView({
     );
   }
   return (
-    <TourStandingsSection
-      tourName={tourName}
-      leaders={leaders}
-      loading={loading}
-      error={error}
-    />
+    <>
+      <TourPicker
+        tours={selectableTours ?? []}
+        selectedTourKey={selectedTourKey}
+        onSelect={onSelectTour}
+      />
+      <TourStandingsSection
+        tourName={tourName}
+        leaders={leaders}
+        loading={loading}
+        error={error}
+      />
+    </>
   );
 }

--- a/src/features/scoring/ui/TourPicker.jsx
+++ b/src/features/scoring/ui/TourPicker.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import FilterPill from '../../../shared/ui/FilterPill';
+
+/**
+ * Tour selection UI for the "Past tours" picker (#295).
+ *
+ * Renders nothing when there is only one (or zero) tours to choose from —
+ * the single-tour case needs no picker UI.
+ *
+ * Responsive:
+ *   - Mobile (< md): native `<select>` for compact, accessible selection.
+ *   - Desktop (≥ md): horizontal pill/chip group matching the pool picker
+ *     pattern in {@link StandingsPoolPicker}.
+ *
+ * @param {{
+ *   tours: Array<{ tour: string }>,
+ *   selectedTourKey: string | null | undefined,
+ *   onSelect: (tourKey: string) => void,
+ *   className?: string,
+ * }} props
+ */
+export default function TourPicker({ tours, selectedTourKey, onSelect, className = '' }) {
+  if (!Array.isArray(tours) || tours.length <= 1) return null;
+
+  const activeKey = selectedTourKey ?? tours[0]?.tour ?? '';
+
+  return (
+    <div className={['mb-4', className].filter(Boolean).join(' ')}>
+      {/* Mobile: native select */}
+      <select
+        className="md:hidden w-full rounded-xl border border-border-subtle bg-surface-panel px-3 py-2 text-sm font-semibold text-white focus:outline-none focus:ring-2 focus:ring-brand"
+        value={activeKey}
+        onChange={(e) => onSelect(e.target.value)}
+        aria-label="Select tour"
+      >
+        {tours.map((t) => (
+          <option key={t.tour} value={t.tour}>
+            {t.tour}
+          </option>
+        ))}
+      </select>
+
+      {/* Desktop: pill group */}
+      <div
+        className="hidden md:flex flex-wrap gap-1.5 px-1"
+        role="group"
+        aria-label="Select tour"
+      >
+        {tours.map((t) => (
+          <FilterPill
+            key={t.tour}
+            selected={activeKey === t.tour}
+            onClick={() => onSelect(t.tour)}
+          >
+            {t.tour}
+          </FilterPill>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/pools/PoolHubPage.jsx
+++ b/src/pages/pools/PoolHubPage.jsx
@@ -37,6 +37,9 @@ export default function PoolHubPage({ user }) {
     loading: standingsLoading,
     scope: standingsScope,
     setScope: setStandingsScope,
+    selectableTours: standingsSelectableTours,
+    selectedTourKey: standingsSelectedTourKey,
+    setTourKey: setStandingsTourKey,
     tourName: standingsTourName,
     tourAvailable: standingsTourAvailable,
   } = usePoolStandingsSection(poolId, pool, members);
@@ -168,6 +171,9 @@ export default function PoolHubPage({ user }) {
           onScopeChange={setStandingsScope}
           tourName={standingsTourName}
           tourAvailable={standingsTourAvailable}
+          selectableTours={standingsSelectableTours}
+          selectedTourKey={standingsSelectedTourKey}
+          onSelectTour={setStandingsTourKey}
         />
         <PoolHubShowArchive poolId={poolId} />
       </div>

--- a/src/pages/standings/StandingsPage.jsx
+++ b/src/pages/standings/StandingsPage.jsx
@@ -31,11 +31,14 @@ export default function StandingsPage({ selectedDate, onSelectShowDate }) {
 
       {screen.view === 'tour' ? (
         <StandingsTourView
-          tourName={screen.currentTour?.tour}
+          tourName={screen.selectedTour?.tour}
           leaders={screen.tourLeaders}
           loading={screen.tourLoading}
           error={screen.tourError}
-          hasCurrentTour={Boolean(screen.currentTour)}
+          hasCurrentTour={Boolean(screen.selectedTour)}
+          selectableTours={screen.selectableTours}
+          selectedTourKey={screen.selectedTour?.tour ?? null}
+          onSelectTour={screen.setTourKey}
         />
       ) : (
         <StandingsShowOrPoolView screen={screen} />


### PR DESCRIPTION
## Summary

- Adds a **Past tours picker** to both the global standings Tour view (`/dashboard/standings?view=tour`) and the pool hub standings section, letting users browse standings for any completed tour.
- New pure helpers `resolveSelectableTours` + `getTourByKey` (17 unit tests) filter and sort the `show_calendar.showDatesByTour` array to post-launch tours with at least one show on-or-before today.
- New `useStandingsTourSelection` hook manages `?tour=<key>` URL state with the same self-heal + canonical-URL patterns as `useStandingsView`.
- New responsive `TourPicker` component: native `<select>` on mobile, pill/chip group on desktop (hidden when only one tour is available).
- Pool hub uses local state (not URL) for tour selection, as specified.

## Architecture

- Strict FSD: no cross-feature deep imports — `TourPicker`, `resolveSelectableTours`, `getTourByKey`, and `useStandingsTourSelection` are all exported from `features/scoring/index.js`.
- The data path (`useTourStandings(tourShows)`) is unchanged — it already accepts any tour's shows array.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 226 tests pass (17 new for `resolveSelectableTours` / `getTourByKey`)
- [x] `npm run verify:dashboard-meta` — 12 cases OK
- [x] `npm run verify:dashboard-ui` — ok

Closes #295

Made with [Cursor](https://cursor.com)