### PR TITLE
fix(ci): scope SemVer version gate to pull_request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,11 @@ jobs:
         run: npm test
 
       - name: Version bumped (SemVer gate)
-        if: github.base_ref != 'main' && !contains(github.event.pull_request.labels.*.name, 'skip-version-bump')
+        # PR-only check: ensures PRs targeting staging bump package.json past the
+        # last release. Skipped on push/schedule where github.base_ref is empty
+        # (so `!= 'main'` was accidentally true) and package.json legitimately
+        # equals the last release tag once a release has been cut.
+        if: github.event_name == 'pull_request' && github.base_ref != 'main' && !contains(github.event.pull_request.labels.*.name, 'skip-version-bump')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **"Version bumped (SemVer gate)"** step in the `verify` job was failing on every push to `main`/`staging` and on the nightly scheduled run (e.g. CI #647 staging push, #648 main push, #649 schedule — all after `v1.10.2` was released).

### Root cause

The step's `if` condition was:

```yaml
if: github.base_ref != 'main' && !contains(github.event.pull_request.labels.*.name, 'skip-version-bump')
```

`github.base_ref` is only populated for `pull_request` events. On `push` and `schedule` events it is an empty string, so `'' != 'main'` evaluated `true` and the gate ran unintentionally. The gate compares `package.json` version against the latest GitHub Release tag and fails when they're equal — but once a release is cut, `main`/`staging` legitimately sit at that version (`1.10.2` == `v1.10.2`). It's a PR-time check with no meaning post-merge, and the `skip-version-bump` label can't apply outside a PR either.

### Fix

Add `github.event_name == 'pull_request'` to the condition so the gate only runs on PRs (its intended scope). PRs to `main` (release PRs) remain exempt via the existing `base_ref != 'main'` guard, and the `skip-version-bump` label still works.

This is a CI workflow YAML change, which per `docs/API.md` / `.cursorrules` §10 is **not** a version bump — `package.json` and `CHANGELOG.md` are intentionally untouched.

## Test plan

- [x] Validated `ci.yml` parses as valid YAML and the resolved `if` expression is correct.
- [x] Confirmed via CI run history that runs #647/#648/#649 failed only on the `Version bumped (SemVer gate)` step, while the PR run #646 passed.
- [ ] After merge: nightly scheduled run and push-to-staging/main runs should no longer fail on this gate; PR runs still enforce the version bump.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://road2-media.slack.com/archives/D0B2RMVCGSD/p1783094539112719?thread_ts=1783094539.112719&cid=D0B2RMVCGSD)

<div><a href="https://cursor.com/agents/bc-c6012461-a50b-50f3-9e00-36489e29b789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6012461-a50b-50f3-9e00-36489e29b789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

