### PR TITLE
feat(comms): add T-3 tour countdown reminder (#463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.10.2] — 2026-07-02
+
+### Added
+- **`tour_countdown` T-3 reminder (#463)** — daily 9am PT cron now fires when a tour's first show is exactly 3 days away (in addition to T-10, T-5, T-1). Summer Tour 2026 (Jul 7 kickoff) sends on Jul 4.
+
+---
+
 ## [1.10.1] — 2026-07-02
 
 ### Fixed

--- a/docs/API.md
+++ b/docs/API.md
@@ -161,7 +161,7 @@ Automated comms delivery triggered by Firestore writes, post-rollup hooks, live-
 | `commsOnPickWrite` | `picks_confirmed` | `picks/{pickId}` create with non-empty picks |
 | Post-rollup hook | `show_recap`, `tour_engagement_reminder` | `rollupScoresForShow` completion |
 | Live-scoring hook | `score_first_points`, `score_leader` | `recomputeLiveScoresForShow` |
-| `scheduledTourCountdownComms` | `tour_countdown` | Daily 9am PT cron (T-10/T-5/T-1) |
+| `scheduledTourCountdownComms` | `tour_countdown` | Daily 9am PT cron (T-10/T-5/T-3/T-1) |
 | `scheduledTourRankingsDailyComms` | `tour_rankings_daily` | Daily 8am PT cron (morning-after show) |
 
 Trigger specs and channels: `docs/comms-triggers/catalog.json`. Admin canary/replay: `runCommsTrigger` (§2.2).

--- a/docs/comms-triggers/FRAMEWORK.md
+++ b/docs/comms-triggers/FRAMEWORK.md
@@ -164,7 +164,7 @@ See [COMMERCIAL_PHASE3.md](./COMMERCIAL_PHASE3.md). Commercial never overrides P
 | W0 | `picks_lock_reminder` | `automated` | Shipped; push-only today |
 | W1 | `account_welcome` | `event_triggered` | Firestore onCreate |
 | W1 | `picks_confirmed` | `event_triggered` | Picks locked confirmation |
-| W2 | `tour_countdown` | `automated` | Daily cron T-10/5/1 |
+| W2 | `tour_countdown` | `automated` | Daily cron T-10/5/3/1 |
 | W2 | `tour_engagement_reminder` | `event_triggered` | After show 1 graded |
 | W3 | `show_recap` | `event_triggered` | After grading; replaces Sphere one-off |
 | W3 | `tour_rankings_daily` | `automated` | Next-morning standings |

--- a/docs/comms-triggers/TRIGGER_CATALOG.md
+++ b/docs/comms-triggers/TRIGGER_CATALOG.md
@@ -124,12 +124,12 @@ Every template draws from this shared set. Each trigger declares the subset it u
 |-------|-------|
 | **Status** | `shipped` |
 | **Automation** | `automated` |
-| **Schedule** | Daily cron; fires when a tour's first show is exactly 10, 5, or 1 day(s) away |
+| **Schedule** | Daily cron; fires when a tour's first show is exactly 10, 5, 3, or 1 day(s) away |
 | **Channels** | `inApp`, `push`, `email` |
 | **Audience** | All users who have logged in within the last 60 days |
 | **Prefs key** | `lifecycle` |
 | **Dedup** | `tour_countdown:{tourId}:{uid}:{days_remaining}` |
-| **Implementation** | `onSchedule` daily; checks tour start date vs today; fires 3 times per tour |
+| **Implementation** | `onSchedule` daily; checks tour start date vs today; fires 4 times per tour |
 
 #### Variables used
 
@@ -141,6 +141,7 @@ Every template draws from this shared set. Each trigger declares the subset it u
 |------|-----------|-----------|
 | `10` | `{{tour_name}} starts in 10 days` | `Picks open soon. Start thinking about your openers, {{handle}}.` |
 | `5` | `5 days until {{tour_name}}` | `Picks are open for the first show. Lock in early, {{handle}}.` |
+| `3` | `3 days until {{tour_name}}` | `First show is {{first_show_date}}. Get your picks in before the weekend, {{handle}}.` |
 | `1` | `{{tour_name}} starts tomorrow` | `{{first_show_city}} — {{first_show_date}}. Have you picked your opener?` |
 
 **Deep link:** `/dashboard/picks`
@@ -158,6 +159,14 @@ Every template draws from this shared set. Each trigger declares the subset it u
 **Heading:** `5 days — {{tour_name}}`
 
 **Body:** Picks are open for the first show at {{first_show_venue}}. Get your opener, closer, encore, and wildcard locked in before the deadline. Every show counts toward the tour standings.
+
+**CTA:** `Make picks for show 1 →`
+
+#### Template — In-App (T-3)
+
+**Heading:** `3 days — {{tour_name}}`
+
+**Body:** {{first_show_venue}}, {{first_show_city}} — show 1 is in three days. If you haven't locked picks yet, now's the time before the weekend rush.
 
 **CTA:** `Make picks for show 1 →`
 

--- a/docs/comms-triggers/catalog.json
+++ b/docs/comms-triggers/catalog.json
@@ -35,7 +35,7 @@
       "family": "show_calendar",
       "priority": "P0",
       "automation": "automated",
-      "schedule": "daily cron; fires when tour first show is exactly 10, 5, or 1 day(s) away",
+      "schedule": "daily cron; fires when tour first show is exactly 10, 5, 3, or 1 day(s) away",
       "audience": "users_active_60d",
       "channels": ["inApp", "push", "email"],
       "prefKeys": ["lifecycle"],
@@ -43,7 +43,7 @@
       "templateId": "tour-countdown",
       "implementationModule": "functions/commsEventAdapters.js",
       "githubIssue": null,
-      "variants": ["t10", "t5", "t1"],
+      "variants": ["t10", "t5", "t3", "t1"],
       "variables": [
         { "name": "handle", "source": "users/{uid}.handle", "fallback": "Picker" },
         { "name": "tour_name", "source": "tour metadata", "fallback": null },

--- a/functions/commsEventAdapters.js
+++ b/functions/commsEventAdapters.js
@@ -19,7 +19,7 @@ const {
 } = require("./commsAdapterRuntime");
 
 const DEFAULT_SHOW_TIME_ZONE = "America/Los_Angeles";
-const COUNTDOWN_DAYS = [10, 5, 1];
+const COUNTDOWN_DAYS = [10, 5, 3, 1];
 
 /**
  * @param {unknown} data

--- a/functions/commsEventAdapters.test.js
+++ b/functions/commsEventAdapters.test.js
@@ -60,7 +60,7 @@ test("computeGlobalRankByUid ranks by score with ties", () => {
   assert.equal(ranks.get("u1")?.total, 3);
 });
 
-test("findTourCountdownTargets hits T-10/T-5/T-1", () => {
+test("findTourCountdownTargets hits T-10/T-5/T-3/T-1", () => {
   const now = new Date("2026-04-06T18:00:00Z");
   const shows = [
     {
@@ -75,6 +75,23 @@ test("findTourCountdownTargets hits T-10/T-5/T-1", () => {
   assert.equal(hits.length, 1);
   assert.equal(hits[0].days_remaining, 10);
   assert.equal(hits[0].tourId, "Sphere '26");
+});
+
+test("findTourCountdownTargets hits T-3 for Summer Tour Jul 7 kickoff", () => {
+  const now = new Date("2026-07-04T16:00:00Z");
+  const shows = [
+    {
+      date: "2026-07-07",
+      venue: "Kohl Center",
+      city: "Madison, WI",
+      timeZone: "America/Chicago",
+      tour: "Summer Tour 2026",
+    },
+  ];
+  const hits = findTourCountdownTargets(shows, now);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].days_remaining, 3);
+  assert.equal(hits[0].tourId, "Summer Tour 2026");
 });
 
 test("leaderUidFromScores returns sole leader only", () => {

--- a/functions/index.js
+++ b/functions/index.js
@@ -1068,7 +1068,7 @@ exports.scheduledPicksLockReminder = onSchedule(
 );
 
 /**
- * Scheduled tour countdown comms (#440) — daily check for T-10/T-5/T-1.
+ * Scheduled tour countdown comms (#440) — daily check for T-10/T-5/T-3/T-1.
  * Gated by `COMMS_EVENT_ADAPTERS_ENABLED=true`.
  */
 exports.scheduledTourCountdownComms = onSchedule(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.10.1",
+  "version": "1.10.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
@@ -145,6 +145,30 @@ export const COMMS_TEMPLATE_REGISTRY = {
         },
       },
       {
+        name: 'T-5',
+        payload: {
+          handle: 'ArmenianMan',
+          tour_name: 'Summer Tour 2026',
+          days_remaining: 5,
+          first_show_date: 'Jul 18',
+          first_show_venue: 'MSG',
+          first_show_city: 'New York, NY',
+          lock_time_local: '7:55 PM',
+        },
+      },
+      {
+        name: 'T-3',
+        payload: {
+          handle: 'ArmenianMan',
+          tour_name: 'Summer Tour 2026',
+          days_remaining: 3,
+          first_show_date: 'Jul 7',
+          first_show_venue: 'Kohl Center',
+          first_show_city: 'Madison, WI',
+          lock_time_local: '7:55 PM',
+        },
+      },
+      {
         name: 'T-1',
         payload: {
           handle: 'ArmenianMan',


### PR DESCRIPTION
Closes #463

## Summary
- Add `days_remaining: 3` to `tour_countdown` schedule (`COUNTDOWN_DAYS = [10, 5, 3, 1]`)
- Summer Tour 2026 first show is Jul 7 (Madison) → T-3 fires **Jul 4 at 9am PT**
- Push/email/in-app copy already dynamic via `days_remaining`; catalog + TRIGGER_CATALOG updated with T-3 variant docs

## Test plan
- [x] `cd functions && npm test` — includes new T-3 unit test (Jul 4 → Jul 7 Summer Tour)
- [ ] Merge + deploy `scheduledTourCountdownComms` before Jul 4 9am PT
- [ ] Monitor Cloud Logging Jul 4 for `comms_delivered` with `comms_trigger_id: tour_countdown`, `days_remaining: 3`

## Cron readiness (pre-deploy)
Production `scheduledTourCountdownComms` is ACTIVE with `COMMS_EVENT_ADAPTERS_ENABLED=true` and Resend secrets bound. **Code change requires redeploy** of that one function after merge.

## Version
PATCH bump to **1.10.2**

Made with [Cursor](https://cursor.com)