### PR TITLE
chore: sync staging with main (v1.18.3 auth header hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.18.3] — 2026-07-04
+
+### Fixed
+- **Auth iframe headers (Vercel)** — replace unsupported negative-lookahead `X-Frame-Options` route with explicit app-route allowlist plus dedicated `/__/auth/*` and `/__/firebase/*` header blocks. v1.18.2 regex still applied `DENY` to Firebase Auth proxy paths on Vercel.
+
+---
+
 ## [1.18.2] — 2026-07-04
 
 ### Fixed

--- a/docs/API.md
+++ b/docs/API.md
@@ -257,7 +257,7 @@ Applied via `vercel.json` to all routes. Policy details: `docs/SECURITY_HEADERS.
 |--------|------|-------|
 | `X-Content-Type-Options` | Enforce | `nosniff` |
 | `Referrer-Policy` | Enforce | `strict-origin-when-cross-origin` |
-| `X-Frame-Options` | Enforce | `DENY` on app routes; **omitted** on `/__/auth/*` and `/__/firebase/*` (Firebase Auth helper iframes) |
+| `X-Frame-Options` | Enforce | `DENY` on listed app routes only; **omitted** on `/__/auth/*` and `/__/firebase/*` (Vercel does not honor negative-lookahead header sources) |
 | `Permissions-Policy` | Enforce | camera/microphone/geolocation disabled |
 | `Content-Security-Policy-Report-Only` | Report-only | Flip to `Content-Security-Policy` after soak (promote-day) |
 

--- a/docs/SECURITY_HEADERS.md
+++ b/docs/SECURITY_HEADERS.md
@@ -10,7 +10,7 @@ Applied to all routes (`/(.*)`):
 |--------|-------|---------|
 | `X-Content-Type-Options` | `nosniff` | Block MIME sniffing |
 | `Referrer-Policy` | `strict-origin-when-cross-origin` | Limit referrer leakage |
-| `X-Frame-Options` | `DENY` | Clickjacking (legacy; CSP `frame-ancestors` is primary). **Not** set on `/__/auth/*` or `/__/firebase/*` — Firebase Auth embeds those helper iframes cross-origin when `authDomain` is `www.setlistpickem.com`; `DENY` there breaks Google and email sign-in. |
+| `X-Frame-Options` | `DENY` | Clickjacking (legacy; CSP `frame-ancestors` is primary). **Not** set on `/__/auth/*` or `/__/firebase/*` — Firebase Auth embeds those helper iframes cross-origin when `authDomain` is `www.setlistpickem.com`; `DENY` there breaks Google and email sign-in. Applied via **explicit app-route list** in `vercel.json` (Vercel does not honor negative-lookahead header `source` patterns). |
 | `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Disable unused powerful APIs |
 
 Cache-Control rules for HTML vs hashed assets are unchanged (see existing `vercel.json` entries).

--- a/docs/SECURITY_HEADERS.md
+++ b/docs/SECURITY_HEADERS.md
@@ -31,6 +31,8 @@ When Realtime / field reports show no unexpected violations on production traffi
 
 Do **not** enforce on a half-broken policy — prefer report-only soak over a login outage.
 
+> **2026-07-04 incident:** Enforcing `frame-ancestors 'none'` on the catch-all `/(.*)` will re-break auth the same way `X-Frame-Options: DENY` did unless `/__/auth/*` has an explicit CSP exception. See [`docs/post-mortems/412-auth-gate-failure-2026-07-04.md`](post-mortems/412-auth-gate-failure-2026-07-04.md).
+
 ## CSP directives and exceptions
 
 Policy (keep in sync with `vercel.json`):
@@ -87,4 +89,5 @@ Vite HMR and `@vite/client` need looser rules; **`vercel.json` does not apply to
 
 - [`vercel.json`](../vercel.json)
 - [`docs/RELEASE_TRAIN_SPRINT_5_6.md`](RELEASE_TRAIN_SPRINT_5_6.md) Wave 4
+- [`docs/post-mortems/412-auth-gate-failure-2026-07-04.md`](post-mortems/412-auth-gate-failure-2026-07-04.md) — 2026-07-04 auth outage post-mortem
 - Client GA gate: `src/shared/lib/ga4.js` (prod hostnames only)

--- a/docs/post-mortems/412-auth-gate-failure-2026-07-04.md
+++ b/docs/post-mortems/412-auth-gate-failure-2026-07-04.md
@@ -1,0 +1,140 @@
+# Post-mortem — Auth gate failure (issue #412)
+
+**Incident:** Production Google and email sign-in broken; marketing email links felt abysmally slow. User-reported ~17 hours after v1.18.0 promote. **Resolved** same day via PR #499 + direct `main` hotfix **v1.18.3**.
+
+**Severity:** P0 — complete auth outage on custom `authDomain` (`www.setlistpickem.com`).
+
+**Tracking:** #412 (security headers) · epic #411 · custom auth domain #282
+
+---
+
+## Timeline (UTC)
+
+| When | Event |
+|------|-------|
+| 2026-07-03 22:26 | **#475** merges #412 — `X-Frame-Options: DENY` added to `vercel.json` catch-all `/(.*)` |
+| 2026-07-03 23:25 | v1.18.0 promote (**#478**) ships headers to production |
+| 2026-07-03 | Summer Tour marketing email (#468) sent — CTAs point at `/join/:code` |
+| 2026-07-04 ~15:30 | User report: slow loads + Google "Sign-in was cancelled" + email sign-in stuck on "SIGNING IN…" |
+| 2026-07-04 15:40 | **#499** merged to `staging` (v1.18.2) — negative-lookahead header exception + invite perf |
+| 2026-07-04 15:41 | v1.18.2 promoted to `main` |
+| 2026-07-04 15:51 | Production deploy of v1.18.2 — **auth still broken** (Vercel ignored lookahead regex) |
+| 2026-07-04 15:54 | **v1.18.3** hotfix to `main` — explicit route allowlist for `X-Frame-Options` |
+| 2026-07-04 15:55 | Verified live: `/__/auth/iframe` no longer returns `X-Frame-Options: DENY` |
+| 2026-07-04 ~16:00 | User confirms sign-in works after hard reload |
+
+---
+
+## Root cause (primary) — `X-Frame-Options: DENY` on Firebase Auth proxy paths
+
+Production uses a **custom Firebase Auth domain** (#282): `authDomain = www.setlistpickem.com`, with `/__/auth/*` proxied to Firebase Hosting via `vercel.json` rewrites.
+
+Firebase Auth (popup **and** email/password) loads a hidden helper iframe from:
+
+`https://www.setlistpickem.com/__/auth/iframe`
+
+That document must be **embeddable cross-origin** by `accounts.google.com` (and Firebase's auth helper). #412 / #475 applied:
+
+```json
+{ "source": "/(.*)", "headers": [{ "key": "X-Frame-Options", "value": "DENY" }] }
+```
+
+Because `/(.*)` matches proxied auth paths, Vercel injected `X-Frame-Options: DENY` on the auth iframe response. Browsers refused to embed the iframe → OAuth handshake failed.
+
+**User-visible symptoms:**
+
+- Google: `auth/popup-closed-by-user` → UI copy **"Sign-in was cancelled."**
+- Email/password: promise hung → button stuck **"SIGNING IN…"** (iframe token exchange never completed)
+
+**Why it shipped:** #412 AC called for frame controls + auth smoke, but promote-day QA did not include `curl -sI …/__/auth/iframe` header inspection. Desktop-only popup smoke on default `firebaseapp.com` previews would also miss this — custom `authDomain` is prod-only (`VITE_FIREBASE_AUTH_DOMAIN`).
+
+---
+
+## Contributing factor — v1.18.2 fix did not work on Vercel
+
+First hotfix (PR #499) moved `DENY` to a negative-lookahead source:
+
+`/((?!__/auth/|__/firebase/).*)`
+
+This works in Node/path-to-regexp tests but **Vercel still applied `DENY` to `/__/auth/iframe`** after deploy. Required second hotfix (**v1.18.3**): explicit `X-Frame-Options: DENY` on listed app routes only + dedicated `/__/auth/*` / `/__/firebase/*` blocks without `DENY`.
+
+---
+
+## Contributing factor (perf, not auth) — marketing `/join/:code` serverless path
+
+Summer Tour email CTAs (#468) link to `/join/:code?utm_…`. That route hits `api/invite/[code].js`, which **queried Firestore Admin on every browser request** before serving the SPA shell (OG lookup only needed for crawlers).
+
+On cold serverless starts this added hundreds of ms–seconds on top of an already heavy client bundle. Fixed in #499 by serving the SPA immediately for non-crawler user agents.
+
+**Not the auth root cause**, but it explains why email links felt especially slow vs direct homepage visits.
+
+---
+
+## Residual risks / follow-ups
+
+### 1. CSP enforce flip will re-break auth if unchanged (HIGH)
+
+CSP is still **Report-Only** on `/(.*)`, including `frame-ancestors 'none'`. When we rename to enforcing `Content-Security-Policy` (promote-day step in `docs/SECURITY_HEADERS.md`), the **same catch-all will block auth iframes** unless `/__/auth/*` gets a separate policy without `frame-ancestors 'none'` (or with an explicit `frame-ancestors` allowlist for Google).
+
+**Action:** Block CSP enforce until auth-proxy routes have an explicit exception. Add to `qa:preview-headers`.
+
+### 2. `signInWithPopup` on mobile Safari (MEDIUM)
+
+We use popup-only Google sign-in (`src/features/auth/api/splashAuthApi.js`). iOS Safari is notoriously flaky with popups even when headers are correct. If cancelled-sign-in reports persist, add `signInWithRedirect` + `getRedirectResult` for touch/narrow viewports.
+
+### 3. Client JS weight on splash (MEDIUM, ongoing)
+
+Production critical path ~**852 KB** raw JS before gzip (`firebase-core` 522 KB + `vendor-react` 190 KB + app chunks). Mobile parse/download dominates perceived load time after HTML arrives. Separate from this incident; tracked under perf work (#242 chunking).
+
+### 4. `/__/firebase/init.json` returns 404 (LOW, monitor)
+
+`GET https://www.setlistpickem.com/__/firebase/init.json` → 404 (rewrite destination may be missing on Firebase Hosting). Not observed to block sign-in after header fix; worth verifying if Auth SDK behavior changes.
+
+### 5. App Check deferred init (LOW)
+
+`whenFirebaseReady()` gates Firestore profile subscription, not Auth sign-in itself. Slow reCAPTCHA Enterprise on mobile could delay post-login routing to dashboard — separate from this outage.
+
+---
+
+## Detection gaps
+
+| Gap | Fix shipped / proposed |
+|-----|------------------------|
+| No automated check for auth iframe framing headers | `qa:preview-headers` now asserts `/__/auth/iframe` has **no** `X-Frame-Options: DENY` (#499) |
+| `qa:preview-headers` skipped on vercel.json-only PRs | CI path gate skipped it on #499 — consider `ci/full` or always run when `vercel.json` changes |
+| Promote QA didn't smoke custom auth domain | Add promote checklist item: auth iframe header curl + mobile Safari Google sign-in |
+| Negative lookahead assumed portable to Vercel | Documented in `SECURITY_HEADERS.md` — use explicit route lists |
+
+---
+
+## Resolution
+
+| PR / version | Change |
+|--------------|--------|
+| PR #499 (v1.18.2) | Remove `DENY` from catch-all; skip Firestore on browser `/join/:code`; QA auth iframe check |
+| `main` direct (v1.18.3) | Explicit `X-Frame-Options` route allowlist — Vercel-compatible |
+| PR #500 | Sync `staging` ← `main` |
+
+**Verification command (run on every security-header or auth-domain change):**
+
+```bash
+# Auth iframe must NOT have X-Frame-Options
+curl -sI https://www.setlistpickem.com/__/auth/iframe | grep -i x-frame
+
+# App shell SHOULD still have DENY
+curl -sI https://www.setlistpickem.com/ | grep -i x-frame
+```
+
+---
+
+## Lessons
+
+1. **Custom `authDomain` is a distinct security surface** — frame headers on `/__/auth/*` are auth-critical, not general clickjacking policy.
+2. **Catch-all `/(.*)` headers apply to Vercel rewrites/proxies**, not just the SPA.
+3. **Test header behavior on deployed prod host**, not only report-only CSP console warnings.
+4. **Vercel `headers[].source` regex ≠ Node** — don't rely on negative lookahead; use explicit routes.
+5. **Marketing campaigns amplify latent perf issues** — serverless + Firestore on every click matters at cohort scale.
+
+---
+
+*Authored 2026-07-04 after user-confirmed recovery.*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.18.2",
+  "version": "1.18.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/vercel.json
+++ b/vercel.json
@@ -46,11 +46,28 @@
       ]
     },
     {
-      "source": "/((?!__/auth/|__/firebase/).*)",
+      "source": "/__/auth/(.*)",
       "headers": [
         {
-          "key": "X-Frame-Options",
-          "value": "DENY"
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        }
+      ]
+    },
+    {
+      "source": "/__/firebase/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
         }
       ]
     },
@@ -67,6 +84,10 @@
       "source": "/",
       "headers": [
         {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
           "key": "Cache-Control",
           "value": "public, max-age=0, must-revalidate"
         }
@@ -75,6 +96,10 @@
     {
       "source": "/index.html",
       "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
         {
           "key": "Cache-Control",
           "value": "public, max-age=0, must-revalidate"
@@ -85,6 +110,10 @@
       "source": "/dashboard(.*)",
       "headers": [
         {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
           "key": "Cache-Control",
           "value": "public, max-age=0, must-revalidate"
         }
@@ -93,6 +122,10 @@
     {
       "source": "/setup",
       "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
         {
           "key": "Cache-Control",
           "value": "public, max-age=0, must-revalidate"
@@ -103,6 +136,10 @@
       "source": "/join(.*)",
       "headers": [
         {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
           "key": "Cache-Control",
           "value": "public, max-age=0, must-revalidate"
         }
@@ -111,6 +148,10 @@
     {
       "source": "/user/(.*)",
       "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
         {
           "key": "Cache-Control",
           "value": "public, max-age=0, must-revalidate"
@@ -121,8 +162,57 @@
       "source": "/password-reset-complete",
       "headers": [
         {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
           "key": "Cache-Control",
           "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/how-it-works",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        }
+      ]
+    },
+    {
+      "source": "/how-scoring-works",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        }
+      ]
+    },
+    {
+      "source": "/privacy",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        }
+      ]
+    },
+    {
+      "source": "/terms",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        }
+      ]
+    },
+    {
+      "source": "/comms-preview",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
         }
       ]
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sync `staging` with `main` after hotfix **v1.18.3** pushed directly to production.

v1.18.2 negative-lookahead `X-Frame-Options` route did not work on Vercel; v1.18.3 uses explicit app-route allowlist.

## Test plan

- [x] Production verified: `/__/auth/iframe` has no `X-Frame-Options: DENY`
- [x] Production verified: `/` still has `X-Frame-Options: DENY`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://road2-media.slack.com/archives/D0B2RMVCGSD/p1783178974002759?thread_ts=1783178974.002759&cid=D0B2RMVCGSD)

<div><a href="https://cursor.com/agents/bc-b779970d-4a17-5aec-a24d-04798499cc65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b779970d-4a17-5aec-a24d-04798499cc65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

