### PR TITLE
feat(legal): explicit re-consent gate for legacy and policy bumps (#396)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.19.0] — 2026-07-03
+
+### Added
+- **Legal re-consent gate (#396)** — dashboard users missing or outdated versioned consent see a blocking modal (checkbox + Terms/Privacy links). Accept writes `users.legalConsent` (`termsVersion`, `privacyVersion`, `acceptedAt`) and refreshes `termsPrivacyAcceptedAt`.
+- **Legal version constants** — `LEGAL_TERMS_VERSION` / `LEGAL_PRIVACY_VERSION` in `src/shared/constants/legalDocVersions.js`; runbook at `docs/LEGAL_UPDATES_RUNBOOK.md`.
+
+---
+
 ## [1.18.1] — 2026-07-03
 
 ### Fixed

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.18.1  
+**Version:** 1.19.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 
@@ -19,11 +19,26 @@ All collections live in the default `(default)` Firestore database for project `
 | `handle` | string | Display name |
 | `email` | string | Auth email — used for comms delivery |
 | `photoURL` | string? | Avatar URL |
-| `termsPrivacyAcceptedAt` | Timestamp? | Legal consent gate |
+| `termsPrivacyAcceptedAt` | Timestamp? | Legal consent gate (legacy timestamp) |
+| `legalConsent` | map? | Versioned Terms/Privacy acceptance (see §1.1a) |
 | `createdAt` | Timestamp | Account creation |
 | `isAdmin` | boolean? | Admin custom claim mirror |
 | `notificationPrefs` | map | Channel opt-in flags (see §1.2) |
 | `seasonStats.{tourKey}` | map | Per-tour aggregated scoring |
+
+### 1.1a `users/{uid}` — `legalConsent` shape
+
+Written by `recordTermsPrivacyConsent` on sign-up and on the dashboard re-consent gate (#396). Version ids are defined in `src/shared/constants/legalDocVersions.js`.
+
+```json
+{
+  "termsVersion": "2026-05-08",
+  "privacyVersion": "2026-05-08",
+  "acceptedAt": "<Timestamp>"
+}
+```
+
+Dashboard users whose stored versions do not match the published constants are blocked by `LegalReconsentModal` until they accept.
 
 ### 1.2 `users/{uid}` — `notificationPrefs` shape
 

--- a/docs/LEGAL_UPDATES_RUNBOOK.md
+++ b/docs/LEGAL_UPDATES_RUNBOOK.md
@@ -1,0 +1,41 @@
+# Legal document updates runbook
+
+How to publish material Terms of Service or Privacy Policy changes and force in-app re-consent (#396).
+
+## Version constants
+
+Published version ids live in `src/shared/constants/legalDocVersions.js`:
+
+- `LEGAL_TERMS_VERSION`
+- `LEGAL_PRIVACY_VERSION`
+
+Initial ids match the **Last updated** dates in `docs/TERMS_OF_SERVICE.md` and `docs/PRIVACY_POLICY.md` (`2026-05-08`).
+
+## What the app stores
+
+On accept (sign-up or dashboard re-consent gate), `recordTermsPrivacyConsent` writes:
+
+| Field | Purpose |
+|-------|---------|
+| `users/{uid}.termsPrivacyAcceptedAt` | Legacy consent timestamp (profile / telemetry) |
+| `users/{uid}.legalConsent.termsVersion` | Accepted Terms version id |
+| `users/{uid}.legalConsent.privacyVersion` | Accepted Privacy version id |
+| `users/{uid}.legalConsent.acceptedAt` | When the current versions were accepted |
+
+Dashboard users whose stored versions do not match the constants see a **blocking** modal (`LegalReconsentModal`) until they check the box and accept.
+
+## Material update checklist
+
+1. Edit `docs/TERMS_OF_SERVICE.md` and/or `docs/PRIVACY_POLICY.md` (and any mirrored UI content under `src/features/legal/ui/`).
+2. Set **Last updated** on the changed doc(s).
+3. Bump the matching constant(s) in `legalDocVersions.js` to a new id (prefer `YYYY-MM-DD`).
+4. Ship via normal PR → `staging` → promote. No Firestore migration — clients gate on mismatch.
+5. Smoke: sign in as a user with the previous versions; confirm modal appears; accept; confirm modal dismisses and `legalConsent` updates.
+
+## Non-material edits
+
+Typos / formatting that do not change user obligations: update the markdown only; **do not** bump version constants (avoids unnecessary re-consent).
+
+## Sign-up path
+
+New accounts already accept Terms/Privacy on splash sign-up and receive current version ids via the same `recordTermsPrivacyConsent` write. They should not see the dashboard gate unless versions are bumped later.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.18.1",
+  "version": "1.19.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/app/routes/DashboardRoute.jsx
+++ b/src/app/routes/DashboardRoute.jsx
@@ -5,7 +5,9 @@ import {
   AuthLoadingScreen,
   trackAuthPartialProfile,
   useAuth,
+  useLegalReconsent,
 } from '../../features/auth';
+import { LegalReconsentModal } from '../../features/legal';
 
 import { ShowCalendarProvider } from '../../features/show-calendar';
 import DashboardLayout from '../layout/DashboardLayout';
@@ -14,6 +16,14 @@ import { decideDashboardRoute } from './profileGuardDecision';
 export default function DashboardRoute() {
   const { user, userProfile, loading } = useAuth();
   const decision = decideDashboardRoute({ loading, user, userProfile });
+  const {
+    needsReconsent,
+    accepted,
+    setAccepted,
+    accept,
+    busy: reconsentBusy,
+    error: reconsentError,
+  } = useLegalReconsent(user, userProfile);
 
   // Anomaly signal for the consent-only orphan regression (May 2026).
   // Keyed on uid so a single mount fires once per user, even across
@@ -39,6 +49,14 @@ export default function DashboardRoute() {
   return (
     <ShowCalendarProvider>
       <DashboardLayout />
+      <LegalReconsentModal
+        open={needsReconsent}
+        accepted={accepted}
+        onAcceptedChange={setAccepted}
+        onAccept={accept}
+        busy={reconsentBusy}
+        error={reconsentError}
+      />
     </ShowCalendarProvider>
   );
 }

--- a/src/features/auth/api/legalConsentApi.js
+++ b/src/features/auth/api/legalConsentApi.js
@@ -1,9 +1,36 @@
 import { doc, serverTimestamp, setDoc } from 'firebase/firestore';
 
+import {
+  LEGAL_PRIVACY_VERSION,
+  LEGAL_TERMS_VERSION,
+} from '../../../shared/constants/legalDocVersions';
 import { db } from '../../../shared/lib/firebase';
 
 /**
- * Records affirmative Terms + Privacy consent at account creation (sign-up).
+ * @param {unknown} profile
+ * @returns {boolean}
+ */
+export function needsLegalReconsent(profile) {
+  if (!profile || typeof profile !== 'object') return false;
+  // Only gate users who finished profile setup (dashboard-eligible).
+  if (typeof profile.handle !== 'string' || !profile.handle.trim()) return false;
+
+  const consent = profile.legalConsent;
+  if (
+    consent &&
+    typeof consent === 'object' &&
+    consent.termsVersion === LEGAL_TERMS_VERSION &&
+    consent.privacyVersion === LEGAL_PRIVACY_VERSION
+  ) {
+    return false;
+  }
+
+  // Missing or outdated versioned consent (includes legacy timestamp-only docs).
+  return true;
+}
+
+/**
+ * Records affirmative Terms + Privacy consent (sign-up or re-consent gate).
  * Uses merge so a later `createInitialUserProfile` write does not overwrite this field.
  *
  * @param {string} uid
@@ -16,6 +43,11 @@ export async function recordTermsPrivacyConsent(uid) {
     doc(db, 'users', uid.trim()),
     {
       termsPrivacyAcceptedAt: serverTimestamp(),
+      legalConsent: {
+        termsVersion: LEGAL_TERMS_VERSION,
+        privacyVersion: LEGAL_PRIVACY_VERSION,
+        acceptedAt: serverTimestamp(),
+      },
     },
     { merge: true }
   );

--- a/src/features/auth/api/legalConsentApi.test.js
+++ b/src/features/auth/api/legalConsentApi.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  LEGAL_PRIVACY_VERSION,
+  LEGAL_TERMS_VERSION,
+} from '../../../shared/constants/legalDocVersions';
+import { needsLegalReconsent } from './legalConsentApi';
+
+describe('needsLegalReconsent', () => {
+  it('returns false when profile is missing or incomplete', () => {
+    expect(needsLegalReconsent(null)).toBe(false);
+    expect(needsLegalReconsent({})).toBe(false);
+    expect(needsLegalReconsent({ handle: '  ' })).toBe(false);
+  });
+
+  it('returns true for legacy users with no versioned consent', () => {
+    expect(needsLegalReconsent({ handle: 'pat' })).toBe(true);
+    expect(
+      needsLegalReconsent({
+        handle: 'pat',
+        termsPrivacyAcceptedAt: { seconds: 1, nanoseconds: 0 },
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when stored versions are outdated', () => {
+    expect(
+      needsLegalReconsent({
+        handle: 'pat',
+        legalConsent: {
+          termsVersion: '2020-01-01',
+          privacyVersion: LEGAL_PRIVACY_VERSION,
+        },
+      })
+    ).toBe(true);
+    expect(
+      needsLegalReconsent({
+        handle: 'pat',
+        legalConsent: {
+          termsVersion: LEGAL_TERMS_VERSION,
+          privacyVersion: '2020-01-01',
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('returns false when versions match current published docs', () => {
+    expect(
+      needsLegalReconsent({
+        handle: 'pat',
+        legalConsent: {
+          termsVersion: LEGAL_TERMS_VERSION,
+          privacyVersion: LEGAL_PRIVACY_VERSION,
+        },
+      })
+    ).toBe(false);
+  });
+});

--- a/src/features/auth/index.js
+++ b/src/features/auth/index.js
@@ -8,10 +8,12 @@ export { default as ProfileSetupForm } from './ui/ProfileSetupForm';
 export { useAuth } from './model/useAuth';
 export { useAuthSession } from './model/useAuthSession';
 export { trackAuthPartialProfile } from './model/authAnalytics';
+export { useLegalReconsent } from './model/useLegalReconsent';
 export { usePasswordReset } from './model/usePasswordReset';
 export { usePasswordResetCompleteState } from './model/usePasswordResetCompleteState';
 export { useProfileSetup } from './model/useProfileSetup';
 export { useSignOut } from './model/useSignOut';
+export { needsLegalReconsent, recordTermsPrivacyConsent } from './api/legalConsentApi';
 export { getFirebaseAuthErrorMessage } from './utils/firebaseAuthMessages';
 export { getPasswordResetActionCodeSettings } from './utils/passwordResetActionSettings';
 export {

--- a/src/features/auth/model/useLegalReconsent.js
+++ b/src/features/auth/model/useLegalReconsent.js
@@ -1,0 +1,42 @@
+import { useCallback, useState } from 'react';
+
+import {
+  needsLegalReconsent,
+  recordTermsPrivacyConsent,
+} from '../api/legalConsentApi';
+
+/**
+ * Dashboard gate for explicit Terms + Privacy acceptance (#396).
+ *
+ * @param {{ uid?: string } | null | undefined} user
+ * @param {Record<string, unknown> | null | undefined} userProfile
+ */
+export function useLegalReconsent(user, userProfile) {
+  const needsReconsent = needsLegalReconsent(userProfile);
+  const [accepted, setAccepted] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  const accept = useCallback(async () => {
+    if (!user?.uid || !accepted) return;
+    setBusy(true);
+    setError('');
+    try {
+      await recordTermsPrivacyConsent(user.uid);
+    } catch (err) {
+      console.error('Legal re-consent write failed:', err);
+      setError('Could not save your acceptance. Please try again.');
+    } finally {
+      setBusy(false);
+    }
+  }, [accepted, user?.uid]);
+
+  return {
+    needsReconsent,
+    accepted,
+    setAccepted,
+    accept,
+    busy,
+    error,
+  };
+}

--- a/src/features/legal/index.js
+++ b/src/features/legal/index.js
@@ -1,3 +1,4 @@
 export { default as LegalPageLayout } from './ui/LegalPageLayout';
+export { default as LegalReconsentModal } from './ui/LegalReconsentModal';
 export { default as PrivacyPolicyContent } from './ui/PrivacyPolicyContent';
 export { default as TermsOfServiceContent } from './ui/TermsOfServiceContent';

--- a/src/features/legal/ui/LegalReconsentModal.jsx
+++ b/src/features/legal/ui/LegalReconsentModal.jsx
@@ -1,0 +1,109 @@
+import React, { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { Link } from 'react-router-dom';
+
+import Button from '../../../shared/ui/Button';
+
+/**
+ * Blocking Terms + Privacy acceptance gate for legacy / outdated consent (#396).
+ * No dismiss — user must check the box and accept.
+ */
+export default function LegalReconsentModal({
+  open,
+  accepted,
+  onAcceptedChange,
+  onAccept,
+  busy = false,
+  error = '',
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[100] flex items-end justify-center p-0 sm:items-center sm:p-4"
+      role="presentation"
+    >
+      <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" aria-hidden />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="legal-reconsent-title"
+        aria-describedby="legal-reconsent-desc"
+        className="relative z-10 w-full max-w-md rounded-t-2xl border border-border-subtle bg-surface-panel-strong p-5 shadow-inset-glass ring-1 ring-border-glass/25 sm:rounded-2xl sm:p-6"
+      >
+        <h2 id="legal-reconsent-title" className="text-lg font-bold text-white">
+          Please review our Terms & Privacy Policy
+        </h2>
+        <p
+          id="legal-reconsent-desc"
+          className="mt-3 text-sm font-medium leading-relaxed text-slate-400"
+        >
+          We need your confirmation that you have read and agree to our current Terms of
+          Service and Privacy Policy before you continue using Setlist Pick&apos;Em.
+        </p>
+
+        <label className="mt-5 flex cursor-pointer items-start gap-3 rounded-2xl border border-border-subtle bg-surface-field/80 p-4 text-left text-sm font-semibold leading-snug text-slate-200">
+          <input
+            type="checkbox"
+            checked={accepted}
+            onChange={(e) => onAcceptedChange(e.target.checked)}
+            disabled={busy}
+            className="mt-1 h-4 w-4 shrink-0 rounded border-slate-500 bg-surface-panel text-brand-primary focus-visible:ring-2 focus-visible:ring-brand"
+            aria-describedby="legal-reconsent-hint"
+          />
+          <span id="legal-reconsent-hint">
+            I agree to the{' '}
+            <Link
+              to="/terms"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-teal-300 underline decoration-teal-500/60 underline-offset-2 hover:text-white"
+              onClick={(e) => e.stopPropagation()}
+            >
+              Terms of Service
+            </Link>{' '}
+            and{' '}
+            <Link
+              to="/privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-teal-300 underline decoration-teal-500/60 underline-offset-2 hover:text-white"
+              onClick={(e) => e.stopPropagation()}
+            >
+              Privacy Policy
+            </Link>
+            .
+          </span>
+        </label>
+
+        {error ? (
+          <p className="mt-3 text-xs font-bold uppercase tracking-wide text-red-400" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        <div className="mt-6">
+          <Button
+            type="button"
+            variant="primary"
+            className="w-full"
+            onClick={onAccept}
+            disabled={busy || !accepted}
+          >
+            {busy ? 'Saving…' : 'Accept and continue'}
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/shared/constants/legalDocVersions.js
+++ b/src/shared/constants/legalDocVersions.js
@@ -1,0 +1,8 @@
+/**
+ * Published legal document version ids.
+ *
+ * Bump when Terms or Privacy change materially (see `docs/LEGAL_UPDATES_RUNBOOK.md`).
+ * Users whose stored `legalConsent` versions do not match are prompted to re-accept.
+ */
+export const LEGAL_TERMS_VERSION = '2026-05-08';
+export const LEGAL_PRIVACY_VERSION = '2026-05-08';


### PR DESCRIPTION
Closes #396

## Summary
- Dashboard users with a completed profile but **missing or outdated** versioned consent see a **blocking** modal (checkbox + Terms/Privacy links in new tabs).
- Accept writes `users.legalConsent` (`termsVersion`, `privacyVersion`, `acceptedAt`) and refreshes `termsPrivacyAcceptedAt` (same path as sign-up).
- Version constants in `src/shared/constants/legalDocVersions.js` (`2026-05-08`); runbook at `docs/LEGAL_UPDATES_RUNBOOK.md`.
- MINOR `1.19.0` (new Firestore field shape).

## Test plan
- [ ] Sign in as a legacy user with `handle` but no `legalConsent` (or only `termsPrivacyAcceptedAt`) — modal appears and cannot be dismissed
- [ ] Open Terms / Privacy links — open in new tab; modal remains
- [ ] Accept without checkbox — button disabled
- [ ] Accept with checkbox — modal closes; Firestore has current versions
- [ ] Reload — modal does not reappear
- [ ] New sign-up still records consent and does not show the gate
- [ ] `npm test -- src/features/auth/api/legalConsentApi.test.js`


Made with [Cursor](https://cursor.com)