### PR TITLE
chore(tooling): manifest-driven comms deploy + SemVer release gate

### DIFF
--- a/.cursor/rules/versioning.mdc
+++ b/.cursor/rules/versioning.mdc
@@ -56,9 +56,11 @@ Never introduce a MAJOR bump silently. If your diff contains a breaking change:
 
 ## Git tag (human step only)
 
-After `staging → main` merges, a human runs:
+After `staging → main` merges, publish with:
+
 ```bash
-git tag v<version> -m "Release <version>"
-git push origin v<version>
+npm run release:gate:full
+npm run release:publish -- --confirm
 ```
-Agents MUST NOT create git tags autonomously.
+
+(`release:publish` creates the tag, pushes it, and opens the GitHub Release.) Agents MUST NOT run `release:publish` unless the user explicitly requests a tag/release.

--- a/.cursor/skills/cloud-dev/SKILL.md
+++ b/.cursor/skills/cloud-dev/SKILL.md
@@ -220,6 +220,19 @@ npm run shell             # firebase functions:shell (REPL)
 Functions use `firebase-admin` + `firebase-functions` v7. Deploy a
 subset with the `deploy:functions:*` script in `package.json`.
 
+### Release gate + comms deploy (agents)
+
+| Command | When |
+|---------|------|
+| `npm run release:gate` | Before tag/release; mirrors CI SemVer check |
+| `npm run release:gate:full` | Gate + full verify matrix |
+| `npm run release:publish -- --confirm` | Tag + GitHub Release (**user must request**) |
+| `npm run comms:deploy:validate` | After editing comms exports or `commsDeployManifest.js` |
+| `npm run comms:deploy:list` | Inspect dynamic deploy targets (6+N adapters) |
+| `npm run comms:deploy -- --confirm --group eventAdapters` | Deploy adapter cron/Firestore exports only |
+
+Manifest source of truth: `functions/commsDeployManifest.js`. Full workflow: `.cursor/skills/comms-architect/SKILL.md` § Release + deploy tooling.
+
 ## 8 — Common gotchas
 
 - **No Auth emulator for the web app.** The Vite SPA always talks to

--- a/.cursor/skills/comms-architect/SKILL.md
+++ b/.cursor/skills/comms-architect/SKILL.md
@@ -117,6 +117,48 @@ Use the MCP for QA, broadcast drafting, and domain/webhook setup — **not** as 
 3. **Enable the event adapter / schedule** for the cohort %, then full audience
 4. Monitor `fcm_notification_log`, Resend webhooks, and CF error logs
 
+## Release + deploy tooling (agents)
+
+**Canonical manifest:** `functions/commsDeployManifest.js` — three groups (`eventAdapters`, `hookHosts`, `infra`). When adapter count grows from 6 to 6+N, append **one row** per new export; scripts derive deploy targets dynamically.
+
+| npm script | Purpose |
+|------------|---------|
+| `npm run release:gate` | SemVer gate (version > latest GH release + CHANGELOG entry) |
+| `npm run release:gate:full` | Gate + lint + vitest + functions tests |
+| `npm run release:publish -- --confirm` | Gate → `git tag` → `gh release create` (**user must request**) |
+| `npm run comms:deploy:validate` | Manifest ↔ `index.js` export + secret binding check |
+| `npm run comms:deploy:list` | Print manifest groups + firebase `--only` targets |
+| `npm run comms:deploy:dry` | Print deploy command without running |
+| `npm run comms:deploy -- --confirm` | Deploy all manifest exports (default `--group all`) |
+| `npm run comms:deploy -- --confirm --group eventAdapters` | Deploy only scheduled/Firestore adapters |
+
+### Agent workflow after a comms PR merges to `main`
+
+1. **`npm run release:gate:full`** — must pass before tag/release (mirrors CI SemVer step on staging PRs).
+2. **`npm run release:publish -- --confirm`** — only when the user explicitly asks to tag/publish.
+3. **`npm run comms:deploy:validate`** — catch manifest drift before deploy.
+4. **`npm run comms:deploy -- --confirm --group eventAdapters`** — after adapter-only changes (e.g. `scheduledTourCountdownComms` cadence tweak).
+5. **`npm run comms:deploy -- --confirm --group hookHosts`** — after live-score/rollup secret or comms hook changes.
+6. **`npm run comms:deploy -- --confirm`** — full comms stack (adapters + hooks + infra).
+
+**Node 24** required for Functions deploy (`export PATH="$HOME/.nvm/versions/node/v24.17.0/bin:$PATH"`).
+
+**Post-deploy verify** (production):
+
+```bash
+gcloud functions describe <export> --gen2 --region=us-central1 --project=set-picks \
+  --format='value(updateTime,serviceConfig.environmentVariables.COMMS_EVENT_ADAPTERS_ENABLED,serviceConfig.secretEnvironmentVariables.key)'
+```
+
+**Cron readiness:** code on `main` ≠ live until deploy completes. Scheduled jobs can fire HTTP 200 while adapters no-op if `COMMS_EVENT_ADAPTERS_ENABLED` was off on that revision — check deploy timestamp vs cron time.
+
+### Adding a new comms adapter (checklist)
+
+1. Export in `functions/index.js` with correct `secrets:` + gate comment.
+2. Append row to `functions/commsDeployManifest.js` → `eventAdapters` (or `hookHosts` / `infra`).
+3. `npm run comms:deploy:validate` + `cd functions && npm test`.
+4. Ship PR; after merge deploy the affected `--group` (not necessarily full `all`).
+
 ## Registry / template extension
 
 - Server copy: add a builder in `functions/commsTemplates.js` (push title/body + email subject/text).
