### PR TITLE
feat(seo): public marketing routes /how-it-works and /how-scoring-works (#339)

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -19,4 +19,6 @@
 ## Links
 
 - Home: https://www.setlistpickem.com/
+- How It Works: https://www.setlistpickem.com/how-it-works
+- How Scoring Works: https://www.setlistpickem.com/how-scoring-works
 - Setlist data: https://phish.net (The Mockingbird Foundation)

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,4 +5,14 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://www.setlistpickem.com/how-it-works</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.setlistpickem.com/how-scoring-works</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -17,6 +17,8 @@ const PoolInviteMissingCodePage = lazy(() =>
   import('../pages/pool-invite/PoolInviteMissingCodePage')
 );
 const PoolInvitePage = lazy(() => import('../pages/pool-invite/PoolInvitePage'));
+const HowItWorksPage = lazy(() => import('../pages/marketing/HowItWorksPage'));
+const HowScoringWorksPage = lazy(() => import('../pages/marketing/HowScoringWorksPage'));
 const PrivacyPolicyPage = lazy(() => import('../pages/legal/PrivacyPolicyPage'));
 const TermsOfServicePage = lazy(() => import('../pages/legal/TermsOfServicePage'));
 const SetupRoute = lazy(() => import('./routes/SetupRoute'));
