### PR TITLE
feat(pools): show invite code and align join-my-pool share copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.14.0] — 2026-07-03
+
+### Added
+- **Visible pool invite code** — pool details, pool cards, and post-create success show the invite code with a one-tap **Copy** control for in-person sharing.
+
+### Changed
+- Invite share clipboard and Open Graph copy use **“Join my Setlist Pick 'Em pool”** wording (pool name included when known). Native share remains URL-only so iMessage can still fetch OG.
+
+---
+
 ## [1.13.0] — 2026-07-03
 
 ### Added

--- a/api/invite/[code].js
+++ b/api/invite/[code].js
@@ -186,16 +186,23 @@ export default async function handler(req, res) {
   const inviteUrl = `${SITE_URL}/join/${code}`;
 
   // 1. Resolve OG copy (best-effort; fall back to defaults on any error).
+  // Keep "Join my … pool" wording aligned with client share/clipboard copy
+  // (`buildPoolInviteShareTitle` in shareOrCopyInviteUrl.js).
   let title = DEFAULT_TITLE;
   let description = DEFAULT_DESCRIPTION;
 
   if (code) {
+    title = "Join my Setlist Pick 'Em pool!";
+    description =
+      "You've been invited to a private Setlist Pick 'Em pool. Pick your setlist and compete to win.";
     try {
       const pool = await fetchPoolByCode(code);
       if (pool?.name) {
         const poolName = String(pool.name).trim();
-        title = `${poolName} - Setlist Pick 'Em Invite`;
-        description = `You've been invited to join ${poolName}! Pick your setlist and compete to win.`;
+        if (poolName) {
+          title = `Join my Setlist Pick 'Em pool: ${poolName}`;
+          description = `Join my Setlist Pick 'Em pool — ${poolName}. Pick openers, closers, and more before each show.`;
+        }
       }
     } catch (err) {
       console.error('[og-invite] Firestore lookup failed:', err?.message ?? err);

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.13.0  
+**Version:** 1.14.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 

--- a/docs/RELEASE_TRAIN_SPRINT_5_6.md
+++ b/docs/RELEASE_TRAIN_SPRINT_5_6.md
@@ -141,3 +141,4 @@ Incomplete features must land **dark** (flags / absent fields / no UX) rather th
 | 2026-07-03 | 0 | Manifest authored | Train defined |
 | 2026-07-03 | 2 | PR #471 | #417 pool standings from membership merged to staging (1.12.0) |
 | 2026-07-03 | 2 | PR #472 | #418 Profile cluster Phase 1 (1.13.0) |
+| 2026-07-03 | 2 | PR #473 | Visible invite code + join-my-pool share copy (1.14.0) |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/pools/model/usePoolInviteShare.js
+++ b/src/features/pools/model/usePoolInviteShare.js
@@ -1,12 +1,20 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { createPoolInviteLink } from '../../../shared/lib/createPoolInviteLink';
-import { shareOrCopyInviteUrl } from '../../../shared/lib/shareOrCopyInviteUrl';
+import {
+  buildPoolInviteShareTitle,
+  shareOrCopyInviteUrl,
+} from '../../../shared/lib/shareOrCopyInviteUrl';
 
 /**
  * Orchestrates pool invite link sharing (Web Share API or clipboard).
  */
-export function usePoolInviteShare({ inviteCode, onSuccess, disabled = false }) {
+export function usePoolInviteShare({
+  inviteCode,
+  poolName,
+  onSuccess,
+  disabled = false,
+}) {
   const [status, setStatus] = useState('idle');
 
   useEffect(() => {
@@ -17,7 +25,8 @@ export function usePoolInviteShare({ inviteCode, onSuccess, disabled = false }) 
     if (disabled || !inviteCode) return;
     const url = createPoolInviteLink(inviteCode);
     const result = await shareOrCopyInviteUrl(url, {
-      copyToastMessage: 'Link copied!',
+      poolName,
+      copyToastMessage: 'Invite link copied!',
     });
 
     if (result.ok) {
@@ -28,7 +37,7 @@ export function usePoolInviteShare({ inviteCode, onSuccess, disabled = false }) 
       setStatus('error');
       window.setTimeout(() => setStatus('idle'), 2000);
     }
-  }, [inviteCode, onSuccess, disabled]);
+  }, [inviteCode, poolName, onSuccess, disabled]);
 
   const label =
     status === 'shared'
@@ -43,6 +52,6 @@ export function usePoolInviteShare({ inviteCode, onSuccess, disabled = false }) 
     label,
     onShareClick: handleShareClick,
     disabled: disabled || !inviteCode,
-    title: 'Invite friends to this pool',
+    title: buildPoolInviteShareTitle(poolName),
   };
 }

--- a/src/features/pools/ui/PoolCard.jsx
+++ b/src/features/pools/ui/PoolCard.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 
 import Card from '../../../shared/ui/Card';
 import StatusBadge from '../../../shared/ui/StatusBadge';
+import PoolInviteCodeRow from './PoolInviteCodeRow';
 import PoolInviteShareButton from './PoolInviteShareButton';
 
 export default function PoolCard({
@@ -49,9 +50,13 @@ export default function PoolCard({
           <p className="mt-1 text-xs uppercase tracking-widest text-content-secondary">
             {memberCount} {memberCount === 1 ? 'Member' : 'Members'}
           </p>
+          <PoolInviteCodeRow inviteCode={pool?.inviteCode} className="mt-2" />
         </div>
         <div className="flex shrink-0 items-start pt-0.5">
-          <PoolInviteShareButton inviteCode={pool?.inviteCode} />
+          <PoolInviteShareButton
+            inviteCode={pool?.inviteCode}
+            poolName={pool?.name}
+          />
         </div>
       </div>
     </Card>

--- a/src/features/pools/ui/PoolHubHeader.jsx
+++ b/src/features/pools/ui/PoolHubHeader.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import PoolInviteCodeRow from './PoolInviteCodeRow';
 import PoolInviteShareButton from './PoolInviteShareButton';
 
 export default function PoolHubHeader({
@@ -11,10 +12,10 @@ export default function PoolHubHeader({
   isArchived = false,
 }) {
   return (
-    <header className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6">
+    <header className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
       <div className="min-w-0">
-        <div className="flex flex-wrap items-center gap-2 min-w-0">
-          <h1 className="text-xl font-bold text-white truncate">{poolName}</h1>
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <h1 className="truncate text-xl font-bold text-white">{poolName}</h1>
           {isArchived ? (
             <span className="shrink-0 rounded-md border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-black uppercase tracking-wider text-amber-200">
               Archived
@@ -25,10 +26,16 @@ export default function PoolHubHeader({
           {memberCount} {memberCount === 1 ? 'member' : 'members'}
           {creatorLabel ? ` · ${creatorLabel}` : null}
         </p>
+        <PoolInviteCodeRow
+          inviteCode={inviteCode}
+          disabled={isArchived}
+          className="mt-2"
+        />
       </div>
       <div className="shrink-0 sm:self-center">
         <PoolInviteShareButton
           inviteCode={inviteCode}
+          poolName={poolName}
           onSuccess={onInviteShareSuccess}
           disabled={isArchived}
         />

--- a/src/features/pools/ui/PoolInviteCodeRow.jsx
+++ b/src/features/pools/ui/PoolInviteCodeRow.jsx
@@ -1,0 +1,67 @@
+import React, { useCallback, useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+
+import { showSuccessToast } from '../../../shared/ui/toast';
+
+/**
+ * Visible invite code with one-tap copy (in-person / manual entry).
+ *
+ * @param {{
+ *   inviteCode?: string | null,
+ *   disabled?: boolean,
+ *   className?: string,
+ * }} props
+ */
+export default function PoolInviteCodeRow({
+  inviteCode,
+  disabled = false,
+  className = '',
+}) {
+  const code = inviteCode?.trim?.().toUpperCase?.() ?? '';
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    if (disabled || !code) return;
+    if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(code);
+      showSuccessToast('Invite code copied!');
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // ignore — button stays idle
+    }
+  }, [code, disabled]);
+
+  if (!code) return null;
+
+  return (
+    <div
+      className={`flex flex-wrap items-center gap-2 ${className}`.trim()}
+    >
+      <span className="text-[10px] font-black uppercase tracking-widest text-content-secondary">
+        Invite code
+      </span>
+      <code className="rounded-md border border-border-subtle bg-surface-field px-2 py-1 font-mono text-sm font-bold tracking-[0.2em] text-white">
+        {code}
+      </code>
+      <button
+        type="button"
+        onClick={handleCopy}
+        disabled={disabled}
+        className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-xs font-semibold text-content-secondary transition-colors hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand disabled:cursor-not-allowed disabled:opacity-40"
+        title="Copy invite code"
+        aria-label={copied ? 'Invite code copied' : 'Copy invite code'}
+      >
+        {copied ? (
+          <Check className="h-3.5 w-3.5 shrink-0 text-brand-primary" aria-hidden />
+        ) : (
+          <Copy className="h-3.5 w-3.5 shrink-0" aria-hidden />
+        )}
+        <span>{copied ? 'Copied' : 'Copy'}</span>
+      </button>
+    </div>
+  );
+}

--- a/src/features/pools/ui/PoolInviteShareButton.jsx
+++ b/src/features/pools/ui/PoolInviteShareButton.jsx
@@ -8,11 +8,12 @@ import { PoolInviteShareButtonView } from './PoolInviteShareButtonView';
  */
 export default function PoolInviteShareButton({
   inviteCode,
+  poolName,
   onSuccess,
   disabled = false,
   className = '',
 }) {
-  const share = usePoolInviteShare({ inviteCode, onSuccess, disabled });
+  const share = usePoolInviteShare({ inviteCode, poolName, onSuccess, disabled });
 
   return (
     <PoolInviteShareButtonView

--- a/src/features/pools/ui/PoolJoinCreateCard.jsx
+++ b/src/features/pools/ui/PoolJoinCreateCard.jsx
@@ -4,6 +4,7 @@ import { createPoolInviteLink } from '../../../shared/lib/createPoolInviteLink';
 import Button from '../../../shared/ui/Button';
 import Card from '../../../shared/ui/Card';
 import Input from '../../../shared/ui/Input';
+import PoolInviteCodeRow from './PoolInviteCodeRow';
 import PoolInviteShareButton from './PoolInviteShareButton';
 
 export default function PoolJoinCreateCard({
@@ -163,6 +164,10 @@ export default function PoolJoinCreateCard({
                 Pool created!
               </p>
               <p className="mt-1 text-base font-bold text-white">{createSuccess.name}</p>
+              <PoolInviteCodeRow
+                inviteCode={createSuccess.inviteCode}
+                className="mt-3"
+              />
               <p className="mt-3 text-xs font-bold uppercase tracking-widest text-content-secondary">
                 Your invite link
               </p>
@@ -171,7 +176,10 @@ export default function PoolJoinCreateCard({
               </p>
             </div>
             <div className="flex flex-wrap items-center gap-3">
-              <PoolInviteShareButton inviteCode={createSuccess.inviteCode} />
+              <PoolInviteShareButton
+                inviteCode={createSuccess.inviteCode}
+                poolName={createSuccess.name}
+              />
             </div>
           </div>
         ) : (

--- a/src/shared/lib/shareOrCopyInviteUrl.js
+++ b/src/shared/lib/shareOrCopyInviteUrl.js
@@ -1,6 +1,18 @@
 import { showSuccessToast } from '../ui/toast';
 
-const DEFAULT_SHARE_TITLE = "Join My Setlist Pick 'Em Pool!";
+const DEFAULT_SHARE_TITLE = "Join my Setlist Pick 'Em pool!";
+
+/**
+ * Share / clipboard headline for pool invites (also mirrored in invite OG copy).
+ *
+ * @param {string | null | undefined} poolName
+ * @returns {string}
+ */
+export function buildPoolInviteShareTitle(poolName) {
+  const name = typeof poolName === 'string' ? poolName.trim() : '';
+  if (name) return `Join my Setlist Pick 'Em pool: ${name}`;
+  return DEFAULT_SHARE_TITLE;
+}
 
 /**
  * Try Web Share API with URL only for the native sheet payload.
@@ -8,12 +20,13 @@ const DEFAULT_SHARE_TITLE = "Join My Setlist Pick 'Em Pool!";
  * fetching Open Graph for the link (Chrome WKWebView shows a blank preview;
  * Safari share still works). Clipboard fallback still uses title + URL.
  * @param {string} url
- * @param {{ title?: string, copyToastMessage?: string }} [options]
+ * @param {{ title?: string, poolName?: string, copyToastMessage?: string }} [options]
  * @returns {Promise<{ ok: boolean, via?: 'share' | 'copy', reason?: string }>}
  */
 export async function shareOrCopyInviteUrl(url, options = {}) {
   const {
-    title = DEFAULT_SHARE_TITLE,
+    title,
+    poolName,
     copyToastMessage = 'Link copied!',
   } = options;
 
@@ -22,7 +35,7 @@ export async function shareOrCopyInviteUrl(url, options = {}) {
   }
 
   const trimmedUrl = url.trim();
-  const shareText = title.trim();
+  const shareText = (title ?? buildPoolInviteShareTitle(poolName)).trim();
 
   if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
     try {

--- a/src/shared/lib/shareOrCopyInviteUrl.test.js
+++ b/src/shared/lib/shareOrCopyInviteUrl.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildPoolInviteShareTitle } from './shareOrCopyInviteUrl';
+
+describe('buildPoolInviteShareTitle', () => {
+  it('includes pool name when provided', () => {
+    expect(buildPoolInviteShareTitle('Denver Crew')).toBe(
+      "Join my Setlist Pick 'Em pool: Denver Crew",
+    );
+  });
+
+  it('falls back when name is missing', () => {
+    expect(buildPoolInviteShareTitle(null)).toBe("Join my Setlist Pick 'Em pool!");
+    expect(buildPoolInviteShareTitle('   ')).toBe("Join my Setlist Pick 'Em pool!");
+  });
+});


### PR DESCRIPTION
## Summary
- Pool details, pool cards, and post-create success show the **invite code** with a one-tap **Copy** control (in-person / manual entry).
- Clipboard share text and invite Open Graph use **“Join my Setlist Pick 'Em pool”** wording (pool name included when known).
- Native share stays **URL-only** so iMessage can still fetch OG (unchanged intentional behavior).

Release train: **staging only**.

**Version note:** bumps to **1.12.0**. Rebase and bump if another train PR lands first.

## Test plan
- [ ] Open pool details — invite code visible; **Copy** copies code only and toasts
- [ ] Pool list card shows code + copy
- [ ] Create pool success shows code + link + share
- [ ] **Invite Friends!** on clipboard path pastes `Join my Setlist Pick 'Em pool: {name}` + URL
- [ ] On production (or public host), share `/join/{CODE}` and confirm OG title/description use join-my-pool wording


Made with [Cursor](https://cursor.com)