### PR TITLE
feat(comms): email prefs UI + callables, bundle as v1.10.0 (#455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,53 +12,33 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
-## [1.9.0] — 2026-07-02
+## [1.10.0] — 2026-07-02
 
-### Added
-- **Branded HTML email body (#455)** — comms email now sends a branded `html` part (logo, CTA button, footer with "Manage preferences"/"Unsubscribe" links) alongside the existing plain-text fallback, instead of plain text only. Body copy renders as a single `<p>` with `<br>` line breaks rather than one `<p>` per line, avoiding a Gmail content-folding quirk that collapsed multi-line bodies behind a clickable "..." pill.
-- **`bypassDailyCap` (admin-only, `runCommsTrigger`)** — skips the #453 daily email fatigue cap reservation so a reviewer can preview every email-capable trigger template in one sitting without being capped to one send/day. Never set by production event adapters. See `scripts/canary-comms-preview.mjs`.
-- **Push notification click-through** — `firebase-messaging-sw.js` now handles `notificationclick`, focusing an existing app window or opening one to the notification's deep link. Previously clicking a desktop push notification did nothing.
-- `functions/commsEmailUnsubscribe.test.js` — direct unit coverage for `processOneClickUnsubscribe`, `buildOneClickUnsubscribeUrl`, the signed-token round trip, and the new GET-confirmation helpers (closes out #456's test-coverage gap).
-
-### Changed
-- **`forceResend` (`runCommsTrigger`)** now also varies the Resend `idempotencyKey` (timestamp + random suffix) in addition to bypassing dedup, so repeated QA sends with changed template content no longer collide with Resend's 24h idempotency window.
-- The branded HTML body no longer repeats the plain-text "Open the app: `<url>`" line — the HTML already has its own CTA button to the same destination. The plain-text-only fallback (no button available there) still includes it.
-- **`commsEmailUnsubscribe` is now method-gated (#456, security hardening):** POST (the real RFC 8058 one-click action mail clients issue automatically) suppresses immediately, same as before. GET (the visible footer link, or a link-scanner/antivirus gateway prefetching it) no longer suppresses by itself — it now renders a confirmation page requiring one explicit form submit. Any other method returns `405`. Live-verified against the deployed endpoint.
-- The branded HTML footer's visible "Unsubscribe" link now points at the `/dashboard/notifications` preferences page instead of the raw signed one-click suppression URL, which is now reserved exclusively for the invisible `List-Unsubscribe` header.
-
-### Fixed
-- Executed the #453 daily-cap manual test plan for real (no bypass): two non-exempt triggers same day → first sends, second is capped with `comms_capped` logging the winning trigger. Previously unverified in production.
-
----
-
-## [1.8.0] — 2026-07-02
-
-### Added
-- **Per-user daily email fatigue cap (#453)** — at most one discretionary email per user per `America/Los_Angeles` day, enforced transactionally via a new `email_cap:{uid}:{day}` doc-id shape inside the existing `fcm_notification_log` collection (no new collection/rules entry). Checked in `commsEmailWorker.js` after the suppression check, before the real Resend send; fails open on transaction errors so a Firestore hiccup can never silently swallow a legitimate email.
-- `account_welcome` is exempt from the cap (one-time-ever send, can't cause fatigue).
-- New `comms_capped` structured log event (Cloud Logging, not yet GA4 — see epic #441) fired when a trigger's email is skipped due to the cap.
-
-### Changed
-- **Known limitation:** the cap is first-reservation-wins (whichever trigger's email worker runs first that day keeps the slot) rather than a true priority queue — a higher-value trigger firing later in the day cannot preempt an already-sent lower-value one, since an email can't be unsent. In practice this means the two morning crons (`tour_rankings_daily` 8am PT, `tour_countdown` 9am PT) will usually win over the evening-firing `tour_engagement_reminder` on a contested day. Revisit if `comms_capped` data shows this ordering is hurting engagement.
-
----
-
-## [1.7.2] — 2026-07-02
-
-### Changed
-- **Comms fatigue reduction (#451)** — `show_recap` no longer emails; its "your night" recap content (score, rank) is folded into `tour_rankings_daily`'s next-morning email instead. Eliminates the dominant same-day email collision (both triggers previously fired for the same `(uid, showDate)` on every single-tour-night). `inApp`/`push` channels are unchanged — night-of delivery still fires immediately from `show_recap`.
-- Fixed stale `tour_rankings_daily` schedule description in `docs/comms-triggers/` (documented as "10:00 AM ET"; actual `onSchedule` cron is 8:00 AM `America/Los_Angeles`)
-
----
-
-## [1.7.1] — 2026-06-30
+Bundled comms phase-1 release to production: rolls up staging-only increments 1.7.1–1.9.0 plus #455 email preferences UI. Main was at 1.7.0 (event adapters, gated off). `COMMS_EVENT_ADAPTERS_ENABLED` remains off until post-deploy canary (#438).
 
 ### Added
 - **Resend deliverability (#442)** — `commsResendWebhook` (bounce/complaint/suppression → `email_suppression`), `commsEmailUnsubscribe` (RFC 8058 one-click), email worker suppression gate
 - **Firestore** — `email_suppression/{sha256(email)}` server-only collection
+- **Per-user daily email fatigue cap (#453)** — at most one discretionary email per user per `America/Los_Angeles` day, enforced transactionally via `email_cap:{uid}:{day}` inside `fcm_notification_log`. `account_welcome` is exempt. New `comms_capped` structured log event (Cloud Logging, not yet GA4 — see epic #441).
+- **Branded HTML email body (#456)** — comms email sends a branded `html` part (logo, CTA button, footer with "Manage preferences"/"Unsubscribe" links) alongside plain-text fallback. Body copy renders as a single `<p>` with `<br>` line breaks (avoids Gmail content-folding quirk).
+- **`bypassDailyCap` (admin-only, `runCommsTrigger`)** — skips the #453 daily cap for QA template preview runs. See `scripts/canary-comms-preview.mjs`.
+- **Push notification click-through** — `firebase-messaging-sw.js` handles `notificationclick`, focusing an existing app window or opening the deep link.
+- **Notifications email preferences UI (#455)** — Email accordion on `/dashboard/notifications` shows lifecycle email status, suppression reason, and unsubscribe / re-enable actions. "Tour & onboarding updates" copy now states it applies to push, in-app, and email.
+- **Comms email subscription callables (#455)** — `getCommsEmailStatus`, `unsubscribeCommsEmail`, `resubscribeCommsEmail` (clients cannot read `email_suppression` directly). Self-serve resubscribe clears `one_click_unsubscribe` and `user_preferences` suppressions; hard bounces and spam complaints stay blocked.
+- `functions/commsEmailUnsubscribe.test.js`, `functions/commsEmailPrefs.test.js` — unit coverage for unsubscribe and prefs callables.
 
 ### Changed
-- Comms email `List-Unsubscribe` headers now include signed one-click unsubscribe URLs when `RESEND_WEBHOOK_SECRET` is set
+- Comms email `List-Unsubscribe` headers include signed one-click unsubscribe URLs when `RESEND_WEBHOOK_SECRET` is set
+- **Comms fatigue reduction (#451)** — `show_recap` no longer emails; recap content folded into `tour_rankings_daily`'s next-morning email. `inApp`/`push` unchanged.
+- Fixed stale `tour_rankings_daily` schedule description in `docs/comms-triggers/` (documented as "10:00 AM ET"; actual cron is 8:00 AM `America/Los_Angeles`)
+- **Known daily-cap limitation:** first-reservation-wins per day — morning crons (`tour_rankings_daily`, `tour_countdown`) usually win over evening `tour_engagement_reminder`.
+- **`forceResend` (`runCommsTrigger`)** varies the Resend `idempotencyKey` (timestamp + random suffix) in addition to bypassing dedup.
+- Branded HTML body no longer repeats the plain-text "Open the app: `<url>`" line (HTML has its own CTA).
+- **`commsEmailUnsubscribe` method gating (#456):** POST suppresses immediately (RFC 8058 one-click); GET renders a confirmation form (link-scanner safe); other methods return `405`.
+- Branded HTML footer "Unsubscribe" link points at `/dashboard/notifications`; raw one-click URL is only in the `List-Unsubscribe` header.
+
+### Fixed
+- Executed the #453 daily-cap manual test plan: two non-exempt triggers same day → first sends, second capped with `comms_capped` logging.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.8.0  
+**Version:** 1.10.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 
@@ -181,6 +181,16 @@ Configure the Resend dashboard webhook URL to the deployed `commsResendWebhook` 
 - Any other method, or an invalid/missing signature, returns `400`/`405` without touching `email_suppression`.
 
 The branded HTML email body's visible footer link points at the `/dashboard/notifications` settings page, not this endpoint directly — the raw one-click URL is only ever embedded in the invisible `List-Unsubscribe` header.
+
+### 2.6 Comms email subscription callables (v1.10.0, #455)
+
+Authenticated callables backing the Notifications screen email section. Clients cannot read `email_suppression` directly.
+
+| Export | Auth | Description |
+|--------|------|-------------|
+| `getCommsEmailStatus` | Signed-in user | Returns `{ hasEmail, suppressed, reason, canResubscribe, message, lifecycleEnabled }` for the caller's account email |
+| `unsubscribeCommsEmail` | Signed-in user | Writes `email_suppression` with `reason: user_preferences` and opts out `notificationPrefs.lifecycle` |
+| `resubscribeCommsEmail` | Signed-in user | Clears self-serve suppressions (`one_click_unsubscribe`, `user_preferences`) and re-enables `notificationPrefs.lifecycle`; hard bounces and spam complaints are rejected |
 
 ---
 

--- a/functions/commsEmailPrefs.js
+++ b/functions/commsEmailPrefs.js
@@ -1,0 +1,159 @@
+/**
+ * Signed-in email subscription status + self-serve subscribe/unsubscribe (#455).
+ *
+ * Clients cannot read `email_suppression` directly (server-only collection).
+ * These helpers back authenticated callables used by `/dashboard/notifications`.
+ */
+
+"use strict";
+
+const {
+  SUPPRESSION_COLLECTION,
+  normalizeEmail,
+  emailSuppressionDocId,
+  suppressEmail,
+  optOutUserEmailPrefs,
+} = require("./commsEmailSuppression");
+
+/** Reasons a user may clear via the Notifications screen (not deliverability blocks). */
+const RESUBSCRIBABLE_REASONS = new Set(["one_click_unsubscribe", "user_preferences"]);
+
+/**
+ * @param {string | null | undefined} reason
+ * @returns {string | null}
+ */
+function userFacingSuppressionLabel(reason) {
+  switch (reason) {
+    case "one_click_unsubscribe":
+    case "user_preferences":
+      return "You unsubscribed from email updates.";
+    case "hard_bounce":
+      return "Email is paused because messages to this address could not be delivered.";
+    case "spam_complaint":
+      return "Email is paused after a spam report was received for this address.";
+    case "resend_suppressed":
+      return "Email is paused by our delivery provider for this address.";
+    default:
+      return reason ? "Email is paused for this address." : null;
+  }
+}
+
+/**
+ * @param {import("firebase-admin").firestore.Firestore} db
+ * @param {string} uid
+ * @returns {Promise<{
+ *   ok: boolean,
+ *   hasEmail: boolean,
+ *   suppressed: boolean,
+ *   reason: string | null,
+ *   canResubscribe: boolean,
+ *   message: string | null,
+ *   lifecycleEnabled: boolean,
+ * }>}
+ */
+async function getCommsEmailStatusForUser(db, uid) {
+  if (!uid) return { ok: false, hasEmail: false, suppressed: false, reason: null, canResubscribe: false, message: null, lifecycleEnabled: true };
+
+  const userSnap = await db.collection("users").doc(uid).get();
+  if (!userSnap.exists) {
+    return {
+      ok: true,
+      hasEmail: false,
+      suppressed: false,
+      reason: null,
+      canResubscribe: false,
+      message: "Add an email address to your account to receive updates.",
+      lifecycleEnabled: true,
+    };
+  }
+
+  const userData = userSnap.data() || {};
+  const email = normalizeEmail(userData.email);
+  const lifecycleEnabled = userData.notificationPrefs?.lifecycle !== false;
+
+  if (!email) {
+    return {
+      ok: true,
+      hasEmail: false,
+      suppressed: false,
+      reason: null,
+      canResubscribe: false,
+      message: "Add an email address to your account to receive updates.",
+      lifecycleEnabled,
+    };
+  }
+
+  const docId = emailSuppressionDocId(email);
+  const snap = await db.collection(SUPPRESSION_COLLECTION).doc(docId).get();
+  const suppressed = snap.exists && snap.data()?.suppressed === true;
+  const reason = suppressed ? String(snap.data()?.reason || "unknown") : null;
+  const canResubscribe = suppressed && RESUBSCRIBABLE_REASONS.has(reason);
+
+  return {
+    ok: true,
+    hasEmail: true,
+    suppressed,
+    reason,
+    canResubscribe,
+    message: suppressed ? userFacingSuppressionLabel(reason) : null,
+    lifecycleEnabled,
+  };
+}
+
+/**
+ * @param {import("firebase-admin").firestore.Firestore} db
+ * @param {typeof import("firebase-admin")} admin
+ * @param {string} uid
+ * @returns {Promise<{ ok: boolean, reason?: string }>}
+ */
+async function resubscribeCommsEmailForUser(db, admin, uid) {
+  const status = await getCommsEmailStatusForUser(db, uid);
+  if (!status.hasEmail) return { ok: false, reason: "no_email" };
+  if (!status.suppressed) return { ok: true };
+  if (!status.canResubscribe) return { ok: false, reason: "not_resubscribable" };
+
+  const userSnap = await db.collection("users").doc(uid).get();
+  const email = normalizeEmail(userSnap.data()?.email);
+  const docId = emailSuppressionDocId(email);
+  if (!docId) return { ok: false, reason: "invalid_email" };
+
+  await db.collection(SUPPRESSION_COLLECTION).doc(docId).delete();
+  await db.collection("users").doc(uid).set(
+    {
+      "notificationPrefs.lifecycle": true,
+    },
+    { merge: true }
+  );
+
+  return { ok: true };
+}
+
+/**
+ * @param {import("firebase-admin").firestore.Firestore} db
+ * @param {typeof import("firebase-admin")} admin
+ * @param {string} uid
+ * @returns {Promise<{ ok: boolean, reason?: string }>}
+ */
+async function unsubscribeCommsEmailForUser(db, admin, uid) {
+  const userSnap = await db.collection("users").doc(uid).get();
+  if (!userSnap.exists) return { ok: false, reason: "no_user" };
+  const email = normalizeEmail(userSnap.data()?.email);
+  if (!email) return { ok: false, reason: "no_email" };
+
+  await suppressEmail(db, admin, {
+    email,
+    reason: "user_preferences",
+    source: "notifications_preferences",
+    eventId: null,
+  });
+  await optOutUserEmailPrefs(db, uid);
+  return { ok: true };
+}
+
+module.exports = {
+  RESUBSCRIBABLE_REASONS,
+  userFacingSuppressionLabel,
+  getCommsEmailStatusForUser,
+  resubscribeCommsEmailForUser,
+  unsubscribeCommsEmailForUser,
+};

--- a/functions/commsEmailPrefs.test.js
+++ b/functions/commsEmailPrefs.test.js
@@ -1,0 +1,134 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  getCommsEmailStatusForUser,
+  resubscribeCommsEmailForUser,
+  unsubscribeCommsEmailForUser,
+  userFacingSuppressionLabel,
+} = require("./commsEmailPrefs");
+const { emailSuppressionDocId } = require("./commsEmailSuppression");
+
+function fakeDb({ users = {}, suppressions = {} } = {}) {
+  const userDocs = new Map(Object.entries(users));
+  const suppressionDocs = new Map(Object.entries(suppressions));
+  return {
+    collection(name) {
+      if (name === "users") {
+        return {
+          doc(id) {
+            return {
+              async get() {
+                const data = userDocs.get(id);
+                return { exists: userDocs.has(id), data: () => data };
+              },
+              async set(data, opts) {
+                const prev = userDocs.get(id) || {};
+                userDocs.set(id, opts?.merge ? { ...prev, ...data } : data);
+              },
+            };
+          },
+        };
+      }
+      if (name === "email_suppression") {
+        return {
+          doc(id) {
+            return {
+              async get() {
+                const data = suppressionDocs.get(id);
+                return { exists: suppressionDocs.has(id), data: () => data };
+              },
+              async delete() {
+                suppressionDocs.delete(id);
+              },
+              async set(data, opts) {
+                const prev = suppressionDocs.get(id) || {};
+                suppressionDocs.set(id, opts?.merge ? { ...prev, ...data } : data);
+              },
+            };
+          },
+        };
+      }
+      throw new Error(`unexpected collection ${name}`);
+    },
+    _userDocs: userDocs,
+    _suppressionDocs: suppressionDocs,
+  };
+}
+
+const fakeAdmin = {
+  firestore: { FieldValue: { serverTimestamp: () => ({ __ts: true }) } },
+};
+
+test("userFacingSuppressionLabel maps known reasons", () => {
+  assert.match(userFacingSuppressionLabel("one_click_unsubscribe"), /unsubscribed/i);
+  assert.match(userFacingSuppressionLabel("hard_bounce"), /delivered/i);
+});
+
+test("getCommsEmailStatusForUser reports not suppressed when no doc exists", async () => {
+  const db = fakeDb({
+    users: {
+      u1: { email: "picker@example.com", notificationPrefs: { lifecycle: true } },
+    },
+  });
+  const status = await getCommsEmailStatusForUser(db, "u1");
+  assert.equal(status.suppressed, false);
+  assert.equal(status.hasEmail, true);
+  assert.equal(status.lifecycleEnabled, true);
+});
+
+test("getCommsEmailStatusForUser reports one-click suppression as resubscribable", async () => {
+  const email = "picker@example.com";
+  const docId = emailSuppressionDocId(email);
+  const db = fakeDb({
+    users: { u1: { email, notificationPrefs: { lifecycle: false } } },
+    suppressions: {
+      [docId]: { suppressed: true, reason: "one_click_unsubscribe" },
+    },
+  });
+  const status = await getCommsEmailStatusForUser(db, "u1");
+  assert.equal(status.suppressed, true);
+  assert.equal(status.canResubscribe, true);
+  assert.match(status.message, /unsubscribed/i);
+});
+
+test("getCommsEmailStatusForUser treats hard bounce as not resubscribable", async () => {
+  const email = "bad@example.com";
+  const docId = emailSuppressionDocId(email);
+  const db = fakeDb({
+    users: { u1: { email } },
+    suppressions: {
+      [docId]: { suppressed: true, reason: "hard_bounce" },
+    },
+  });
+  const status = await getCommsEmailStatusForUser(db, "u1");
+  assert.equal(status.canResubscribe, false);
+});
+
+test("resubscribeCommsEmailForUser clears a one-click suppression and re-enables lifecycle", async () => {
+  const email = "picker@example.com";
+  const docId = emailSuppressionDocId(email);
+  const db = fakeDb({
+    users: { u1: { email, notificationPrefs: { lifecycle: false } } },
+    suppressions: {
+      [docId]: { suppressed: true, reason: "one_click_unsubscribe" },
+    },
+  });
+  const result = await resubscribeCommsEmailForUser(db, fakeAdmin, "u1");
+  assert.equal(result.ok, true);
+  assert.equal(db._suppressionDocs.has(docId), false);
+  assert.equal(db._userDocs.get("u1")["notificationPrefs.lifecycle"], true);
+});
+
+test("unsubscribeCommsEmailForUser writes suppression and opts out lifecycle prefs", async () => {
+  const db = fakeDb({
+    users: { u1: { email: "picker@example.com", notificationPrefs: { lifecycle: true } } },
+  });
+  const result = await unsubscribeCommsEmailForUser(db, fakeAdmin, "u1");
+  assert.equal(result.ok, true);
+  const docId = emailSuppressionDocId("picker@example.com");
+  assert.equal(db._suppressionDocs.get(docId).reason, "user_preferences");
+  assert.equal(db._userDocs.get("u1")["notificationPrefs.lifecycle"], false);
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -56,6 +56,11 @@ const {
   renderUnsubscribeSuccessPage,
 } = require("./commsEmailUnsubscribe");
 const {
+  getCommsEmailStatusForUser,
+  resubscribeCommsEmailForUser,
+  unsubscribeCommsEmailForUser,
+} = require("./commsEmailPrefs");
+const {
   handleAccountWelcome,
   handlePicksConfirmed,
   deliverLiveScoreComms,
@@ -608,6 +613,77 @@ exports.commsEmailUnsubscribe = onRequest(
     }
 
     res.status(405).send("Method Not Allowed");
+  }
+);
+
+/**
+ * Read lifecycle email subscription status for the signed-in user (#455).
+ * Clients cannot query `email_suppression` directly.
+ */
+exports.getCommsEmailStatus = onCall(
+  {
+    region: PHISHNET_FUNCTIONS_REGION,
+    invoker: "public",
+    enforceAppCheck: false,
+  },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError("unauthenticated", "Sign in required.");
+    }
+    return getCommsEmailStatusForUser(db, request.auth.uid);
+  }
+);
+
+/**
+ * Self-serve lifecycle email unsubscribe from Notifications preferences (#455).
+ */
+exports.unsubscribeCommsEmail = onCall(
+  {
+    region: PHISHNET_FUNCTIONS_REGION,
+    invoker: "public",
+    enforceAppCheck: false,
+  },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError("unauthenticated", "Sign in required.");
+    }
+    const result = await unsubscribeCommsEmailForUser(db, admin, request.auth.uid);
+    if (!result.ok) {
+      throw new HttpsError("failed-precondition", result.reason || "unsubscribe_failed");
+    }
+    logger.info("comms_email_unsubscribed", {
+      comms_channel: "email",
+      uid: request.auth.uid,
+      source: "notifications_preferences",
+    });
+    return { ok: true };
+  }
+);
+
+/**
+ * Clear a self-serve email suppression and re-enable lifecycle prefs (#455).
+ * Only allowed for user-initiated reasons — not hard bounces or spam complaints.
+ */
+exports.resubscribeCommsEmail = onCall(
+  {
+    region: PHISHNET_FUNCTIONS_REGION,
+    invoker: "public",
+    enforceAppCheck: false,
+  },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError("unauthenticated", "Sign in required.");
+    }
+    const result = await resubscribeCommsEmailForUser(db, admin, request.auth.uid);
+    if (!result.ok) {
+      throw new HttpsError("failed-precondition", result.reason || "resubscribe_failed");
+    }
+    logger.info("comms_email_resubscribed", {
+      comms_channel: "email",
+      uid: request.auth.uid,
+      source: "notifications_preferences",
+    });
+    return { ok: true };
   }
 );
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
-    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js accountDelete.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js showFinalizationGate.test.js revertRollupCore.test.js postShowRollupPush.test.js picksLockReminder.test.js fcmMessagingCore.test.js sphereTourRecapDelivery.test.js commsCatalog.test.js commsTemplates.test.js commsEmailWorker.test.js commsEmailSuppression.test.js commsEmailDailyCap.test.js commsResendWebhook.test.js commsDelivery.test.js commsEventAdapters.test.js",
+    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js accountDelete.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js showFinalizationGate.test.js revertRollupCore.test.js postShowRollupPush.test.js picksLockReminder.test.js fcmMessagingCore.test.js sphereTourRecapDelivery.test.js commsCatalog.test.js commsTemplates.test.js commsEmailWorker.test.js commsEmailSuppression.test.js commsEmailDailyCap.test.js commsEmailUnsubscribe.test.js commsEmailPrefs.test.js commsResendWebhook.test.js commsDelivery.test.js commsEventAdapters.test.js",
     "serve": "firebase emulators:start --only functions",
     "shell": "firebase functions:shell",
     "start": "npm run shell",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "phish-pool",
-  "version": "1.7.0",
+  "name": "setlistpickem",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "phish-pool",
-      "version": "1.7.0",
+      "name": "setlistpickem",
+      "version": "1.10.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "firebase": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/notifications/api/commsEmailPrefsApi.js
+++ b/src/features/notifications/api/commsEmailPrefsApi.js
@@ -1,0 +1,58 @@
+import { getFunctions, httpsCallable } from 'firebase/functions';
+
+import { app } from '../../../shared/lib/firebase';
+
+const FUNCTIONS_REGION = 'us-central1';
+
+/**
+ * @typedef {{
+ *   ok: boolean,
+ *   hasEmail: boolean,
+ *   suppressed: boolean,
+ *   reason: string | null,
+ *   canResubscribe: boolean,
+ *   message: string | null,
+ *   lifecycleEnabled: boolean,
+ * }} CommsEmailStatus
+ */
+
+/**
+ * @returns {Promise<CommsEmailStatus>}
+ */
+export async function fetchCommsEmailStatus() {
+  const functions = getFunctions(app, FUNCTIONS_REGION);
+  const callable = httpsCallable(functions, 'getCommsEmailStatus');
+  const result = await callable({});
+  const data = /** @type {Record<string, unknown>} */ (result?.data ?? {});
+  return {
+    ok: data.ok === true,
+    hasEmail: data.hasEmail === true,
+    suppressed: data.suppressed === true,
+    reason: typeof data.reason === 'string' ? data.reason : null,
+    canResubscribe: data.canResubscribe === true,
+    message: typeof data.message === 'string' ? data.message : null,
+    lifecycleEnabled: data.lifecycleEnabled !== false,
+  };
+}
+
+/**
+ * @returns {Promise<{ ok: boolean }>}
+ */
+export async function unsubscribeCommsEmail() {
+  const functions = getFunctions(app, FUNCTIONS_REGION);
+  const callable = httpsCallable(functions, 'unsubscribeCommsEmail');
+  const result = await callable({});
+  const data = /** @type {Record<string, unknown>} */ (result?.data ?? {});
+  return { ok: data.ok === true };
+}
+
+/**
+ * @returns {Promise<{ ok: boolean }>}
+ */
+export async function resubscribeCommsEmail() {
+  const functions = getFunctions(app, FUNCTIONS_REGION);
+  const callable = httpsCallable(functions, 'resubscribeCommsEmail');
+  const result = await callable({});
+  const data = /** @type {Record<string, unknown>} */ (result?.data ?? {});
+  return { ok: data.ok === true };
+}

--- a/src/features/notifications/index.js
+++ b/src/features/notifications/index.js
@@ -9,4 +9,5 @@ export {
   subscribeNotificationPrefs,
 } from './api/notificationPrefsApi';
 export { useNotificationPrefs } from './model/useNotificationPrefs';
+export { useCommsEmailStatus } from './model/useCommsEmailStatus';
 export { usePushTokenRegistration } from './model/usePushTokenRegistration';

--- a/src/features/notifications/model/useCommsEmailStatus.js
+++ b/src/features/notifications/model/useCommsEmailStatus.js
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useAuth } from '../../auth';
+import {
+  fetchCommsEmailStatus,
+  resubscribeCommsEmail,
+  unsubscribeCommsEmail,
+} from '../api/commsEmailPrefsApi';
+
+/**
+ * @typedef {import('../api/commsEmailPrefsApi').CommsEmailStatus} CommsEmailStatus
+ */
+
+const EMPTY_STATUS = /** @type {CommsEmailStatus} */ ({
+  ok: false,
+  hasEmail: false,
+  suppressed: false,
+  reason: null,
+  canResubscribe: false,
+  message: null,
+  lifecycleEnabled: true,
+});
+
+export function useCommsEmailStatus() {
+  const { user } = useAuth();
+  const uid = user?.uid;
+  const [status, setStatus] = useState(EMPTY_STATUS);
+  const [loading, setLoading] = useState(false);
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState('');
+
+  const refresh = useCallback(async () => {
+    if (!uid) {
+      setStatus(EMPTY_STATUS);
+      return;
+    }
+    setLoading(true);
+    setError('');
+    try {
+      const next = await fetchCommsEmailStatus();
+      setStatus(next);
+    } catch (e) {
+      console.error(e);
+      setError('Could not load email status.');
+    } finally {
+      setLoading(false);
+    }
+  }, [uid]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const unsubscribe = useCallback(async () => {
+    if (!uid) return false;
+    setWorking(true);
+    setError('');
+    try {
+      await unsubscribeCommsEmail();
+      await refresh();
+      return true;
+    } catch (e) {
+      console.error(e);
+      setError('Could not unsubscribe from email. Try again.');
+      return false;
+    } finally {
+      setWorking(false);
+    }
+  }, [refresh, uid]);
+
+  const resubscribe = useCallback(async () => {
+    if (!uid) return false;
+    setWorking(true);
+    setError('');
+    try {
+      await resubscribeCommsEmail();
+      await refresh();
+      return true;
+    } catch (e) {
+      console.error(e);
+      setError('Could not re-enable email. Try again.');
+      return false;
+    } finally {
+      setWorking(false);
+    }
+  }, [refresh, uid]);
+
+  return useMemo(
+    () => ({
+      status,
+      loading,
+      working,
+      error,
+      refresh,
+      unsubscribe,
+      resubscribe,
+    }),
+    [error, loading, refresh, resubscribe, status, unsubscribe, working],
+  );
+}

--- a/src/features/notifications/ui/NotificationsPrototypeScreen.jsx
+++ b/src/features/notifications/ui/NotificationsPrototypeScreen.jsx
@@ -5,6 +5,7 @@ import { Bell, ChevronDown, Mail, Smartphone } from 'lucide-react';
 import { dashboardPageTitleGradientClasses } from '../../../shared/config/dashboardHeadingTypography';
 import { logCommsPrefChanged } from '../../comms';
 import CommsInboxSection from './CommsInboxSection.jsx';
+import { useCommsEmailStatus } from '../model/useCommsEmailStatus';
 import { useNotificationPrefs } from '../model/useNotificationPrefs';
 import { usePushTokenRegistration } from '../model/usePushTokenRegistration';
 
@@ -130,6 +131,14 @@ export default function NotificationsPrototypeScreen() {
     isSaving: prefsSaving,
     error: prefsError,
   } = useNotificationPrefs();
+  const {
+    status: emailStatus,
+    loading: emailLoading,
+    working: emailWorking,
+    error: emailError,
+    unsubscribe: unsubscribeEmail,
+    resubscribe: resubscribeEmail,
+  } = useCommsEmailStatus();
 
   const handlePrefChange = useCallback(
     (key, value) => {
@@ -147,7 +156,24 @@ export default function NotificationsPrototypeScreen() {
     unsupported: 'Unsupported',
     error: 'Error',
   }[status] ?? 'Off';
+
+  const emailSummary = emailLoading
+    ? 'Checking status…'
+    : !emailStatus.hasEmail
+      ? 'Add an account email to receive updates.'
+      : emailStatus.suppressed
+        ? 'Email paused.'
+        : emailStatus.lifecycleEnabled
+          ? 'On — tour and onboarding emails are enabled.'
+          : 'Off — turn on Tour & onboarding updates below.';
+
   const showUpcomingChannels = false;
+
+  const emailLeading = (
+    <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-brand-primary/30 bg-brand-primary/10">
+      <Mail className="h-5 w-5 text-brand-primary" aria-hidden />
+    </span>
+  );
 
   const pushLeading = (
     <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-brand-primary/30 bg-brand-primary/10">
@@ -175,6 +201,69 @@ export default function NotificationsPrototypeScreen() {
       </p>
 
       <ul className="mt-3 space-y-3">
+        <NotificationAccordionSection
+          sectionId="notif-email"
+          title="Email"
+          summary={emailSummary}
+          leading={emailLeading}
+          open={openSection === 'email'}
+          onToggle={() => handleAccordion('email')}
+        >
+          <p className="text-sm font-bold leading-relaxed text-content-secondary">
+            Tour countdowns, pick reminders, and post-show recaps can arrive at the email
+            address on your account. These use the same &ldquo;Tour &amp; onboarding updates&rdquo;
+            preference as push for that message family.
+          </p>
+
+          {emailStatus.suppressed && emailStatus.message ? (
+            <p className="mt-3 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-xs font-bold leading-relaxed text-amber-100">
+              {emailStatus.message}
+            </p>
+          ) : null}
+
+          {!emailStatus.hasEmail ? (
+            <p className="mt-3 text-xs font-bold leading-relaxed text-content-secondary">
+              Add an email address to your account to receive tour and onboarding updates by email.
+            </p>
+          ) : null}
+
+          {emailStatus.hasEmail ? (
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+              <span className="text-xs font-bold uppercase tracking-wider text-content-secondary">
+                {emailStatus.suppressed
+                  ? 'Paused'
+                  : emailStatus.lifecycleEnabled
+                    ? 'Receiving emails'
+                    : 'Off (preference)'}
+              </span>
+              <div className="flex flex-wrap items-center gap-2">
+                {emailStatus.suppressed && emailStatus.canResubscribe ? (
+                  <button
+                    type="button"
+                    onClick={resubscribeEmail}
+                    disabled={emailWorking}
+                    className="rounded-lg border border-brand-primary/40 bg-brand-primary/10 px-3 py-1.5 text-xs font-black uppercase tracking-widest text-brand-primary transition-colors hover:border-brand-primary hover:bg-brand-primary/20 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {emailWorking ? 'Working…' : 'Re-enable email'}
+                  </button>
+                ) : null}
+                {!emailStatus.suppressed && emailStatus.lifecycleEnabled ? (
+                  <button
+                    type="button"
+                    onClick={unsubscribeEmail}
+                    disabled={emailWorking}
+                    className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs font-black uppercase tracking-widest text-amber-200 transition-colors hover:border-amber-500 hover:bg-amber-500/20 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {emailWorking ? 'Working…' : 'Unsubscribe from email'}
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
+
+          {emailError ? <p className="mt-3 text-xs text-amber-300">{emailError}</p> : null}
+        </NotificationAccordionSection>
+
         <NotificationAccordionSection
           sectionId="notif-push"
           title="Push notifications"
@@ -269,7 +358,7 @@ export default function NotificationsPrototypeScreen() {
             />
             <ChannelToggle
               label="Tour & onboarding updates"
-              description="Welcome notes, tour countdowns, pick confirmations, and post-show nudges."
+              description="Welcome notes, tour countdowns, pick confirmations, and post-show nudges — on push, in-app, and email."
               checked={prefs.lifecycle}
               disabled={prefsSaving}
               onChange={(v) => handlePrefChange('lifecycle', v)}
@@ -302,38 +391,6 @@ export default function NotificationsPrototypeScreen() {
             </p>
           </div>
         </NotificationAccordionSection>
-
-        {showUpcomingChannels ? (
-          <NotificationAccordionSection
-            sectionId="notif-email"
-            title="Email"
-            summary="Coming soon — tap for details."
-            leading={
-              <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-border-muted bg-surface-inset">
-                <Mail className="h-5 w-5 text-content-secondary" aria-hidden />
-              </span>
-            }
-            open={openSection === 'email'}
-            onToggle={() => handleAccordion('email')}
-          >
-            <p className="text-sm font-bold leading-relaxed text-content-secondary">
-              Teaser + CTA messages (e.g. tour recaps) tied to your account email.
-            </p>
-            <div className="mt-4 flex items-center justify-between gap-3 opacity-60">
-              <span className="text-xs font-bold uppercase tracking-wider text-content-secondary">
-                Off
-              </span>
-              <button
-                type="button"
-                disabled
-                className="relative h-8 w-14 shrink-0 rounded-full bg-surface-inset ring-1 ring-border-muted"
-                aria-label="Email notifications — coming soon"
-              >
-                <span className="absolute left-1 top-1 h-6 w-6 rounded-full bg-content-secondary/40" />
-              </button>
-            </div>
-          </NotificationAccordionSection>
-        ) : null}
 
         {showUpcomingChannels ? (
           <NotificationAccordionSection


### PR DESCRIPTION
Closes #455

## Summary

- Adds authenticated callables `getCommsEmailStatus`, `unsubscribeCommsEmail`, and `resubscribeCommsEmail` so clients can read/write lifecycle email subscription state without direct access to `email_suppression`.
- Surfaces the Email accordion on `/dashboard/notifications` with status, suppression messaging, unsubscribe, and re-enable actions for user-initiated suppressions.
- Updates "Tour & onboarding updates" copy to clarify it applies to push, in-app, and email.
- Consolidates staging-only semver increments (1.7.1–1.9.0) into **v1.10.0** for the upcoming staging→main comms phase-1 release. CHANGELOG and `docs/API.md` updated accordingly.

## Test plan

- [ ] `cd functions && npm test` — includes new `commsEmailPrefs.test.js`
- [ ] `npm test && npm run lint`
- [ ] Sign in on staging preview → `/dashboard/notifications` → Email section shows status
- [ ] With lifecycle on and no suppression: "Receiving emails" + Unsubscribe button works
- [ ] After unsubscribe: status shows paused + lifecycle pref off
- [ ] After one-click email unsub (or prefs unsub): "Re-enable email" clears suppression and re-enables lifecycle
- [ ] Hard-bounce / spam-complaint suppressions show message but no re-enable button


Made with [Cursor](https://cursor.com)