### PR TITLE
perf(pools,scoring): cap pool reads and skip unchanged live grades (#415, #416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.18.0] — 2026-07-03
+
+### Added
+- **Pool read caps (#415)** — pool hub loads members via `pool.members` (capped at 100); user pool lists capped at 50 (`MAX_POOL_MEMBERS_FETCH` / `MAX_USER_POOLS_FETCH`).
+- **Live grading early-exit (#416)** — `gradePicksOnSetlistWrite` skips the full picks scan when the playable scoring setlist is unchanged (metadata-only writes).
+
+---
+
 ## [1.17.0] — 2026-07-03
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.17.0  
+**Version:** 1.18.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 

--- a/docs/RELEASE_TRAIN_SPRINT_5_6.md
+++ b/docs/RELEASE_TRAIN_SPRINT_5_6.md
@@ -18,6 +18,8 @@
 |-------|--------|------|-------|
 | [#417](https://github.com/pat792/set-picks/issues/417) | 5 | Code | Pool standings from membership (new pools only) |
 | [#418](https://github.com/pat792/set-picks/issues/418) | 5 | Code | Profile cluster **Phase 1** (IA split + redirects) |
+| [#415](https://github.com/pat792/set-picks/issues/415) | 5 | Code | Cap large pool / member Firestore reads |
+| [#416](https://github.com/pat792/set-picks/issues/416) | 5 | Code | Reduce redundant live grading on setlist writes |
 | [#461](https://github.com/pat792/set-picks/issues/461) | 5 / #441 | Code + secret | Server `comms_delivered` → GA4 Measurement Protocol |
 | [#291](https://github.com/pat792/set-picks/issues/291) | 5 | Ops (GA4 Admin) | Register `method` / `error_code` custom dimensions |
 | [#438](https://github.com/pat792/set-picks/issues/438) | 5 | Ops | Remaining post-deploy checklist (Functions, Auth templates, adapter gate) |
@@ -34,8 +36,13 @@
 | Issue | Notes |
 |-------|-------|
 | [#301](https://github.com/pat792/set-picks/issues/301) | Multi-band Phase 0 — additive contracts only, no UX/Firestore writes |
-| [#415](https://github.com/pat792/set-picks/issues/415) | Cap/paginate large pool reads |
-| [#416](https://github.com/pat792/set-picks/issues/416) | Reduce redundant live grading on setlist writes |
+
+### Moved into Sprint 5 (train)
+
+| Issue | Notes |
+|-------|-------|
+| [#415](https://github.com/pat792/set-picks/issues/415) | Cap large pool / member reads (was stretch) |
+| [#416](https://github.com/pat792/set-picks/issues/416) | Live grading early-exit on unchanged playable setlist (was stretch) |
 
 ### OUT — explicit defer (Sprint 7+ / separate train)
 
@@ -74,8 +81,7 @@ Wave 3  Comms observability closeout
 Wave 4  Security headers
         • #412 CSP report-only on preview → enforce on prod (tiered)
 
-Wave 5  Stretch (optional) then promote freeze
-        • #415 / #416 if ready
+Wave 5  Promote freeze
         • Staging soak + QA checklist
         • One staging → main PR
         • Tag vX.Y.0 (MINOR — new routes/schema fields/callables as applicable)
@@ -146,4 +152,5 @@ Incomplete features must land **dark** (flags / absent fields / no UX) rather th
 | 2026-07-03 | 3 | PR #474 | #461 GA4 MP for `comms_delivered` (1.15.0); Functions deploy + canary; **#461 and #291 closed**; #441 measurement bullets updated |
 | 2026-07-03 | 3 | fix commits on staging | `commsDeliverySecrets` validate; await MP posts (Cloud Functions freeze) |
 | 2026-07-03 | 4 | PR #475 | #412 CSP Report-Only + security headers (1.16.0); **#412 closed** |
-| 2026-07-03 | 1 | `feat/413-414-indexes-dependabot` | Wave 1 catch-up: #413 indexes + #414 Dependabot/audit (1.17.0) |
+| 2026-07-03 | 1 | PR #476 | Wave 1 catch-up: #413 indexes + #414 Dependabot/audit (1.17.0); **#413 #414 closed** |
+| 2026-07-03 | 5 | `feat/415-416-pool-reads-live-grade-skip` | #415/#416 moved to Sprint 5; pool read caps + live-grade early-exit (1.18.0) |

--- a/functions/index.js
+++ b/functions/index.js
@@ -29,6 +29,7 @@ const {
 const {
   calculateTotalScore,
   persistableActualSetlistFromOfficialDoc,
+  shouldSkipLiveScoreRecompute,
 } = require("./scoringCore");
 const { runBackfill } = require("./backfillBustoutsCore");
 const { runRollupForShow } = require("./rollupCore");
@@ -217,10 +218,24 @@ exports.gradePicksOnSetlistWrite = onDocumentWritten(
 
     const showDate = event.params.showDate;
     const setlistDoc = event.data.after.data() || {};
-    const actualSetlist = persistableActualSetlistFromOfficialDoc(setlistDoc);
+    const beforeDoc = event.data.before.exists ? event.data.before.data() || {} : null;
 
-    await recomputeLiveScoresForShow(showDate, actualSetlist);
-    return null;
+    // #416: skip full picks scan when playable scoring payload is unchanged
+    // (metadata-only admin/Phish.net writes).
+    if (shouldSkipLiveScoreRecompute(beforeDoc, setlistDoc)) {
+      logger.info("gradePicksOnSetlistWrite skip: playable setlist unchanged", {
+        showDate,
+      });
+      return { skipped: true, reason: "setlist_unchanged" };
+    }
+
+    const actualSetlist = persistableActualSetlistFromOfficialDoc(setlistDoc);
+    const result = await recomputeLiveScoresForShow(showDate, actualSetlist);
+    logger.info("gradePicksOnSetlistWrite complete", {
+      showDate,
+      updatedPicks: result?.updatedPicks ?? 0,
+    });
+    return result;
   }
 );
 

--- a/functions/scoringCore.js
+++ b/functions/scoringCore.js
@@ -195,6 +195,32 @@ function actualSetlistFromOfficialDoc(setlistDoc) {
   return out;
 }
 
+/**
+ * Stable JSON for playable-setlist equality (#416). `persistableActualSetlistFromOfficialDoc`
+ * always emits SCORE_FIELDS in fixed order, so stringify is sufficient.
+ *
+ * @param {Record<string, unknown> | null | undefined} playable
+ */
+function playableSetlistFingerprint(playable) {
+  if (!playable || typeof playable !== "object") return "";
+  return JSON.stringify(playable);
+}
+
+/**
+ * True when before/after official_setlists docs yield the same scoring payload
+ * (metadata-only writes should not re-grade every pick).
+ *
+ * @param {Record<string, unknown> | null | undefined} beforeDoc
+ * @param {Record<string, unknown> | null | undefined} afterDoc
+ */
+function shouldSkipLiveScoreRecompute(beforeDoc, afterDoc) {
+  if (!afterDoc || typeof afterDoc !== "object") return true;
+  if (!beforeDoc || typeof beforeDoc !== "object") return false;
+  const before = persistableActualSetlistFromOfficialDoc(beforeDoc);
+  const after = persistableActualSetlistFromOfficialDoc(afterDoc);
+  return playableSetlistFingerprint(before) === playableSetlistFingerprint(after);
+}
+
 module.exports = {
   SCORING_RULES,
   SCORE_FIELDS,
@@ -207,4 +233,6 @@ module.exports = {
   calculateTotalScore,
   actualSetlistFromOfficialDoc,
   persistableActualSetlistFromOfficialDoc,
+  playableSetlistFingerprint,
+  shouldSkipLiveScoreRecompute,
 };

--- a/functions/scoringCore.test.js
+++ b/functions/scoringCore.test.js
@@ -7,6 +7,7 @@ const {
   setlistHasAnyPlayedSong,
   actualSetlistFromOfficialDoc,
   persistableActualSetlistFromOfficialDoc,
+  shouldSkipLiveScoreRecompute,
 } = require("./scoringCore");
 
 test("setlistHasAnyPlayedSong: false when all slots empty and no ordered list", () => {
@@ -48,4 +49,34 @@ test("persistableActualSetlistFromOfficialDoc: ignores junk slot keys not in SCO
   };
   assert.equal(setlistHasAnyPlayedSong(actualSetlistFromOfficialDoc(doc)), true);
   assert.equal(setlistHasAnyPlayedSong(persistableActualSetlistFromOfficialDoc(doc)), false);
+});
+
+test("shouldSkipLiveScoreRecompute: true when only non-scoring metadata changes", () => {
+  const playable = {
+    setlist: { s1o: "Fee", s1c: "", s2o: "", s2c: "", enc: "", wild: "" },
+    officialSetlist: ["Fee"],
+  };
+  const before = { ...playable, updatedAt: "t1", source: "phishnet" };
+  const after = { ...playable, updatedAt: "t2", source: "admin", notes: "typo fix" };
+  assert.equal(shouldSkipLiveScoreRecompute(before, after), true);
+});
+
+test("shouldSkipLiveScoreRecompute: false when a scored slot changes", () => {
+  const before = {
+    setlist: { s1o: "Fee", s1c: "", s2o: "", s2c: "", enc: "", wild: "" },
+    officialSetlist: ["Fee"],
+  };
+  const after = {
+    setlist: { s1o: "Ghost", s1c: "", s2o: "", s2c: "", enc: "", wild: "" },
+    officialSetlist: ["Ghost"],
+  };
+  assert.equal(shouldSkipLiveScoreRecompute(before, after), false);
+});
+
+test("shouldSkipLiveScoreRecompute: false on first write (no before doc)", () => {
+  const after = {
+    setlist: { s1o: "Fee", s1c: "", s2o: "", s2c: "", enc: "", wild: "" },
+    officialSetlist: ["Fee"],
+  };
+  assert.equal(shouldSkipLiveScoreRecompute(null, after), false);
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.17.0",
+  "version": "1.18.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/pools/api/poolHubApi.js
+++ b/src/features/pools/api/poolHubApi.js
@@ -3,11 +3,15 @@ import {
   doc,
   getDoc,
   getDocs,
+  limit,
   query,
   where,
 } from 'firebase/firestore';
 
 import { db } from '../../../shared/lib/firebase';
+import { MAX_POOL_MEMBERS_FETCH } from './poolReadLimits';
+
+export { MAX_POOL_MEMBERS_FETCH, MAX_USER_POOLS_FETCH } from './poolReadLimits';
 
 export async function fetchPoolById(poolId) {
   const trimmed = poolId?.trim();
@@ -20,23 +24,49 @@ export async function fetchPoolById(poolId) {
 }
 
 /**
- * Loads member profiles for a pool via users where `pools` array-contains poolId.
- * Results are sorted by totalPoints descending.
+ * Load member profiles for a pool, capped at {@link MAX_POOL_MEMBERS_FETCH}.
+ *
+ * Prefer `memberIds` from the pool document (`members` array) so we only read
+ * known members (O(members)) instead of an unbounded `users` collection query.
+ *
+ * @param {string} poolId
+ * @param {{ memberIds?: string[], maxMembers?: number }} [options]
  */
-export async function fetchPoolMemberProfiles(poolId) {
+export async function fetchPoolMemberProfiles(poolId, options = {}) {
   const trimmed = poolId?.trim();
   if (!trimmed) return [];
 
+  const maxMembers =
+    typeof options.maxMembers === 'number' && options.maxMembers > 0
+      ? options.maxMembers
+      : MAX_POOL_MEMBERS_FETCH;
+
+  const memberIds = Array.isArray(options.memberIds)
+    ? options.memberIds.map((id) => String(id || '').trim()).filter(Boolean)
+    : null;
+
   let rows = [];
   try {
-    const q = query(
-      collection(db, 'users'),
-      where('pools', 'array-contains', trimmed)
-    );
-    const snap = await getDocs(q);
-    rows = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    if (memberIds && memberIds.length > 0) {
+      const cappedIds = memberIds.slice(0, maxMembers);
+      const snaps = await Promise.all(
+        cappedIds.map((uid) => getDoc(doc(db, 'users', uid)))
+      );
+      rows = snaps.map((snap, i) => {
+        if (!snap.exists()) return { id: cappedIds[i] };
+        return { id: snap.id, ...snap.data() };
+      });
+    } else {
+      const q = query(
+        collection(db, 'users'),
+        where('pools', 'array-contains', trimmed),
+        limit(maxMembers)
+      );
+      const snap = await getDocs(q);
+      rows = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    }
   } catch (e) {
-    console.error('Pool hub: users pools query failed:', e);
+    console.error('Pool hub: member profiles query failed:', e);
   }
 
   rows.sort(

--- a/src/features/pools/api/poolReadLimits.js
+++ b/src/features/pools/api/poolReadLimits.js
@@ -1,0 +1,10 @@
+/**
+ * Caps for pool-related Firestore list reads (#415).
+ * Documented product limits — not a hard product ban on larger pools.
+ */
+
+/** Max member profiles loaded for pool hub / leaderboard surfaces. */
+export const MAX_POOL_MEMBERS_FETCH = 100;
+
+/** Max pools returned for a single user's membership list. */
+export const MAX_USER_POOLS_FETCH = 50;

--- a/src/features/pools/api/poolReadLimits.test.js
+++ b/src/features/pools/api/poolReadLimits.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { MAX_POOL_MEMBERS_FETCH, MAX_USER_POOLS_FETCH } from './poolReadLimits';
+
+describe('pool read limits (#415)', () => {
+  it('caps member profile loads at a documented maximum', () => {
+    expect(MAX_POOL_MEMBERS_FETCH).toBe(100);
+  });
+
+  it('caps per-user pool membership lists', () => {
+    expect(MAX_USER_POOLS_FETCH).toBe(50);
+  });
+});

--- a/src/features/pools/api/poolsApi.js
+++ b/src/features/pools/api/poolsApi.js
@@ -3,6 +3,7 @@ import {
   collection,
   doc,
   getDocs,
+  limit,
   query,
   where,
   writeBatch,
@@ -10,6 +11,7 @@ import {
 
 import { arrayUnionPoolOntoUserPickDocs } from '../../picks';
 import { db } from '../../../shared/lib/firebase';
+import { MAX_USER_POOLS_FETCH } from './poolReadLimits';
 import {
   STANDINGS_SCOPE_FROM_MEMBERSHIP,
   isFromMembershipStandingsScope,
@@ -29,7 +31,8 @@ export async function fetchPools(userId) {
 
   const poolsQuery = query(
     collection(db, 'pools'),
-    where('members', 'array-contains', userId)
+    where('members', 'array-contains', userId),
+    limit(MAX_USER_POOLS_FETCH)
   );
   const snapshot = await getDocs(poolsQuery);
 

--- a/src/features/pools/index.js
+++ b/src/features/pools/index.js
@@ -9,6 +9,10 @@ export {
   MEMBERSHIP_DAY_TIME_ZONE,
   POOL_NAME_MAX_LENGTH,
 } from './api/poolFirestore';
+export {
+  MAX_POOL_MEMBERS_FETCH,
+  MAX_USER_POOLS_FETCH,
+} from './api/poolReadLimits';
 export { usePoolHub } from './model/usePoolHub';
 export { usePoolAdminControls } from './model/usePoolAdminControls';
 export { usePoolStandingsSection } from './model/usePoolStandingsSection';

--- a/src/features/pools/model/usePoolHub.js
+++ b/src/features/pools/model/usePoolHub.js
@@ -45,7 +45,9 @@ export function usePoolHub(poolId, currentUser) {
         return;
       }
 
-      const profiles = await fetchPoolMemberProfiles(poolId);
+      const profiles = await fetchPoolMemberProfiles(poolId, {
+        memberIds: Array.isArray(poolData.members) ? poolData.members : undefined,
+      });
       setMembers(profiles);
     } catch (e) {
       console.error('Pool hub load error:', e);

--- a/src/features/profile/api/publicProfileApi.js
+++ b/src/features/profile/api/publicProfileApi.js
@@ -8,6 +8,7 @@ import {
   where,
 } from 'firebase/firestore';
 
+import { MAX_USER_POOLS_FETCH } from '../../pools';
 import { db } from '../../../shared/lib/firebase';
 import { whenFirebaseReady } from '../../../shared/lib/firebaseAppCheck';
 
@@ -52,7 +53,8 @@ export async function fetchPoolsForMember(uid) {
   await whenFirebaseReady();
   const poolsQuery = query(
     collection(db, 'pools'),
-    where('members', 'array-contains', id)
+    where('members', 'array-contains', id),
+    limit(MAX_USER_POOLS_FETCH)
   );
   const poolSnapshot = await getDocs(poolsQuery);
   return poolSnapshot.docs.map((poolDoc) => ({


### PR DESCRIPTION
Closes #415
Closes #416

## Summary
- **#415:** Documented caps (`MAX_POOL_MEMBERS_FETCH=100`, `MAX_USER_POOLS_FETCH=50`). Pool hub loads profiles via `pool.members` (O(members), capped) instead of an unbounded `users` query. User pool lists use `limit(50)`.
- **#416:** `gradePicksOnSetlistWrite` early-exits when `persistableActualSetlistFromOfficialDoc` is unchanged (metadata-only writes no longer re-scan all picks). Logs skip vs complete with pick counts.
- Moved both issues into **Sprint 5** milestone; bumps to **1.18.0**.

Release train: Wave 5 stretch pulled into Sprint 5.

## Test plan
- [x] `npm test` / lint
- [x] Functions: `shouldSkipLiveScoreRecompute` unit tests
- [ ] Pool hub still lists members for a normal-sized pool
- [ ] Deploy Functions before relying on #416 in prod (`gradePicksOnSetlistWrite`)


Made with [Cursor](https://cursor.com)