@@ -31,6 +33,10 @@ function App() {
 
         {/* Public player profile (e.g. from leaderboard links) */}
         <Route path="/user/:userId" element={<PublicProfilePage />} />
+
+        {/* Marketing / educational pages — public, crawlable, no auth */}
+        <Route path="/how-it-works" element={<HowItWorksPage />} />
+        <Route path="/how-scoring-works" element={<HowScoringWorksPage />} />
 
         {/* Legal pages — public, no auth (required for GCP OAuth consent screen) */}
         <Route path="/privacy" element={<PrivacyPolicyPage />} />

--- a/src/features/landing/index.js
+++ b/src/features/landing/index.js
@@ -1,4 +1,6 @@
+export { default as HowItWorksPageContent } from './ui/HowItWorksPageContent';
 export { default as LandingSeo } from './ui/LandingSeo';
+export { default as MarketingPageShell } from './ui/MarketingPageShell';
 export { default as SplashAboutSection } from './ui/SplashAboutSection';
 export { default as SplashAuthModals } from './ui/SplashAuthModals';
 export { default as SplashGetStartedSection } from './ui/SplashGetStartedSection';

--- a/src/features/landing/ui/HowItWorksPageContent.jsx
+++ b/src/features/landing/ui/HowItWorksPageContent.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowRight } from 'lucide-react';
+
+/**
+ * Standalone "How It Works" content for the `/how-it-works` public page.
+ * Mirrors `SplashHowItWorksSection` but replaces the scoring-rules modal
+ * trigger with a direct `<Link>` to `/how-scoring-works`, so this component
+ * can render without a `ScoringRulesModalProvider`.
+ */
+export default function HowItWorksPageContent() {
+  return (
+    <section className="relative z-10 w-full bg-slate-50 py-20 md:py-24 lg:py-32">
+      <div className="w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h1 className="mb-4 text-center font-display text-display-lg font-bold text-slate-900 md:text-display-lg-lg">
+          How to Play Setlist Pick&apos;Em
+        </h1>
+        <p className="mb-12 text-center text-slate-600 text-lg max-w-2xl mx-auto">
+          The free live setlist prediction game for Phish fans. Lock your picks before the lights
+          go down and compete in real-time as songs are played.
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 lg:gap-8">
+          <div className="rounded-2xl bg-white p-6 md:p-8 shadow-xl shadow-slate-200/50 ring-1 ring-slate-100 flex flex-col items-center text-center md:items-start md:text-left transition-transform hover:-translate-y-1 hover:shadow-2xl hover:shadow-slate-200/60 duration-300">
+            <div className="w-12 h-12 rounded-full bg-emerald-100 flex items-center justify-center text-emerald-600 font-black shrink-0 text-xl mb-5">1</div>
+            <h2 className="font-bold text-xl text-slate-900 mb-3">Lock It In</h2>
+            <p className="text-slate-600 leading-relaxed">
+              Pick openers, closers, encore and wildcard before showtime. Earn points for correct
+              picks, higher points for exact slot picks, plus a Bustout Boost&trade; for calling longshots.
+            </p>
+            <Link
+              to="/how-scoring-works"
+              className="mt-4 inline-flex items-center gap-1 rounded-md text-sm font-bold text-emerald-700 underline underline-offset-4 decoration-emerald-300 transition-colors hover:text-emerald-800 hover:decoration-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue"
+            >
+              Learn how scoring works
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Link>
+          </div>
+          <div className="rounded-2xl bg-white p-6 md:p-8 shadow-xl shadow-slate-200/50 ring-1 ring-slate-100 flex flex-col items-center text-center md:items-start md:text-left transition-transform hover:-translate-y-1 hover:shadow-2xl hover:shadow-slate-200/60 duration-300">
+            <div className="w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center text-blue-600 font-black shrink-0 text-xl mb-5">2</div>
+            <h2 className="font-bold text-xl text-slate-900 mb-3">Watch It Unfold</h2>
+            <p className="text-slate-600 leading-relaxed">
+              Live scores and standings update in real-time as songs are played. See your picks and
+              everyone else&apos;s light up the leaderboard.
+            </p>
+          </div>
+          <div className="rounded-2xl bg-white p-6 md:p-8 shadow-xl shadow-slate-200/50 ring-1 ring-slate-100 flex flex-col items-center text-center md:items-start md:text-left transition-transform hover:-translate-y-1 hover:shadow-2xl hover:shadow-slate-200/60 duration-300">
+            <div className="w-12 h-12 rounded-full bg-purple-100 flex items-center justify-center text-purple-600 font-black shrink-0 text-xl mb-5">3</div>
+            <h2 className="font-bold text-xl text-slate-900 mb-3">Claim the Crown</h2>
+            <p className="text-slate-600 leading-relaxed">
+              Challenge friends in private pools and compete in global standings with everyone
+              playing that night. See all-time stats in private pools to compete across tours and years.
+            </p>
+          </div>
+        </div>
+        <div className="mt-14 flex justify-center">
+          <Link
+            to="/"
+            className="inline-flex items-center gap-2 rounded-xl bg-brand-primary px-10 py-3.5 text-base font-bold text-white shadow-[0_10px_20px_-10px_rgba(16,185,129,0.5)] transition-all hover:bg-brand-primary-hover hover:shadow-[0_15px_30px_-15px_rgba(16,185,129,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue"
+          >
+            Play for Free
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/landing/ui/MarketingPageShell.jsx
+++ b/src/features/landing/ui/MarketingPageShell.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { ChevronLeft } from 'lucide-react';
+
+import {
+  BRAND_SPLASH_HEADER_VINYL_MARK_SRC,
+  brandSplashHeaderVinylMarkImgClassNames,
+} from '../../../shared/config/branding';
+
+/**
+ * Minimal shell for standalone marketing / educational pages
+ * (`/how-it-works`, `/how-scoring-works`). Provides a sticky header with home
+ * link and a simple footer — no auth logic, no scroll machinery.
+ */
+export default function MarketingPageShell({ children }) {
+  return (
+    <div className="relative flex min-h-screen w-full flex-col bg-transparent text-white">
+      <header className="sticky top-0 z-50 flex h-[5.35rem] items-center border-b border-white/5 bg-brand-bg/80 backdrop-blur-lg sm:h-[5.25rem]">
+        <div className="flex w-full max-w-5xl mx-auto items-center justify-between px-4 sm:px-6 lg:px-8">
+          <Link
+            to="/"
+            aria-label="Setlist Pick \'Em — back to home"
+            className="flex items-center gap-2 outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue rounded-md"
+          >
+            <img
+              src={BRAND_SPLASH_HEADER_VINYL_MARK_SRC}
+              alt="Setlist Pick \'Em"
+              width={36}
+              height={36}
+              decoding="async"
+              className={brandSplashHeaderVinylMarkImgClassNames}
+            />
+            <span className="hidden sm:block font-display font-bold text-white text-base tracking-tight">
+              Setlist Pick&nbsp;&apos;Em
+            </span>
+          </Link>
+          <Link
+            to="/"
+            className="inline-flex items-center gap-1 text-sm font-semibold text-slate-400 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue rounded-sm"
+          >
+            <ChevronLeft className="h-4 w-4" aria-hidden />
+            Back to Home
+          </Link>
+        </div>
+      </header>
+      <main className="flex-1 w-full">{children}</main>
+      <footer className="relative z-10 border-t border-slate-800/60 bg-transparent px-4 py-6 text-center text-xs font-medium leading-relaxed text-slate-500 sm:px-6 lg:px-8">
+        <p>&copy; {new Date().getFullYear()} Road2 Media, LLC. All rights reserved.</p>
+        <p className="mt-1">
+          Song and setlist data provided by{' '}
+          <a
+            href="https://phish.net"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400"
+          >
+            The Mockingbird Foundation / Phish.Net
+          </a>
+          .
+        </p>
+        <p className="mt-2 space-x-3">
+          <Link to="/how-it-works" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400">How It Works</Link>
+          <Link to="/how-scoring-works" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400">How Scoring Works</Link>
+          <Link to="/privacy" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400">Privacy Policy</Link>
+          <Link to="/terms" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400">Terms of Service</Link>
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/src/features/landing/ui/SplashPageShell.jsx
+++ b/src/features/landing/ui/SplashPageShell.jsx
@@ -74,6 +74,18 @@ export default function SplashPageShell({
           </p>
           <p className="mt-2 space-x-3">
             <Link
+              to="/how-it-works"
+              className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400"
+            >
+              How It Works
+            </Link>
+            <Link
+              to="/how-scoring-works"
+              className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400"
+            >
+              How Scoring Works
+            </Link>
+            <Link
               to="/privacy"
               className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400"
             >

--- a/src/pages/marketing/HowItWorksPage.jsx
+++ b/src/pages/marketing/HowItWorksPage.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+
+import { HowItWorksPageContent, MarketingPageShell } from '../../features/landing';
+import { SEO_CONFIG } from '../../shared/config/seo';
+
+const PAGE_TITLE = "How to Play Setlist Pick\'Em | The Live Music Prediction Game";
+const PAGE_DESCRIPTION =
+  "Learn how Setlist Pick\'Em works: lock your song picks before showtime, score points for openers, closers, encore, and wildcard predictions, and compete live on the leaderboard.";
+const CANONICAL_URL = `${SEO_CONFIG.siteUrl}/how-it-works`;
+
+const HOW_IT_WORKS_JSON_LD = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebPage',
+      '@id': CANONICAL_URL,
+      url: CANONICAL_URL,
+      name: PAGE_TITLE,
+      description: PAGE_DESCRIPTION,
+      isPartOf: { '@id': `${SEO_CONFIG.siteUrl}/#website` },
+    },
+    {
+      '@type': 'HowTo',
+      name: "How to play Setlist Pick\'Em",
+      description: PAGE_DESCRIPTION,
+      step: [
+        { '@type': 'HowToStep', position: 1, name: 'Lock It In', text: 'Pick openers, closers, encore, and a wildcard before showtime. Earn points for correct picks, higher points for exact slot picks, plus a Bustout Boost for calling longshots.' },
+        { '@type': 'HowToStep', position: 2, name: 'Watch It Unfold', text: "Live scores and standings update in real-time as songs are played. See your picks and everyone else's light up the leaderboard." },
+        { '@type': 'HowToStep', position: 3, name: 'Claim the Crown', text: 'Challenge friends in private pools and compete in global standings with everyone playing that night.' },
+      ],
+    },
+  ],
+};
+
+export default function HowItWorksPage() {
+  return (
+    <>
+      <Helmet>
+        <title>{PAGE_TITLE}</title>
+        <meta name="description" content={PAGE_DESCRIPTION} />
+        <meta name="author" content={SEO_CONFIG.publisherName} />
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={PAGE_TITLE} />
+        <meta property="og:description" content={PAGE_DESCRIPTION} />
+        <meta property="og:url" content={CANONICAL_URL} />
+        <meta property="og:image" content={SEO_CONFIG.ogImageUrl} />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta property="og:image:alt" content="Setlist Pick \'Em — live setlist prediction game" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={PAGE_TITLE} />
+        <meta name="twitter:description" content={PAGE_DESCRIPTION} />
+        <meta name="twitter:image" content={SEO_CONFIG.ogImageUrl} />
+        <link rel="canonical" href={CANONICAL_URL} />
+        <script type="application/ld+json">{JSON.stringify(HOW_IT_WORKS_JSON_LD)}</script>
+      </Helmet>
+      <MarketingPageShell>
+        <HowItWorksPageContent />
+      </MarketingPageShell>
+    </>
+  );
+}

--- a/src/pages/marketing/HowScoringWorksPage.jsx
+++ b/src/pages/marketing/HowScoringWorksPage.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+
+import { ScoringRulesContent } from '../../features/scoring';
+import { MarketingPageShell } from '../../features/landing';
+import { SEO_CONFIG } from '../../shared/config/seo';
+import { SCORING_RULES } from '../../shared/utils/scoring';
+
+const {
+  EXACT_SLOT,
+  ENCORE_EXACT,
+  IN_SETLIST,
+  WILDCARD_HIT,
+  BUSTOUT_BOOST,
+  BUSTOUT_MIN_GAP,
+} = SCORING_RULES;
+
+const PAGE_TITLE = "How Scoring Works | Setlist Pick\'Em";
+const PAGE_DESCRIPTION = `Setlist Pick\'Em scoring guide: In setlist (${IN_SETLIST} pts), exact slot (${EXACT_SLOT} pts), wildcard (${WILDCARD_HIT} pts), encore (${ENCORE_EXACT} pts), plus a Bustout Boost of ${BUSTOUT_BOOST} points for songs with a ${BUSTOUT_MIN_GAP}+ show gap.`;
+const CANONICAL_URL = `${SEO_CONFIG.siteUrl}/how-scoring-works`;
+
+const HOW_SCORING_JSON_LD = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    { '@type': 'WebPage', '@id': CANONICAL_URL, url: CANONICAL_URL, name: PAGE_TITLE, description: PAGE_DESCRIPTION, isPartOf: { '@id': `${SEO_CONFIG.siteUrl}/#website` } },
+    {
+      '@type': 'FAQPage',
+      mainEntity: [
+        { '@type': 'Question', name: 'How many points do I get for an in-setlist pick?', acceptedAnswer: { '@type': 'Answer', text: `If your pick is played anywhere in the setlist but not in the exact slot you chose, you earn ${IN_SETLIST} points.` } },
+        { '@type': 'Question', name: 'How many points for an exact slot pick?', acceptedAnswer: { '@type': 'Answer', text: `If your pick lands in the exact slot you selected (Set 1 opener/closer or Set 2 opener/closer), you earn ${EXACT_SLOT} points.` } },
+        { '@type': 'Question', name: 'How many points for the wildcard?', acceptedAnswer: { '@type': 'Answer', text: `If your wildcard pick is played anywhere in the show, you earn ${WILDCARD_HIT} points.` } },
+        { '@type': 'Question', name: 'How many points for an encore pick?', acceptedAnswer: { '@type': 'Answer', text: `If your pick is played during the encore, you earn ${ENCORE_EXACT} points — the highest base score because the encore is the toughest call.` } },
+        { '@type': 'Question', name: 'What is the Bustout Boost?', acceptedAnswer: { '@type': 'Answer', text: `Correct picks on songs with a ${BUSTOUT_MIN_GAP}+ show gap earn a bonus ${BUSTOUT_BOOST} points on top of base points — rewarding strategic picks over heavy rotation songs.` } },
+      ],
+    },
+  ],
+};
+
+export default function HowScoringWorksPage() {
+  return (
+    <>
+      <Helmet>
+        <title>{PAGE_TITLE}</title>
+        <meta name="description" content={PAGE_DESCRIPTION} />
+        <meta name="author" content={SEO_CONFIG.publisherName} />
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={PAGE_TITLE} />
+        <meta property="og:description" content={PAGE_DESCRIPTION} />
+        <meta property="og:url" content={CANONICAL_URL} />
+        <meta property="og:image" content={SEO_CONFIG.ogImageUrl} />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta property="og:image:alt" content="Setlist Pick \'Em — live setlist prediction game" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={PAGE_TITLE} />
+        <meta name="twitter:description" content={PAGE_DESCRIPTION} />
+        <meta name="twitter:image" content={SEO_CONFIG.ogImageUrl} />
+        <link rel="canonical" href={CANONICAL_URL} />
+        <script type="application/ld+json">{JSON.stringify(HOW_SCORING_JSON_LD)}</script>
+      </Helmet>
+      <MarketingPageShell>
+        <div className="w-full max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-24">
+          <ScoringRulesContent />
+        </div>
+      </MarketingPageShell>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Implements [#339](https://github.com/pat792/set-picks/issues/339) — dedicated public routes for marketing/educational content to improve SEO and shareability.

### Routes added

- **`/how-it-works`** — Standalone "How to Play" page with full game format explanation (3-step cards: Lock It In → Watch It Unfold → Claim the Crown). Links to `/how-scoring-works` instead of opening the modal.
- **`/how-scoring-works`** — Standalone scoring rules page, reusing `ScoringRulesContent` in a minimal public shell.

Both pages have:
- Unique `<Helmet>` `title`, `description`, `canonical`, and `og:` / `twitter:` tags
- `WebPage` + `HowTo`/`FAQPage` JSON-LD structured data
- Lazy-loaded via `React.lazy()` in `App.jsx`
- No auth required

### Other changes

- `MarketingPageShell` — minimal sticky header (logo + "Back to Home") + footer shared by both pages
- `HowItWorksPageContent` — standalone version of the how-it-works section (no `ScoringRulesModalProvider` dependency)
- `public/sitemap.xml` — new entries for both routes (priority 0.8, monthly)
- `public/llms.txt` — links added
- `SplashPageShell` footer — "How It Works" and "How Scoring Works" links added alongside Privacy/Terms

## Test plan

- [ ] `npm run lint` — passes
- [ ] `npm test` — 209 tests pass
- [ ] `npm run verify:dashboard-meta` — passes
- [ ] `npm run verify:dashboard-ui` — passes
- [ ] Navigate to `/how-it-works` — page renders with correct heading and 3 cards
- [ ] "Learn how scoring works" link on `/how-it-works` navigates to `/how-scoring-works`
- [ ] Navigate to `/how-scoring-works` — scoring rules content renders correctly
- [ ] "Back to Home" link returns to splash
- [ ] Splash page footer shows "How It Works" and "How Scoring Works" links
- [ ] View page source / inspect `<head>` — canonical, og:tags, JSON-LD present

Closes #339