### PR TITLE
chore: set up Cloud dev environment + correct AGENTS.md dev notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,15 +4,19 @@
 
 ### Environment
 
-- **Node.js 24** is required (Cloud Functions `engines.node: "24"`). The VM uses `nvm` with Node 24 set as default.
-- **Package manager:** npm (lockfile: `package-lock.json`). Two install targets: root (`/workspace`) and `functions/`.
-- **`.env`** is gitignored. Copy `.env.example` to `.env` for local dev; most values can stay empty/default.
+- **Node.js 24** is needed for Cloud Functions (`engines.node: "24"`). `nvm install 24` provides it. Caveat: a daemon-managed `node` at `/exec-daemon/node` (Node 22) sits ahead of `nvm` on `PATH`, so a bare `node` is v22. For Functions work prepend the nvm bin first: `export PATH="$HOME/.nvm/versions/node/v24.17.0/bin:$PATH"`. Root web app (Vite 4 / Vitest) runs fine on Node 22 too; only deploy/Functions strictly want 24.
+- **Package manager:** npm (lockfile: `package-lock.json`). Two install targets: root (`/workspace`) and `functions/` — both have their own lockfile.
+- **`.env`** is gitignored. Copy `.env.example` to `.env` for local dev. The `VITE_FIREBASE_*` config plus `QA_TEST_EMAIL` / `QA_TEST_PASSWORD` are injected as Cloud Agent secrets (env vars) and Vite picks them up automatically — you do not need to add them to `.env`.
 
 ### Running the application
 
 - **Dev server:** `npm run dev` — Vite on `http://localhost:5173` (`strictPort: true`; free that port or it will fail).
 - The app connects to the **remote Firebase project** (Firestore, Auth, Storage). There is no local emulator-first workflow for the SPA.
-- App Check is auto-disabled in dev mode (`FIREBASE_APPCHECK_DEBUG_TOKEN = true` when `import.meta.env.DEV`).
+- **App Check is NOT actually disabled in dev.** `src/shared/lib/firebaseAppCheck.js` sets `self.FIREBASE_APPCHECK_DEBUG_TOKEN = true`, which makes Firebase mint a fresh, *unregistered* debug token → the App Check exchange returns **403** and Firestore/Auth-backed flows (sign-in, sign-up, picks, pools) fail. To make signed-in flows work on localhost, seed the **pre-registered** debug token (`38422efd-029f-45b4-b028-7cf7fcaeeffc`, from `docs/TESTING.md`) into IndexedDB once, then reload: load the page, then in DevTools console run
+  `indexedDB.open('firebase-app-check-database',1).onsuccess=e=>{const tx=e.target.result.transaction('firebase-app-check-store','readwrite');tx.objectStore('firebase-app-check-store').put({compositeKey:'debug-token',value:'38422efd-029f-45b4-b028-7cf7fcaeeffc'});}`
+  and reload. The token persists in that browser profile. (The `true` branch reuses an IndexedDB-stored token if one exists, so seeding wins.)
+- **Test account:** sign in with `QA_TEST_EMAIL` / `QA_TEST_PASSWORD` (injected secrets) instead of creating throwaway accounts you cannot delete (the cleanup protocol in `docs/TESTING.md` needs Firebase Console access).
+- **Firebase Storage `song-catalog.json` returns 402 (Payment Required)** on the current project (billing state). This is non-blocking: the song-search autocomplete falls back to the bundled static catalog, and Firestore (the actual game data) is unaffected. Ignore 402s from `firebasestorage.googleapis.com`; only worry about non-200s from `firestore.googleapis.com`.
 
 ### Lint / Test / Build (CI matrix)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified the Cloud Agent development environment for the Setlist Pick 'Em SPA + Cloud Functions, and corrected a few non-obvious, inaccurate notes in `AGENTS.md` discovered during setup.

Environment work (no app code changed):
- Installed Node 24 via `nvm` and root + `functions/` npm deps.
- Verified the full local CI matrix, a production build, and the dev server.
- Ran the app end-to-end against the remote Firebase project and completed a core-functionality "hello world" (created an account, made setlist picks, created a pool).

`AGENTS.md` corrections (only file changed):
- **App Check is not actually disabled in dev.** The dev path mints an *unregistered* debug token → App Check `403`, breaking signed-in flows. Documented seeding the pre-registered debug token (`38422efd-…`) into IndexedDB to make localhost signed-in flows work.
- **Node 24 PATH caveat:** `/exec-daemon/node` (v22) shadows `nvm` on `PATH`; prepend the nvm bin for Functions work.
- **Firebase Storage `song-catalog.json` returns `402`** (project billing) — non-blocking; autocomplete falls back to the bundled catalog and Firestore is unaffected.
- Noted `QA_TEST_EMAIL` / `QA_TEST_PASSWORD` + `VITE_FIREBASE_*` are injected as secrets.

## Test plan

- ✅ `npm run lint`
- ✅ `npm test` (209 passed)
- ✅ `npm run verify:dashboard-meta`
- ✅ `npm run verify:dashboard-ui`
- ✅ `cd functions && npm test` (161 passed)
- ✅ `npm run build`
- ✅ `npm run dev` → signed-in flow: account creation, picks saved + persisted (Firestore `200`), pool created + persisted
- ⚠️ `npm run test:rules` not run (needs global `firebase-tools` + emulator; out of scope, not in regular CI matrix)
- ⚠️ `npm run qa:chunks` / `npm run qa:cache` not run (need Playwright Chromium + `.env.qa.local`)

Update script (VM startup dependency refresh):
```
npm ci
npm ci --prefix functions
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3c1f913-da92-44c2-ac0e-076f9488c342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3c1f913-da92-44c2-ac0e-076f9488c342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

