### PR TITLE
fix(functions): bind Resend secrets on scoring and rollup exports (#460)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.10.1] — 2026-07-02
+
+### Fixed
+- **Live-scoring and post-rollup email channel** — bind `RESEND_API_KEY` / `RESEND_WEBHOOK_SECRET` on `gradePicksOnSetlistWrite`, `rollupScoresForShow`, `refreshLiveScoresForShow`, `scheduledPhishnetLiveSetlistPoll`, and `pollLiveSetlistNow` so comms event adapters can send email (inApp/push already worked; email skipped without secret injection). Closes #460.
+
+---
+
 ## [1.10.0] — 2026-07-02
 
 Bundled comms phase-1 release to production: rolls up staging-only increments 1.7.1–1.9.0 plus #455 email preferences UI. Main was at 1.7.0 (event adapters, gated off). `COMMS_EVENT_ADAPTERS_ENABLED` remains off until post-deploy canary (#438).

--- a/functions/index.js
+++ b/functions/index.js
@@ -193,7 +193,11 @@ async function recomputeLiveScoresForShow(showDate, actualSetlistFromWrite = nul
 }
 
 exports.gradePicksOnSetlistWrite = onDocumentWritten(
-  "official_setlists/{showDate}",
+  {
+    document: "official_setlists/{showDate}",
+    region: PHISHNET_FUNCTIONS_REGION,
+    secrets: [resendApiKey, resendWebhookSecret],
+  },
   async (event) => {
     if (!event.data.after.exists) {
       return null;
@@ -274,6 +278,7 @@ exports.refreshLiveScoresForShow = onCall(
     region: PHISHNET_FUNCTIONS_REGION,
     invoker: "public",
     enforceAppCheck: false,
+    secrets: [resendApiKey, resendWebhookSecret],
   },
   async (request) => {
     assertAdminClaim(request);
@@ -315,6 +320,7 @@ exports.rollupScoresForShow = onCall(
     region: PHISHNET_FUNCTIONS_REGION,
     invoker: "public",
     enforceAppCheck: false,
+    secrets: [resendApiKey, resendWebhookSecret],
   },
   async (request) => {
     assertAdminClaim(request);
@@ -1124,7 +1130,7 @@ exports.scheduledPhishnetLiveSetlistPoll = onSchedule(
     schedule: "*/2 * * * *",
     timeZone: "America/New_York",
     region: PHISHNET_FUNCTIONS_REGION,
-    secrets: [phishnetApiKey],
+    secrets: [phishnetApiKey, resendApiKey, resendWebhookSecret],
   },
   async () => {
     const key = phishnetApiKey.value();
@@ -1225,7 +1231,7 @@ exports.setLiveSetlistAutomationState = onCall(
 exports.pollLiveSetlistNow = onCall(
   {
     region: PHISHNET_FUNCTIONS_REGION,
-    secrets: [phishnetApiKey],
+    secrets: [phishnetApiKey, resendApiKey, resendWebhookSecret],
     invoker: "public",
     enforceAppCheck: false,
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #460

## Summary
- Bind `RESEND_API_KEY` / `RESEND_WEBHOOK_SECRET` on the five Cloud Functions exports that invoke live-scoring or post-rollup comms adapters but previously lacked secret injection.
- Email channel was silently skipped on these paths while inApp/push delivered; this closes the gap identified in Phase 1 go-live smoke (#438 §4).

## Exports updated
- `gradePicksOnSetlistWrite` — setlist write → `deliverLiveScoreComms`
- `rollupScoresForShow` — admin finalize → `deliverPostRollupComms`
- `refreshLiveScoresForShow` — admin live-score refresh
- `scheduledPhishnetLiveSetlistPoll` — auto-finalize rollup path
- `pollLiveSetlistNow` — admin poll → live score recompute

## Test plan
- [x] `cd functions && npm test` (245 pass)
- [ ] Merge + deploy functions to production
- [ ] Confirm `RESEND_API_KEY` bound on all five services in Firebase Console
- [ ] On next live setlist write or admin finalize: verify email sends when user prefs allow (check Cloud Logging for `comms_delivered` with `comms_channel: email`)

## Version
PATCH bump to **1.10.1**

Made with [Cursor](https://cursor.com)