### PR TITLE
feat(security): CSP Report-Only and browser security headers (#412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.16.0] — 2026-07-03
+
+### Added
+- **Security headers + CSP Report-Only (#412)** — `vercel.json` sets `X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`, `Permissions-Policy`, and `Content-Security-Policy-Report-Only` (Firebase, GA4, reCAPTCHA Enterprise, Google Fonts, Phish.in). Documented in `docs/SECURITY_HEADERS.md`; enforce flip is promote-day after report-only soak.
+
+---
+
 ## [1.15.0] — 2026-07-03
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.15.0  
+**Version:** 1.16.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 
@@ -248,6 +248,20 @@ These routes are part of the public surface. Renaming or removing them is a MAJO
 | `/dashboard/*` | Auth | Full game dashboard |
 
 Dashboard sub-routes are documented in `docs/DASHBOARD_IA.md`.
+
+### 3.1 HTTP security headers (Vercel)
+
+Applied via `vercel.json` to all routes. Policy details: `docs/SECURITY_HEADERS.md`.
+
+| Header | Mode | Notes |
+|--------|------|-------|
+| `X-Content-Type-Options` | Enforce | `nosniff` |
+| `Referrer-Policy` | Enforce | `strict-origin-when-cross-origin` |
+| `X-Frame-Options` | Enforce | `DENY` |
+| `Permissions-Policy` | Enforce | camera/microphone/geolocation disabled |
+| `Content-Security-Policy-Report-Only` | Report-only | Flip to `Content-Security-Policy` after soak (promote-day) |
+
+Adding or tightening enforced CSP is MINOR; removing a security header is MAJOR.
 
 ---
 

--- a/docs/RELEASE_TRAIN_SPRINT_5_6.md
+++ b/docs/RELEASE_TRAIN_SPRINT_5_6.md
@@ -140,7 +140,9 @@ Incomplete features must land **dark** (flags / absent fields / no UX) rather th
 | Date | Wave | PR / action | Notes |
 |------|------|-------------|-------|
 | 2026-07-03 | 0 | Manifest authored | Train defined |
-| 2026-07-03 | 2 | PR #471 | #417 pool standings from membership merged to staging (1.12.0) |
-| 2026-07-03 | 2 | PR #472 | #418 Profile cluster Phase 1 (1.13.0) |
+| 2026-07-03 | 2 | PR #471 | #417 pool standings from membership merged to staging (1.12.0); **issue #417 closed** |
+| 2026-07-03 | 2 | PR #472 | #418 Profile cluster Phase 1 (1.13.0); **#418 Phase 1 noted, epic left open for Phases 2–4** |
 | 2026-07-03 | 2 | PR #473 | Visible invite code + join-my-pool share copy (1.14.0) |
-| 2026-07-03 | 3 | `feat/461-comms-ga4-measurement-protocol` | #461 GA4 MP for `comms_delivered` (1.15.0); #291 is GA4 Admin (human) |
+| 2026-07-03 | 3 | PR #474 | #461 GA4 MP for `comms_delivered` (1.15.0); Functions deploy + canary; **#461 and #291 closed**; #441 measurement bullets updated |
+| 2026-07-03 | 3 | fix commits on staging | `commsDeliverySecrets` validate; await MP posts (Cloud Functions freeze) |
+| 2026-07-03 | 4 | `feat/412-csp-security-headers` | #412 CSP Report-Only + security headers (1.16.0) |

--- a/docs/SECURITY_HEADERS.md
+++ b/docs/SECURITY_HEADERS.md
@@ -1,0 +1,89 @@
+# Security headers (Vercel)
+
+Browser-facing headers for the Vite SPA on Vercel. Configured in [`vercel.json`](../vercel.json). Issue [#412](https://github.com/pat792/set-picks/issues/412) / epic [#411](https://github.com/pat792/set-picks/issues/411).
+
+## Always-on headers
+
+Applied to all routes (`/(.*)`):
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `X-Content-Type-Options` | `nosniff` | Block MIME sniffing |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Limit referrer leakage |
+| `X-Frame-Options` | `DENY` | Clickjacking (legacy; CSP `frame-ancestors` is primary) |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Disable unused powerful APIs |
+
+Cache-Control rules for HTML vs hashed assets are unchanged (see existing `vercel.json` entries).
+
+## Content-Security-Policy (tiered)
+
+### Current train phase: **Report-Only**
+
+`Content-Security-Policy-Report-Only` is set on all routes. Browsers **do not block** violations; they only report in DevTools (and to a `report-uri` if we add one later). This is intentional for preview **and** production until reports are clean.
+
+### Promote-day / follow-up: **Enforce**
+
+When Realtime / field reports show no unexpected violations on production traffic:
+
+1. In `vercel.json`, rename `Content-Security-Policy-Report-Only` → `Content-Security-Policy` (same value).
+2. Deploy and smoke: Google sign-in, App Check, Firestore, FCM, GA4 (prod host only), admin Phish.in fetch.
+3. Keep `frame-ancestors 'none'` and the always-on headers.
+
+Do **not** enforce on a half-broken policy — prefer report-only soak over a login outage.
+
+## CSP directives and exceptions
+
+Policy (keep in sync with `vercel.json`):
+
+```text
+default-src 'self';
+base-uri 'self';
+object-src 'none';
+frame-ancestors 'none';
+form-action 'self';
+script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://www.google.com https://www.gstatic.com https://apis.google.com https://www.recaptcha.net;
+style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+font-src 'self' https://fonts.gstatic.com data:;
+img-src 'self' data: blob: https:;
+connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://*.cloudfunctions.net https://*.firebaseapp.com https://*.firebasestorage.app https://firebasestorage.googleapis.com https://storage.googleapis.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://analytics.google.com https://www.google.com https://www.gstatic.com https://phish.in wss://*.googleapis.com wss://*.firebaseio.com;
+frame-src https://accounts.google.com https://*.firebaseapp.com https://www.google.com https://www.recaptcha.net https://recaptcha.google.com;
+worker-src 'self' blob:;
+manifest-src 'self';
+upgrade-insecure-requests
+```
+
+| Directive | Why these hosts |
+|-----------|-----------------|
+| `script-src` | Vite bundles (`'self'`); GA4; Google Identity / gapi; App Check **reCAPTCHA Enterprise** (`google.com`, `gstatic.com`, `recaptcha.net`) |
+| `style-src` | App CSS; Google Fonts CSS; `'unsafe-inline'` for runtime style attributes (Tailwind / UI) |
+| `font-src` | Inter from `fonts.gstatic.com` |
+| `img-src` | Local assets, avatars, Google favicon on splash, HTTPS images |
+| `connect-src` | Firebase (Auth, Firestore, Storage, Installations, App Check, Functions), GA4 beacons, Phish.in admin fetch, WebChannel `wss://` |
+| `frame-src` | Google sign-in, Firebase auth helper frames, reCAPTCHA challenges |
+| `worker-src` | FCM service worker + module workers |
+| `frame-ancestors` | No embedding (pairs with `X-Frame-Options: DENY`) |
+
+### Explicitly not allowed
+
+- `'unsafe-eval'` — not required by current Vite production builds
+- Arbitrary third-party ads / tag managers beyond GA4
+- `data:` / `blob:` in `script-src`
+
+### Local `npm run dev`
+
+Vite HMR and `@vite/client` need looser rules; **`vercel.json` does not apply to localhost**. Dev is ungated by design. Validate CSP on a Vercel preview or production deploy.
+
+## Verification
+
+1. **Deployed preview / staging:** DevTools → Network → document → Response Headers:
+   - Always-on headers present
+   - `content-security-policy-report-only` present (not `content-security-policy` until enforce flip)
+2. **Smoke:** sign-in, dashboard load, picks save, pool invite, notifications bell (FCM path).
+3. **Console:** filter `Content-Security-Policy` — note any report-only violations; fix policy before enforce.
+4. **Optional automation:** `npm run qa:preview-headers` (with `QA_PREVIEW_BASE_URL`) asserts cache-control **and** the always-on security headers + report-only CSP.
+
+## Related
+
+- [`vercel.json`](../vercel.json)
+- [`docs/RELEASE_TRAIN_SPRINT_5_6.md`](RELEASE_TRAIN_SPRINT_5_6.md) Wave 4
+- Client GA gate: `src/shared/lib/ga4.js` (prod hostnames only)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.15.0",
+  "version": "1.16.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/qa/preview-cache-headers.mjs
+++ b/scripts/qa/preview-cache-headers.mjs
@@ -92,6 +92,37 @@ async function run() {
     process.exit(1);
   }
 
+  // Security headers (#412) — always-on + CSP Report-Only until enforce flip.
+  const nosniff = (indexRes.headers.get('x-content-type-options') || '').toLowerCase();
+  if (nosniff !== 'nosniff') {
+    console.error(
+      `[qa:preview-headers] FAIL: expected X-Content-Type-Options: nosniff; ` +
+        `got: "${indexRes.headers.get('x-content-type-options')}"`,
+    );
+    process.exit(1);
+  }
+  const referrer = (indexRes.headers.get('referrer-policy') || '').toLowerCase();
+  if (!referrer.includes('strict-origin-when-cross-origin')) {
+    console.error(
+      `[qa:preview-headers] FAIL: expected Referrer-Policy strict-origin-when-cross-origin; ` +
+        `got: "${indexRes.headers.get('referrer-policy')}"`,
+    );
+    process.exit(1);
+  }
+  const cspRo = indexRes.headers.get('content-security-policy-report-only') || '';
+  const cspEnforce = indexRes.headers.get('content-security-policy') || '';
+  if (!cspRo.includes("default-src 'self'") && !cspEnforce.includes("default-src 'self'")) {
+    console.error(
+      '[qa:preview-headers] FAIL: expected Content-Security-Policy-Report-Only (or enforce) with default-src \'self\'.',
+    );
+    process.exit(1);
+  }
+  if (cspEnforce && !cspRo) {
+    console.log(
+      '[qa:preview-headers] note: CSP is enforcing (promote-day flip complete).',
+    );
+  }
+
   const html = await indexRes.text();
   const assetPath = firstAssetJsPath(html);
   if (!assetPath) {
@@ -123,7 +154,7 @@ async function run() {
   }
 
   console.log(
-    '[qa:preview-headers] PASS: HTML and /assets/*.js cache-control match recipes.md §C.',
+    '[qa:preview-headers] PASS: HTML and /assets/*.js cache-control match recipes.md §C; security headers (#412) present.',
   );
   process.exit(0);
 }

--- a/vercel.json
+++ b/vercel.json
@@ -24,6 +24,31 @@
   ],
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        },
+        {
+          "key": "Content-Security-Policy-Report-Only",
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://www.google.com https://www.gstatic.com https://apis.google.com https://www.recaptcha.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://*.cloudfunctions.net https://*.firebaseapp.com https://*.firebasestorage.app https://firebasestorage.googleapis.com https://storage.googleapis.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://analytics.google.com https://www.google.com https://www.gstatic.com https://phish.in wss://*.googleapis.com wss://*.firebaseio.com; frame-src https://accounts.google.com https://*.firebaseapp.com https://www.google.com https://www.recaptcha.net https://recaptcha.google.com; worker-src 'self' blob:; manifest-src 'self'; upgrade-insecure-requests"
+        }
+      ]
+    },
+    {
       "source": "/assets/(.*)",
       "headers": [
         {


### PR DESCRIPTION
Closes #412

## Summary
- `vercel.json`: always-on `X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`, `Permissions-Policy`, and **`Content-Security-Policy-Report-Only`** (Firebase Auth/Firestore/Storage/Functions, App Check reCAPTCHA Enterprise, GA4, Google Fonts, Phish.in).
- `docs/SECURITY_HEADERS.md` documents directives, exceptions, and the promote-day flip to enforce.
- `qa:preview-headers` asserts security headers when a preview URL is configured.
- Bumps to **1.16.0**.

Release train: **staging only** (Wave 4). CSP stays **report-only** until soak is clean (enforce is promote-day per manifest).

## Test plan
- [x] `npm run lint` / `npm test` / dashboard verify
- [ ] After Vercel preview deploys: DevTools → document response headers show report-only CSP + always-on headers
- [ ] Smoke on preview: Google sign-in, dashboard, picks, pools (no functional breaks; report-only does not block)
- [ ] Console: note any `Content-Security-Policy` report-only violations for policy follow-up
- [ ] Optional: `npm run qa:preview-headers` with `QA_PREVIEW_BASE_URL`


Made with [Cursor](https://cursor.com)