### PR TITLE
fix(tooling): forward release/comms deploy scripts from functions/

### DIFF
--- a/.cursor/skills/cloud-dev/SKILL.md
+++ b/.cursor/skills/cloud-dev/SKILL.md
@@ -233,6 +233,8 @@ subset with the `deploy:functions:*` script in `package.json`.
 
 Manifest source of truth: `functions/commsDeployManifest.js`. Full workflow: `.cursor/skills/comms-architect/SKILL.md` § Release + deploy tooling.
 
+Scripts live in root `package.json`; **`functions/package.json` forwards the same names** so `cd functions && npm run comms:deploy:list` works.
+
 ## 8 — Common gotchas
 
 - **No Auth emulator for the web app.** The Vite SPA always talks to

--- a/.cursor/skills/comms-architect/SKILL.md
+++ b/.cursor/skills/comms-architect/SKILL.md
@@ -143,6 +143,8 @@ Use the MCP for QA, broadcast drafting, and domain/webhook setup — **not** as 
 
 **Node 24** required for Functions deploy (`export PATH="$HOME/.nvm/versions/node/v24.17.0/bin:$PATH"`).
 
+Run from **repo root** (`npm run comms:deploy:list`) or from **`functions/`** (same script names are forwarded in `functions/package.json`).
+
 **Post-deploy verify** (production):
 
 ```bash

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,7 +17,14 @@
     "backfill:bustouts": "node scripts/backfillBustouts.js",
     "backfill:season-aggregates": "node scripts/backfillSeasonAggregates.js",
     "rollup:reset-premature-grade": "node scripts/resetPrematureGrade.js",
-    "comms:deliver-sphere-inbox": "node scripts/deliverSphere2026TourRecapInbox.js"
+    "comms:deliver-sphere-inbox": "node scripts/deliverSphere2026TourRecapInbox.js",
+    "release:gate": "node ../scripts/release-gate.mjs",
+    "release:gate:full": "node ../scripts/release-gate.mjs --verify",
+    "release:publish": "node ../scripts/release-publish.mjs",
+    "comms:deploy:validate": "node ../scripts/comms-deploy-validate.mjs",
+    "comms:deploy:list": "node ../scripts/deploy-comms-functions.mjs --list",
+    "comms:deploy:dry": "node ../scripts/deploy-comms-functions.mjs --dry-run",
+    "comms:deploy": "node ../scripts/deploy-comms-functions.mjs"
   },
   "engines": {
     "node": "24"


### PR DESCRIPTION
## Summary
Forward `release:gate`, `release:publish`, and `comms:deploy:*` npm scripts into `functions/package.json` so they work when agents run from `functions/` after `firebase deploy`.

## Test plan
- [x] `cd functions && npm run comms:deploy:list`
- [x] `cd functions && npm run comms:deploy:validate`

Made with [Cursor](https://cursor.com)