### PR TITLE
feat(scoring): last-show winner banner purple-red gradient (#328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.18.2] — 2026-07-03
+
+### Changed
+- **Last-show winner banner (#328)** — purple→red gradient treatment for `variant === 'lastShow'` on Standings (container, heading, View results pill); tonight’s winner amber treatment unchanged.
+
+---
+
 ## [1.18.1] — 2026-07-03
 
 ### Fixed

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.18.1  
+**Version:** 1.18.2  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.18.1",
+  "version": "1.18.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
+++ b/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
@@ -67,28 +67,38 @@ export default function StandingsWinnerOfTheNightBanner({
     viewResults?.labelCompact ||
     (showViewResultsLink ? viewResults.showDate : '');
 
+  // Last-show uses purple→red; tonight keeps amber (#328).
+  const isLastShow = variant === 'lastShow';
+  const containerClassName = isLastShow
+    ? compact
+      ? 'relative mx-0.5 mb-2 rounded-lg border border-violet-400/35 bg-gradient-to-br from-brand-primary/[0.16] via-violet-500/[0.1] to-red-500/[0.12] px-2 py-1.5 shadow-inset-glass'
+      : 'relative mx-0.5 mb-4 rounded-xl border border-violet-400/40 bg-gradient-to-br from-brand-primary/[0.2] via-violet-500/[0.14] to-red-500/[0.16] px-3 py-2 shadow-inset-glass'
+    : compact
+      ? 'relative mx-0.5 mb-2 rounded-lg border border-amber-500/35 bg-gradient-to-br from-amber-500/[0.1] via-amber-500/[0.05] to-brand-primary/[0.06] px-2 py-1.5 shadow-inset-glass'
+      : 'relative mx-0.5 mb-4 rounded-xl border border-amber-500/40 bg-gradient-to-br from-amber-500/[0.12] via-amber-500/[0.06] to-brand-primary/[0.08] px-3 py-2 shadow-inset-glass';
+  const headingClassName = isLastShow
+    ? compact
+      ? 'relative z-0 min-w-0 text-[9px] font-black uppercase tracking-widest text-violet-200'
+      : 'relative z-0 min-w-0 text-[10px] font-black uppercase tracking-widest text-violet-200'
+    : compact
+      ? 'relative z-0 min-w-0 text-[9px] font-black uppercase tracking-widest text-amber-300'
+      : 'relative z-0 min-w-0 text-[10px] font-black uppercase tracking-widest text-amber-300';
+  const viewResultsPillClassName = isLastShow
+    ? 'relative z-10 shrink-0 !border-violet-300/50 !bg-gradient-to-r !from-brand-primary/30 !to-red-500/25 !text-violet-100 !shadow-none hover:!border-violet-200/70 hover:!from-brand-primary/40 hover:!to-red-500/35 hover:!text-violet-50 focus-visible:!ring-violet-300/70'
+    : 'relative z-10 shrink-0 !border-amber-400/45 !bg-amber-950/35 !text-amber-100 !shadow-none hover:!border-amber-300/55 hover:!bg-amber-500/20 hover:!text-amber-50 focus-visible:!ring-amber-300/70';
+
   return (
     <div
       role="region"
       aria-label={`${heading}: ${handlesLabel} — ${max} points`}
-      className={
-        compact
-          ? 'relative mx-0.5 mb-2 rounded-lg border border-amber-500/35 bg-gradient-to-br from-amber-500/[0.1] via-amber-500/[0.05] to-brand-primary/[0.06] px-2 py-1.5 shadow-inset-glass'
-          : 'relative mx-0.5 mb-4 rounded-xl border border-amber-500/40 bg-gradient-to-br from-amber-500/[0.12] via-amber-500/[0.06] to-brand-primary/[0.08] px-3 py-2 shadow-inset-glass'
-      }
+      className={containerClassName}
     >
       <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1">
         {/*
           If the heading flex item ever paints over the pill (min-width / overflow),
           keep the link above in the hit-test order.
         */}
-        <p
-          className={
-            compact
-              ? 'relative z-0 min-w-0 text-[9px] font-black uppercase tracking-widest text-amber-300'
-              : 'relative z-0 min-w-0 text-[10px] font-black uppercase tracking-widest text-amber-300'
-          }
-        >
+        <p className={headingClassName}>
           {heading}
         </p>
         {showViewResultsLink ? (
@@ -106,7 +116,7 @@ export default function StandingsWinnerOfTheNightBanner({
                 ? `View full standings for ${viewResultsHint}`
                 : 'View full standings for this show'
             }
-            className="relative z-10 shrink-0 !border-amber-400/45 !bg-amber-950/35 !text-amber-100 !shadow-none hover:!border-amber-300/55 hover:!bg-amber-500/20 hover:!text-amber-50 focus-visible:!ring-amber-300/70"
+            className={viewResultsPillClassName}
             onClick={() => {
               const d = viewResults.showDate;
               // Layout `selectedDate` can differ from URL (picker does not write


### PR DESCRIPTION
Closes #328

## Summary
- Standings last-show winner banner (`variant === 'lastShow'`) uses a purple→red gradient on the container, heading, and View results pill.
- Tonight’s winner (`variant === 'tonight'`) amber treatment is unchanged.
- `compact` sizing still works for both variants.
- PATCH `1.18.2`.

## Test plan
- [ ] Open `/dashboard/standings` when a last-show winner banner is visible — purple/red gradient, not amber
- [ ] Confirm tonight’s winner banner (if shown) is still amber
- [ ] Click View results — still navigates to that show’s standings
- [ ] Compact placement (if used on mobile/pool surfaces) still sizes correctly


Made with [Cursor](https://cursor.com)