### PR TITLE
chore(platform): version Firestore indexes and enable Dependabot (#413, #414)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+# Dependabot — weekly npm updates for the SPA and Cloud Functions (#414).
+# Grouped PRs reduce noise; triage notes in AGENTS.md.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      root-production:
+        dependency-type: production
+      root-development:
+        dependency-type: development
+
+  - package-ecosystem: npm
+    directory: "/functions"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      functions-production:
+        dependency-type: production
+      functions-development:
+        dependency-type: development
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,17 @@ jobs:
       - name: Client tests (vitest)
         run: npm test
 
+      # Informational only (#414) — does not fail the job. Triage notes in AGENTS.md.
+      - name: npm audit (informational)
+        continue-on-error: true
+        run: |
+          echo "::group::root"
+          npm audit --omit=dev || true
+          echo "::endgroup::"
+          echo "::group::functions"
+          npm audit --omit=dev --prefix functions || true
+          echo "::endgroup::"
+
       - name: Version bumped (SemVer gate)
         # PR-only check: ensures PRs targeting staging bump package.json past the
         # last release. Skipped on push/schedule where github.base_ref is empty

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,18 @@ Core local commands:
 | QA runners | `npm run qa:chunks && npm run qa:cache` |
 | Build | `npm run build` |
 
+### Dependabot / npm audit (#414)
+
+- **Dependabot** (`.github/dependabot.yml`) opens weekly grouped PRs for root and `functions/` npm deps, plus monthly GitHub Actions updates. Base branch is the repo default; retarget to `staging` if GitHub opens against `main` only.
+- **CI `npm audit`** on the `verify` job is **informational** (`continue-on-error: true`). It does not block merge.
+- **Triage:** Critical/high in **production** deps → fix or upgrade in a normal PR. Dev-only / low noise → defer or group into a maintenance PR. Do not mass-upgrade without running `npm test` and `cd functions && npm test`.
+
+### Firestore indexes (#413)
+
+- Composite indexes live in `firestore.indexes.json` (wired from `firebase.json`). Refresh from prod:
+  `firebase firestore:indexes --project set-picks > firestore.indexes.json`
+- Empty `indexes: []` is valid when production has no composites (single-field indexes are automatic). Add composites here when a new query requires them (Console link or CLI), then deploy with `firebase deploy --only firestore:indexes`.
+
 ### PR workflow notes
 
 - **Base branch is `staging`**, not `main` (per `.cursorrules` §10).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.17.0] — 2026-07-03
+
+### Added
+- **Versioned Firestore indexes (#413)** — `firestore.indexes.json` wired in `firebase.json` (exported baseline from prod; currently no composites).
+- **Dependabot + informational npm audit (#414)** — weekly npm updates for root and `functions/`, monthly Actions; CI audit step is non-blocking. Triage notes in `AGENTS.md`.
+
+---
+
 ## [1.16.0] — 2026-07-03
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.16.0  
+**Version:** 1.17.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 

--- a/docs/RELEASE_TRAIN_SPRINT_5_6.md
+++ b/docs/RELEASE_TRAIN_SPRINT_5_6.md
@@ -145,4 +145,5 @@ Incomplete features must land **dark** (flags / absent fields / no UX) rather th
 | 2026-07-03 | 2 | PR #473 | Visible invite code + join-my-pool share copy (1.14.0) |
 | 2026-07-03 | 3 | PR #474 | #461 GA4 MP for `comms_delivered` (1.15.0); Functions deploy + canary; **#461 and #291 closed**; #441 measurement bullets updated |
 | 2026-07-03 | 3 | fix commits on staging | `commsDeliverySecrets` validate; await MP posts (Cloud Functions freeze) |
-| 2026-07-03 | 4 | `feat/412-csp-security-headers` | #412 CSP Report-Only + security headers (1.16.0) |
+| 2026-07-03 | 4 | PR #475 | #412 CSP Report-Only + security headers (1.16.0); **#412 closed** |
+| 2026-07-03 | 1 | `feat/413-414-indexes-dependabot` | Wave 1 catch-up: #413 indexes + #414 Dependabot/audit (1.17.0) |

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,7 @@
 {
   "firestore": {
-    "rules": "firestore.rules"
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
   },
   "storage": {
     "rules": "storage.rules"

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.16.0",
+  "version": "1.17.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #413
Closes #414

## Summary
- **#413:** Add `firestore.indexes.json` (exported from prod — currently no composites) and wire it in `firebase.json`. CI `rules` path filter already includes this file.
- **#414:** `.github/dependabot.yml` for root + `functions/` npm (weekly, grouped) and GitHub Actions (monthly). Informational `npm audit` on the `verify` job (`continue-on-error`). Triage notes in `AGENTS.md`.
- Bumps to **1.17.0**.

Release train: Wave 1 catch-up (after Waves 2–4).

## Test plan
- [x] `firebase firestore:indexes --project set-picks` matches committed file (empty composites)
- [x] `firebase.json` references `indexes`
- [ ] CI on this PR: `verify` green; audit step may warn but must not fail the job
- [ ] After merge: Dependabot appears under repo Insights → Dependency graph → Dependabot


Made with [Cursor](https://cursor.com)