### PR TITLE
feat(comms): server comms_delivered → GA4 Measurement Protocol (#461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.15.0] — 2026-07-03
+
+### Added
+- **Server `comms_delivered` → GA4 Measurement Protocol (#461)** — `functions/commsGa4Measurement.js` posts per-channel delivery events (params match client `comms_*` dimensions) from `deliverCommsTrigger` on real sends. Gated by `GA4_MEASUREMENT_ID` + `GA4_MP_API_SECRET`, prod project, and non-emulator.
+
+---
+
 ## [1.14.0] — 2026-07-03
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.14.0  
+**Version:** 1.15.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 
@@ -277,6 +277,8 @@ Set in Firebase Functions config or Cloud Secret Manager. Adding one is a MINOR 
 |----------|----------|-------------|
 | `RESEND_API_KEY` | For email channel | Resend API key (Secret Manager); bound to `runCommsTrigger`, `deliverMarketingSummerTour2026Launch`, and comms adapters |
 | `RESEND_WEBHOOK_SECRET` | For email deliverability | Resend/Svix webhook signing secret (`whsec_…`); also signs one-click unsubscribe URLs |
+| `GA4_MEASUREMENT_ID` | For server `comms_delivered` MP | Same `G-…` id as `VITE_GA_MEASUREMENT_ID`; Functions `defineString` / `.env.set-picks` |
+| `GA4_MP_API_SECRET` | For server `comms_delivered` MP | GA4 Measurement Protocol API secret (Secret Manager); bound on all `deliverCommsTrigger` hosts; unset → no-op |
 | `COMMS_EVENT_ADAPTERS_ENABLED` | No | Must be `"true"` for v1 event adapters to fire; default off |
 | `PHISHNET_API_KEY` | For Phish.net callables | Phish.net API key (Secret Manager) |
 

--- a/docs/RELEASE_TRAIN_SPRINT_5_6.md
+++ b/docs/RELEASE_TRAIN_SPRINT_5_6.md
@@ -93,7 +93,8 @@ Wave 5  Stretch (optional) then promote freeze
 |------|------------------|--------------------|
 | `COMMS_EVENT_ADAPTERS_ENABLED` | Already canaried per #461 notes; verify on live revisions | Confirm `"true"` on all adapter + hook-host exports via deploy manifest |
 | `RESEND_API_KEY` / `RESEND_WEBHOOK_SECRET` | Bound on email path | Confirm bound on scoring/rollup hosts (#460) |
-| GA4 MP API secret (new, #461) | Unset → no-op send | Set secret, bind, canary one `runCommsTrigger` |
+| `GA4_MEASUREMENT_ID` + `GA4_MP_API_SECRET` (#461) | Unset → no-op send | Set measurement id param + MP secret, redeploy comms hosts, canary one `runCommsTrigger` |
+| GA4 custom dimensions (#291 + #461) | Not registered | Human: Admin → register `method`, `error_code`, `comms_*` event params |
 | CSP (#412) | Report-Only on preview first | Flip to enforce only after report-only is clean |
 | `pools.standingsScope` (#417) | Absent = `legacy` | New pools write `from_membership`; no migration |
 | Multi-band (#301) | Phish-only registry | No user-visible switcher |
@@ -142,3 +143,4 @@ Incomplete features must land **dark** (flags / absent fields / no UX) rather th
 | 2026-07-03 | 2 | PR #471 | #417 pool standings from membership merged to staging (1.12.0) |
 | 2026-07-03 | 2 | PR #472 | #418 Profile cluster Phase 1 (1.13.0) |
 | 2026-07-03 | 2 | PR #473 | Visible invite code + join-my-pool share copy (1.14.0) |
+| 2026-07-03 | 3 | `feat/461-comms-ga4-measurement-protocol` | #461 GA4 MP for `comms_delivered` (1.15.0); #291 is GA4 Admin (human) |

--- a/docs/comms-triggers/MEASUREMENT_PLAN.md
+++ b/docs/comms-triggers/MEASUREMENT_PLAN.md
@@ -6,11 +6,11 @@ GA4 property: **set-picks** (`527619709`). Comms events should register on **pro
 
 ## 1. Events to emit
 
-Deliver through a future `src/features/comms/model/commsAnalytics.js` (or extend `authAnalytics` only where lifecycle overlaps). Client events use `ga4Event`; server delivery logs use Cloud Functions structured logs + optional GA4 Measurement Protocol.
+Client engagement events use `ga4Event` via `src/features/comms/model/commsAnalytics.js`. Server delivery emits structured Cloud Logging **and** GA4 Measurement Protocol (`functions/commsGa4Measurement.js`, wired from `deliverCommsTrigger` on real non-dry-run channel success — #461).
 
 | Event | When | Params |
 |-------|------|--------|
-| `comms_delivered` | Server wrote inbox row or sent FCM | `trigger_id`, `template_id`, `channel`, `variant`, `message_id` |
+| `comms_delivered` | Server wrote inbox row, sent FCM, or sent email (per channel) | `comms_trigger_id`, `comms_template_id`, `comms_channel`, `comms_variant` (MP + logs; `user_id` = Firebase uid on MP) |
 | `comms_opened` | User opens inbox message or expands bell item | `trigger_id`, `template_id`, `channel`, `message_id` |
 | `comms_dismissed` | User dismisses without reading | `trigger_id`, `template_id`, `message_id` |
 | `comms_cta_click` | User taps CTA in message | `trigger_id`, `template_id`, `cta`, `destination` |
@@ -23,17 +23,28 @@ Even single-variant templates pass `variant: control` on every `comms_*` event s
 
 ## 2. GA4 custom dimensions (register once)
 
-Admin → Property → Custom definitions → Event-scoped:
+Admin → Property → Custom definitions → Event-scoped. Event parameter names match client + server emitters (`comms_*` prefix):
 
 | Display name | Event parameter |
 |--------------|-----------------|
-| `comms_trigger_id` | `trigger_id` |
-| `comms_template_id` | `template_id` |
-| `comms_channel` | `channel` |
-| `comms_variant` | `variant` |
-| `comms_cta` | `cta` |
+| Comms trigger id | `comms_trigger_id` |
+| Comms template id | `comms_template_id` |
+| Comms channel | `comms_channel` |
+| Comms variant | `comms_variant` |
+| Comms CTA | `comms_cta` |
+
+Also register auth dimensions from #291 (`method`, `error_code`) in the same Admin pass.
 
 Historical data is not backfilled after registration.
+
+### Server MP credentials (ops)
+
+| Var | Where | Notes |
+|-----|-------|-------|
+| `GA4_MEASUREMENT_ID` | Functions param / `.env.set-picks` | Same `G-…` as `VITE_GA_MEASUREMENT_ID` |
+| `GA4_MP_API_SECRET` | Secret Manager (`firebase functions:secrets:set GA4_MP_API_SECRET`) | GA4 Admin → Data stream → Measurement Protocol API secrets |
+
+Gate: both set, project `set-picks`, not Functions emulator. Unset secret → no-op (safe for local/CI).
 
 ## 3. Funnels per trigger family
 
@@ -72,7 +83,8 @@ Eligible → comms_delivered → comms_opened → dashboard visit within 24h
 | GA4 MCP `run_report` | Event counts, cohorts |
 | GA4 MCP `run_realtime_report` | Show-day spikes |
 | Firestore | `fcm_notification_log` delivery counts, `commsInbox` readAt |
-| Cloud Functions logs | Server-side `comms_delivered` audit |
+| Cloud Functions logs | Server-side `comms_delivered` audit (always) |
+| GA4 MP (`comms_delivered`) | Server delivery counts in GA4 (when MP secret bound) |
 
 ## 5. Squad KPIs
 

--- a/functions/commsDelivery.js
+++ b/functions/commsDelivery.js
@@ -18,6 +18,7 @@ const { getTriggerSpec, resolveDedupKey } = require("./commsCatalog");
 const { renderCommsTemplate } = require("./commsTemplates");
 const { deliverCommsInbox } = require("./commsInboxWorker");
 const { deliverCommsPush } = require("./commsPushWorker");
+const { sendCommsDeliveredEvent } = require("./commsGa4Measurement");
 
 const DEDUP_COLLECTION = "fcm_notification_log";
 const DEFAULT_FATIGUE_CAP = 2; // max comms per user per delivery run (FRAMEWORK §OPTIMIZE)
@@ -63,6 +64,7 @@ function recipientAllowsTrigger(userData, prefKeys) {
  *   fatigueCap?: number,
  *   variant?: string,
  *   logger?: { info?: Function, warn?: Function, error?: Function },
+ *   sendGa4Delivered?: typeof sendCommsDeliveredEvent,
  * }} params
  */
 async function deliverCommsTrigger({
@@ -77,6 +79,7 @@ async function deliverCommsTrigger({
   fatigueCap = DEFAULT_FATIGUE_CAP,
   variant = "control",
   logger,
+  sendGa4Delivered = sendCommsDeliveredEvent,
 }) {
   const spec = getTriggerSpec(triggerId);
   if (!spec) {
@@ -171,7 +174,7 @@ async function deliverCommsTrigger({
       if (res?.ok && res.skipReason !== "dry_run") {
         deliveredChannels.push(channel);
         summary.byChannel[channel] = (summary.byChannel[channel] || 0) + 1;
-        // 6) Measurement — structured server log per channel.
+        // 6) Measurement — structured server log + GA4 MP per channel (#461).
         logger?.info?.("comms_delivered", {
           comms_trigger_id: triggerId,
           comms_template_id: spec.templateId,
@@ -179,6 +182,18 @@ async function deliverCommsTrigger({
           comms_variant: variant,
           uid,
         });
+        // Fire-and-forget: MP failures must not block delivery.
+        // eslint-disable-next-line no-void
+        void sendGa4Delivered(
+          {
+            uid,
+            triggerId,
+            templateId: spec.templateId,
+            channel,
+            variant,
+          },
+          { logger }
+        );
       }
     }
 

--- a/functions/commsDelivery.test.js
+++ b/functions/commsDelivery.test.js
@@ -153,6 +153,7 @@ test("real delivery dispatches channels, writes dedup, logs comms_delivered", as
   const inApp = recordingWorker("inApp", { ok: true });
   const push = recordingWorker("push", { ok: true, sent: 1 });
   const logger = makeLogger();
+  const ga4Calls = [];
 
   const summary = await deliverCommsTrigger({
     db,
@@ -162,6 +163,10 @@ test("real delivery dispatches channels, writes dedup, logs comms_delivered", as
     workers: { inApp, push },
     dryRun: false,
     logger,
+    sendGa4Delivered: async (input) => {
+      ga4Calls.push(input);
+      return { sent: true };
+    },
   });
 
   assert.equal(summary.delivered, 1);
@@ -174,6 +179,31 @@ test("real delivery dispatches channels, writes dedup, logs comms_delivered", as
   assert.equal(delivered.length, 2);
   assert.equal(delivered[0].data.comms_trigger_id, "picks_confirmed");
   assert.equal(delivered[0].data.comms_variant, "control");
+  assert.equal(ga4Calls.length, 2);
+  assert.equal(ga4Calls[0].triggerId, "picks_confirmed");
+  assert.equal(ga4Calls[0].uid, "u1");
+  assert.ok(["inApp", "push"].includes(ga4Calls[0].channel));
+});
+
+test("dry run does not call GA4 MP", async () => {
+  const db = makeFakeDb();
+  const inApp = recordingWorker("inApp", { ok: true, skipReason: "dry_run" });
+  const ga4Calls = [];
+
+  await deliverCommsTrigger({
+    db,
+    admin: fakeAdmin,
+    triggerId: "picks_confirmed",
+    recipients: [{ uid: "u1", userData: {}, vars: { showDate: "2026-07-18" } }],
+    workers: { inApp },
+    dryRun: true,
+    sendGa4Delivered: async (input) => {
+      ga4Calls.push(input);
+      return { sent: true };
+    },
+  });
+
+  assert.equal(ga4Calls.length, 0);
 });
 
 test("prefs_off short-circuits before any channel work", async () => {

--- a/functions/commsGa4Measurement.js
+++ b/functions/commsGa4Measurement.js
@@ -1,0 +1,155 @@
+/**
+ * Server-side GA4 Measurement Protocol bridge for comms delivery (#461).
+ *
+ * Mirrors client param names in `src/features/comms/model/commsAnalytics.js`
+ * (`comms_trigger_id`, `comms_template_id`, `comms_channel`, `comms_variant`)
+ * and the structured `comms_delivered` Cloud Logging fields in `commsDelivery.js`.
+ *
+ * Production-only gate (server equivalent of `src/shared/lib/ga4.js` hostname
+ * guard): requires measurement id + API secret, and refuses the Functions
+ * emulator so local/CI never phones home.
+ */
+
+"use strict";
+
+const MP_COLLECT_URL = "https://www.google-analytics.com/mp/collect";
+
+/** Firebase project id for production analytics (matches `.firebaserc`). */
+const PROD_PROJECT_IDS = new Set(["set-picks"]);
+
+/**
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {{ measurementId: string, apiSecret: string }}
+ */
+function readGa4MpConfig(env = process.env) {
+  return {
+    measurementId: String(env.GA4_MEASUREMENT_ID || "").trim(),
+    apiSecret: String(env.GA4_MP_API_SECRET || "").trim(),
+  };
+}
+
+/**
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {boolean}
+ */
+function isGa4MpEnabled(env = process.env) {
+  if (env.FUNCTIONS_EMULATOR === "true") return false;
+  const projectId = String(env.GCLOUD_PROJECT || env.GCP_PROJECT || "").trim();
+  if (projectId && !PROD_PROJECT_IDS.has(projectId)) return false;
+  const { measurementId, apiSecret } = readGa4MpConfig(env);
+  return Boolean(measurementId && apiSecret);
+}
+
+/**
+ * Build the MP collect body for one `comms_delivered` event.
+ * `client_id` is a stable pseudo-id derived from uid so GA4 accepts the hit;
+ * `user_id` is the Firebase uid for user-scoped reporting (pair with client
+ * `gtag('set','user_id', uid)` when that lands).
+ *
+ * @param {{
+ *   uid: string,
+ *   triggerId: string,
+ *   templateId: string,
+ *   channel: string,
+ *   variant?: string,
+ * }} input
+ */
+function buildCommsDeliveredMpPayload({
+  uid,
+  triggerId,
+  templateId,
+  channel,
+  variant = "control",
+}) {
+  const safeUid = String(uid || "").trim();
+  const params = {
+    comms_trigger_id: String(triggerId || ""),
+    comms_template_id: String(templateId || ""),
+    comms_channel: String(channel || ""),
+    comms_variant: String(variant || "control"),
+  };
+  /** @type {Record<string, unknown>} */
+  const body = {
+    client_id: safeUid ? `server.${safeUid}` : "server.anonymous",
+    events: [
+      {
+        name: "comms_delivered",
+        params,
+      },
+    ],
+  };
+  if (safeUid) body.user_id = safeUid;
+  return body;
+}
+
+/**
+ * Fire-and-forget safe: never throws. No-ops when the production gate fails.
+ *
+ * @param {{
+ *   uid: string,
+ *   triggerId: string,
+ *   templateId: string,
+ *   channel: string,
+ *   variant?: string,
+ * }} input
+ * @param {{
+ *   env?: NodeJS.ProcessEnv,
+ *   fetchImpl?: typeof fetch,
+ *   logger?: { warn?: Function, info?: Function },
+ * }} [opts]
+ * @returns {Promise<{ sent: boolean, reason?: string, status?: number }>}
+ */
+async function sendCommsDeliveredEvent(input, opts = {}) {
+  const env = opts.env || process.env;
+  const logger = opts.logger;
+  if (!isGa4MpEnabled(env)) {
+    return { sent: false, reason: "gate_off" };
+  }
+
+  const { measurementId, apiSecret } = readGa4MpConfig(env);
+  const body = buildCommsDeliveredMpPayload(input);
+  const url = `${MP_COLLECT_URL}?measurement_id=${encodeURIComponent(
+    measurementId
+  )}&api_secret=${encodeURIComponent(apiSecret)}`;
+
+  const fetchImpl = opts.fetchImpl || globalThis.fetch;
+  if (typeof fetchImpl !== "function") {
+    logger?.warn?.("comms_delivered GA4 MP skipped: fetch unavailable");
+    return { sent: false, reason: "no_fetch" };
+  }
+
+  try {
+    const res = await fetchImpl(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    // MP returns 2xx with empty body on success; 204 is common.
+    if (!res.ok) {
+      logger?.warn?.("comms_delivered GA4 MP non-OK", {
+        status: res.status,
+        triggerId: input.triggerId,
+        channel: input.channel,
+      });
+      return { sent: false, reason: "http_error", status: res.status };
+    }
+    return { sent: true, status: res.status };
+  } catch (err) {
+    const msg = err && typeof err === "object" && "message" in err ? err.message : String(err);
+    logger?.warn?.("comms_delivered GA4 MP failed", {
+      msg,
+      triggerId: input.triggerId,
+      channel: input.channel,
+    });
+    return { sent: false, reason: "network_error" };
+  }
+}
+
+module.exports = {
+  MP_COLLECT_URL,
+  PROD_PROJECT_IDS,
+  readGa4MpConfig,
+  isGa4MpEnabled,
+  buildCommsDeliveredMpPayload,
+  sendCommsDeliveredEvent,
+};

--- a/functions/commsGa4Measurement.test.js
+++ b/functions/commsGa4Measurement.test.js
@@ -1,0 +1,180 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  MP_COLLECT_URL,
+  isGa4MpEnabled,
+  buildCommsDeliveredMpPayload,
+  sendCommsDeliveredEvent,
+} = require("./commsGa4Measurement");
+
+test("isGa4MpEnabled: false when secrets missing", () => {
+  assert.equal(
+    isGa4MpEnabled({
+      GCLOUD_PROJECT: "set-picks",
+      GA4_MEASUREMENT_ID: "",
+      GA4_MP_API_SECRET: "",
+    }),
+    false
+  );
+  assert.equal(
+    isGa4MpEnabled({
+      GCLOUD_PROJECT: "set-picks",
+      GA4_MEASUREMENT_ID: "G-TEST",
+      GA4_MP_API_SECRET: "",
+    }),
+    false
+  );
+});
+
+test("isGa4MpEnabled: false on emulator even with secrets", () => {
+  assert.equal(
+    isGa4MpEnabled({
+      FUNCTIONS_EMULATOR: "true",
+      GCLOUD_PROJECT: "set-picks",
+      GA4_MEASUREMENT_ID: "G-TEST",
+      GA4_MP_API_SECRET: "secret",
+    }),
+    false
+  );
+});
+
+test("isGa4MpEnabled: false on non-prod project", () => {
+  assert.equal(
+    isGa4MpEnabled({
+      GCLOUD_PROJECT: "set-picks-dev",
+      GA4_MEASUREMENT_ID: "G-TEST",
+      GA4_MP_API_SECRET: "secret",
+    }),
+    false
+  );
+});
+
+test("isGa4MpEnabled: true for prod project with both credentials", () => {
+  assert.equal(
+    isGa4MpEnabled({
+      GCLOUD_PROJECT: "set-picks",
+      GA4_MEASUREMENT_ID: "G-TEST",
+      GA4_MP_API_SECRET: "secret",
+    }),
+    true
+  );
+});
+
+test("buildCommsDeliveredMpPayload: mirrors client/log param names", () => {
+  const body = buildCommsDeliveredMpPayload({
+    uid: "user-1",
+    triggerId: "account_welcome",
+    templateId: "account-welcome",
+    channel: "email",
+    variant: "control",
+  });
+
+  assert.equal(body.client_id, "server.user-1");
+  assert.equal(body.user_id, "user-1");
+  assert.equal(body.events.length, 1);
+  assert.equal(body.events[0].name, "comms_delivered");
+  assert.deepEqual(body.events[0].params, {
+    comms_trigger_id: "account_welcome",
+    comms_template_id: "account-welcome",
+    comms_channel: "email",
+    comms_variant: "control",
+  });
+});
+
+test("buildCommsDeliveredMpPayload: defaults variant to control", () => {
+  const body = buildCommsDeliveredMpPayload({
+    uid: "u",
+    triggerId: "t",
+    templateId: "tmpl",
+    channel: "inApp",
+  });
+  assert.equal(body.events[0].params.comms_variant, "control");
+});
+
+test("sendCommsDeliveredEvent: no network when gate off", async () => {
+  let called = 0;
+  const result = await sendCommsDeliveredEvent(
+    {
+      uid: "u1",
+      triggerId: "account_welcome",
+      templateId: "account-welcome",
+      channel: "inApp",
+    },
+    {
+      env: { GCLOUD_PROJECT: "set-picks" },
+      fetchImpl: async () => {
+        called += 1;
+        return { ok: true, status: 204 };
+      },
+    }
+  );
+  assert.equal(result.sent, false);
+  assert.equal(result.reason, "gate_off");
+  assert.equal(called, 0);
+});
+
+test("sendCommsDeliveredEvent: posts MP payload shape (no real network)", async () => {
+  /** @type {{ url?: string, init?: RequestInit }} */
+  const seen = {};
+  const result = await sendCommsDeliveredEvent(
+    {
+      uid: "u1",
+      triggerId: "picks_confirmed",
+      templateId: "picks-confirmed",
+      channel: "push",
+      variant: "control",
+    },
+    {
+      env: {
+        GCLOUD_PROJECT: "set-picks",
+        GA4_MEASUREMENT_ID: "G-TESTID",
+        GA4_MP_API_SECRET: "test-secret",
+      },
+      fetchImpl: async (url, init) => {
+        seen.url = url;
+        seen.init = init;
+        return { ok: true, status: 204 };
+      },
+    }
+  );
+
+  assert.equal(result.sent, true);
+  assert.equal(result.status, 204);
+  assert.ok(String(seen.url).startsWith(MP_COLLECT_URL));
+  assert.ok(String(seen.url).includes("measurement_id=G-TESTID"));
+  assert.ok(String(seen.url).includes("api_secret=test-secret"));
+  assert.equal(seen.init?.method, "POST");
+
+  const body = JSON.parse(String(seen.init?.body || "{}"));
+  assert.equal(body.events[0].name, "comms_delivered");
+  assert.equal(body.events[0].params.comms_trigger_id, "picks_confirmed");
+  assert.equal(body.events[0].params.comms_channel, "push");
+  assert.equal(body.user_id, "u1");
+});
+
+test("sendCommsDeliveredEvent: swallows network errors", async () => {
+  const result = await sendCommsDeliveredEvent(
+    {
+      uid: "u1",
+      triggerId: "t",
+      templateId: "tmpl",
+      channel: "email",
+    },
+    {
+      env: {
+        GCLOUD_PROJECT: "set-picks",
+        GA4_MEASUREMENT_ID: "G-TESTID",
+        GA4_MP_API_SECRET: "test-secret",
+      },
+      fetchImpl: async () => {
+        throw new Error("offline");
+      },
+      logger: { warn: () => {} },
+    }
+  );
+  assert.equal(result.sent, false);
+  assert.equal(result.reason, "network_error");
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,7 +1,7 @@
 const { onDocumentWritten } = require("firebase-functions/v2/firestore");
 const { onCall, HttpsError, onRequest } = require("firebase-functions/v2/https");
 const { onSchedule } = require("firebase-functions/v2/scheduler");
-const { defineSecret } = require("firebase-functions/params");
+const { defineSecret, defineString } = require("firebase-functions/params");
 const { logger } = require("firebase-functions");
 const admin = require("firebase-admin");
 const {
@@ -75,6 +75,17 @@ const phishnetApiKey = defineSecret("PHISHNET_API_KEY");
 const resendApiKey = defineSecret("RESEND_API_KEY");
 // Resend webhook signing secret (Svix) for bounce/complaint suppression (#442).
 const resendWebhookSecret = defineSecret("RESEND_WEBHOOK_SECRET");
+// GA4 Measurement Protocol (#461). Measurement id is public (same as VITE_GA_MEASUREMENT_ID);
+// API secret is created in GA4 Admin → Data streams → Measurement Protocol API secrets.
+// Both surface as process.env for `commsGa4Measurement.js`. Unset → no-op send.
+const ga4MeasurementId = defineString("GA4_MEASUREMENT_ID", { default: "" });
+const ga4MpApiSecret = defineSecret("GA4_MP_API_SECRET");
+// Keep the defineString in the module graph for deploy-time param discovery;
+// runtime reads `process.env.GA4_MEASUREMENT_ID` inside `commsGa4Measurement.js`.
+void ga4MeasurementId;
+
+/** Secrets bound on every export that can call `deliverCommsTrigger`. */
+const commsDeliverySecrets = [resendApiKey, resendWebhookSecret, ga4MpApiSecret];
 
 admin.initializeApp();
 const db = admin.firestore();
@@ -197,7 +208,7 @@ exports.gradePicksOnSetlistWrite = onDocumentWritten(
   {
     document: "official_setlists/{showDate}",
     region: PHISHNET_FUNCTIONS_REGION,
-    secrets: [resendApiKey, resendWebhookSecret],
+    secrets: commsDeliverySecrets,
   },
   async (event) => {
     if (!event.data.after.exists) {
@@ -221,7 +232,7 @@ exports.commsOnUserProfileWrite = onDocumentWritten(
   {
     document: "users/{uid}",
     region: PHISHNET_FUNCTIONS_REGION,
-    secrets: [resendApiKey, resendWebhookSecret],
+    secrets: commsDeliverySecrets,
   },
   async (event) => {
     if (!event.data?.after?.exists) return null;
@@ -251,7 +262,7 @@ exports.commsOnPickWrite = onDocumentWritten(
   {
     document: "picks/{pickId}",
     region: PHISHNET_FUNCTIONS_REGION,
-    secrets: [resendApiKey, resendWebhookSecret],
+    secrets: commsDeliverySecrets,
   },
   async (event) => {
     if (!event.data?.after?.exists) return null;
@@ -279,7 +290,7 @@ exports.refreshLiveScoresForShow = onCall(
     region: PHISHNET_FUNCTIONS_REGION,
     invoker: "public",
     enforceAppCheck: false,
-    secrets: [resendApiKey, resendWebhookSecret],
+    secrets: commsDeliverySecrets,
   },
   async (request) => {
     assertAdminClaim(request);
@@ -321,7 +332,7 @@ exports.rollupScoresForShow = onCall(
     region: PHISHNET_FUNCTIONS_REGION,
     invoker: "public",
     enforceAppCheck: false,
-    secrets: [resendApiKey, resendWebhookSecret],
+    secrets: commsDeliverySecrets,
   },
   async (request) => {
     assertAdminClaim(request);
@@ -458,7 +469,7 @@ exports.deliverMarketingSummerTour2026Launch = onCall(
     region: PHISHNET_FUNCTIONS_REGION,
     invoker: "public",
     enforceAppCheck: false,
-    secrets: [resendApiKey, resendWebhookSecret],
+    secrets: commsDeliverySecrets,
   },
   async (request) => {
     assertAdminClaim(request);
@@ -495,7 +506,7 @@ exports.runCommsTrigger = onCall(
     region: PHISHNET_FUNCTIONS_REGION,
     invoker: "public",
     enforceAppCheck: false,
-    secrets: [resendApiKey, resendWebhookSecret],
+    secrets: commsDeliverySecrets,
   },
   async (request) => {
     assertAdminClaim(request);
@@ -1118,7 +1129,7 @@ exports.scheduledTourCountdownComms = onSchedule(
     schedule: "0 9 * * *",
     timeZone: "America/Los_Angeles",
     region: PHISHNET_FUNCTIONS_REGION,
-    secrets: [resendApiKey, resendWebhookSecret],
+    secrets: commsDeliverySecrets,
   },
   async () => {
     try {
@@ -1146,7 +1157,7 @@ exports.scheduledTourRankingsDailyComms = onSchedule(
     schedule: "0 8 * * *",
     timeZone: "America/Los_Angeles",
     region: PHISHNET_FUNCTIONS_REGION,
-    secrets: [resendApiKey, resendWebhookSecret],
+    secrets: commsDeliverySecrets,
   },
   async () => {
     try {
@@ -1172,7 +1183,7 @@ exports.scheduledPhishnetLiveSetlistPoll = onSchedule(
     schedule: "*/2 * * * *",
     timeZone: "America/New_York",
     region: PHISHNET_FUNCTIONS_REGION,
-    secrets: [phishnetApiKey, resendApiKey, resendWebhookSecret],
+    secrets: [phishnetApiKey, ...commsDeliverySecrets],
   },
   async () => {
     const key = phishnetApiKey.value();
@@ -1273,7 +1284,7 @@ exports.setLiveSetlistAutomationState = onCall(
 exports.pollLiveSetlistNow = onCall(
   {
     region: PHISHNET_FUNCTIONS_REGION,
-    secrets: [phishnetApiKey, resendApiKey, resendWebhookSecret],
+    secrets: [phishnetApiKey, ...commsDeliverySecrets],
     invoker: "public",
     enforceAppCheck: false,
   },

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
-    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js accountDelete.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js showFinalizationGate.test.js revertRollupCore.test.js postShowRollupPush.test.js picksLockReminder.test.js fcmMessagingCore.test.js sphereTourRecapDelivery.test.js commsCatalog.test.js commsTemplates.test.js commsEmailWorker.test.js commsEmailSuppression.test.js commsEmailDailyCap.test.js commsEmailUnsubscribe.test.js commsEmailPrefs.test.js commsResendWebhook.test.js commsDelivery.test.js commsEventAdapters.test.js commsDeployManifest.test.js marketingCommsTemplates.test.js",
+    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js accountDelete.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js showFinalizationGate.test.js revertRollupCore.test.js postShowRollupPush.test.js picksLockReminder.test.js fcmMessagingCore.test.js sphereTourRecapDelivery.test.js commsCatalog.test.js commsTemplates.test.js commsEmailWorker.test.js commsEmailSuppression.test.js commsEmailDailyCap.test.js commsEmailUnsubscribe.test.js commsEmailPrefs.test.js commsResendWebhook.test.js commsDelivery.test.js commsGa4Measurement.test.js commsEventAdapters.test.js commsDeployManifest.test.js marketingCommsTemplates.test.js",
     "serve": "firebase emulators:start --only functions",
     "shell": "firebase functions:shell",
     "start": "npm run shell",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.14.0",
+  "version": "1.15.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #461

## Summary
- New `functions/commsGa4Measurement.js` posts `comms_delivered` to GA4 Measurement Protocol on real (non-dry-run) channel success from `deliverCommsTrigger`.
- Params match client/log fields: `comms_trigger_id`, `comms_template_id`, `comms_channel`, `comms_variant`; `user_id` = Firebase uid.
- Gate: `GA4_MEASUREMENT_ID` + `GA4_MP_API_SECRET`, project `set-picks`, not Functions emulator. Unset → no-op.
- Binds `GA4_MP_API_SECRET` on all `deliverCommsTrigger` hosts; documents ops + custom-dimension registration in `MEASUREMENT_PLAN.md`.
- Bumps to **1.15.0**.

Release train: **staging only** (Wave 3).

## Test plan
- [x] `cd functions && npm test` (includes `commsGa4Measurement` + delivery wiring)
- [x] Frontend verify matrix green
- [ ] **Ops (human):** create MP API secret in GA4 Admin → Data stream
- [ ] `firebase functions:secrets:set GA4_MP_API_SECRET`
- [ ] Set `GA4_MEASUREMENT_ID` (same `G-…` as `VITE_GA_MEASUREMENT_ID`) via `.env.set-picks` / Functions param
- [ ] Redeploy comms delivery hosts (`npm run comms:deploy` or full functions deploy)
- [ ] Canary: `runCommsTrigger` with `dryRun: false` for `account_welcome` (one uid)
- [ ] Confirm Cloud Logging `comms_delivered` + GA4 realtime within ~60s
- [ ] **Ops (human, #291 + #461):** register event-scoped custom dimensions (`method`, `error_code`, `comms_*`)


Made with [Cursor](https://cursor.com)