### PR TITLE
feat(comms): per-user daily email fatigue cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.8.0] — 2026-07-02
+
+### Added
+- **Per-user daily email fatigue cap (#453)** — at most one discretionary email per user per `America/Los_Angeles` day, enforced transactionally via a new `email_cap:{uid}:{day}` doc-id shape inside the existing `fcm_notification_log` collection (no new collection/rules entry). Checked in `commsEmailWorker.js` after the suppression check, before the real Resend send; fails open on transaction errors so a Firestore hiccup can never silently swallow a legitimate email.
+- `account_welcome` is exempt from the cap (one-time-ever send, can't cause fatigue).
+- New `comms_capped` structured log event (Cloud Logging, not yet GA4 — see epic #441) fired when a trigger's email is skipped due to the cap.
+
+### Changed
+- **Known limitation:** the cap is first-reservation-wins (whichever trigger's email worker runs first that day keeps the slot) rather than a true priority queue — a higher-value trigger firing later in the day cannot preempt an already-sent lower-value one, since an email can't be unsent. In practice this means the two morning crons (`tour_rankings_daily` 8am PT, `tour_countdown` 9am PT) will usually win over the evening-firing `tour_engagement_reminder` on a contested day. Revisit if `comms_capped` data shows this ordering is hurting engagement.
+
+---
+
 ## [1.7.2] — 2026-07-02
 
 ### Changed
@@ -135,7 +147,8 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
-[Unreleased]: https://github.com/pat792/set-picks/compare/v1.7.2...HEAD
+[Unreleased]: https://github.com/pat792/set-picks/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/pat792/set-picks/compare/v1.7.2...v1.8.0
 [1.7.2]: https://github.com/pat792/set-picks/compare/v1.7.1...v1.7.2
 [1.7.1]: https://github.com/pat792/set-picks/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/pat792/set-picks/compare/v1.6.0...v1.7.0

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.7.1  
+**Version:** 1.8.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 
@@ -71,6 +71,8 @@ Stores per-user, per-show slot picks and computed scores.
 ### 1.7 `fcm_notification_log/{dedupId}`
 
 Deduplication log shared by all comms channels. Document ID is the `dedupKey` from the trigger spec (e.g. `welcome:{uid}`). Presence of a doc = trigger already delivered; delete to allow re-send.
+
+Also hosts the per-user daily email fatigue cap (#453): doc ID `email_cap:{uid}:{day}` (`day` = `YYYY-MM-DD` in `America/Los_Angeles`), `{ kind: "email_daily_cap", count, cap, lastTriggerId, lastEmailSentAt }`. Written transactionally by `commsEmailDailyCap.js`. `account_welcome` is exempt and never creates one of these docs. Not a new collection — same server-only rules entry as the dedup docs above.
 
 ### 1.8 `show_calendar` (singleton or subcollection — see `docs/SHOW_CALENDAR_TOUR_LABELS.md`)
 

--- a/functions/commsAdapterRuntime.js
+++ b/functions/commsAdapterRuntime.js
@@ -34,6 +34,7 @@ function createCommsAdapterRuntime({ db, admin, resendApiKey, resendWebhookSecre
   const emailWorker = createCommsEmailWorker({
     resendClient: buildResendClient(resendApiKey, logger),
     db,
+    admin,
     unsubscribeSigningSecret: resendWebhookSecret,
     logger,
   });

--- a/functions/commsEmailDailyCap.js
+++ b/functions/commsEmailDailyCap.js
@@ -1,0 +1,130 @@
+/**
+ * Per-user daily email fatigue cap (#453, epic #441).
+ *
+ * Piggybacks on the existing `fcm_notification_log` collection (already the
+ * shared, server-only comms dedup log — see `commsCatalog.js` dedup keys)
+ * with a new `email_cap:{uid}:{day}` doc-id shape, instead of introducing a
+ * new collection/`firestore.rules` entry. Written transactionally so
+ * concurrent Cloud Function invocations for the same user (e.g. two
+ * different triggers firing near-simultaneously) can't both win the same
+ * day's slot.
+ *
+ * Day boundary is `America/Los_Angeles`, not per-show venue-local time: a
+ * user's inbox isn't tied to a single show/venue (they may follow multiple
+ * tours/timezones, or the trigger may have no show at all), so reusing the
+ * picks-lock per-show timezone would make "today" incoherently different
+ * depending on which trigger is checked. LA also matches the existing daily
+ * batch cron's own anchor (`scheduledTourRankingsDailyComms`).
+ */
+
+"use strict";
+
+const { ymdInTimeZone } = require("./phishnetLiveSetlistAutomation");
+
+const CAP_COLLECTION = "fcm_notification_log";
+const DAY_TIME_ZONE = "America/Los_Angeles";
+const EMAIL_DAILY_CAP = 1;
+
+/**
+ * One-time-ever lifecycle sends can never contribute to fatigue (there's
+ * only ever one) and must never be silently dropped by a same-day
+ * collision with another trigger — this is the highest-trust send a new
+ * user gets.
+ */
+const EXEMPT_TRIGGERS = new Set(["account_welcome"]);
+
+/**
+ * @param {string} triggerId
+ * @returns {boolean}
+ */
+function isExemptFromDailyCap(triggerId) {
+  return EXEMPT_TRIGGERS.has(triggerId);
+}
+
+/**
+ * @param {string} uid
+ * @param {string} day `YYYY-MM-DD` in `DAY_TIME_ZONE`.
+ * @returns {string}
+ */
+function emailDailyCapDocId(uid, day) {
+  if (!uid || !day) return "";
+  return `email_cap:${uid}:${day}`;
+}
+
+/**
+ * Reserve today's one discretionary-email slot for a user.
+ *
+ * - Exempt triggers (`account_welcome`) always return `{allowed: true}`
+ *   without touching Firestore.
+ * - Non-exempt triggers race for the slot transactionally — whichever
+ *   trigger's email worker reserves it first that day wins; later attempts
+ *   for the same `(uid, day)` are capped.
+ * - **Fails open** (`allowed: true, failedOpen: true`) on any transaction
+ *   error. This is a fatigue/UX guard, not a compliance gate — a transient
+ *   Firestore hiccup must never silently swallow a legitimate email (e.g.
+ *   `picks_lock_reminder`, which isn't even email-channel today, or a
+ *   future transactional trigger).
+ *
+ * @param {import("firebase-admin").firestore.Firestore} db
+ * @param {typeof import("firebase-admin")} admin
+ * @param {{ uid: string, triggerId: string, now?: Date, logger?: { warn?: Function } }} params
+ * @returns {Promise<{ allowed: boolean, exempt?: boolean, failedOpen?: boolean, day?: string, winningTriggerId?: string | null }>}
+ */
+async function reserveEmailDailyCapSlot(db, admin, { uid, triggerId, now = new Date(), logger } = {}) {
+  if (isExemptFromDailyCap(triggerId)) {
+    return { allowed: true, exempt: true };
+  }
+  if (!db || !admin || !uid) {
+    return { allowed: true };
+  }
+
+  const day = ymdInTimeZone(now, DAY_TIME_ZONE);
+  const docId = emailDailyCapDocId(uid, day);
+  if (!docId) return { allowed: true };
+  const ref = db.collection(CAP_COLLECTION).doc(docId);
+
+  try {
+    return await db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      const data = snap.exists ? snap.data() || {} : {};
+      const count = typeof data.count === "number" ? data.count : 0;
+
+      if (count >= EMAIL_DAILY_CAP) {
+        return { allowed: false, day, winningTriggerId: data.lastTriggerId || null };
+      }
+
+      tx.set(
+        ref,
+        {
+          kind: "email_daily_cap",
+          uid,
+          day,
+          cap: EMAIL_DAILY_CAP,
+          count: count + 1,
+          lastTriggerId: triggerId,
+          lastEmailSentAt: admin.firestore.FieldValue.serverTimestamp(),
+          createdAt: snap.exists ? data.createdAt || null : admin.firestore.FieldValue.serverTimestamp(),
+        },
+        { merge: true }
+      );
+      return { allowed: true, day };
+    });
+  } catch (error) {
+    logger?.warn?.("reserveEmailDailyCapSlot: transaction failed, failing open", {
+      uid,
+      triggerId,
+      error: error?.message || String(error),
+    });
+    return { allowed: true, failedOpen: true };
+  }
+}
+
+module.exports = {
+  CAP_COLLECTION,
+  DAY_TIME_ZONE,
+  EMAIL_DAILY_CAP,
+  EXEMPT_TRIGGERS,
+  isExemptFromDailyCap,
+  emailDailyCapDocId,
+  reserveEmailDailyCapSlot,
+};

--- a/functions/commsEmailDailyCap.test.js
+++ b/functions/commsEmailDailyCap.test.js
@@ -1,0 +1,170 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  EMAIL_DAILY_CAP,
+  isExemptFromDailyCap,
+  emailDailyCapDocId,
+  reserveEmailDailyCapSlot,
+} = require("./commsEmailDailyCap");
+
+const fakeAdmin = {
+  firestore: { FieldValue: { serverTimestamp: () => "ts" } },
+};
+
+/** Minimal fake Firestore with transaction support (get + set, merge-aware). */
+function makeFakeDb(seed = {}) {
+  const store = new Map(Object.entries(seed));
+  function makeRef(name, id) {
+    const key = `${name}/${id}`;
+    return {
+      _key: key,
+      async get() {
+        return { exists: store.has(key), data: () => store.get(key) };
+      },
+    };
+  }
+  return {
+    _store: store,
+    collection(name) {
+      return { doc: (id) => makeRef(name, id) };
+    },
+    async runTransaction(updateFn) {
+      const tx = {
+        async get(ref) {
+          return ref.get();
+        },
+        set(ref, data, opts) {
+          const prev = store.get(ref._key) || {};
+          store.set(ref._key, opts?.merge ? { ...prev, ...data } : data);
+        },
+      };
+      return updateFn(tx);
+    },
+  };
+}
+
+test("EMAIL_DAILY_CAP is 1", () => {
+  assert.equal(EMAIL_DAILY_CAP, 1);
+});
+
+test("isExemptFromDailyCap: only account_welcome is exempt", () => {
+  assert.equal(isExemptFromDailyCap("account_welcome"), true);
+  assert.equal(isExemptFromDailyCap("tour_rankings_daily"), false);
+  assert.equal(isExemptFromDailyCap("tour_countdown"), false);
+});
+
+test("emailDailyCapDocId builds the expected doc-id shape", () => {
+  assert.equal(emailDailyCapDocId("u1", "2026-07-18"), "email_cap:u1:2026-07-18");
+  assert.equal(emailDailyCapDocId("", "2026-07-18"), "");
+  assert.equal(emailDailyCapDocId("u1", ""), "");
+});
+
+test("account_welcome is always exempt and never touches Firestore", async () => {
+  const throwingDb = {
+    collection() {
+      throw new Error("should not be called for an exempt trigger");
+    },
+  };
+  const res = await reserveEmailDailyCapSlot(throwingDb, fakeAdmin, {
+    uid: "u1",
+    triggerId: "account_welcome",
+  });
+  assert.deepEqual(res, { allowed: true, exempt: true });
+});
+
+test("first attempt for a user/day reserves the slot", async () => {
+  const db = makeFakeDb();
+  const now = new Date("2026-07-18T20:00:00-07:00");
+  const res = await reserveEmailDailyCapSlot(db, fakeAdmin, {
+    uid: "u1",
+    triggerId: "tour_countdown",
+    now,
+  });
+  assert.equal(res.allowed, true);
+  assert.equal(res.day, "2026-07-18");
+  const stored = db._store.get("fcm_notification_log/email_cap:u1:2026-07-18");
+  assert.equal(stored.count, 1);
+  assert.equal(stored.lastTriggerId, "tour_countdown");
+  assert.equal(stored.cap, EMAIL_DAILY_CAP);
+});
+
+test("second non-exempt trigger the same day is capped, reports the winner", async () => {
+  const db = makeFakeDb();
+  const now = new Date("2026-07-18T20:00:00-07:00");
+  const first = await reserveEmailDailyCapSlot(db, fakeAdmin, {
+    uid: "u1",
+    triggerId: "tour_engagement_reminder",
+    now,
+  });
+  assert.equal(first.allowed, true);
+
+  const second = await reserveEmailDailyCapSlot(db, fakeAdmin, {
+    uid: "u1",
+    triggerId: "tour_rankings_daily",
+    now: new Date("2026-07-18T23:00:00-07:00"),
+  });
+  assert.equal(second.allowed, false);
+  assert.equal(second.winningTriggerId, "tour_engagement_reminder");
+});
+
+test("a new America/Los_Angeles day resets the cap", async () => {
+  const db = makeFakeDb();
+  const day1 = await reserveEmailDailyCapSlot(db, fakeAdmin, {
+    uid: "u1",
+    triggerId: "tour_countdown",
+    now: new Date("2026-07-18T23:00:00-07:00"),
+  });
+  assert.equal(day1.allowed, true);
+
+  const day2 = await reserveEmailDailyCapSlot(db, fakeAdmin, {
+    uid: "u1",
+    triggerId: "tour_rankings_daily",
+    now: new Date("2026-07-19T08:00:00-07:00"),
+  });
+  assert.equal(day2.allowed, true);
+  assert.equal(day2.day, "2026-07-19");
+});
+
+test("different users never contend for the same slot", async () => {
+  const db = makeFakeDb();
+  const now = new Date("2026-07-18T20:00:00-07:00");
+  const u1 = await reserveEmailDailyCapSlot(db, fakeAdmin, { uid: "u1", triggerId: "tour_countdown", now });
+  const u2 = await reserveEmailDailyCapSlot(db, fakeAdmin, { uid: "u2", triggerId: "tour_countdown", now });
+  assert.equal(u1.allowed, true);
+  assert.equal(u2.allowed, true);
+});
+
+test("fails open when the transaction throws", async () => {
+  const events = [];
+  const db = {
+    collection() {
+      return { doc: () => ({}) };
+    },
+    async runTransaction() {
+      throw new Error("firestore unavailable");
+    },
+  };
+  const res = await reserveEmailDailyCapSlot(db, fakeAdmin, {
+    uid: "u1",
+    triggerId: "tour_countdown",
+    logger: { warn: (msg, data) => events.push({ msg, data }) },
+  });
+  assert.deepEqual(res, { allowed: true, failedOpen: true });
+  assert.equal(events.length, 1);
+  assert.equal(events[0].msg, "reserveEmailDailyCapSlot: transaction failed, failing open");
+});
+
+test("missing uid/db/admin degrades to allowed without throwing", async () => {
+  assert.deepEqual(await reserveEmailDailyCapSlot(null, fakeAdmin, { uid: "u1", triggerId: "x" }), {
+    allowed: true,
+  });
+  assert.deepEqual(await reserveEmailDailyCapSlot(makeFakeDb(), null, { uid: "u1", triggerId: "x" }), {
+    allowed: true,
+  });
+  assert.deepEqual(await reserveEmailDailyCapSlot(makeFakeDb(), fakeAdmin, { uid: "", triggerId: "x" }), {
+    allowed: true,
+  });
+});

--- a/functions/commsEmailWorker.js
+++ b/functions/commsEmailWorker.js
@@ -18,6 +18,7 @@
 
 const { isEmailSuppressed } = require("./commsEmailSuppression");
 const { buildOneClickUnsubscribeUrl } = require("./commsEmailUnsubscribe");
+const { reserveEmailDailyCapSlot } = require("./commsEmailDailyCap");
 
 const DEFAULT_FROM = "Setlist Pick'em <updates@setlistpickem.com>";
 const DEFAULT_SITE_URL = "https://www.setlistpickem.com";
@@ -72,6 +73,7 @@ function unsubscribeHeaders(siteUrl, opts = {}) {
  * @param {{
  *   resendClient: object | null,
  *   db?: import("firebase-admin").firestore.Firestore,
+ *   admin?: typeof import("firebase-admin"),
  *   fromAddress?: string,
  *   siteUrl?: string,
  *   unsubscribeSigningSecret?: string,
@@ -90,6 +92,7 @@ function unsubscribeHeaders(siteUrl, opts = {}) {
 function createCommsEmailWorker({
   resendClient,
   db,
+  admin,
   fromAddress,
   siteUrl,
   unsubscribeSigningSecret,
@@ -119,6 +122,18 @@ function createCommsEmailWorker({
     }
     if (dryRun) {
       return { ok: true, skipReason: "dry_run" };
+    }
+    if (db && admin) {
+      const cap = await reserveEmailDailyCapSlot(db, admin, { uid, triggerId, logger });
+      if (!cap.allowed) {
+        logger?.info?.("comms_capped", {
+          comms_trigger_id: triggerId,
+          comms_channel: "email",
+          comms_cap_winner: cap.winningTriggerId || null,
+          uid,
+        });
+        return { ok: false, skipReason: "daily_email_cap" };
+      }
     }
 
     const headers = unsubscribeHeaders(siteUrl, {

--- a/functions/commsEmailWorker.test.js
+++ b/functions/commsEmailWorker.test.js
@@ -121,3 +121,78 @@ test("unsubscribeHeaders point at the notifications screen when unsigned", () =>
   const headers = unsubscribeHeaders("https://www.setlistpickem.com");
   assert.match(headers["List-Unsubscribe"], /\/dashboard\/notifications/);
 });
+
+const fakeAdmin = {
+  firestore: { FieldValue: { serverTimestamp: () => "ts" } },
+};
+
+/** Fake Firestore with transaction support, for the daily-cap wiring tests (#453). */
+function makeFakeTxDb(seed = {}) {
+  const store = new Map(Object.entries(seed));
+  function makeRef(name, id) {
+    const key = `${name}/${id}`;
+    return {
+      _key: key,
+      async get() {
+        return { exists: store.has(key), data: () => store.get(key) };
+      },
+    };
+  }
+  return {
+    collection(name) {
+      return { doc: (id) => makeRef(name, id) };
+    },
+    async runTransaction(updateFn) {
+      const tx = {
+        async get(ref) {
+          return ref.get();
+        },
+        set(ref, data, opts) {
+          const prev = store.get(ref._key) || {};
+          store.set(ref._key, opts?.merge ? { ...prev, ...data } : data);
+        },
+      };
+      return updateFn(tx);
+    },
+  };
+}
+
+test("daily cap (#453): second same-day trigger for a user is skipped, first is not double-charged", async () => {
+  const captured = [];
+  const db = makeFakeTxDb();
+  const worker = createCommsEmailWorker({ resendClient: fakeResend(captured), db, admin: fakeAdmin });
+
+  const first = await worker({ ...baseCtx, triggerId: "tour_engagement_reminder", dedupId: "tour_engage:u1:t1" });
+  assert.equal(first.ok, true);
+  assert.equal(captured.length, 1);
+
+  const second = await worker({ ...baseCtx, triggerId: "tour_rankings_daily", dedupId: "tour_rank:u1:2026-07-18" });
+  assert.equal(second.ok, false);
+  assert.equal(second.skipReason, "daily_email_cap");
+  assert.equal(captured.length, 1, "capped attempt must not call Resend");
+});
+
+test("daily cap (#453): account_welcome always sends even after the day's slot is used", async () => {
+  const captured = [];
+  const db = makeFakeTxDb();
+  const worker = createCommsEmailWorker({ resendClient: fakeResend(captured), db, admin: fakeAdmin });
+
+  await worker({ ...baseCtx, triggerId: "tour_countdown", dedupId: "tour_countdown:t:u1:1" });
+  assert.equal(captured.length, 1);
+
+  const welcome = await worker({ ...baseCtx, triggerId: "account_welcome", dedupId: "welcome:u1" });
+  assert.equal(welcome.ok, true);
+  assert.equal(captured.length, 2, "account_welcome must not be blocked by an already-used slot");
+});
+
+test("daily cap (#453): skipped entirely when admin is not provided (backward compatible)", async () => {
+  const captured = [];
+  const db = makeFakeTxDb();
+  const worker = createCommsEmailWorker({ resendClient: fakeResend(captured), db });
+
+  const first = await worker({ ...baseCtx, triggerId: "tour_countdown" });
+  const second = await worker({ ...baseCtx, triggerId: "tour_rankings_daily" });
+  assert.equal(first.ok, true);
+  assert.equal(second.ok, true, "no admin instance means the cap check is skipped, not enforced");
+  assert.equal(captured.length, 2);
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -72,6 +72,7 @@ function buildCommsEmailWorkerInstance() {
   return createCommsEmailWorker({
     resendClient: buildResendClient(process.env.RESEND_API_KEY, logger),
     db,
+    admin,
     unsubscribeSigningSecret: process.env.RESEND_WEBHOOK_SECRET,
     logger,
   });

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
-    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js accountDelete.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js showFinalizationGate.test.js revertRollupCore.test.js postShowRollupPush.test.js picksLockReminder.test.js fcmMessagingCore.test.js sphereTourRecapDelivery.test.js commsCatalog.test.js commsTemplates.test.js commsEmailWorker.test.js commsEmailSuppression.test.js commsResendWebhook.test.js commsDelivery.test.js commsEventAdapters.test.js",
+    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js accountDelete.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js showFinalizationGate.test.js revertRollupCore.test.js postShowRollupPush.test.js picksLockReminder.test.js fcmMessagingCore.test.js sphereTourRecapDelivery.test.js commsCatalog.test.js commsTemplates.test.js commsEmailWorker.test.js commsEmailSuppression.test.js commsEmailDailyCap.test.js commsResendWebhook.test.js commsDelivery.test.js commsEventAdapters.test.js",
     "serve": "firebase emulators:start --only functions",
     "shell": "firebase functions:shell",
     "start": "npm run shell",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.7.2",
+  "version": "1.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #453

## Summary

Part 2 of 2 for the email fatigue-cap work (epic #441). Part 1 (#451/#452, merged) eliminated the dominant same-day collision structurally by folding `show_recap` into `tour_rankings_daily`. This PR adds a cap for the residual, lower-frequency cross-trigger collisions (e.g. `account_welcome` landing the same day as a tour email for a brand-new user).

Design was worked through with the comms-architect and comms-analyst skills (see linked chat/issue #453 for the full back-and-forth on cost analysis, engagement policy, and timezone reasoning).

## Mechanism

- **`functions/commsEmailDailyCap.js`** (new) — at most **1 discretionary email/user/day**, keyed by `America/Los_Angeles` calendar day (not per-show venue-local time — a user's inbox isn't tied to a single show/venue). Piggybacks on the **existing** `fcm_notification_log` collection with a new doc-id shape (`email_cap:{uid}:{day}`) instead of a new collection — no `firestore.rules` change. Written **transactionally** for correctness under concurrent invocations; **fails open** on transaction errors (fatigue guard, not a compliance gate — must never silently swallow a real send).
- **`account_welcome` is exempt** — one-time-ever send, can't itself cause fatigue.
- Checked in `commsEmailWorker.js` right after the suppression check and before the real Resend send — the single chokepoint every email-channel trigger already flows through, so it never suppresses `inApp`/`push` for the same trigger.
- Threaded `admin` through `createCommsEmailWorker`'s two call sites (`commsAdapterRuntime.js`, `index.js`'s `buildCommsEmailWorkerInstance`) since the transaction needs it.
- New `comms_capped` structured log event (Cloud Logging only — confirmed this session there's no server-side GA4 Measurement Protocol bridge yet; tracked separately under epic #441, not re-scoped into this PR).

## ⚠️ Known limitation (call out for review)

This is **first-reservation-wins**, not a true priority queue. An email can't be unsent, so if a higher-value trigger fires *later* in the day than a lower-value one, it cannot preempt an already-sent slot. Concretely: `tour_rankings_daily` (8am PT cron) and `tour_countdown` (9am PT cron) fire before `tour_engagement_reminder` (evening, event-triggered), so the two morning crons will usually win any contested day even though the original engagement-policy analysis ranked `tour_engagement_reminder` as more valuable. True preemption would require batching all of a day's sends to a single evaluation point (a digest-style redesign) — out of scope here. Flagged in the CHANGELOG as a documented limitation to revisit once `comms_capped` data exists.

## Test plan

- [x] `npm run lint && npm test` (241 passing)
- [x] `cd functions && npm test` (216 passing — 10 new tests in `commsEmailDailyCap.test.js` covering exemption, reservation, same-day capping, day-boundary reset, per-user isolation, and fail-open-on-error; 3 new integration tests in `commsEmailWorker.test.js` covering the wiring)
- [x] `npm run verify:dashboard-meta && npm run verify:dashboard-ui`
- [x] `npm run build`
- [ ] CI verify + functions job green

## Version

MINOR bump (1.7.2 → 1.8.0) — new production behavior (a cap that can affect delivery), no new routes/callables/removed fields.

Made with [Cursor](https://cursor.com)