@@ -135,7 +177,7 @@ Use the MCP for QA, broadcast drafting, and domain/webhook setup — **not** as 
 **Dedup:** ...
 **Prefs:** ...
 **Dry run:** callable flag / script
-**Deploy:** firebase deploy --only functions:...
+**Deploy:** firebase deploy --only functions:... (prefer `npm run comms:deploy:list` / `comms:deploy -- --confirm --group …` — see **Release + deploy tooling** below)
 **Rules:** firestore deploy if inbox reads affected
 **Measurement:** server log fields
 ```
@@ -149,6 +191,6 @@ Use the MCP for QA, broadcast drafting, and domain/webhook setup — **not** as 
 ## Constraints
 
 - PR base branch: **staging**
-- Deploy functions per `functions/package.json` scripts
+- Deploy functions per `functions/package.json` scripts; **comms** exports use `npm run comms:deploy:*` (manifest-driven — see **Release + deploy tooling**)
 - Fatigue: max 2 push/user/show day (document in catalog notes)
 - Commercial slots only via `COMMERCIAL_PHASE3.md` gates

--- a/functions/commsDeployManifest.js
+++ b/functions/commsDeployManifest.js
@@ -1,0 +1,103 @@
+/**
+ * Canonical deploy manifest for comms-related Cloud Functions exports.
+ *
+ * When you add a new comms event adapter, hook host, or infra export:
+ *   1. Wire the export in `functions/index.js` (with correct secrets/env).
+ *   2. Append ONE entry below in the appropriate group.
+ *   3. Run `npm run comms:deploy:validate` — fails if manifest ↔ index.js drift.
+ *
+ * Read by: `scripts/deploy-comms-functions.mjs`, `scripts/comms-deploy-validate.mjs`,
+ *          `functions/commsDeployManifest.test.js`.
+ *
+ * @typedef {'resend'|'webhook'|'none'} SecretExpectation
+ * @typedef {{ export: string, triggerId?: string, commsPath?: string, note?: string, secretExpectation?: SecretExpectation, gated?: boolean }} ManifestEntry
+ */
+
+/** @type {Record<string, ManifestEntry[]>} */
+const COMMS_DEPLOY_GROUPS = {
+  /**
+   * Thin exports gated by COMMS_EVENT_ADAPTERS_ENABLED — one row per scheduled/Firestore adapter.
+   */
+  eventAdapters: [
+    { export: "commsOnUserProfileWrite", triggerId: "account_welcome", gated: true, secretExpectation: "resend" },
+    { export: "commsOnPickWrite", triggerId: "picks_confirmed", gated: true, secretExpectation: "resend" },
+    { export: "scheduledTourCountdownComms", triggerId: "tour_countdown", gated: true, secretExpectation: "resend" },
+    { export: "scheduledTourRankingsDailyComms", triggerId: "tour_rankings_daily", gated: true, secretExpectation: "resend" },
+  ],
+
+  /**
+   * Functions that invoke comms adapters from shared code paths (live score / rollup / poll).
+   */
+  hookHosts: [
+    { export: "gradePicksOnSetlistWrite", commsPath: "deliverLiveScoreComms", secretExpectation: "resend" },
+    { export: "rollupScoresForShow", commsPath: "deliverPostRollupComms", secretExpectation: "resend" },
+    { export: "refreshLiveScoresForShow", commsPath: "deliverLiveScoreComms", secretExpectation: "resend" },
+    {
+      export: "scheduledPhishnetLiveSetlistPoll",
+      commsPath: "deliverPostRollupComms (auto-finalize)",
+      secretExpectation: "resend",
+    },
+    { export: "pollLiveSetlistNow", commsPath: "deliverLiveScoreComms", secretExpectation: "resend" },
+  ],
+
+  /**
+   * Orchestrator, deliverability, and email-prefs callables — deploy with adapter changes when touched.
+   */
+  infra: [
+    { export: "runCommsTrigger", note: "admin canary/replay", secretExpectation: "resend" },
+    { export: "commsResendWebhook", note: "Resend bounce/complaint webhook", secretExpectation: "webhook" },
+    { export: "commsEmailUnsubscribe", note: "RFC 8058 one-click unsubscribe", secretExpectation: "none" },
+    { export: "getCommsEmailStatus", note: "email prefs status", secretExpectation: "none" },
+    { export: "unsubscribeCommsEmail", note: "email prefs unsubscribe", secretExpectation: "none" },
+    { export: "resubscribeCommsEmail", note: "email prefs resubscribe", secretExpectation: "none" },
+  ],
+};
+
+const GROUP_ORDER = ["eventAdapters", "hookHosts", "infra"];
+
+/**
+ * @param {typeof COMMS_DEPLOY_GROUPS} [groups]
+ * @returns {ManifestEntry[]}
+ */
+function flattenManifest(groups = COMMS_DEPLOY_GROUPS) {
+  return GROUP_ORDER.flatMap((key) => groups[key] || []);
+}
+
+/**
+ * @param {string|string[]} [groupKeys] — subset of GROUP_ORDER, or 'all'
+ * @returns {string[]}
+ */
+function listExportNames(groupKeys = "all") {
+  const keys =
+    groupKeys === "all" || groupKeys == null
+      ? GROUP_ORDER
+      : Array.isArray(groupKeys)
+        ? groupKeys
+        : [groupKeys];
+  return keys.flatMap((key) => (COMMS_DEPLOY_GROUPS[key] || []).map((e) => e.export));
+}
+
+/**
+ * @param {string[]} exportNames
+ * @returns {string} firebase `--only` fragment (comma-separated, no leading `--only`)
+ */
+function buildFirebaseOnlyTargets(exportNames) {
+  return exportNames.map((name) => `functions:${name}`).join(",");
+}
+
+/**
+ * @param {string|string[]} [groupKeys]
+ * @returns {string}
+ */
+function buildFirebaseDeployOnlyArg(groupKeys = "all") {
+  return buildFirebaseOnlyTargets(listExportNames(groupKeys));
+}
+
+module.exports = {
+  COMMS_DEPLOY_GROUPS,
+  GROUP_ORDER,
+  flattenManifest,
+  listExportNames,
+  buildFirebaseOnlyTargets,
+  buildFirebaseDeployOnlyArg,
+};

--- a/functions/commsDeployManifest.test.js
+++ b/functions/commsDeployManifest.test.js
@@ -1,0 +1,49 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  COMMS_DEPLOY_GROUPS,
+  GROUP_ORDER,
+  flattenManifest,
+  listExportNames,
+  buildFirebaseDeployOnlyArg,
+} = require("./commsDeployManifest");
+
+const indexSource = fs.readFileSync(path.join(__dirname, "index.js"), "utf8");
+
+test("manifest export names are unique", () => {
+  const names = flattenManifest().map((e) => e.export);
+  assert.equal(names.length, new Set(names).size, `duplicate exports: ${names}`);
+});
+
+test("every manifest export is declared in index.js", () => {
+  for (const entry of flattenManifest()) {
+    assert.match(
+      indexSource,
+      new RegExp(`exports\\.${entry.export}\\s*=`),
+      `missing exports.${entry.export} in index.js — add export or remove from commsDeployManifest.js`
+    );
+  }
+});
+
+test("listExportNames matches group counts", () => {
+  const all = listExportNames("all");
+  assert.equal(all.length, flattenManifest().length);
+  assert.equal(listExportNames("eventAdapters").length, COMMS_DEPLOY_GROUPS.eventAdapters.length);
+});
+
+test("buildFirebaseDeployOnlyArg includes every export in group", () => {
+  const arg = buildFirebaseDeployOnlyArg("eventAdapters");
+  for (const name of listExportNames("eventAdapters")) {
+    assert.ok(arg.includes(`functions:${name}`), arg);
+  }
+});
+
+test("GROUP_ORDER covers all manifest keys", () => {
+  for (const key of Object.keys(COMMS_DEPLOY_GROUPS)) {
+    assert.ok(GROUP_ORDER.includes(key), `GROUP_ORDER missing ${key}`);
+  }
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
-    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js accountDelete.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js showFinalizationGate.test.js revertRollupCore.test.js postShowRollupPush.test.js picksLockReminder.test.js fcmMessagingCore.test.js sphereTourRecapDelivery.test.js commsCatalog.test.js commsTemplates.test.js commsEmailWorker.test.js commsEmailSuppression.test.js commsEmailDailyCap.test.js commsEmailUnsubscribe.test.js commsEmailPrefs.test.js commsResendWebhook.test.js commsDelivery.test.js commsEventAdapters.test.js",
+    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js accountDelete.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js showFinalizationGate.test.js revertRollupCore.test.js postShowRollupPush.test.js picksLockReminder.test.js fcmMessagingCore.test.js sphereTourRecapDelivery.test.js commsCatalog.test.js commsTemplates.test.js commsEmailWorker.test.js commsEmailSuppression.test.js commsEmailDailyCap.test.js commsEmailUnsubscribe.test.js commsEmailPrefs.test.js commsResendWebhook.test.js commsDelivery.test.js commsEventAdapters.test.js commsDeployManifest.test.js",
     "serve": "firebase emulators:start --only functions",
     "shell": "firebase functions:shell",
     "start": "npm run shell",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,14 @@
     "test:rules": "firebase emulators:exec --only firestore --project setlist-pickem-rules-test \"node --test firestore.rules.test.cjs\"",
     "qa:cache": "node --env-file-if-exists=.env.qa.local scripts/qa/firestore-cache.mjs",
     "qa:chunks": "node --env-file-if-exists=.env.qa.local scripts/qa/chunk-split.mjs",
-    "qa:preview-headers": "node --env-file-if-exists=.env.qa.local scripts/qa/preview-cache-headers.mjs"
+    "qa:preview-headers": "node --env-file-if-exists=.env.qa.local scripts/qa/preview-cache-headers.mjs",
+    "release:gate": "node scripts/release-gate.mjs",
+    "release:gate:full": "node scripts/release-gate.mjs --verify",
+    "release:publish": "node scripts/release-publish.mjs",
+    "comms:deploy:validate": "node scripts/comms-deploy-validate.mjs",
+    "comms:deploy:list": "node scripts/deploy-comms-functions.mjs --list",
+    "comms:deploy:dry": "node scripts/deploy-comms-functions.mjs --dry-run",
+    "comms:deploy": "node scripts/deploy-comms-functions.mjs"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.0.0",

--- a/scripts/comms-deploy-validate.mjs
+++ b/scripts/comms-deploy-validate.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Validate `functions/commsDeployManifest.js` ↔ `functions/index.js` alignment.
+ *
+ *   npm run comms:deploy:validate
+ *
+ * Fails when a manifest export is missing from index.js or its secret binding
+ * does not match `secretExpectation` (resend / webhook / none).
+ */
+
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+const { flattenManifest } = require(path.join(root, "functions/commsDeployManifest.js"));
+
+const indexSource = readFileSync(path.join(root, "functions/index.js"), "utf8");
+
+/** @param {string} exportName */
+function exportBlock(exportName) {
+  const marker = `exports.${exportName}`;
+  const start = indexSource.indexOf(marker);
+  if (start === -1) return null;
+  const next = indexSource.indexOf("\nexports.", start + marker.length);
+  const end = next === -1 ? indexSource.length : next;
+  return indexSource.slice(start, end);
+}
+
+/** @param {import('../functions/commsDeployManifest.js').ManifestEntry} entry */
+function validateEntry(entry) {
+  const block = exportBlock(entry.export);
+  if (!block) {
+    return `exports.${entry.export} not found in functions/index.js`;
+  }
+  const exp = entry.secretExpectation || "none";
+  const hasResend = block.includes("resendApiKey");
+  const hasWebhook = block.includes("resendWebhookSecret");
+  if (exp === "resend" && !hasResend) {
+    return `${entry.export}: expected secrets: [resendApiKey, …] in index.js`;
+  }
+  if (exp === "webhook" && !hasWebhook) {
+    return `${entry.export}: expected resendWebhookSecret in index.js`;
+  }
+  if (exp === "none" && hasResend) {
+    return `${entry.export}: secretExpectation is 'none' but index.js binds resendApiKey (update manifest or export)`;
+  }
+  return null;
+}
+
+const errors = [];
+for (const entry of flattenManifest()) {
+  const err = validateEntry(entry);
+  if (err) errors.push(err);
+}
+
+if (errors.length) {
+  console.error("❌ comms deploy manifest validation failed:\n");
+  for (const e of errors) console.error(`  - ${e}`);
+  console.error("\nFix functions/index.js and/or functions/commsDeployManifest.js");
+  process.exit(1);
+}
+
+console.log(`✅ comms deploy manifest OK (${flattenManifest().length} exports)`);

--- a/scripts/deploy-comms-functions.mjs
+++ b/scripts/deploy-comms-functions.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Deploy comms Cloud Functions using the canonical manifest (`functions/commsDeployManifest.js`).
+ *
+ *   npm run comms:deploy:list
+ *   npm run comms:deploy:dry
+ *   npm run comms:deploy -- --group eventAdapters
+ *   npm run comms:deploy -- --confirm
+ *
+ * Groups (dynamic — driven by manifest, not hardcoded counts):
+ *   eventAdapters | hookHosts | infra | all (default)
+ *
+ * When adding adapter #7, #8, … append one row to commsDeployManifest.js only.
+ */
+
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+const require = createRequire(import.meta.url);
+const {
+  COMMS_DEPLOY_GROUPS,
+  GROUP_ORDER,
+  listExportNames,
+  buildFirebaseDeployOnlyArg,
+} = require(path.join(root, "functions/commsDeployManifest.js"));
+
+const args = process.argv.slice(2);
+const project = args.includes("--project")
+  ? args[args.indexOf("--project") + 1]
+  : process.env.FIREBASE_PROJECT || "set-picks";
+
+function parseGroup() {
+  const idx = args.indexOf("--group");
+  if (idx === -1) return "all";
+  const value = args[idx + 1];
+  if (value === "all") return "all";
+  if (GROUP_ORDER.includes(value)) return value;
+  console.error(`Unknown --group ${value}. Valid: all, ${GROUP_ORDER.join(", ")}`);
+  process.exit(1);
+}
+
+function runValidate() {
+  const r = spawnSync("node", ["scripts/comms-deploy-validate.mjs"], {
+    cwd: root,
+    stdio: "inherit",
+  });
+  if (r.status !== 0) process.exit(r.status ?? 1);
+}
+
+function printList(groupKey) {
+  const keys = groupKey === "all" ? GROUP_ORDER : [groupKey];
+  console.log("Comms deploy manifest\n");
+  for (const key of keys) {
+    const rows = COMMS_DEPLOY_GROUPS[key] || [];
+    console.log(`## ${key} (${rows.length})`);
+    for (const row of rows) {
+      const meta = row.triggerId || row.commsPath || row.note || "";
+      const gate = row.gated ? " [COMMS_EVENT_ADAPTERS_ENABLED]" : "";
+      const secret = row.secretExpectation ? ` secret=${row.secretExpectation}` : "";
+      console.log(`  - ${row.export}${gate}${secret}${meta ? ` — ${meta}` : ""}`);
+    }
+    console.log("");
+  }
+  const names = listExportNames(groupKey);
+  console.log(`Total exports: ${names.length}`);
+  console.log(`firebase deploy --only ${buildFirebaseDeployOnlyArg(groupKey)} --project ${project}`);
+}
+
+const groupKey = parseGroup();
+const listOnly = args.includes("--list");
+const dryRun = args.includes("--dry-run");
+const deploy = args.includes("--confirm");
+
+if (listOnly || (!dryRun && !deploy)) {
+  printList(groupKey);
+  if (!listOnly && !deploy) {
+    console.log("\nPass --dry-run to print the deploy command, or --confirm to deploy.");
+  }
+  process.exit(0);
+}
+
+runValidate();
+
+const onlyArg = buildFirebaseDeployOnlyArg(groupKey);
+const cmd = ["deploy", "--only", onlyArg, "--project", project];
+
+console.log(`\nfirebase ${cmd.join(" ")}\n`);
+
+if (dryRun) {
+  process.exit(0);
+}
+
+if (!deploy) {
+  console.error("Refusing to deploy without --confirm");
+  process.exit(1);
+}
+
+const r = spawnSync("firebase", cmd, { cwd: root, stdio: "inherit" });
+if (r.status !== 0) process.exit(r.status ?? 1);
+
+console.log("\n✅ Comms functions deploy complete");
+console.log("Post-deploy: verify secrets with:");
+console.log(
+  "  gcloud functions describe <export> --gen2 --region=us-central1 --project=set-picks --format='value(serviceConfig.secretEnvironmentVariables.key)'"
+);

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * SemVer release gate — mirrors `.github/workflows/ci.yml` "Version bumped" step
+ * plus CHANGELOG presence. Run before tagging or publishing a GitHub Release.
+ *
+ *   npm run release:gate
+ *   npm run release:gate:full   # also runs lint + unit tests
+ *
+ * Exit 0 when package.json version is ahead of the latest GitHub Release tag and
+ * CHANGELOG.md contains a matching `## [X.Y.Z]` section.
+ */
+
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+const require = createRequire(import.meta.url);
+const pkg = require(path.join(root, "package.json"));
+
+const args = new Set(process.argv.slice(2));
+const runVerify = args.has("--verify");
+
+function run(cmd, cmdArgs, opts = {}) {
+  const r = spawnSync(cmd, cmdArgs, { stdio: "inherit", shell: false, ...opts });
+  if (r.status !== 0) process.exit(r.status ?? 1);
+}
+
+function latestReleaseTag() {
+  const gh = spawnSync("gh", ["release", "list", "--limit", "1", "--json", "tagName", "-q", ".[0].tagName"], {
+    encoding: "utf8",
+    shell: false,
+  });
+  if (gh.status === 0 && gh.stdout?.trim()) {
+    return gh.stdout.trim();
+  }
+  const tags = spawnSync("git", ["tag", "--list", "v*", "--sort=-v:refname"], {
+    encoding: "utf8",
+    shell: false,
+  });
+  if (tags.status === 0 && tags.stdout?.trim()) {
+    return tags.stdout.trim().split("\n")[0];
+  }
+  return "v0.0.0";
+}
+
+function changelogHasVersion(version) {
+  const cl = readFileSync(path.join(root, "CHANGELOG.md"), "utf8");
+  return cl.includes(`## [${version}]`);
+}
+
+const current = pkg.version;
+const tagged = latestReleaseTag();
+const taggedVersion = tagged.startsWith("v") ? tagged.slice(1) : tagged;
+
+console.log(`Latest release tag : ${tagged}`);
+console.log(`package.json version: ${current}`);
+
+if (`v${current}` === tagged) {
+  console.error(`\n❌ package.json version (${current}) matches the last release tag (${tagged}).`);
+  console.error("   Bump version in package.json and add a CHANGELOG.md entry before releasing.");
+  console.error("   See docs/API.md §6 and .cursor/rules/versioning.mdc.");
+  process.exit(1);
+}
+
+if (!changelogHasVersion(current)) {
+  console.error(`\n❌ CHANGELOG.md has no section for ## [${current}].`);
+  console.error("   Add a Keep-a-Changelog entry before releasing.");
+  process.exit(1);
+}
+
+console.log(`✓ version ${current} is ahead of last release ${tagged}`);
+console.log(`✓ CHANGELOG.md contains ## [${current}]`);
+
+if (runVerify) {
+  console.log("\nRunning verify matrix…");
+  run("npm", ["run", "lint"]);
+  run("npm", ["test"]);
+  run("npm", ["test"], { cwd: path.join(root, "functions") });
+}
+
+console.log("\n✅ Release gate passed");

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Publish a GitHub Release from the current package.json version.
+ *
+ * Requires explicit opt-in:
+ *   npm run release:publish -- --confirm
+ *
+ * Steps: release-gate → git tag vX.Y.Z → push tag → gh release create
+ *
+ * Agents MUST only run this when the user explicitly requests a release/tag.
+ */
+
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+const require = createRequire(import.meta.url);
+const pkg = require(path.join(root, "package.json"));
+
+const args = process.argv.slice(2);
+if (!args.includes("--confirm")) {
+  console.error("Refusing to publish without --confirm");
+  console.error("Usage: npm run release:publish -- --confirm [--verify] [--title \"…\"] [--notes-file path]");
+  process.exit(1);
+}
+
+const runVerify = args.includes("--verify");
+const titleIdx = args.indexOf("--title");
+const notesFileIdx = args.indexOf("--notes-file");
+const customTitle = titleIdx >= 0 ? args[titleIdx + 1] : null;
+const notesFile = notesFileIdx >= 0 ? args[notesFileIdx + 1] : null;
+
+function run(cmd, cmdArgs, opts = {}) {
+  const r = spawnSync(cmd, cmdArgs, { stdio: "inherit", shell: false, cwd: root, ...opts });
+  if (r.status !== 0) process.exit(r.status ?? 1);
+}
+
+function extractChangelogSection(version) {
+  const cl = readFileSync(path.join(root, "CHANGELOG.md"), "utf8");
+  const header = `## [${version}]`;
+  const start = cl.indexOf(header);
+  if (start === -1) return null;
+  const afterHeader = cl.indexOf("\n", start);
+  const next = cl.indexOf("\n## [", afterHeader + 1);
+  return cl.slice(afterHeader + 1, next === -1 ? cl.length : next).trim();
+}
+
+const version = pkg.version;
+const tag = `v${version}`;
+
+console.log(`Publishing release ${tag}…\n`);
+
+run("node", ["scripts/release-gate.mjs", ...(runVerify ? ["--verify"] : [])]);
+
+const gateNotes = extractChangelogSection(version);
+const notes =
+  notesFile != null
+    ? readFileSync(path.resolve(root, notesFile), "utf8")
+    : gateNotes || `Release ${version}`;
+
+const title = customTitle || `v${version}`;
+
+run("git", ["tag", tag, "-m", `Release ${version}`]);
+run("git", ["push", "origin", tag]);
+
+const ghArgs = ["release", "create", tag, "--title", title, "--latest", "--notes", notes];
+run("gh", ghArgs);
+
+console.log(`\n✅ Published ${tag}`);


### PR DESCRIPTION
## Summary
- Add `functions/commsDeployManifest.js` — canonical, group-based deploy manifest for comms Cloud Functions (scales 6→6+N without hardcoding)
- Add npm scripts: `release:gate`, `release:gate:full`, `release:publish`, `comms:deploy:*` (all require `--confirm` for deploy/publish)
- Validate manifest ↔ `index.js` secret bindings via `comms:deploy:validate`
- Document agent workflow in `comms-architect` + `cloud-dev` skills; update `versioning.mdc`

## Test plan
- [x] `npm run comms:deploy:validate`
- [x] `npm run comms:deploy:list`
- [x] `cd functions && node --test commsDeployManifest.test.js`
- [x] `npm run release:gate` (correctly fails when version matches latest release)

## Notes
Scripts-only change — no `package.json` version bump per versioning rules.

Made with [Cursor](https://cursor.com)