### PR TITLE
feat(pools): new pools start standings from membership (#417)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.12.0] — 2026-07-03
+
+### Added
+- **Pool standings from membership (#417)** — new pools write `standingsScope: 'from_membership'` and `memberJoinedAt.{uid}`; pool-scoped standings (hub + Standings Pools filter) count only picks that list the pool and whose `showDate` is on/after that member’s join day (`America/Los_Angeles`). Existing pools (no field) keep legacy retroactive carryover and create/join backfill.
+
+### Changed
+- `deletePoolWithCleanup` activity scan honors `from_membership` so pre-join legacy pick docs do not block delete on new-mode pools.
+
+---
+
 ## [1.11.0] — 2026-07-03
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.10.0  
+**Version:** 1.12.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 
@@ -59,10 +59,13 @@ All collections live in the default `(default)` Firestore database for project `
 | Field | Type | Notes |
 |-------|------|-------|
 | `name` | string | Pool display name |
-| `hostUid` | string | Owner uid |
+| `ownerId` | string | Owner uid |
 | `inviteCode` | string | Used in `/join/:code` URLs |
-| `memberUids` | string[] | |
-| `createdAt` | Timestamp | |
+| `members` | string[] | Member uids |
+| `createdAt` | string (ISO8601) | Pool create time |
+| `status` | `'active' \| 'archived'` | |
+| `standingsScope` | `'legacy' \| 'from_membership'`? | **Absent = `legacy`.** New pools write `from_membership` (#417): pool standings count only picks that list this pool in `pick.pools` **and** whose `showDate` is on/after that member’s membership calendar day (`America/Los_Angeles`). Legacy pools keep retroactive carryover + create/join backfill. |
+| `memberJoinedAt` | map `{ [uid]: ISO8601 }`? | Per-member join/create anchor for `from_membership` pools. Set for creator on create; updated on join. |
 
 ### 1.6 `picks/{pickId}` (subcollection: `pools/{poolId}/picks/{uid}`)
 

--- a/docs/RELEASE_TRAIN_SPRINT_5_6.md
+++ b/docs/RELEASE_TRAIN_SPRINT_5_6.md
@@ -1,0 +1,142 @@
+# Release train — Sprint 5/6 rollup
+
+**Goal:** Land remaining Sprint 5 carryover + a focused Sprint 6 hardening slice as **many PRs into `staging`**, then **one** `staging → main` promote + SemVer tag.
+
+**Baseline:** `main` and `staging` are aligned at **1.11.0** (2026-07-03). Comms phase-1 code is already on `main`; adapters are gated by `COMMS_EVENT_ADAPTERS_ENABLED` (canary path documented in #438 / #461).
+
+**Pattern:** Same as the comms rollup (`1.10.0`): continuous merges to `staging`, freeze promotes to `main` until the train is green, one production release entry that rolls up intermediate staging versions.
+
+**Tracking:** Parent issues stay open until their train AC is met. Placeholders (#424–#427) are umbrellas — close them when their in-train children ship, or leave open if deferred children remain.
+
+---
+
+## In train vs out of train
+
+### IN — ship in this promote
+
+| Issue | Sprint | Type | Notes |
+|-------|--------|------|-------|
+| [#417](https://github.com/pat792/set-picks/issues/417) | 5 | Code | Pool standings from membership (new pools only) |
+| [#418](https://github.com/pat792/set-picks/issues/418) | 5 | Code | Profile cluster **Phase 1** (IA split + redirects) |
+| [#461](https://github.com/pat792/set-picks/issues/461) | 5 / #441 | Code + secret | Server `comms_delivered` → GA4 Measurement Protocol |
+| [#291](https://github.com/pat792/set-picks/issues/291) | 5 | Ops (GA4 Admin) | Register `method` / `error_code` custom dimensions |
+| [#438](https://github.com/pat792/set-picks/issues/438) | 5 | Ops | Remaining post-deploy checklist (Functions, Auth templates, adapter gate) |
+| [#441](https://github.com/pat792/set-picks/issues/441) | 5 | Epic close | Close when #461 + measurement dims + adapter enablement AC met |
+| [#272](https://github.com/pat792/set-picks/issues/272) | 5 | Epic close | Children already shipped; close after smoke on push/install |
+| [#412](https://github.com/pat792/set-picks/issues/412) | 6 / #411 | Code | CSP + security headers (report-only → enforce) |
+| [#413](https://github.com/pat792/set-picks/issues/413) | 6 / #411 | Config | Version Firestore composite indexes in repo |
+| [#414](https://github.com/pat792/set-picks/issues/414) | 6 / #411 | Config | Dependabot / npm audit baseline |
+| [#411](https://github.com/pat792/set-picks/issues/411) | 6 | Epic partial | Close only if #412–#414 land; leave open if #415–#416 slip |
+| [#424](https://github.com/pat792/set-picks/issues/424) | 6 | Placeholder | Close when security slice above is done |
+
+### STRETCH — land on `staging` if capacity; do not block promote
+
+| Issue | Notes |
+|-------|-------|
+| [#301](https://github.com/pat792/set-picks/issues/301) | Multi-band Phase 0 — additive contracts only, no UX/Firestore writes |
+| [#415](https://github.com/pat792/set-picks/issues/415) | Cap/paginate large pool reads |
+| [#416](https://github.com/pat792/set-picks/issues/416) | Reduce redundant live grading on setlist writes |
+
+### OUT — explicit defer (Sprint 7+ / separate train)
+
+| Issue | Why |
+|-------|-----|
+| [#121](https://github.com/pat792/set-picks/issues/121), [#426](https://github.com/pat792/set-picks/issues/426) | Ads / monetization — separate risk and CMP story |
+| [#425](https://github.com/pat792/set-picks/issues/425) beyond #301 | Multi-band Phase 1+ needs commercial posture |
+| [#427](https://github.com/pat792/set-picks/issues/427) children | Tech debt / research (#145, #168, #396, #227, #122, #80, #42) |
+| [#418](https://github.com/pat792/set-picks/issues/418) Phases 2–4 | Notifications UX polish, inbox scale, identity extensions — follow-on PRs OK on staging **after** promote if not ready |
+| [#93](https://github.com/pat792/set-picks/issues/93) | Password-reset PRD — not required for profile IA Phase 1 |
+
+---
+
+## Merge order (waves)
+
+Merge each wave to **`staging` only**. Do **not** open `staging → main` until Wave 5.
+
+```text
+Wave 0  Docs / train plan
+        • This manifest
+        • Comms send/routing/tracking docs (branch cursor/comms-send-routing-tracking-docs)
+
+Wave 1  Low-risk platform (parallel PRs)
+        • #413 firestore.indexes.json (export from Firebase, commit)
+        • #414 .github/dependabot.yml
+        • #301 multi-band Phase 0 (optional stretch)
+
+Wave 2  Product (Sprint 5 carryover)
+        • #417 pool standings from membership
+        • #418 Profile cluster Phase 1 (routes, layout, redirects, meta)
+
+Wave 3  Comms observability closeout
+        • #461 GA4 Measurement Protocol for comms_delivered
+        • #291 GA4 Admin: register auth + comms custom dimensions (human)
+
+Wave 4  Security headers
+        • #412 CSP report-only on preview → enforce on prod (tiered)
+
+Wave 5  Stretch (optional) then promote freeze
+        • #415 / #416 if ready
+        • Staging soak + QA checklist
+        • One staging → main PR
+        • Tag vX.Y.0 (MINOR — new routes/schema fields/callables as applicable)
+        • #438 remaining ops (Functions deploy, Auth email templates, adapter gate verify)
+        • Close #272, #441, #424 (and #411 if stretch slipped)
+```
+
+**Hotfix rule:** If prod needs a fix mid-train, branch from `main`, ship, then merge `main` → `staging` before continuing train PRs.
+
+---
+
+## Flag / config gates
+
+| Gate | Default on train | Promote-day action |
+|------|------------------|--------------------|
+| `COMMS_EVENT_ADAPTERS_ENABLED` | Already canaried per #461 notes; verify on live revisions | Confirm `"true"` on all adapter + hook-host exports via deploy manifest |
+| `RESEND_API_KEY` / `RESEND_WEBHOOK_SECRET` | Bound on email path | Confirm bound on scoring/rollup hosts (#460) |
+| GA4 MP API secret (new, #461) | Unset → no-op send | Set secret, bind, canary one `runCommsTrigger` |
+| CSP (#412) | Report-Only on preview first | Flip to enforce only after report-only is clean |
+| `pools.standingsScope` (#417) | Absent = `legacy` | New pools write `from_membership`; no migration |
+| Multi-band (#301) | Phish-only registry | No user-visible switcher |
+
+Incomplete features must land **dark** (flags / absent fields / no UX) rather than blocking merge to `staging`.
+
+---
+
+## Versioning for the train
+
+1. Each feature PR may bump `package.json` + `CHANGELOG` on `staging` (PATCH/MINOR per change).
+2. On promote day, write **one** production `CHANGELOG` entry that rolls up the train (same style as `1.10.0`).
+3. Tag **only** on `main` after promote (`npm run release:gate:full` → `npm run release:publish -- --confirm`).
+4. Expected bump: **MINOR** (`1.12.0` or whatever is current+1) — new profile routes, pool schema field, GA4 secret, security headers.
+
+---
+
+## Promote-day checklist
+
+- [ ] All **IN** issues merged to `staging` (or explicitly waived in this doc)
+- [ ] `npm run lint` / `npm test` / `npm run verify:dashboard-meta` / `npm run verify:dashboard-ui` green on staging tip
+- [ ] Functions tests green if Functions touched (`cd functions && npm test`)
+- [ ] Manual QA: new pool starts at zero; legacy pool unchanged; profile cluster redirects; push/install smoke
+- [ ] `staging → main` PR opened and merged
+- [ ] Release tag published
+- [ ] #438 ops completed (or residual items filed as post-release follow-ups)
+- [ ] #291 / #461 GA4 dimensions registered (no backfill — register before relying on reports)
+- [ ] Close epics/placeholders that met AC
+
+---
+
+## PR hygiene
+
+- Branch: `feat/<issue#>-<kebab-slug>` (one primary issue per PR; mention related issues in body).
+- Base: **`staging`**.
+- Do not open promote PRs until Wave 5.
+- Agents: no autonomous approve/merge of the promote PR.
+
+---
+
+## Work log
+
+| Date | Wave | PR / action | Notes |
+|------|------|-------------|-------|
+| 2026-07-03 | 0 | Manifest authored | Train defined |
+| 2026-07-03 | 2 | `feat/417-pool-standings-from-membership` | #417 implementation in progress |

--- a/functions/index.js
+++ b/functions/index.js
@@ -1008,6 +1008,16 @@ exports.deletePoolWithCleanup = onCall(
       poolId,
       memberIds,
       showDates,
+      standingsScope:
+        typeof poolData.standingsScope === "string"
+          ? poolData.standingsScope
+          : null,
+      memberJoinedAt:
+        poolData.memberJoinedAt &&
+        typeof poolData.memberJoinedAt === "object" &&
+        !Array.isArray(poolData.memberJoinedAt)
+          ? poolData.memberJoinedAt
+          : null,
     });
     if (hasActivity) {
       throw new HttpsError(

--- a/functions/poolDelete.js
+++ b/functions/poolDelete.js
@@ -21,22 +21,76 @@ function hasNonEmptyPicksObject(picks) {
   );
 }
 
+const STANDINGS_SCOPE_FROM_MEMBERSHIP = "from_membership";
+const MEMBERSHIP_DAY_TIME_ZONE = "America/Los_Angeles";
+
+/**
+ * @param {unknown} scope
+ * @returns {boolean}
+ */
+function isFromMembershipStandingsScope(scope) {
+  return scope === STANDINGS_SCOPE_FROM_MEMBERSHIP;
+}
+
+/**
+ * @param {string | Date | null | undefined} isoOrDate
+ * @returns {string | null}
+ */
+function membershipCalendarDay(isoOrDate) {
+  if (isoOrDate == null || isoOrDate === "") return null;
+  const date =
+    isoOrDate instanceof Date ? isoOrDate : new Date(String(isoOrDate));
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: MEMBERSHIP_DAY_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+}
+
 /**
  * Whether a pick document counts toward this pool. Legacy picks without an
  * embedded `pools` snapshot count toward any pool (matches client).
+ * `from_membership` pools (#417) require an explicit snapshot + showDate
+ * on/after the author's membership calendar day.
  *
  * @param {Record<string, unknown> | null | undefined} pickData
  * @param {string} poolId
+ * @param {{
+ *   standingsScope?: string | null,
+ *   memberJoinedOn?: string | null,
+ *   showDate?: string | null,
+ * }} [ctx]
  */
-function pickDataCountsForPool(pickData, poolId) {
+function pickDataCountsForPool(pickData, poolId, ctx = {}) {
   if (!poolId || typeof poolId !== "string" || !poolId.trim()) return false;
   if (!pickData || typeof pickData !== "object") return false;
   const pools = /** @type {unknown} */ (pickData.pools);
-  if (Array.isArray(pools) && pools.length > 0) {
-    return pools.some(
+  const hasSnapshot = Array.isArray(pools) && pools.length > 0;
+  const inSnapshot =
+    hasSnapshot &&
+    pools.some(
       (p) => p && typeof p === "object" && /** @type {any} */ (p).id === poolId
     );
+
+  if (isFromMembershipStandingsScope(ctx.standingsScope)) {
+    if (!inSnapshot) return false;
+    const showDate =
+      typeof ctx.showDate === "string" && ctx.showDate
+        ? ctx.showDate
+        : typeof /** @type {any} */ (pickData).showDate === "string"
+          ? /** @type {any} */ (pickData).showDate
+          : null;
+    const joinedOn =
+      typeof ctx.memberJoinedOn === "string" && ctx.memberJoinedOn
+        ? ctx.memberJoinedOn
+        : null;
+    if (!showDate || !joinedOn) return false;
+    return showDate >= joinedOn;
   }
+
+  if (hasSnapshot) return inSnapshot;
   return true;
 }
 
@@ -46,9 +100,14 @@ function pickDataCountsForPool(pickData, poolId) {
  *
  * @param {Record<string, unknown> | null | undefined} pickData
  * @param {string} poolId
+ * @param {{
+ *   standingsScope?: string | null,
+ *   memberJoinedOn?: string | null,
+ *   showDate?: string | null,
+ * }} [ctx]
  */
-function pickDocHasPoolActivity(pickData, poolId) {
-  if (!pickDataCountsForPool(pickData, poolId)) return false;
+function pickDocHasPoolActivity(pickData, poolId, ctx = {}) {
+  if (!pickDataCountsForPool(pickData, poolId, ctx)) return false;
   if (!pickData || typeof pickData !== "object") return false;
   if (hasNonEmptyPicksObject(/** @type {any} */ (pickData).picks)) return true;
   if (/** @type {any} */ (pickData).isGraded === true) return true;
@@ -121,6 +180,8 @@ function pickDocId(showDate, userId) {
  *   memberIds: string[],
  *   showDates: string[],
  *   chunkSize?: number,
+ *   standingsScope?: string | null,
+ *   memberJoinedAt?: Record<string, string> | null,
  * }} opts
  * @returns {Promise<boolean>}
  */
@@ -130,6 +191,8 @@ async function findPoolPickActivity({
   memberIds,
   showDates,
   chunkSize = 24,
+  standingsScope = null,
+  memberJoinedAt = null,
 }) {
   const pid = typeof poolId === "string" ? poolId.trim() : "";
   const members = Array.isArray(memberIds)
@@ -159,10 +222,24 @@ async function findPoolPickActivity({
         db.collection("picks").doc(pickDocId(date, uid)).get()
       )
     );
-    for (const snap of snaps) {
+    for (let j = 0; j < slice.length; j += 1) {
+      const snap = snaps[j];
+      const { date, uid } = slice[j];
       if (!snap || !snap.exists) continue;
       const data = snap.data ? snap.data() : null;
-      if (pickDocHasPoolActivity(data || {}, pid)) return true;
+      const joinedOn =
+        memberJoinedAt && typeof memberJoinedAt === "object"
+          ? membershipCalendarDay(memberJoinedAt[uid])
+          : null;
+      if (
+        pickDocHasPoolActivity(data || {}, pid, {
+          standingsScope,
+          memberJoinedOn: joinedOn,
+          showDate: date,
+        })
+      ) {
+        return true;
+      }
     }
   }
   return false;

--- a/functions/poolDelete.test.js
+++ b/functions/poolDelete.test.js
@@ -68,6 +68,27 @@ test("pickDataCountsForPool: embedded pools snapshot scopes to id match", () => 
   assert.equal(pickDataCountsForPool(data, "p3"), false);
 });
 
+test("pickDataCountsForPool: from_membership requires snapshot + showDate floor", () => {
+  const ctx = {
+    standingsScope: "from_membership",
+    memberJoinedOn: "2026-07-03",
+    showDate: "2026-07-05",
+  };
+  assert.equal(pickDataCountsForPool({ picks: { s1o: "Foo" } }, "p1", ctx), false);
+  assert.equal(
+    pickDataCountsForPool({ pools: [{ id: "p1" }] }, "p1", ctx),
+    true
+  );
+  assert.equal(
+    pickDataCountsForPool(
+      { pools: [{ id: "p1" }] },
+      "p1",
+      { ...ctx, showDate: "2026-07-02" }
+    ),
+    false
+  );
+});
+
 test("pickDocHasPoolActivity: non-empty picks triggers activity", () => {
   assert.equal(
     pickDocHasPoolActivity({ picks: { s1o: "Bag" } }, "p1"),
@@ -219,6 +240,39 @@ test("findPoolPickActivity: scopes to embedded pools array when present", async 
     showDates: ["2026-04-16"],
   });
   assert.equal(got, false);
+});
+
+test("findPoolPickActivity: from_membership ignores legacy empty-pools activity", async () => {
+  const db = createFakeDb({
+    "2026-07-01_u1": { picks: { s1o: "Foo" } },
+  });
+  const got = await findPoolPickActivity({
+    db,
+    poolId: "p1",
+    memberIds: ["u1"],
+    showDates: ["2026-07-01"],
+    standingsScope: "from_membership",
+    memberJoinedAt: { u1: "2026-07-03T12:00:00.000Z" },
+  });
+  assert.equal(got, false);
+});
+
+test("findPoolPickActivity: from_membership counts post-join snapshot picks", async () => {
+  const db = createFakeDb({
+    "2026-07-05_u1": {
+      pools: [{ id: "p1" }],
+      picks: { s1o: "Foo" },
+    },
+  });
+  const got = await findPoolPickActivity({
+    db,
+    poolId: "p1",
+    memberIds: ["u1"],
+    showDates: ["2026-07-05"],
+    standingsScope: "from_membership",
+    memberJoinedAt: { u1: "2026-07-03T12:00:00.000Z" },
+  });
+  assert.equal(got, true);
 });
 
 test("findPoolPickActivity: treats legacy (no pools) pick doc as in-pool activity", async () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/picks/api/picksApi.js
+++ b/src/features/picks/api/picksApi.js
@@ -109,10 +109,14 @@ function normalizeCalendarDates(showDates) {
 }
 
 /**
- * After creating or joining a pool, merge `{ id, name }` into `pools` on every
- * existing pick doc for this user across the season calendar. Idempotent via
- * {@link arrayUnion}. Picks saved before the pool existed otherwise stay
- * invisible to `pickDataCountsForPool` / pool standings.
+ * After creating or joining a **legacy** pool, merge `{ id, name }` into
+ * `pools` on every existing pick doc for this user across the season
+ * calendar. Idempotent via {@link arrayUnion}. Picks saved before the pool
+ * existed otherwise stay invisible to `pickDataCountsForPool` / pool
+ * standings.
+ *
+ * Not used for `standingsScope: 'from_membership'` pools (#417) — those
+ * start at zero and only count picks saved while the user is a member.
  *
  * Failures are swallowed by callers (pool membership still succeeds); this
  * only repairs snapshot alignment.

--- a/src/features/pools/api/poolFirestore.js
+++ b/src/features/pools/api/poolFirestore.js
@@ -1,35 +1,114 @@
 import { doc, updateDoc } from 'firebase/firestore';
 
 import { db } from '../../../shared/lib/firebase';
+import { ymdInTimeZone } from '../../../shared/utils/dateUtils';
 
 /** @type {number} */
 export const POOL_NAME_MAX_LENGTH = 80;
+
+/**
+ * Membership calendar day uses the app default show timezone so join/create
+ * anchors align with `showDate` (`YYYY-MM-DD`) comparisons elsewhere.
+ * @see docs/RELEASE_TRAIN_SPRINT_5_6.md (#417)
+ */
+export const MEMBERSHIP_DAY_TIME_ZONE = 'America/Los_Angeles';
+
+/** Absent / unknown scope behaves as legacy (retroactive carryover). */
+export const STANDINGS_SCOPE_LEGACY = 'legacy';
+
+/** New pools: standings count only from each member's join day onward. */
+export const STANDINGS_SCOPE_FROM_MEMBERSHIP = 'from_membership';
+
+/**
+ * @param {unknown} scope
+ * @returns {boolean}
+ */
+export function isFromMembershipStandingsScope(scope) {
+  return scope === STANDINGS_SCOPE_FROM_MEMBERSHIP;
+}
+
+/**
+ * Calendar day (`YYYY-MM-DD`) for a membership timestamp.
+ *
+ * @param {string | Date | null | undefined} isoOrDate
+ * @returns {string | null}
+ */
+export function membershipCalendarDay(isoOrDate) {
+  if (isoOrDate == null || isoOrDate === '') return null;
+  const date =
+    isoOrDate instanceof Date ? isoOrDate : new Date(String(isoOrDate));
+  if (Number.isNaN(date.getTime())) return null;
+  return ymdInTimeZone(date, MEMBERSHIP_DAY_TIME_ZONE);
+}
 
 /**
  * Whether a pick document should count toward this pool (snapshot or legacy).
  *
  * Pool standings, the active-show pool view, and the server-side pool
  * delete path all gate inclusion on `pick.pools` (the snapshot of which
- * pools the author belonged to at pick-save time). After pool **create**
- * or **join**, `arrayUnionPoolOntoUserPickDocs` (picks API) merges the
- * pool into that user's existing pick docs for the season calendar so
- * pre-create / pre-join graded picks count for that pool.
+ * pools the author belonged to at pick-save time).
  *
- * Legacy fallback: pick docs written before snapshots were introduced
- * (no `pools` field, or `pools: []`) count for every pool the user is
- * currently a member of — there is no other signal available for those
- * rows.
+ * **Legacy pools** (default — `standingsScope` absent or not
+ * `from_membership`): after pool **create** or **join**,
+ * `arrayUnionPoolOntoUserPickDocs` merges the pool into that user's
+ * existing pick docs so pre-create / pre-join graded picks count.
+ * Pick docs without a `pools` snapshot (or `pools: []`) count for every
+ * pool the user is currently a member of.
+ *
+ * **`from_membership` pools** (new docs only, #417): no historical
+ * backfill. A pick counts only when it **explicitly** lists this pool in
+ * `pools` **and** `showDate` is on or after the author's membership
+ * calendar day (`memberJoinedOn`). Empty-snapshot legacy fallback does
+ * **not** apply.
  *
  * @param {Record<string, unknown>} pickData
  * @param {string} poolId
+ * @param {{
+ *   standingsScope?: string | null,
+ *   memberJoinedOn?: string | null,
+ *   showDate?: string | null,
+ * }} [ctx]
  */
-export function pickDataCountsForPool(pickData, poolId) {
+export function pickDataCountsForPool(pickData, poolId, ctx = {}) {
   if (!poolId?.trim() || !pickData) return false;
   const pools = pickData.pools;
-  if (Array.isArray(pools) && pools.length > 0) {
-    return pools.some((p) => p && p.id === poolId);
+  const hasSnapshot = Array.isArray(pools) && pools.length > 0;
+  const inSnapshot =
+    hasSnapshot && pools.some((p) => p && p.id === poolId);
+
+  if (isFromMembershipStandingsScope(ctx.standingsScope)) {
+    if (!inSnapshot) return false;
+    const showDate =
+      typeof ctx.showDate === 'string' && ctx.showDate
+        ? ctx.showDate
+        : typeof pickData.showDate === 'string'
+          ? pickData.showDate
+          : null;
+    const joinedOn =
+      typeof ctx.memberJoinedOn === 'string' && ctx.memberJoinedOn
+        ? ctx.memberJoinedOn
+        : null;
+    if (!showDate || !joinedOn) return false;
+    return showDate >= joinedOn;
   }
+
+  if (hasSnapshot) return inSnapshot;
   return true;
+}
+
+/**
+ * Resolve the membership calendar day for a uid from a pool's
+ * `memberJoinedAt` map (ISO strings).
+ *
+ * @param {Record<string, unknown> | null | undefined} memberJoinedAt
+ * @param {string} userId
+ * @returns {string | null}
+ */
+export function memberJoinedOnForUser(memberJoinedAt, userId) {
+  if (!userId?.trim() || !memberJoinedAt || typeof memberJoinedAt !== 'object') {
+    return null;
+  }
+  return membershipCalendarDay(memberJoinedAt[userId]);
 }
 
 export async function updatePoolNameApi(poolId, newName) {
@@ -53,4 +132,3 @@ export async function updatePoolStatusApi(poolId, status) {
   }
   await updateDoc(doc(db, 'pools', poolId.trim()), { status });
 }
-

--- a/src/features/pools/api/poolFirestore.test.js
+++ b/src/features/pools/api/poolFirestore.test.js
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  STANDINGS_SCOPE_FROM_MEMBERSHIP,
+  memberJoinedOnForUser,
+  membershipCalendarDay,
+  pickDataCountsForPool,
+} from './poolFirestore';
+
+describe('membershipCalendarDay', () => {
+  it('returns YYYY-MM-DD in America/Los_Angeles', () => {
+    // 2026-07-03T08:00:00Z is still Jul 3 in LA (UTC-7).
+    expect(membershipCalendarDay('2026-07-03T08:00:00.000Z')).toBe('2026-07-03');
+  });
+
+  it('returns null for invalid input', () => {
+    expect(membershipCalendarDay(null)).toBe(null);
+    expect(membershipCalendarDay('not-a-date')).toBe(null);
+  });
+});
+
+describe('pickDataCountsForPool — legacy (default)', () => {
+  it('rejects empty inputs', () => {
+    expect(pickDataCountsForPool(null, 'p1')).toBe(false);
+    expect(pickDataCountsForPool({}, '')).toBe(false);
+  });
+
+  it('counts legacy picks (no pools snapshot) everywhere', () => {
+    expect(pickDataCountsForPool({ picks: { s1: 'Foo' } }, 'p1')).toBe(true);
+    expect(pickDataCountsForPool({ pools: [] }, 'p1')).toBe(true);
+  });
+
+  it('scopes embedded pools snapshot to id match', () => {
+    const data = { pools: [{ id: 'p1' }, { id: 'p2' }] };
+    expect(pickDataCountsForPool(data, 'p1')).toBe(true);
+    expect(pickDataCountsForPool(data, 'p3')).toBe(false);
+  });
+});
+
+describe('pickDataCountsForPool — from_membership (#417)', () => {
+  const ctx = (overrides = {}) => ({
+    standingsScope: STANDINGS_SCOPE_FROM_MEMBERSHIP,
+    memberJoinedOn: '2026-07-03',
+    showDate: '2026-07-05',
+    ...overrides,
+  });
+
+  it('requires explicit pools snapshot (no legacy empty-pools fallback)', () => {
+    expect(
+      pickDataCountsForPool({ picks: { s1: 'Foo' } }, 'p1', ctx()),
+    ).toBe(false);
+    expect(pickDataCountsForPool({ pools: [] }, 'p1', ctx())).toBe(false);
+  });
+
+  it('includes picks on/after membership day when pool is in snapshot', () => {
+    const data = { pools: [{ id: 'p1' }], showDate: '2026-07-05' };
+    expect(pickDataCountsForPool(data, 'p1', ctx())).toBe(true);
+    expect(
+      pickDataCountsForPool(data, 'p1', ctx({ showDate: '2026-07-03' })),
+    ).toBe(true);
+  });
+
+  it('excludes picks before membership day', () => {
+    const data = { pools: [{ id: 'p1' }] };
+    expect(
+      pickDataCountsForPool(data, 'p1', ctx({ showDate: '2026-07-02' })),
+    ).toBe(false);
+  });
+
+  it('excludes picks that list other pools only', () => {
+    const data = { pools: [{ id: 'p2' }] };
+    expect(pickDataCountsForPool(data, 'p1', ctx())).toBe(false);
+  });
+
+  it('excludes when membership day is missing', () => {
+    const data = { pools: [{ id: 'p1' }] };
+    expect(
+      pickDataCountsForPool(data, 'p1', ctx({ memberJoinedOn: null })),
+    ).toBe(false);
+  });
+
+  it('uses pickData.showDate when ctx.showDate omitted', () => {
+    const data = { pools: [{ id: 'p1' }], showDate: '2026-07-10' };
+    expect(
+      pickDataCountsForPool(data, 'p1', {
+        standingsScope: STANDINGS_SCOPE_FROM_MEMBERSHIP,
+        memberJoinedOn: '2026-07-03',
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('memberJoinedOnForUser', () => {
+  it('resolves calendar day from memberJoinedAt map', () => {
+    expect(
+      memberJoinedOnForUser(
+        { u1: '2026-07-03T18:00:00.000Z' },
+        'u1',
+      ),
+    ).toBe('2026-07-03');
+    expect(memberJoinedOnForUser({ u1: '2026-07-03T18:00:00.000Z' }, 'u2')).toBe(
+      null,
+    );
+  });
+});

--- a/src/features/pools/api/poolStandings.js
+++ b/src/features/pools/api/poolStandings.js
@@ -4,7 +4,10 @@ import { db } from '../../../shared/lib/firebase';
 import { GAME_LAUNCH_SHOW_DATE } from '../../../shared/config/gameLaunch';
 import { pickCountsTowardSeason } from '../../../shared/utils/showAggregation';
 import { fetchGlobalMaxScoreForShow } from '../../scoring';
-import { pickDataCountsForPool } from './poolFirestore';
+import {
+  memberJoinedOnForUser,
+  pickDataCountsForPool,
+} from './poolFirestore';
 
 /**
  * @typedef {Object} PoolStandingsRow
@@ -127,6 +130,8 @@ export function aggregatePoolStandings(memberIds, picks, globalMaxByShow) {
  * @param {{
  *   onTelemetry?: (t: PoolStandingsTelemetry) => void,
  *   scope?: 'all-time' | 'tour',
+ *   standingsScope?: string | null,
+ *   memberJoinedAt?: Record<string, string> | null,
  * }} [options]
  * @returns {Promise<Map<string, PoolStandingsRow>>}
  */
@@ -136,7 +141,12 @@ export async function loadPoolStandings(
   effectiveShowDates,
   options = {}
 ) {
-  const { onTelemetry, scope = 'all-time' } = options;
+  const {
+    onTelemetry,
+    scope = 'all-time',
+    standingsScope = null,
+    memberJoinedAt = null,
+  } = options;
 
   const pid = poolId?.trim();
   const members = Array.isArray(memberIds) ? memberIds.filter(Boolean) : [];
@@ -201,7 +211,15 @@ export async function loadPoolStandings(
       const { showDate, userId } = slice[j];
       if (!snap.exists()) continue;
       const data = snap.data() || {};
-      if (!pickDataCountsForPool(data, pid)) continue;
+      if (
+        !pickDataCountsForPool(data, pid, {
+          standingsScope,
+          memberJoinedOn: memberJoinedOnForUser(memberJoinedAt, userId),
+          showDate,
+        })
+      ) {
+        continue;
+      }
       if (!pickCountsTowardSeason(data)) continue;
       const score = typeof data.score === 'number' ? data.score : 0;
       eligiblePicks.push({ showDate, userId, score });

--- a/src/features/pools/api/poolsApi.js
+++ b/src/features/pools/api/poolsApi.js
@@ -10,6 +10,10 @@ import {
 
 import { arrayUnionPoolOntoUserPickDocs } from '../../picks';
 import { db } from '../../../shared/lib/firebase';
+import {
+  STANDINGS_SCOPE_FROM_MEMBERSHIP,
+  isFromMembershipStandingsScope,
+} from './poolFirestore';
 
 function generateInviteCode() {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
@@ -39,8 +43,10 @@ export async function fetchPools(userId) {
 
 /**
  * @param {{ userId: string, name: string, showDates?: Array<string | { date?: string }> }} params
+ * `showDates` is accepted for call-site compatibility but unused: new pools are
+ * `from_membership` and never backfill historical `pick.pools` snapshots (#417).
  */
-export async function createPool({ userId, name, showDates }) {
+export async function createPool({ userId, name, showDates: _showDates }) {
   const trimmedName = name?.trim();
   if (!userId || !trimmedName) {
     throw new Error('Missing required create pool fields.');
@@ -51,6 +57,8 @@ export async function createPool({ userId, name, showDates }) {
   const userRef = doc(db, 'users', userId);
   const createdAt = new Date().toISOString();
 
+  // New pools start at zero for every member (#417). Absent standingsScope
+  // on existing docs remains legacy (retroactive carryover + backfill).
   const poolPayload = {
     name: trimmedName,
     inviteCode,
@@ -58,6 +66,8 @@ export async function createPool({ userId, name, showDates }) {
     members: [userId],
     createdAt,
     status: 'active',
+    standingsScope: STANDINGS_SCOPE_FROM_MEMBERSHIP,
+    memberJoinedAt: { [userId]: createdAt },
   };
 
   const batch = writeBatch(db);
@@ -71,16 +81,7 @@ export async function createPool({ userId, name, showDates }) {
   );
   await batch.commit();
 
-  try {
-    await arrayUnionPoolOntoUserPickDocs(
-      userId,
-      { id: poolRef.id, name: trimmedName },
-      showDates
-    );
-  } catch (e) {
-    console.error('createPool: pick snapshot backfill failed:', e);
-  }
-
+  // from_membership: do not backfill historical pick.pools snapshots.
   return {
     id: poolRef.id,
     ...poolPayload,
@@ -135,9 +136,16 @@ export async function joinPool({ userId, inviteCode, showDates }) {
 
   const poolRef = doc(db, 'pools', poolDoc.id);
   const userRef = doc(db, 'users', userId);
+  const joinedAt = new Date().toISOString();
+  const fromMembership = isFromMembershipStandingsScope(poolData.standingsScope);
+
+  const poolUpdate = { members: arrayUnion(userId) };
+  if (fromMembership) {
+    poolUpdate[`memberJoinedAt.${userId}`] = joinedAt;
+  }
 
   const batch = writeBatch(db);
-  batch.update(poolRef, { members: arrayUnion(userId) });
+  batch.update(poolRef, poolUpdate);
   batch.set(
     userRef,
     {
@@ -147,25 +155,38 @@ export async function joinPool({ userId, inviteCode, showDates }) {
   );
   await batch.commit();
 
-  try {
-    await arrayUnionPoolOntoUserPickDocs(
-      userId,
-      {
-        id: poolDoc.id,
-        name:
-          typeof poolData.name === 'string' && poolData.name.trim()
-            ? poolData.name.trim()
-            : '',
-      },
-      showDates
-    );
-  } catch (e) {
-    console.error('joinPool: pick snapshot backfill failed:', e);
+  const poolName =
+    typeof poolData.name === 'string' && poolData.name.trim()
+      ? poolData.name.trim()
+      : '';
+
+  // Legacy pools only: backfill pick.pools so pre-join graded shows count.
+  if (!fromMembership) {
+    try {
+      await arrayUnionPoolOntoUserPickDocs(
+        userId,
+        { id: poolDoc.id, name: poolName },
+        showDates
+      );
+    } catch (e) {
+      console.error('joinPool: pick snapshot backfill failed:', e);
+    }
   }
+
+  const nextMemberJoinedAt = fromMembership
+    ? {
+        ...(poolData.memberJoinedAt &&
+        typeof poolData.memberJoinedAt === 'object'
+          ? poolData.memberJoinedAt
+          : {}),
+        [userId]: joinedAt,
+      }
+    : poolData.memberJoinedAt;
 
   return {
     id: poolDoc.id,
     ...poolData,
     members: [...(poolData.members || []), userId],
+    ...(fromMembership ? { memberJoinedAt: nextMemberJoinedAt } : {}),
   };
 }

--- a/src/features/pools/index.js
+++ b/src/features/pools/index.js
@@ -1,5 +1,14 @@
 export { joinPool } from './api/poolsApi';
-export { pickDataCountsForPool, POOL_NAME_MAX_LENGTH } from './api/poolFirestore';
+export {
+  pickDataCountsForPool,
+  memberJoinedOnForUser,
+  membershipCalendarDay,
+  isFromMembershipStandingsScope,
+  STANDINGS_SCOPE_FROM_MEMBERSHIP,
+  STANDINGS_SCOPE_LEGACY,
+  MEMBERSHIP_DAY_TIME_ZONE,
+  POOL_NAME_MAX_LENGTH,
+} from './api/poolFirestore';
 export { usePoolHub } from './model/usePoolHub';
 export { usePoolAdminControls } from './model/usePoolAdminControls';
 export { usePoolStandingsSection } from './model/usePoolStandingsSection';

--- a/src/features/pools/model/usePoolStandingsSection.js
+++ b/src/features/pools/model/usePoolStandingsSection.js
@@ -84,6 +84,15 @@ export function usePoolStandingsSection(poolId, pool, memberProfiles) {
     () => [...memberIds].sort().join('|'),
     [memberIds]
   );
+  const standingsScope = pool?.standingsScope ?? null;
+  const memberJoinedAt = pool?.memberJoinedAt ?? null;
+  const membershipKey = useMemo(() => {
+    if (!memberJoinedAt || typeof memberJoinedAt !== 'object') return '';
+    return Object.keys(memberJoinedAt)
+      .sort()
+      .map((uid) => `${uid}:${memberJoinedAt[uid] ?? ''}`)
+      .join('|');
+  }, [memberJoinedAt]);
   const showDatesKey = useMemo(
     () => effectiveShowDates.map((s) => s.date).join('|'),
     [effectiveShowDates]
@@ -115,6 +124,8 @@ export function usePoolStandingsSection(poolId, pool, memberProfiles) {
       tourKey || '',
       memberKey,
       showDatesKey,
+      standingsScope || '',
+      membershipKey,
     ],
     enabled,
     queryFn: async () => {
@@ -137,6 +148,8 @@ export function usePoolStandingsSection(poolId, pool, memberProfiles) {
           effectiveShowDates,
           {
             scope: tourKey ? 'tour' : 'all-time',
+            standingsScope,
+            memberJoinedAt,
             onTelemetry: (t) => {
               captured = { ...t };
             },

--- a/src/features/scoring/model/useDisplayedPicks.js
+++ b/src/features/scoring/model/useDisplayedPicks.js
@@ -1,6 +1,9 @@
 import { useMemo } from 'react';
 
-import { pickDataCountsForPool } from '../../pools';
+import {
+  memberJoinedOnForUser,
+  pickDataCountsForPool,
+} from '../../pools';
 
 /**
  * Pure derivation: filter the show-scoped picks array down to a target
@@ -12,8 +15,14 @@ import { pickDataCountsForPool } from '../../pools';
  * `@testing-library/react` (the repo avoids that dep).
  *
  * @param {{
- *   picks: Array<{ userId?: string } & Record<string, unknown>>,
- *   userPools?: Array<{ id: string, members?: string[], name?: string }> | null,
+ *   picks: Array<{ userId?: string, showDate?: string } & Record<string, unknown>>,
+ *   userPools?: Array<{
+ *     id: string,
+ *     members?: string[],
+ *     name?: string,
+ *     standingsScope?: string,
+ *     memberJoinedAt?: Record<string, string>,
+ *   }> | null,
  *   activeFilter: 'global' | string,
  * }} options
  */
@@ -23,11 +32,17 @@ export function filterPicksToAudience({ picks, userPools, activeFilter }) {
   const selectedPool = userPools?.find((p) => p.id === activeFilter);
   if (!selectedPool) return picks;
 
-  return picks.filter(
-    (pick) =>
-      selectedPool.members?.includes(pick.userId) &&
-      pickDataCountsForPool(pick, selectedPool.id),
-  );
+  return picks.filter((pick) => {
+    if (!selectedPool.members?.includes(pick.userId)) return false;
+    return pickDataCountsForPool(pick, selectedPool.id, {
+      standingsScope: selectedPool.standingsScope,
+      memberJoinedOn: memberJoinedOnForUser(
+        selectedPool.memberJoinedAt,
+        pick.userId,
+      ),
+      showDate: typeof pick.showDate === 'string' ? pick.showDate : null,
+    });
+  });
 }
 
 /**

--- a/src/features/scoring/model/useDisplayedPicks.test.js
+++ b/src/features/scoring/model/useDisplayedPicks.test.js
@@ -107,4 +107,34 @@ describe('filterPicksToAudience', () => {
       filterPicksToAudience({ picks, userPools: null, activeFilter: 'pool-a' }),
     ).toBe(picks);
   });
+
+  it('from_membership: excludes legacy empty-pools and pre-join shows', () => {
+    const pools = [
+      {
+        id: 'pool-new',
+        members: ['u-alice', 'u-bob'],
+        standingsScope: 'from_membership',
+        memberJoinedAt: {
+          'u-alice': '2026-07-03T18:00:00.000Z',
+          'u-bob': '2026-07-05T18:00:00.000Z',
+        },
+      },
+    ];
+    const picks = [
+      { ...pickLegacy('u-alice'), showDate: '2026-07-10' },
+      { ...pickSnapshotIn('u-alice', ['pool-new']), showDate: '2026-07-02' },
+      { ...pickSnapshotIn('u-alice', ['pool-new']), showDate: '2026-07-04' },
+      { ...pickSnapshotIn('u-bob', ['pool-new']), showDate: '2026-07-04' },
+      { ...pickSnapshotIn('u-bob', ['pool-new']), showDate: '2026-07-06' },
+    ];
+    const result = filterPicksToAudience({
+      picks,
+      userPools: pools,
+      activeFilter: 'pool-new',
+    });
+    expect(result).toEqual([
+      picks[2], // alice on/after join
+      picks[4], // bob on/after join
+    ]);
+  });
 });


### PR DESCRIPTION
Closes #417

## Summary
- New pools write `standingsScope: 'from_membership'` and `memberJoinedAt.{uid}`; pool-scoped standings (hub + Standings Pools filter) count only picks that list the pool and whose `showDate` is on/after that member’s join day (`America/Los_Angeles`).
- Existing pools (no field) keep legacy retroactive carryover and create/join backfill.
- `deletePoolWithCleanup` activity scan honors `from_membership` so pre-join legacy pick docs do not block delete on new-mode pools.
- Adds Sprint 5/6 release-train manifest (`docs/RELEASE_TRAIN_SPRINT_5_6.md`) and bumps to **1.12.0**.

## Test plan
- [ ] Unit tests: `npm test -- --run src/features/pools/api/poolFirestore.test.js src/features/scoring/model/useDisplayedPicks.test.js`
- [ ] Functions: `cd functions && npm test -- --test-name-pattern='pickDataCountsForPool|findPoolPickActivity'`
- [ ] Create a **new** pool with an account that has past graded shows → pool all-time/tour totals are **0** until picks are saved while in the pool
- [ ] Join a **new-mode** pool via invite → pre-join shows excluded; post-join picks with pool snapshot included
- [ ] Open an **existing** (legacy) pool → standings match pre-change behavior (retroactive carryover)
- [ ] Standings **Show** / **Tour** (global) views unchanged
- [ ] Deploy Functions before relying on delete activity parity in prod (`deletePoolWithCleanup`)


Made with [Cursor](https://cursor.com)