### PR TITLE
feat(comms): branded HTML email + unsubscribe safety hardening + daily-cap QA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.9.0] — 2026-07-02
+
+### Added
+- **Branded HTML email body (#455)** — comms email now sends a branded `html` part (logo, CTA button, footer with "Manage preferences"/"Unsubscribe" links) alongside the existing plain-text fallback, instead of plain text only. Body copy renders as a single `<p>` with `<br>` line breaks rather than one `<p>` per line, avoiding a Gmail content-folding quirk that collapsed multi-line bodies behind a clickable "..." pill.
+- **`bypassDailyCap` (admin-only, `runCommsTrigger`)** — skips the #453 daily email fatigue cap reservation so a reviewer can preview every email-capable trigger template in one sitting without being capped to one send/day. Never set by production event adapters. See `scripts/canary-comms-preview.mjs`.
+- **Push notification click-through** — `firebase-messaging-sw.js` now handles `notificationclick`, focusing an existing app window or opening one to the notification's deep link. Previously clicking a desktop push notification did nothing.
+- `functions/commsEmailUnsubscribe.test.js` — direct unit coverage for `processOneClickUnsubscribe`, `buildOneClickUnsubscribeUrl`, the signed-token round trip, and the new GET-confirmation helpers (closes out #456's test-coverage gap).
+
+### Changed
+- **`forceResend` (`runCommsTrigger`)** now also varies the Resend `idempotencyKey` (timestamp + random suffix) in addition to bypassing dedup, so repeated QA sends with changed template content no longer collide with Resend's 24h idempotency window.
+- The branded HTML body no longer repeats the plain-text "Open the app: `<url>`" line — the HTML already has its own CTA button to the same destination. The plain-text-only fallback (no button available there) still includes it.
+- **`commsEmailUnsubscribe` is now method-gated (#456, security hardening):** POST (the real RFC 8058 one-click action mail clients issue automatically) suppresses immediately, same as before. GET (the visible footer link, or a link-scanner/antivirus gateway prefetching it) no longer suppresses by itself — it now renders a confirmation page requiring one explicit form submit. Any other method returns `405`. Live-verified against the deployed endpoint.
+- The branded HTML footer's visible "Unsubscribe" link now points at the `/dashboard/notifications` preferences page instead of the raw signed one-click suppression URL, which is now reserved exclusively for the invisible `List-Unsubscribe` header.
+
+### Fixed
+- Executed the #453 daily-cap manual test plan for real (no bypass): two non-exempt triggers same day → first sends, second is capped with `comms_capped` logging the winning trigger. Previously unverified in production.
+
+---
+
 ## [1.8.0] — 2026-07-02
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -118,9 +118,12 @@ General-purpose comms delivery callable. Runs a named trigger through the full p
   "triggerId": "account_welcome",
   "recipients": [{ "uid": "...", "payload": {}, "vars": {} }],
   "dryRun": true,
-  "forceResend": false
+  "forceResend": false,
+  "bypassDailyCap": false
 }
 ```
+
+`bypassDailyCap` (v1.9.0+, admin-only QA) skips the #453 per-user daily email fatigue cap reservation entirely — never set by the production event adapters, only used by this callable so a reviewer can preview every template's rendered email in one sitting (see `scripts/canary-comms-preview.mjs`). `forceResend` bypasses dedup *and* varies the Resend idempotency key (timestamp + random suffix), so repeated QA sends with changed content don't collide with Resend's 24h idempotency window ("request body was modified and doesn't match the original request").
 
 **Response:**
 ```json
@@ -171,6 +174,13 @@ Trigger specs and channels: `docs/comms-triggers/catalog.json`. Admin canary/rep
 | `commsEmailUnsubscribe` | GET/POST | HMAC query params (`uid`, `email`, `sig`) | RFC 8058 one-click unsubscribe; opts user out of lifecycle email |
 
 Configure the Resend dashboard webhook URL to the deployed `commsResendWebhook` HTTPS endpoint. Signing secret: `firebase functions:secrets:set RESEND_WEBHOOK_SECRET`.
+
+**`commsEmailUnsubscribe` method gating (v1.9.0+, #456):** the two HTTP methods behave differently by design —
+- **POST** with a valid signature (the real RFC 8058 one-click action; mail clients issue this automatically via `List-Unsubscribe-Post`) suppresses immediately and returns a success page.
+- **GET** with a valid signature (the visible footer "Unsubscribe"/"Manage preferences" link, or any link-scanner/antivirus gateway prefetching it) never suppresses by itself — it renders an HTML confirmation page with a form that must be explicitly submitted (a real POST) to complete the unsubscribe.
+- Any other method, or an invalid/missing signature, returns `400`/`405` without touching `email_suppression`.
+
+The branded HTML email body's visible footer link points at the `/dashboard/notifications` settings page, not this endpoint directly — the raw one-click URL is only ever embedded in the invisible `List-Unsubscribe` header.
 
 ---
 

--- a/functions/commsDelivery.js
+++ b/functions/commsDelivery.js
@@ -59,6 +59,7 @@ function recipientAllowsTrigger(userData, prefKeys) {
  *   workers?: { inApp?: Function, push?: Function, email?: Function },
  *   dryRun?: boolean,
  *   forceResend?: boolean,
+ *   bypassDailyCap?: boolean,
  *   fatigueCap?: number,
  *   variant?: string,
  *   logger?: { info?: Function, warn?: Function, error?: Function },
@@ -72,6 +73,7 @@ async function deliverCommsTrigger({
   workers = {},
   dryRun = true,
   forceResend = false,
+  bypassDailyCap = false,
   fatigueCap = DEFAULT_FATIGUE_CAP,
   variant = "control",
   logger,
@@ -150,6 +152,8 @@ async function deliverCommsTrigger({
       rendered,
       dedupId,
       dryRun,
+      forceResend,
+      bypassDailyCap,
       logger,
     };
 

--- a/functions/commsDelivery.test.js
+++ b/functions/commsDelivery.test.js
@@ -71,6 +71,57 @@ test("recipientAllowsTrigger requires every prefKey to allow", () => {
   assert.equal(recipientAllowsTrigger({ notificationPrefs: { results: false } }, ["results"]), false);
 });
 
+test("bypassDailyCap threads through to the channel worker ctx (admin QA preview)", async () => {
+  const db = makeFakeDb();
+  const email = recordingWorker("email", { ok: true });
+
+  await deliverCommsTrigger({
+    db,
+    admin: fakeAdmin,
+    triggerId: "account_welcome",
+    recipients: [{ uid: "u1", userData: { email: "u1@example.com" } }],
+    workers: { email },
+    dryRun: false,
+    bypassDailyCap: true,
+  });
+
+  assert.equal(email.calls.length, 1);
+  assert.equal(email.calls[0].bypassDailyCap, true);
+});
+
+test("bypassDailyCap defaults to false when not passed", async () => {
+  const db = makeFakeDb();
+  const email = recordingWorker("email", { ok: true });
+
+  await deliverCommsTrigger({
+    db,
+    admin: fakeAdmin,
+    triggerId: "account_welcome",
+    recipients: [{ uid: "u1", userData: { email: "u1@example.com" } }],
+    workers: { email },
+    dryRun: false,
+  });
+
+  assert.equal(email.calls[0].bypassDailyCap, false);
+});
+
+test("forceResend threads through to the channel worker ctx (so email can vary its Resend idempotency key)", async () => {
+  const db = makeFakeDb();
+  const email = recordingWorker("email", { ok: true });
+
+  await deliverCommsTrigger({
+    db,
+    admin: fakeAdmin,
+    triggerId: "account_welcome",
+    recipients: [{ uid: "u1", userData: { email: "u1@example.com" } }],
+    workers: { email },
+    dryRun: false,
+    forceResend: true,
+  });
+
+  assert.equal(email.calls[0].forceResend, true);
+});
+
 test("dry run reports would_deliver and writes nothing", async () => {
   const db = makeFakeDb();
   const inApp = recordingWorker("inApp", { ok: true, skipReason: "dry_run" });

--- a/functions/commsEmailUnsubscribe.js
+++ b/functions/commsEmailUnsubscribe.js
@@ -85,9 +85,60 @@ async function processOneClickUnsubscribe({
   return { ok: true };
 }
 
+/**
+ * Validates the signed unsubscribe token WITHOUT applying suppression.
+ * Used to gate the GET confirmation page — a link-scanner or accidental
+ * click merely fetches this page, it never mutates state.
+ *
+ * @param {{ uid: string, email: string, sig: string, signingSecret: string }} params
+ * @returns {boolean}
+ */
+function verifyOneClickUnsubscribeToken({ uid, email, sig, signingSecret }) {
+  const normalized = normalizeEmail(email);
+  return Boolean(uid && normalized && verifyUnsubscribeToken(uid, normalized, sig, signingSecret));
+}
+
+/**
+ * Renders the interstitial GET confirmation page: a link-scanner or an
+ * antivirus gateway that prefetches the visible "Unsubscribe" footer link
+ * only ever issues a GET, so this page must not, by itself, unsubscribe
+ * anyone — it requires one explicit form submission (a real POST) to do so.
+ * The real RFC 8058 one-click action (mail client `List-Unsubscribe-Post`)
+ * always POSTs directly and never sees this page.
+ *
+ * @param {{ uid: string, email: string, sig: string, baseUrl?: string }} params
+ * @returns {string}
+ */
+function renderUnsubscribeConfirmPage({ uid, email, sig, baseUrl }) {
+  const endpoint = resolveUnsubscribeBaseUrl(baseUrl);
+  const action = `${endpoint}?uid=${encodeURIComponent(uid)}&email=${encodeURIComponent(normalizeEmail(email))}&sig=${encodeURIComponent(sig)}`;
+  return `<!DOCTYPE html>
+<html>
+  <body style="margin:0;padding:0;background-color:#0b0b14;font-family:-apple-system,Helvetica,Arial,sans-serif;">
+    <div style="max-width:420px;margin:64px auto;background:#ffffff;border-radius:16px;padding:32px;text-align:center;">
+      <h1 style="font-size:18px;color:#1a1a2e;margin:0 0 12px 0;">Unsubscribe from Setlist Pick&apos;em emails?</h1>
+      <p style="font-size:14px;color:#555555;margin:0 0 24px 0;">You&apos;ll stop receiving lifecycle and update emails at ${normalizeEmail(email) || "this address"}. You can re-enable them anytime from Notifications settings.</p>
+      <form method="POST" action="${action}">
+        <button type="submit" style="background-color:#7c3aed;color:#ffffff;border:none;border-radius:8px;padding:12px 24px;font-weight:700;font-size:14px;cursor:pointer;">Yes, unsubscribe me</button>
+      </form>
+    </div>
+  </body>
+</html>`;
+}
+
+/**
+ * @returns {string}
+ */
+function renderUnsubscribeSuccessPage() {
+  return "<!DOCTYPE html><html><body><p>You have been unsubscribed from Setlist Pick'em email updates.</p></body></html>";
+}
+
 module.exports = {
   DEFAULT_UNSUBSCRIBE_BASE_URL,
   resolveUnsubscribeBaseUrl,
   buildOneClickUnsubscribeUrl,
   processOneClickUnsubscribe,
+  verifyOneClickUnsubscribeToken,
+  renderUnsubscribeConfirmPage,
+  renderUnsubscribeSuccessPage,
 };

--- a/functions/commsEmailUnsubscribe.test.js
+++ b/functions/commsEmailUnsubscribe.test.js
@@ -1,0 +1,189 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  buildOneClickUnsubscribeUrl,
+  processOneClickUnsubscribe,
+  verifyOneClickUnsubscribeToken,
+  renderUnsubscribeConfirmPage,
+  renderUnsubscribeSuccessPage,
+  resolveUnsubscribeBaseUrl,
+  DEFAULT_UNSUBSCRIBE_BASE_URL,
+} = require("./commsEmailUnsubscribe");
+const { signUnsubscribeToken, isEmailSuppressed } = require("./commsEmailSuppression");
+
+const SECRET = "test-signing-secret";
+const UID = "u1";
+const EMAIL = "picker@example.com";
+
+function fakeDb() {
+  const docs = new Map();
+  const users = new Map();
+  return {
+    collection(name) {
+      if (name === "users") {
+        return {
+          doc(id) {
+            return {
+              async set(data, opts) {
+                const prev = users.get(id) || {};
+                users.set(id, opts?.merge ? { ...prev, ...data } : data);
+              },
+              async get() {
+                return { exists: users.has(id), data: () => users.get(id) };
+              },
+            };
+          },
+        };
+      }
+      return {
+        doc(id) {
+          const key = `${name}/${id}`;
+          return {
+            async get() {
+              return { exists: docs.has(key), data: () => docs.get(key) };
+            },
+            async set(data, opts) {
+              const prev = docs.get(key) || {};
+              docs.set(key, opts?.merge ? { ...prev, ...data } : data);
+            },
+          };
+        },
+      };
+    },
+    _docs: docs,
+    _users: users,
+  };
+}
+
+const fakeAdmin = {
+  firestore: { FieldValue: { serverTimestamp: () => ({ __ts: true }) } },
+};
+
+test("buildOneClickUnsubscribeUrl signs uid + email into the query string", () => {
+  const url = buildOneClickUnsubscribeUrl("https://www.setlistpickem.com", {
+    uid: UID,
+    email: EMAIL,
+    signingSecret: SECRET,
+  });
+  const expectedSig = signUnsubscribeToken(UID, EMAIL, SECRET);
+  assert.match(url, new RegExp(`^${DEFAULT_UNSUBSCRIBE_BASE_URL}\\?`));
+  assert.match(url, /uid=u1/);
+  assert.match(url, new RegExp(`email=${encodeURIComponent(EMAIL)}`));
+  assert.match(url, new RegExp(`sig=${expectedSig}`));
+});
+
+test("buildOneClickUnsubscribeUrl falls back to the notifications settings page when unsigned", () => {
+  const url = buildOneClickUnsubscribeUrl("https://www.setlistpickem.com", {
+    uid: "",
+    email: "",
+    signingSecret: "",
+  });
+  assert.equal(url, "https://www.setlistpickem.com/dashboard/notifications");
+});
+
+test("resolveUnsubscribeBaseUrl honors COMMS_UNSUBSCRIBE_BASE_URL override", () => {
+  const prev = process.env.COMMS_UNSUBSCRIBE_BASE_URL;
+  process.env.COMMS_UNSUBSCRIBE_BASE_URL = "https://example.test/unsub/";
+  try {
+    assert.equal(resolveUnsubscribeBaseUrl(), "https://example.test/unsub");
+  } finally {
+    if (prev === undefined) delete process.env.COMMS_UNSUBSCRIBE_BASE_URL;
+    else process.env.COMMS_UNSUBSCRIBE_BASE_URL = prev;
+  }
+});
+
+test("processOneClickUnsubscribe suppresses + opts out prefs on a valid signature", async () => {
+  const db = fakeDb();
+  const sig = signUnsubscribeToken(UID, EMAIL, SECRET);
+  const result = await processOneClickUnsubscribe({
+    db,
+    admin: fakeAdmin,
+    uid: UID,
+    email: EMAIL,
+    sig,
+    signingSecret: SECRET,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(await isEmailSuppressed(db, EMAIL), true);
+  assert.equal(db._users.get(UID)["notificationPrefs.lifecycle"], false);
+  assert.equal(db._users.get(UID)["notificationPrefs.commercial"], false);
+});
+
+test("processOneClickUnsubscribe rejects a tampered signature", async () => {
+  const db = fakeDb();
+  const result = await processOneClickUnsubscribe({
+    db,
+    admin: fakeAdmin,
+    uid: UID,
+    email: EMAIL,
+    sig: "not-the-real-signature",
+    signingSecret: SECRET,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "invalid_token");
+  assert.equal(await isEmailSuppressed(db, EMAIL), false);
+});
+
+test("processOneClickUnsubscribe rejects a signature minted for a different uid/email", async () => {
+  const db = fakeDb();
+  const sig = signUnsubscribeToken("someone-else", EMAIL, SECRET);
+  const result = await processOneClickUnsubscribe({
+    db,
+    admin: fakeAdmin,
+    uid: UID,
+    email: EMAIL,
+    sig,
+    signingSecret: SECRET,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "invalid_token");
+});
+
+test("processOneClickUnsubscribe rejects missing uid or email", async () => {
+  const db = fakeDb();
+  const sig = signUnsubscribeToken(UID, EMAIL, SECRET);
+  assert.equal(
+    (await processOneClickUnsubscribe({ db, admin: fakeAdmin, uid: "", email: EMAIL, sig, signingSecret: SECRET })).ok,
+    false
+  );
+  assert.equal(
+    (await processOneClickUnsubscribe({ db, admin: fakeAdmin, uid: UID, email: "", sig, signingSecret: SECRET })).ok,
+    false
+  );
+});
+
+test("verifyOneClickUnsubscribeToken matches a valid token and does not mutate state", () => {
+  const sig = signUnsubscribeToken(UID, EMAIL, SECRET);
+  assert.equal(
+    verifyOneClickUnsubscribeToken({ uid: UID, email: EMAIL, sig, signingSecret: SECRET }),
+    true
+  );
+});
+
+test("verifyOneClickUnsubscribeToken rejects tampering", () => {
+  const sig = signUnsubscribeToken(UID, EMAIL, SECRET);
+  assert.equal(
+    verifyOneClickUnsubscribeToken({ uid: UID, email: "other@example.com", sig, signingSecret: SECRET }),
+    false
+  );
+  assert.equal(
+    verifyOneClickUnsubscribeToken({ uid: UID, email: EMAIL, sig: "garbage", signingSecret: SECRET }),
+    false
+  );
+});
+
+test("renderUnsubscribeConfirmPage requires a real POST form submit, not a bare link", () => {
+  const sig = signUnsubscribeToken(UID, EMAIL, SECRET);
+  const html = renderUnsubscribeConfirmPage({ uid: UID, email: EMAIL, sig });
+  assert.match(html, /<form method="POST"/);
+  assert.match(html, new RegExp(`uid=${UID}`));
+  assert.match(html, new RegExp(`email=${encodeURIComponent(EMAIL)}`));
+  assert.match(html, new RegExp(`sig=${sig}`));
+});
+
+test("renderUnsubscribeSuccessPage returns a confirmation message", () => {
+  assert.match(renderUnsubscribeSuccessPage(), /unsubscribed/i);
+});

--- a/functions/commsEmailWorker.js
+++ b/functions/commsEmailWorker.js
@@ -8,10 +8,27 @@
  *
  * Idempotency: the orchestrator's dedup scope becomes the Resend `idempotencyKey`,
  * so email shares the same idempotency guarantee as push + in-app — retries / re-ticks
- * never double-send.
+ * never double-send. Resend rejects reusing a key with a *different* request body
+ * within 24h ("idempotency key ... doesn't match the original request"), so a
+ * `forceResend` (admin QA re-run, or `runCommsTrigger` replay) also appends a
+ * timestamp to the key — otherwise iterating on template content and re-sending
+ * the same (triggerId, uid, dedupId) QA case would collide with the prior send's
+ * cached key instead of actually resending.
  *
  * Compliance: marketing/lifecycle mail carries `List-Unsubscribe` + one-click
- * (RFC 8058) headers wired to the Notifications settings screen.
+ * (RFC 8058) headers wired to the Notifications settings screen, *and* a
+ * visible "Unsubscribe" / "Manage preferences" link in the HTML body itself
+ * (headers alone satisfy RFC 8058 but most inboxes never surface them to a
+ * human reader).
+ *
+ * Every send carries both `html` (branded — logo, button, footer links) and
+ * `text` (plain-text fallback derived from the same content) parts.
+ *
+ * `ctx.bypassDailyCap` skips the #453 daily fatigue-cap reservation entirely.
+ * Only the admin-only `runCommsTrigger` QA/canary callable ever sets this
+ * (never the production event adapters), so a reviewer can preview every
+ * template's rendered email in one sitting without burning through — or being
+ * blocked by — the real per-user daily cap.
  */
 
 "use strict";
@@ -50,8 +67,9 @@ function buildResendClient(apiKey, logger) {
 /**
  * @param {string} [siteUrl]
  * @param {{ uid?: string, email?: string, signingSecret?: string, baseUrl?: string }} [opts]
+ * @returns {{ settingsUrl: string, oneClickUrl: string }}
  */
-function unsubscribeHeaders(siteUrl, opts = {}) {
+function resolveUnsubscribeLinks(siteUrl, opts = {}) {
   const base = (siteUrl || DEFAULT_SITE_URL).replace(/\/+$/, "");
   const settingsUrl = `${base}${UNSUB_PATH}`;
   const oneClickUrl =
@@ -63,10 +81,124 @@ function unsubscribeHeaders(siteUrl, opts = {}) {
           baseUrl: opts.baseUrl,
         })
       : settingsUrl;
+  return { settingsUrl, oneClickUrl };
+}
+
+/**
+ * @param {string} [siteUrl]
+ * @param {{ uid?: string, email?: string, signingSecret?: string, baseUrl?: string }} [opts]
+ */
+function unsubscribeHeaders(siteUrl, opts = {}) {
+  const { oneClickUrl } = resolveUnsubscribeLinks(siteUrl, opts);
   return {
     "List-Unsubscribe": `<${oneClickUrl}>, <mailto:unsubscribe@setlistpickem.com>`,
     "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
   };
+}
+
+/**
+ * @param {string} str
+ * @returns {string}
+ */
+function escapeHtml(str) {
+  return String(str ?? "").replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c])
+  );
+}
+
+// Template bodies (`commsTemplates.js`) append a plain "Open the app: <url>"
+// line so the plain-text MIME part (no clickable button available) still has
+// a way to click through. The HTML part renders its own CTA button pointing
+// at the same URL, so re-printing it as a bare link right above the button
+// is a redundant, less-trustworthy-looking duplicate — strip it for HTML only.
+const APP_LINK_LINE_RE = /^open the app:\s*https?:\/\/\S+\s*$/i;
+
+/**
+ * @param {string} text
+ * @returns {string}
+ */
+function stripRedundantCtaLine(text) {
+  return String(text || "")
+    .split("\n")
+    .filter((line) => !APP_LINK_LINE_RE.test(line.trim()))
+    .join("\n");
+}
+
+/**
+ * Wrap plain-text email content in a small branded HTML shell: logo, a CTA
+ * button back into the app, and a visible unsubscribe / preferences footer.
+ * Uses inline styles + a table layout (no external CSS/JS) for broad email
+ * client compatibility.
+ *
+ * The visible footer link intentionally points at `settingsUrl` (the
+ * preferences screen) rather than a one-click suppression URL: a plain
+ * `<a href>` is a GET request that any link-scanner/antivirus gateway can
+ * trigger, and RFC 8058's instant, no-confirmation one-click action is
+ * reserved for the invisible `List-Unsubscribe` header, which mail clients
+ * only ever invoke via POST (see `unsubscribeHeaders`).
+ *
+ * @param {{
+ *   siteUrl: string,
+ *   bodyText: string,
+ *   ctaUrl: string,
+ *   settingsUrl: string,
+ * }} opts
+ * @returns {string}
+ */
+function buildBrandedEmailHtml({ siteUrl, bodyText, ctaUrl, settingsUrl }) {
+  const base = (siteUrl || DEFAULT_SITE_URL).replace(/\/+$/, "");
+  const logoUrl = `${base}/favicon/web-app-manifest-512x512.png`;
+  // A stack of several short, single-line <p> blocks is a well-known trigger
+  // for Gmail's content-folding heuristic (it renders a clickable "..." pill
+  // in place of the text, which most recipients never think to expand). A
+  // single <p> with <br> between lines reads identically but avoids it.
+  const bodyLines = stripRedundantCtaLine(bodyText)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => escapeHtml(line))
+    .join("<br />");
+  const paragraphs = bodyLines
+    ? `<p style="margin:0 0 20px 0;font-size:15px;line-height:1.6;color:#1a1a2e;">${bodyLines}</p>`
+    : "";
+
+  return `<!DOCTYPE html>
+<html>
+  <body style="margin:0;padding:0;background-color:#0b0b14;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#0b0b14;padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width:480px;width:100%;background-color:#ffffff;border-radius:16px;overflow:hidden;">
+            <tr>
+              <td style="padding:32px 32px 8px 32px;text-align:center;">
+                <img src="${logoUrl}" width="48" height="48" alt="Setlist Pick'em" style="border-radius:12px;display:inline-block;" />
+                <div style="margin-top:12px;font-size:18px;font-weight:800;color:#1a1a2e;font-family:-apple-system,Helvetica,Arial,sans-serif;">Setlist Pick&apos;em</div>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:16px 32px 8px 32px;font-family:-apple-system,Helvetica,Arial,sans-serif;">
+                ${paragraphs}
+                <a href="${escapeHtml(ctaUrl)}" style="display:inline-block;margin-top:8px;padding:12px 24px;background-color:#7c3aed;color:#ffffff;text-decoration:none;border-radius:8px;font-weight:700;font-size:14px;">Open Setlist Pick&apos;em</a>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:24px 32px;border-top:1px solid #eeeeee;text-align:center;font-family:-apple-system,Helvetica,Arial,sans-serif;">
+                <p style="margin:0 0 8px 0;font-size:12px;color:#888888;">
+                  You&apos;re receiving this because you have a Setlist Pick&apos;em account.
+                </p>
+                <p style="margin:0;font-size:12px;color:#888888;">
+                  <a href="${escapeHtml(settingsUrl)}" style="color:#7c3aed;text-decoration:underline;">Manage preferences</a>
+                  &nbsp;&middot;&nbsp;
+                  <a href="${escapeHtml(settingsUrl)}" style="color:#7c3aed;text-decoration:underline;">Unsubscribe</a>
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
 }
 
 /**
@@ -87,6 +219,8 @@ function unsubscribeHeaders(siteUrl, opts = {}) {
  *   rendered: { email: { subject: string, text: string } },
  *   dedupId: string,
  *   dryRun?: boolean,
+ *   forceResend?: boolean,
+ *   bypassDailyCap?: boolean,
  * }) => Promise<{ ok: boolean, skipReason?: string, id?: string }>}
  */
 function createCommsEmailWorker({
@@ -102,7 +236,7 @@ function createCommsEmailWorker({
   const from = fromAddress || DEFAULT_FROM;
 
   return async function deliverCommsEmail(ctx) {
-    const { uid, userData, triggerId, rendered, dedupId, dryRun } = ctx;
+    const { uid, userData, triggerId, rendered, dedupId, dryRun, forceResend, bypassDailyCap } = ctx;
     const to = userData?.email;
 
     if (!rendered?.email?.subject) {
@@ -123,7 +257,7 @@ function createCommsEmailWorker({
     if (dryRun) {
       return { ok: true, skipReason: "dry_run" };
     }
-    if (db && admin) {
+    if (db && admin && !bypassDailyCap) {
       const cap = await reserveEmailDailyCapSlot(db, admin, { uid, triggerId, logger });
       if (!cap.allowed) {
         logger?.info?.("comms_capped", {
@@ -136,13 +270,26 @@ function createCommsEmailWorker({
       }
     }
 
-    const headers = unsubscribeHeaders(siteUrl, {
+    const { settingsUrl, oneClickUrl } = resolveUnsubscribeLinks(siteUrl, {
       uid,
       email: to,
       signingSecret: unsubscribeSigningSecret,
       baseUrl: unsubscribeBaseUrl,
     });
-    const idempotencyKey = `${triggerId}/${uid}:${dedupId || "default"}`;
+    const headers = {
+      "List-Unsubscribe": `<${oneClickUrl}>, <mailto:unsubscribe@setlistpickem.com>`,
+      "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+    };
+    const base = (siteUrl || DEFAULT_SITE_URL).replace(/\/+$/, "");
+    const html = buildBrandedEmailHtml({
+      siteUrl,
+      bodyText: rendered.email.text,
+      ctaUrl: `${base}/dashboard`,
+      settingsUrl,
+    });
+    const idempotencyKey = forceResend
+      ? `${triggerId}/${uid}:${dedupId || "default"}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`
+      : `${triggerId}/${uid}:${dedupId || "default"}`;
 
     try {
       const result = await resendClient.emails.send(
@@ -151,6 +298,7 @@ function createCommsEmailWorker({
           to: [to],
           subject: rendered.email.subject,
           text: rendered.email.text,
+          html,
           headers,
         },
         { idempotencyKey }
@@ -179,5 +327,9 @@ module.exports = {
   createCommsEmailWorker,
   buildResendClient,
   unsubscribeHeaders,
+  resolveUnsubscribeLinks,
+  buildBrandedEmailHtml,
+  stripRedundantCtaLine,
+  escapeHtml,
   DEFAULT_FROM,
 };

--- a/functions/commsEmailWorker.test.js
+++ b/functions/commsEmailWorker.test.js
@@ -7,6 +7,9 @@ const {
   createCommsEmailWorker,
   unsubscribeHeaders,
   buildResendClient,
+  buildBrandedEmailHtml,
+  stripRedundantCtaLine,
+  escapeHtml,
 } = require("./commsEmailWorker");
 
 function fakeResend(captured) {
@@ -43,6 +46,27 @@ test("sends via Resend with idempotency key + unsubscribe headers", async () => 
   assert.equal(captured[0].options.idempotencyKey, "show_recap/u1:show_recap:u1:2026-07-18");
   assert.match(captured[0].message.headers["List-Unsubscribe"], /commsEmailUnsubscribe/);
   assert.equal(captured[0].message.headers["List-Unsubscribe-Post"], "List-Unsubscribe=One-Click");
+});
+
+test("idempotencyKey is stable (no forceResend) — production retries never double-send", async () => {
+  const captured = [];
+  const worker = createCommsEmailWorker({ resendClient: fakeResend(captured) });
+  await worker(baseCtx);
+  await worker(baseCtx);
+  assert.equal(captured[0].options.idempotencyKey, captured[1].options.idempotencyKey);
+});
+
+test("forceResend varies the idempotencyKey so Resend doesn't reject a re-run with different content", async () => {
+  const captured = [];
+  const worker = createCommsEmailWorker({ resendClient: fakeResend(captured) });
+  await worker({ ...baseCtx, forceResend: true });
+  await worker({ ...baseCtx, forceResend: true });
+  assert.notEqual(
+    captured[0].options.idempotencyKey,
+    captured[1].options.idempotencyKey,
+    "each forceResend call must get a unique Resend idempotency key"
+  );
+  assert.match(captured[0].options.idempotencyKey, /^show_recap\/u1:show_recap:u1:2026-07-18:\d+:[a-z0-9]+$/);
 });
 
 test("dry run does not send", async () => {
@@ -122,6 +146,105 @@ test("unsubscribeHeaders point at the notifications screen when unsigned", () =>
   assert.match(headers["List-Unsubscribe"], /\/dashboard\/notifications/);
 });
 
+test("sends a branded HTML body alongside the plain-text fallback", async () => {
+  const captured = [];
+  const worker = createCommsEmailWorker({
+    resendClient: fakeResend(captured),
+    unsubscribeSigningSecret: "test-secret",
+  });
+  await worker(baseCtx);
+
+  const { html, headers } = captured[0].message;
+  assert.ok(html.includes("<!DOCTYPE html>"));
+  assert.match(html, /web-app-manifest-512x512\.png/, "includes the hosted app logo");
+  assert.match(html, /Setlist Pick&apos;em/, "includes the brand name");
+  assert.match(html, /Manage preferences/);
+  assert.match(html, /Unsubscribe/);
+  assert.match(html, /\/dashboard\/notifications/, "visible footer link goes to the preferences page");
+  // #456: the visible body link must be a safe GET (preferences page), never the
+  // raw signed one-click suppression URL — that's reserved for the invisible
+  // List-Unsubscribe header, which mail clients only ever invoke via POST.
+  assert.ok(
+    !html.includes("commsEmailUnsubscribe"),
+    "visible body link must not be the one-click suppression endpoint"
+  );
+  assert.match(
+    headers["List-Unsubscribe"],
+    /commsEmailUnsubscribe/,
+    "the true one-click action still lives in the header, for mail clients"
+  );
+});
+
+test("stripRedundantCtaLine drops the plain-text 'Open the app' line", () => {
+  const text = "Hi Pat!\n\nOpen the app: https://www.setlistpickem.com/dashboard\n\nSee you there.";
+  assert.equal(
+    stripRedundantCtaLine(text),
+    "Hi Pat!\n\n\nSee you there."
+  );
+});
+
+test("branded HTML body omits the redundant plain-text app link (button already covers it)", async () => {
+  const captured = [];
+  const worker = createCommsEmailWorker({
+    resendClient: fakeResend(captured),
+    unsubscribeSigningSecret: "test-secret",
+  });
+  const ctx = {
+    ...baseCtx,
+    rendered: {
+      email: {
+        subject: "Your recap",
+        text: [
+          "Hi Pat, here is your recap.",
+          "",
+          "Open the app: https://www.setlistpickem.com/dashboard",
+          "",
+          "Manage which updates you get in Notifications settings.",
+          "— Setlist Pick'em",
+        ].join("\n"),
+      },
+    },
+  };
+  await worker(ctx);
+
+  const { html, text } = captured[0].message;
+  // The plain-text fallback (no button available) still needs the link.
+  assert.match(text, /Open the app: https:\/\/www\.setlistpickem\.com\/dashboard/);
+  // The HTML body has its own CTA button pointing at the same URL, so the
+  // bare-text duplicate would just look like clutter next to it.
+  assert.ok(!html.includes("Open the app:"));
+  assert.match(html, /Open Setlist Pick&apos;em/, "the CTA button is still present");
+});
+
+test("buildBrandedEmailHtml joins multi-line bodies into a single <p> with <br> breaks", () => {
+  // Gmail's content-folding heuristic collapses stacked short <p> blocks
+  // behind a clickable "..." pill; a single <p> with <br> line breaks avoids it.
+  const html = buildBrandedEmailHtml({
+    siteUrl: "https://www.setlistpickem.com",
+    bodyText: "Line one.\nLine two.\nLine three.",
+    ctaUrl: "https://www.setlistpickem.com/dashboard",
+    settingsUrl: "https://www.setlistpickem.com/dashboard/notifications",
+  });
+  const bodyParagraphCount = (html.match(/<p style="margin:0 0 20px 0/g) || []).length;
+  assert.equal(bodyParagraphCount, 1, "body text should render as a single <p> block");
+  assert.match(html, /Line one\.<br \/>Line two\.<br \/>Line three\./);
+});
+
+test("buildBrandedEmailHtml escapes body text to avoid HTML injection", () => {
+  const html = buildBrandedEmailHtml({
+    siteUrl: "https://www.setlistpickem.com",
+    bodyText: "Hi <script>alert(1)</script>",
+    ctaUrl: "https://www.setlistpickem.com/dashboard",
+    settingsUrl: "https://www.setlistpickem.com/dashboard/notifications",
+  });
+  assert.ok(!html.includes("<script>alert(1)</script>"));
+  assert.match(html, /&lt;script&gt;/);
+});
+
+test("escapeHtml escapes the standard entity set", () => {
+  assert.equal(escapeHtml(`<a href="x">'&'</a>`), "&lt;a href=&quot;x&quot;&gt;&#39;&amp;&#39;&lt;/a&gt;");
+});
+
 const fakeAdmin = {
   firestore: { FieldValue: { serverTimestamp: () => "ts" } },
 };
@@ -183,6 +306,21 @@ test("daily cap (#453): account_welcome always sends even after the day's slot i
   const welcome = await worker({ ...baseCtx, triggerId: "account_welcome", dedupId: "welcome:u1" });
   assert.equal(welcome.ok, true);
   assert.equal(captured.length, 2, "account_welcome must not be blocked by an already-used slot");
+});
+
+test("daily cap: bypassDailyCap lets every trigger send in one sitting (admin QA preview)", async () => {
+  const captured = [];
+  const db = makeFakeTxDb();
+  const worker = createCommsEmailWorker({ resendClient: fakeResend(captured), db, admin: fakeAdmin });
+
+  const first = await worker({ ...baseCtx, triggerId: "tour_countdown", bypassDailyCap: true });
+  const second = await worker({ ...baseCtx, triggerId: "tour_rankings_daily", bypassDailyCap: true });
+  const third = await worker({ ...baseCtx, triggerId: "tour_engagement_reminder", bypassDailyCap: true });
+
+  assert.equal(first.ok, true);
+  assert.equal(second.ok, true);
+  assert.equal(third.ok, true);
+  assert.equal(captured.length, 3, "bypassDailyCap must skip the cap reservation entirely");
 });
 
 test("daily cap (#453): skipped entirely when admin is not provided (backward compatible)", async () => {

--- a/functions/index.js
+++ b/functions/index.js
@@ -49,7 +49,12 @@ const {
   verifyResendWebhookPayload,
   handleResendWebhookEvent,
 } = require("./commsResendWebhook");
-const { processOneClickUnsubscribe } = require("./commsEmailUnsubscribe");
+const {
+  processOneClickUnsubscribe,
+  verifyOneClickUnsubscribeToken,
+  renderUnsubscribeConfirmPage,
+  renderUnsubscribeSuccessPage,
+} = require("./commsEmailUnsubscribe");
 const {
   handleAccountWelcome,
   handlePicksConfirmed,
@@ -459,6 +464,11 @@ exports.runCommsTrigger = onCall(
 
     const dryRun = request.data?.dryRun !== false;
     const forceResend = request.data?.forceResend === true;
+    // QA/canary-only: skips the #453 per-user daily email cap so an admin can
+    // preview every template's real rendered email in one sitting. Never set
+    // by the production event adapters — those always go through the default
+    // (capped) path.
+    const bypassDailyCap = request.data?.bypassDailyCap === true;
     const requested = Array.isArray(request.data?.recipients) ? request.data.recipients : [];
     if (requested.length === 0) {
       throw new HttpsError("invalid-argument", "recipients[] is required.");
@@ -489,6 +499,7 @@ exports.runCommsTrigger = onCall(
       workers: buildDefaultWorkers({ emailWorker }),
       dryRun,
       forceResend,
+      bypassDailyCap,
       logger,
     });
   }
@@ -542,7 +553,14 @@ exports.commsResendWebhook = onRequest(
 
 /**
  * RFC 8058 one-click unsubscribe for comms marketing/lifecycle email (#442).
- * GET/POST with `uid`, `email`, and HMAC `sig` query params.
+ *
+ * Method-gated by design (#456): mail clients honor `List-Unsubscribe-Post`
+ * by issuing a real POST with no human interaction — that's the true
+ * "one-click" action and suppresses immediately. A GET (the visible footer
+ * link, or a link-scanner/antivirus gateway prefetching it) must NOT
+ * suppress by itself, since scanners only ever issue GET/HEAD — it renders
+ * a confirmation page requiring one explicit form submit (a real POST)
+ * before anything is written to `email_suppression`.
  */
 exports.commsEmailUnsubscribe = onRequest(
   {
@@ -554,25 +572,42 @@ exports.commsEmailUnsubscribe = onRequest(
     const uid = String(req.query?.uid || "").trim();
     const email = String(req.query?.email || "").trim();
     const sig = String(req.query?.sig || "").trim();
-    const result = await processOneClickUnsubscribe({
-      db,
-      admin,
-      uid,
-      email,
-      sig,
-      signingSecret: process.env.RESEND_WEBHOOK_SECRET,
-      logger,
-    });
-    if (!result.ok) {
-      res.status(400).send("Invalid unsubscribe link");
+    const signingSecret = process.env.RESEND_WEBHOOK_SECRET;
+
+    if (req.method === "POST") {
+      const result = await processOneClickUnsubscribe({
+        db,
+        admin,
+        uid,
+        email,
+        sig,
+        signingSecret,
+        logger,
+      });
+      if (!result.ok) {
+        res.status(400).send("Invalid unsubscribe link");
+        return;
+      }
+      res
+        .status(200)
+        .set("Content-Type", "text/html; charset=utf-8")
+        .send(renderUnsubscribeSuccessPage());
       return;
     }
-    res
-      .status(200)
-      .set("Content-Type", "text/html; charset=utf-8")
-      .send(
-        "<!DOCTYPE html><html><body><p>You have been unsubscribed from Setlist Pick'em email updates.</p></body></html>"
-      );
+
+    if (req.method === "GET") {
+      if (!verifyOneClickUnsubscribeToken({ uid, email, sig, signingSecret })) {
+        res.status(400).send("Invalid unsubscribe link");
+        return;
+      }
+      res
+        .status(200)
+        .set("Content-Type", "text/html; charset=utf-8")
+        .send(renderUnsubscribeConfirmPage({ uid, email, sig }));
+      return;
+    }
+
+    res.status(405).send("Method Not Allowed");
   }
 );
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -16,14 +16,57 @@ firebase.initializeApp({
 
 const messaging = firebase.messaging();
 
+const DEFAULT_CLICK_URL = '/dashboard/notifications';
+
+// Registering `onBackgroundMessage` takes over notification display from the
+// FCM SDK's own default handler, which means its automatic `fcmOptions.link`
+// click-to-open behavior no longer applies either — we have to wire our own
+// `notificationclick` listener below and stash the target URL in `data.url`
+// ourselves (server sends the link via `webpush.fcmOptions.link`, see
+// `functions/fcmMessagingCore.js`).
 messaging.onBackgroundMessage((payload) => {
   const title = payload?.notification?.title || 'Setlist Pick Em';
+  const url = payload?.fcmOptions?.link || payload?.data?.url || DEFAULT_CLICK_URL;
   const options = {
     body: payload?.notification?.body || '',
     icon: '/favicon/web-app-manifest-192x192.png',
-    data: payload?.data ?? {},
+    data: { ...(payload?.data ?? {}), url },
   };
   self.registration.showNotification(title, options);
+});
+
+// Focus an existing Setlist Pick'em tab (navigating it to the target URL) or
+// open a new one — without this, tapping/clicking a notification just closes
+// it with no navigation.
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = event.notification?.data?.url || DEFAULT_CLICK_URL;
+  const targetHref = new URL(targetUrl, self.location.origin).href;
+
+  event.waitUntil(
+    (async () => {
+      const windowClients = await clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true,
+      });
+      for (const client of windowClients) {
+        if (client.url.startsWith(self.location.origin) && 'focus' in client) {
+          if ('navigate' in client) {
+            try {
+              await client.navigate(targetHref);
+            } catch {
+              // Cross-origin or unsupported navigate — fall back to focus only.
+            }
+          }
+          return client.focus();
+        }
+      }
+      if (clients.openWindow) {
+        return clients.openWindow(targetHref);
+      }
+      return undefined;
+    })()
+  );
 });
 
 // Allow the app shell to trigger skipWaiting so a waiting SW activates

--- a/scripts/canary-comms-preview.mjs
+++ b/scripts/canary-comms-preview.mjs
@@ -1,0 +1,178 @@
+/**
+ * Comms email preview script — sends every email-capable v1 trigger template
+ * to the admin account so the actual rendered Resend output can be reviewed
+ * before flipping `COMMS_EVENT_ADAPTERS_ENABLED` on in production.
+ *
+ * Reuses the auth flow from `scripts/canary-comms.mjs` (mint a custom token
+ * for the admin uid, exchange for an ID token, call `runCommsTrigger` over
+ * HTTPS — no password or browser needed).
+ *
+ * Uses `bypassDailyCap: true` (admin-only, QA-only — see `commsEmailWorker.js`)
+ * so all 5 templates land in one sitting instead of being capped to 1/day.
+ * Uses `forceResend: true` so re-running this script always sends again
+ * instead of getting deduped against a prior test send.
+ *
+ * Usage:
+ *   node scripts/canary-comms-preview.mjs
+ */
+
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const envPath = resolve(__dirname, '../.env');
+const envVars = {};
+for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+  const m = line.match(/^([^#=]+)=(.*)$/);
+  if (m) envVars[m[1].trim()] = m[2].trim().replace(/^"|"$/g, '');
+}
+
+const API_KEY = envVars.VITE_FIREBASE_API_KEY;
+const PROJECT_ID = 'set-picks';
+const REGION = 'us-central1';
+const ADMIN_EMAIL = 'pat@road2media.com';
+
+const serviceAccount = {
+  projectId: PROJECT_ID,
+  clientEmail: envVars.GCP_CLIENT_EMAIL,
+  privateKey: envVars.GCP_PRIVATE_KEY.replace(/\\n/g, '\n'),
+};
+
+const admin = require('../functions/node_modules/firebase-admin/lib/index.js');
+
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccount),
+    projectId: PROJECT_ID,
+  });
+}
+
+async function getAdminUid() {
+  const user = await admin.auth().getUserByEmail(ADMIN_EMAIL);
+  return user.uid;
+}
+
+async function mintIdToken(uid) {
+  const customToken = await admin.auth().createCustomToken(uid);
+  const res = await fetch(
+    `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${API_KEY}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Referer: 'https://www.setlistpickem.com/',
+        Origin: 'https://www.setlistpickem.com',
+      },
+      body: JSON.stringify({ token: customToken, returnSecureToken: true }),
+    }
+  );
+  const json = await res.json();
+  if (!res.ok) throw new Error(`Token exchange failed: ${json.error?.message}`);
+  return json.idToken;
+}
+
+async function callRunCommsTrigger(idToken, payload) {
+  const url = `https://${REGION}-${PROJECT_ID}.cloudfunctions.net/runCommsTrigger`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${idToken}` },
+    body: JSON.stringify({ data: payload }),
+  });
+  const json = await res.json();
+  if (!res.ok) throw new Error(`Function error ${res.status}: ${JSON.stringify(json)}`);
+  return json.result ?? json;
+}
+
+// Every trigger whose catalog `channels` includes "email"
+// (functions/commsCatalog.js TRIGGER_SPECS). Payload keys match the
+// placeholders each template reads in functions/commsTemplates.js; vars
+// keys only affect the dedup doc id (harmless with forceResend: true).
+const TRIGGERS_TO_PREVIEW = [
+  {
+    triggerId: 'account_welcome',
+    payload: {
+      handle: 'Pat',
+      next_show_date: 'Sat, Sep 12',
+      next_show_venue: 'Sphere, Las Vegas',
+    },
+  },
+  {
+    triggerId: 'tour_countdown',
+    payload: {
+      tour_name: "Fall Tour '26",
+      days_remaining: 3,
+      lock_time_local: '7:55 PM',
+      first_show_date: 'Fri, Sep 11',
+      first_show_venue: 'Madison Square Garden',
+      first_show_city: 'New York, NY',
+    },
+    vars: { tourId: 'preview-tour', days_remaining: 3 },
+  },
+  {
+    triggerId: 'picks_lock_reminder',
+    payload: {
+      venue_name: 'Madison Square Garden',
+      lock_time_local: '7:55 PM',
+    },
+    vars: { showYmd: '2026-09-11' },
+  },
+  {
+    triggerId: 'tour_rankings_daily',
+    payload: {
+      venue_name: 'Madison Square Garden',
+      venue_city: 'New York',
+      show_score: 42,
+      global_rank: 7,
+      global_total_pickers: 3120,
+      correct_picks_count: 3,
+      total_picks_count: 4,
+      tour_rank: 12,
+      total_tour_pickers: 890,
+      tour_points: 156,
+      rank_change: '+4',
+      next_show_venue: 'TD Garden',
+      next_show_date: 'Sun, Sep 13',
+    },
+    vars: { showDate: '2026-09-11' },
+  },
+  {
+    triggerId: 'tour_engagement_reminder',
+    payload: {
+      global_rank: 12,
+      shows_remaining: 6,
+    },
+    vars: { tourId: 'preview-tour' },
+  },
+];
+
+try {
+  console.log(`\u2192 Looking up admin uid for ${ADMIN_EMAIL}\u2026`);
+  const uid = await getAdminUid();
+  console.log(`\u2713 uid = ${uid}\n`);
+
+  console.log('\u2192 Minting ID token via service account\u2026');
+  const idToken = await mintIdToken(uid);
+  console.log('\u2713 ID token obtained\n');
+
+  for (const { triggerId, payload, vars } of TRIGGERS_TO_PREVIEW) {
+    console.log(`\u2192 runCommsTrigger  triggerId=${triggerId}  dryRun=false  bypassDailyCap=true`);
+    // eslint-disable-next-line no-await-in-loop
+    const result = await callRunCommsTrigger(idToken, {
+      triggerId,
+      recipients: [{ uid, payload, vars }],
+      dryRun: false,
+      forceResend: true,
+      bypassDailyCap: true,
+    });
+    console.log(JSON.stringify(result, null, 2), '\n');
+  }
+
+  console.log(`Done. Check ${ADMIN_EMAIL} for ${TRIGGERS_TO_PREVIEW.length} preview emails.`);
+} catch (err) {
+  console.error('\n\u2717', err.message);
+  process.exit(1);
+}

--- a/scripts/diagnose-comms-email.mjs
+++ b/scripts/diagnose-comms-email.mjs
@@ -1,0 +1,87 @@
+/**
+ * Read-only diagnostic for "push/in-app fired but no email" (#453/#442 area).
+ *
+ * Checks, for the admin test address:
+ *   1. Whether it's on the `email_suppression` list (and why/when, if so).
+ *   2. The most recent `email_cap:{uid}:{day}` doc, so a bad daily-cap read
+ *      isn't mistaken for a suppression issue.
+ *
+ * Uses the same local service-account credentials as scripts/canary-comms.mjs.
+ * Read-only — does not modify Firestore.
+ *
+ * Usage:
+ *   node scripts/diagnose-comms-email.mjs
+ */
+
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import crypto from 'node:crypto';
+
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const envPath = resolve(__dirname, '../.env');
+const envVars = {};
+for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+  const m = line.match(/^([^#=]+)=(.*)$/);
+  if (m) envVars[m[1].trim()] = m[2].trim().replace(/^"|"$/g, '');
+}
+
+const PROJECT_ID = 'set-picks';
+const ADMIN_EMAIL = 'pat@road2media.com';
+
+const serviceAccount = {
+  projectId: PROJECT_ID,
+  clientEmail: envVars.GCP_CLIENT_EMAIL,
+  privateKey: envVars.GCP_PRIVATE_KEY.replace(/\\n/g, '\n'),
+};
+
+const admin = require('../functions/node_modules/firebase-admin/lib/index.js');
+if (!admin.apps.length) {
+  admin.initializeApp({ credential: admin.credential.cert(serviceAccount), projectId: PROJECT_ID });
+}
+const db = admin.firestore();
+
+function emailSuppressionDocId(email) {
+  return crypto.createHash('sha256').update(email.trim().toLowerCase()).digest('hex');
+}
+
+try {
+  console.log(`→ Looking up admin uid for ${ADMIN_EMAIL}…`);
+  const user = await admin.auth().getUserByEmail(ADMIN_EMAIL);
+  const uid = user.uid;
+  console.log(`✓ uid = ${uid}\n`);
+
+  // 1. Suppression check
+  const docId = emailSuppressionDocId(ADMIN_EMAIL);
+  const suppressionSnap = await db.collection('email_suppression').doc(docId).get();
+  if (suppressionSnap.exists) {
+    console.log('✗ SUPPRESSED — this is almost certainly why no email arrived:');
+    console.log(JSON.stringify(suppressionSnap.data(), null, 2));
+  } else {
+    console.log('✓ Not on the email_suppression list.');
+  }
+
+  // 2. Daily cap check (America/Los_Angeles calendar day)
+  const day = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date());
+  const capDocId = `email_cap:${uid}:${day}`;
+  const capSnap = await db.collection('fcm_notification_log').doc(capDocId).get();
+  console.log(`\n→ Daily cap doc (${capDocId}):`);
+  console.log(capSnap.exists ? JSON.stringify(capSnap.data(), null, 2) : '(no doc — cap not yet used today)');
+
+  // 3. User doc notificationPrefs (in case lifecycle/results got flipped off by
+  //    the earlier one-click-unsubscribe test flow, if that was ever run)
+  const userSnap = await db.collection('users').doc(uid).get();
+  console.log('\n→ notificationPrefs on the user doc:');
+  console.log(JSON.stringify(userSnap.data()?.notificationPrefs ?? '(none set — defaults apply)', null, 2));
+} catch (err) {
+  console.error('\n✗', err.message);
+  process.exit(1);
+}

--- a/scripts/qa-daily-cap-test.mjs
+++ b/scripts/qa-daily-cap-test.mjs
@@ -1,0 +1,145 @@
+/**
+ * #453/#456 daily-cap manual test plan: fires two real, non-exempt
+ * email-eligible triggers for the same user on the same day WITHOUT
+ * `bypassDailyCap`, and confirms exactly one sends email while the other is
+ * capped (`skipReason: "daily_email_cap"`, logged as `comms_capped`).
+ *
+ * One-off QA script — not part of the regular canary preview flow.
+ *
+ * Usage:
+ *   node scripts/qa-daily-cap-test.mjs
+ */
+
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const envPath = resolve(__dirname, '../.env');
+const envVars = {};
+for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+  const m = line.match(/^([^#=]+)=(.*)$/);
+  if (m) envVars[m[1].trim()] = m[2].trim().replace(/^"|"$/g, '');
+}
+
+const API_KEY = envVars.VITE_FIREBASE_API_KEY;
+const PROJECT_ID = 'set-picks';
+const REGION = 'us-central1';
+const ADMIN_EMAIL = 'pat@road2media.com';
+
+const serviceAccount = {
+  projectId: PROJECT_ID,
+  clientEmail: envVars.GCP_CLIENT_EMAIL,
+  privateKey: envVars.GCP_PRIVATE_KEY.replace(/\\n/g, '\n'),
+};
+
+const admin = require('../functions/node_modules/firebase-admin/lib/index.js');
+
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccount),
+    projectId: PROJECT_ID,
+  });
+}
+
+async function getAdminUid() {
+  const user = await admin.auth().getUserByEmail(ADMIN_EMAIL);
+  return user.uid;
+}
+
+async function mintIdToken(uid) {
+  const customToken = await admin.auth().createCustomToken(uid);
+  const res = await fetch(
+    `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${API_KEY}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Referer: 'https://www.setlistpickem.com/',
+        Origin: 'https://www.setlistpickem.com',
+      },
+      body: JSON.stringify({ token: customToken, returnSecureToken: true }),
+    }
+  );
+  const json = await res.json();
+  if (!res.ok) throw new Error(`Token exchange failed: ${json.error?.message}`);
+  return json.idToken;
+}
+
+async function callRunCommsTrigger(idToken, payload) {
+  const url = `https://${REGION}-${PROJECT_ID}.cloudfunctions.net/runCommsTrigger`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${idToken}` },
+    body: JSON.stringify({ data: payload }),
+  });
+  const json = await res.json();
+  if (!res.ok) throw new Error(`Function error ${res.status}: ${JSON.stringify(json)}`);
+  return json.result ?? json;
+}
+
+// Both non-exempt (account_welcome is the only EXEMPT_TRIGGERS entry in
+// commsEmailDailyCap.js), so whichever runs first wins today's one
+// discretionary-email slot for this uid.
+const FIRST = {
+  triggerId: 'tour_countdown',
+  payload: {
+    tour_name: "Fall Tour '26",
+    days_remaining: 2,
+    lock_time_local: '7:55 PM',
+    first_show_venue: 'Madison Square Garden',
+  },
+  vars: { tourId: 'daily-cap-qa', days_remaining: 2 },
+};
+const SECOND = {
+  triggerId: 'picks_lock_reminder',
+  payload: { venue_name: 'Madison Square Garden', lock_time_local: '7:55 PM' },
+  vars: { showYmd: '2026-09-12' },
+};
+
+try {
+  console.log(`\u2192 Looking up admin uid for ${ADMIN_EMAIL}\u2026`);
+  const uid = await getAdminUid();
+  console.log(`\u2713 uid = ${uid}\n`);
+
+  console.log('\u2192 Minting ID token\u2026');
+  const idToken = await mintIdToken(uid);
+  console.log('\u2713 ID token obtained\n');
+
+  console.log(`\u2192 [1/2] runCommsTrigger triggerId=${FIRST.triggerId} (no bypassDailyCap, expect email:1)`);
+  const first = await callRunCommsTrigger(idToken, {
+    triggerId: FIRST.triggerId,
+    recipients: [{ uid, payload: FIRST.payload, vars: FIRST.vars }],
+    dryRun: false,
+    forceResend: true,
+  });
+  console.log(JSON.stringify(first, null, 2), '\n');
+
+  console.log(`\u2192 [2/2] runCommsTrigger triggerId=${SECOND.triggerId} (no bypassDailyCap, expect email:0 / capped)`);
+  const second = await callRunCommsTrigger(idToken, {
+    triggerId: SECOND.triggerId,
+    recipients: [{ uid, payload: SECOND.payload, vars: SECOND.vars }],
+    dryRun: false,
+    forceResend: true,
+  });
+  console.log(JSON.stringify(second, null, 2), '\n');
+
+  const firstEmail = first?.byChannel?.email;
+  const secondEmail = second?.byChannel?.email;
+  const secondSkip = second?.results?.[0]?.status === 'skipped' ? second.results[0] : null;
+
+  console.log('--- Result ---');
+  console.log(`First trigger (${FIRST.triggerId}) email delivered: ${firstEmail === 1 ? 'YES' : 'NO'}`);
+  console.log(`Second trigger (${SECOND.triggerId}) email delivered: ${secondEmail === 1 ? 'YES' : 'NO'}`);
+  if (firstEmail === 1 && secondEmail === 0) {
+    console.log('PASS: exactly one discretionary email sent today; the second was capped.');
+  } else {
+    console.log('UNEXPECTED: check output above against #453/#456 test plan expectations.');
+  }
+} catch (err) {
+  console.error('\n\u2717', err.message);
+  process.exit(1);
+}


### PR DESCRIPTION
Closes #456

## Summary

Closes out the remaining phase-1 comms email QA/backlog work identified while live-testing email/push templates against a real account this session:

- **Branded HTML email body** (logo, CTA button, preferences/unsubscribe footer) sent alongside the existing plain-text fallback — replaces plain-text-only sends (contributes to #455). Body copy renders as a single `<p>` with `<br>` line breaks instead of one `<p>` per line, which fixes a Gmail rendering quirk where multi-line bodies collapsed behind a clickable "..." pill. Also drops a redundant plain-text "Open the app: `<url>`" line from the HTML body since the CTA button already covers it (the plain-text-only fallback, which has no button, keeps the line).
- **`bypassDailyCap`** (admin-only, `runCommsTrigger`) lets QA preview every email-capable trigger template in one sitting without hitting the #453 daily fatigue cap. `forceResend` now also varies the Resend `idempotencyKey` so repeated QA sends with changed content don't collide with Resend's 24h idempotency window.
- **`commsEmailUnsubscribe` is now method-gated (#456 security hardening):** POST (the real RFC 8058 one-click action mail clients issue automatically via `List-Unsubscribe-Post`) suppresses immediately, same as before. GET (the visible footer link, or any link-scanner/antivirus gateway prefetching it) no longer suppresses by itself — it now renders a confirmation page requiring one explicit form submit before anything is written to `email_suppression`. Any other method returns `405`.
- The branded HTML footer's visible "Unsubscribe" link now points at the `/dashboard/notifications` preferences page instead of the raw signed one-click suppression URL, which is reserved exclusively for the invisible header.
- Executed the #453 daily-cap manual test plan for real (no `bypassDailyCap`): two non-exempt triggers same day → first sends, second is capped, `comms_capped` logs the winning trigger.
- **Push notification click-through** — `firebase-messaging-sw.js` now handles `notificationclick` and focuses/opens the app to the notification's link (previously clicking a desktop push notification did nothing).
- New `functions/commsEmailUnsubscribe.test.js` — direct unit coverage for `processOneClickUnsubscribe`, `buildOneClickUnsubscribeUrl`, the signed-token round trip, and the new GET-confirmation helpers.

Full results/evidence recorded on #456.

## Semver

Minor bump `1.8.0` → `1.9.0` (new `bypassDailyCap` request field on `runCommsTrigger`, new branded-HTML email capability). `CHANGELOG.md` and `docs/API.md` updated in this PR.

## Test plan

- [x] `cd functions && npm test` — 228/228 passing
- [x] `npm run lint` — clean
- [x] Deployed to `set-picks` and live-verified against the real endpoints:
  - [x] Branded HTML preview sent to `pat@road2media.com` via `scripts/canary-comms-preview.mjs` for all 5 email-capable triggers — confirmed logo/CTA/footer render correctly and the Gmail "..." collapse no longer occurs.
  - [x] `commsEmailUnsubscribe`: GET + valid sig → `200` confirm page, **no** suppression written; POST (form submit) + same sig → `200` success, suppression written; invalid sig → `400`; `PUT` → `405`.
  - [x] Real (non-bypass) daily-cap test: `tour_countdown` then `picks_lock_reminder` same day for the same uid → first delivered on email, second capped; `comms_capped` log confirms `comms_cap_winner: tour_countdown`.
- [ ] User to confirm the redesigned confirmation-page unsubscribe UX reads well in a real inbox click-through.

Made with [Cursor](https://cursor.com)