### PR TITLE
fix(auth,perf): unblock Firebase Auth iframes and speed up marketing /join links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.18.2] — 2026-07-04
+
+### Fixed
+- **Google / email sign-in regression (#412 follow-up)** — `X-Frame-Options: DENY` no longer applies to Firebase Auth proxy routes (`/__/auth/*`, `/__/firebase/*`). The catch-all header from v1.16.0 blocked Auth helper iframes on the custom `www.setlistpickem.com` domain, causing `auth/popup-closed-by-user` ("Sign-in was cancelled") and hung email sign-in.
+- **Marketing `/join/:code` cold starts** — the invite OG serverless handler skips Firestore for regular browsers; only social crawlers pay the Admin lookup.
+
+---
+
 ## [1.18.1] — 2026-07-03
 
 ### Fixed

--- a/api/invite/[code].js
+++ b/api/invite/[code].js
@@ -184,8 +184,33 @@ function loadSpaTemplate() {
 export default async function handler(req, res) {
   const code = String(req.query.code ?? '').trim().toUpperCase();
   const inviteUrl = `${SITE_URL}/join/${code}`;
+  const ua = req.headers['user-agent'] ?? '';
+  const isCrawler = CRAWLER_RE.test(ua);
 
-  // 1. Resolve OG copy (best-effort; fall back to defaults on any error).
+  // 1. Regular browsers: serve the SPA shell immediately — no Firestore round
+  //    trip. Marketing-email /join/:code clicks were paying a cold-start Admin
+  //    lookup on every load even though only crawlers consume OG meta tags.
+  if (!isCrawler) {
+    const spaHtml = loadSpaTemplate();
+    if (spaHtml) {
+      let title = DEFAULT_TITLE;
+      let description = DEFAULT_DESCRIPTION;
+      if (code) {
+        title = "Join my Setlist Pick 'Em pool!";
+        description =
+          "You've been invited to a private Setlist Pick 'Em pool. Pick your setlist and compete to win.";
+      }
+      const og = { title, description, url: inviteUrl, image: DEFAULT_OG_IMAGE };
+      const html = injectOgIntoSpa(spaHtml, og);
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate');
+      return res.status(200).send(html);
+    }
+    // dist/index.html not available (local dev without a prior build).
+    // Fall through to crawler path — acceptable in dev.
+  }
+
+  // 2. Crawlers (or dev fallback): resolve pool-specific OG copy from Firestore.
   // Keep "Join my … pool" wording aligned with client share/clipboard copy
   // (`buildPoolInviteShareTitle` in shareOrCopyInviteUrl.js).
   let title = DEFAULT_TITLE;
@@ -210,23 +235,8 @@ export default async function handler(req, res) {
   }
 
   const og = { title, description, url: inviteUrl, image: DEFAULT_OG_IMAGE };
-  const ua = req.headers['user-agent'] ?? '';
 
-  // 2. For regular browsers, serve the full SPA shell so React Router handles
-  //    the /join/:code route client-side — no redirect loop.
-  if (!CRAWLER_RE.test(ua)) {
-    const spaHtml = loadSpaTemplate();
-    if (spaHtml) {
-      const html = injectOgIntoSpa(spaHtml, og);
-      res.setHeader('Content-Type', 'text/html; charset=utf-8');
-      res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate');
-      return res.status(200).send(html);
-    }
-    // dist/index.html not available (local dev without a prior build).
-    // Fall through to serve the crawler shell — acceptable in dev.
-  }
-
-  // 3. For crawlers (or dev fallback): return a lightweight OG-tagged shell.
+  // 3. Lightweight OG-tagged shell for crawlers (or dev without dist/).
   const html = buildCrawlerHtml(og);
   res.setHeader('Content-Type', 'text/html; charset=utf-8');
   res.setHeader('Cache-Control', 'public, max-age=300, stale-while-revalidate=60');

--- a/docs/API.md
+++ b/docs/API.md
@@ -257,7 +257,7 @@ Applied via `vercel.json` to all routes. Policy details: `docs/SECURITY_HEADERS.
 |--------|------|-------|
 | `X-Content-Type-Options` | Enforce | `nosniff` |
 | `Referrer-Policy` | Enforce | `strict-origin-when-cross-origin` |
-| `X-Frame-Options` | Enforce | `DENY` |
+| `X-Frame-Options` | Enforce | `DENY` on app routes; **omitted** on `/__/auth/*` and `/__/firebase/*` (Firebase Auth helper iframes) |
 | `Permissions-Policy` | Enforce | camera/microphone/geolocation disabled |
 | `Content-Security-Policy-Report-Only` | Report-only | Flip to `Content-Security-Policy` after soak (promote-day) |
 

--- a/docs/SECURITY_HEADERS.md
+++ b/docs/SECURITY_HEADERS.md
@@ -10,7 +10,7 @@ Applied to all routes (`/(.*)`):
 |--------|-------|---------|
 | `X-Content-Type-Options` | `nosniff` | Block MIME sniffing |
 | `Referrer-Policy` | `strict-origin-when-cross-origin` | Limit referrer leakage |
-| `X-Frame-Options` | `DENY` | Clickjacking (legacy; CSP `frame-ancestors` is primary) |
+| `X-Frame-Options` | `DENY` | Clickjacking (legacy; CSP `frame-ancestors` is primary). **Not** set on `/__/auth/*` or `/__/firebase/*` — Firebase Auth embeds those helper iframes cross-origin when `authDomain` is `www.setlistpickem.com`; `DENY` there breaks Google and email sign-in. |
 | `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Disable unused powerful APIs |
 
 Cache-Control rules for HTML vs hashed assets are unchanged (see existing `vercel.json` entries).
@@ -80,7 +80,8 @@ Vite HMR and `@vite/client` need looser rules; **`vercel.json` does not apply to
    - `content-security-policy-report-only` present (not `content-security-policy` until enforce flip)
 2. **Smoke:** sign-in, dashboard load, picks save, pool invite, notifications bell (FCM path).
 3. **Console:** filter `Content-Security-Policy` — note any report-only violations; fix policy before enforce.
-4. **Optional automation:** `npm run qa:preview-headers` (with `QA_PREVIEW_BASE_URL`) asserts cache-control **and** the always-on security headers + report-only CSP.
+4. **Auth proxy:** `GET /__/auth/iframe` must **not** return `X-Frame-Options: DENY` (regression breaks all sign-in when custom `authDomain` is live).
+5. **Optional automation:** `npm run qa:preview-headers` (with `QA_PREVIEW_BASE_URL`) asserts cache-control **and** the always-on security headers + report-only CSP.
 
 ## Related
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.18.1",
+  "version": "1.18.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/qa/preview-cache-headers.mjs
+++ b/scripts/qa/preview-cache-headers.mjs
@@ -123,6 +123,31 @@ async function run() {
     );
   }
 
+  console.log(`[qa:preview-headers] GET ${base}/__/auth/iframe …`);
+  const authIframeRes = await fetchPath(base, '/__/auth/iframe', headers);
+  if (!authIframeRes.ok) {
+    console.error(
+      `[qa:preview-headers] FAIL: GET /__/auth/iframe returned ${authIframeRes.status}.`,
+    );
+    process.exit(1);
+  }
+  const authFrameOpts = (authIframeRes.headers.get('x-frame-options') || '').toLowerCase();
+  if (authFrameOpts === 'deny' || authFrameOpts === 'sameorigin') {
+    console.error(
+      `[qa:preview-headers] FAIL: /__/auth/iframe must not set X-Frame-Options (breaks Firebase Auth iframe); ` +
+        `got: "${authIframeRes.headers.get('x-frame-options')}"`,
+    );
+    process.exit(1);
+  }
+  const indexFrameOpts = (indexRes.headers.get('x-frame-options') || '').toLowerCase();
+  if (indexFrameOpts !== 'deny') {
+    console.error(
+      `[qa:preview-headers] FAIL: expected X-Frame-Options: DENY on /; ` +
+        `got: "${indexRes.headers.get('x-frame-options')}"`,
+    );
+    process.exit(1);
+  }
+
   const html = await indexRes.text();
   const assetPath = firstAssetJsPath(html);
   if (!assetPath) {

--- a/vercel.json
+++ b/vercel.json
@@ -36,16 +36,21 @@
           "value": "strict-origin-when-cross-origin"
         },
         {
-          "key": "X-Frame-Options",
-          "value": "DENY"
-        },
-        {
           "key": "Permissions-Policy",
           "value": "camera=(), microphone=(), geolocation=()"
         },
         {
           "key": "Content-Security-Policy-Report-Only",
           "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://www.google.com https://www.gstatic.com https://apis.google.com https://www.recaptcha.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://*.cloudfunctions.net https://*.firebaseapp.com https://*.firebasestorage.app https://firebasestorage.googleapis.com https://storage.googleapis.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://analytics.google.com https://www.google.com https://www.gstatic.com https://phish.in wss://*.googleapis.com wss://*.firebaseio.com; frame-src https://accounts.google.com https://*.firebaseapp.com https://www.google.com https://www.recaptcha.net https://recaptcha.google.com; worker-src 'self' blob:; manifest-src 'self'; upgrade-insecure-requests"
+        }
+      ]
+    },
+    {
+      "source": "/((?!__/auth/|__/firebase/).*)",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
         }
       ]
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigates slow marketing-email loads and broken Google sign-in reported after yesterday's v1.18.0 release train.

**Root cause (auth):** PR #475 (v1.16.0) added `X-Frame-Options: DENY` on all routes via `vercel.json`. Production uses custom Firebase `authDomain` (`www.setlistpickem.com`), so Auth helper iframes load from `/__/auth/iframe`. `DENY` blocks those cross-origin iframes → `auth/popup-closed-by-user` ("Sign-in was cancelled") and hung email sign-in.

**Root cause (marketing links):** Summer Tour email CTAs point at `/join/:code`. The invite OG serverless function queried Firestore on every browser request before serving the SPA shell, adding cold-start latency on top of the ~850KB JS critical path.

## Changes

- Exclude `/__/auth/*` and `/__/firebase/*` from `X-Frame-Options: DENY`; keep `DENY` on all other app routes.
- Serve `/join/:code` to browsers without a Firestore Admin lookup (crawlers still get pool-specific OG).
- Extend `qa:preview-headers` to assert auth iframe framing is not blocked.
- Document the auth-proxy exception in `docs/SECURITY_HEADERS.md` and `docs/API.md`.
- Bump to **1.18.2** (PATCH).

## Test plan

- [x] `npm run lint`
- [x] `npm test`
- [ ] After deploy: `curl -sI https://www.setlistpickem.com/__/auth/iframe` — must **not** include `X-Frame-Options: DENY`
- [ ] After deploy: `curl -sI https://www.setlistpickem.com/` — must include `X-Frame-Options: DENY`
- [ ] Mobile Safari: Google sign-in from splash modal completes (no "Sign-in was cancelled")
- [ ] Mobile Safari: email/password sign-in no longer hangs on "SIGNING IN..."
- [ ] Marketing `/join/:code` link feels responsive on cold load (no Firestore wait server-side)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://road2-media.slack.com/archives/D0B2RMVCGSD/p1783178974002759?thread_ts=1783178974.002759&cid=D0B2RMVCGSD)

<div><a href="https://cursor.com/agents/bc-b779970d-4a17-5aec-a24d-04798499cc65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b779970d-4a17-5aec-a24d-04798499cc65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

