### PR TITLE
fix(build,ci): restore fast Vercel installs and exempt Dependabot from SemVer gate

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -84,6 +84,7 @@ This repo follows **Semantic Versioning 2.0.0** (https://semver.org). The public
 4. **Update `docs/API.md`** if any declared surface changed (new route, renamed field, new callable, etc.).
 5. **Never tag a release commit** — tagging `vX.Y.Z` on `main` is a human step done after the staging→main merge.
 6. **Never modify a tagged version** — if a mistake is found in a released version, ship a new version.
+7. **Dependabot PRs are exempt** — do not bump `package.json` on `dependabot/*` branches. They ship with `skip-version-bump` (see `.github/dependabot.yml`). If CI still fails the SemVer gate on an open Dependabot PR, add the `skip-version-bump` label and re-run `verify`.
 
 ### Naming and format
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+      - skip-version-bump
     groups:
       root-production:
         dependency-type: production
@@ -27,6 +28,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+      - skip-version-bump
     groups:
       functions-production:
         dependency-type: production
@@ -41,3 +43,4 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - dependencies
+      - skip-version-bump

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         # last release. Skipped on push/schedule where github.base_ref is empty
         # (so `!= 'main'` was accidentally true) and package.json legitimately
         # equals the last release tag once a release has been cut.
-        if: github.event_name == 'pull_request' && github.base_ref != 'main' && !contains(github.event.pull_request.labels.*.name, 'skip-version-bump')
+        if: github.event_name == 'pull_request' && github.base_ref != 'main' && !contains(github.event.pull_request.labels.*.name, 'skip-version-bump') && !startsWith(github.head_ref, 'dependabot/')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Core local commands:
 
 ### Dependabot / npm audit (#414)
 
-- **Dependabot** (`.github/dependabot.yml`) opens weekly grouped PRs for root and `functions/` npm deps, plus monthly GitHub Actions updates. Base branch is the repo default; retarget to `staging` if GitHub opens against `main` only.
+- **Dependabot** (`.github/dependabot.yml`) opens weekly grouped PRs for root and `functions/` npm deps, plus monthly GitHub Actions updates. Base branch is `staging`. New Dependabot PRs get the **`skip-version-bump`** label automatically; CI also skips the SemVer gate for `dependabot/*` head branches. Agents must **not** bump `package.json` on Dependabot PRs — triage and merge (or close) as dependency maintenance only.
 - **CI `npm audit`** on the `verify` job is **informational** (`continue-on-error: true`). It does not block merge.
 - **Triage:** Critical/high in **production** deps → fix or upgrade in a normal PR. Dev-only / low noise → defer or group into a maintenance PR. Do not mass-upgrade without running `npm test` and `cd functions && npm test`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.18.4] — 2026-07-04
+
+### Fixed
+- **Vercel build time** — drop explicit `npm ci` install command so Vercel restores its dependency cache (`up to date in 1s`) instead of reinstalling 685 packages (~2 min). `.npmrc` `legacy-peer-deps` retains the v1.18.1 peer-resolution fix.
+
+### Changed
+- **Dependabot CI** — auto-apply `skip-version-bump` label and exempt `dependabot/*` branches from the SemVer gate (dependency-only PRs do not bump `package.json`).
+
+---
+
 ## [1.18.3] — 2026-07-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.18.3",
+  "version": "1.18.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "installCommand": "npm ci",
   "functions": {
     "api/invite/[code].js": {
       "includeFiles": "dist/index.html"


### PR DESCRIPTION
## Summary

- **Vercel deploy time regression (v1.18.1):** `installCommand: npm ci` forces a full 685-package reinstall (~2 min) on every deploy, bypassing Vercel's dependency cache. Pre-v1.18.1 builds used cached `npm install` (`up to date in 1s`) for ~20–25s total. Drop explicit `installCommand`; `.npmrc` `legacy-peer-deps` retains the peer-resolution fix.
- **Dependabot SemVer gate:** All 7 open Dependabot PRs failed `verify` because `package.json` (1.18.1) matched the latest release tag. Auto-apply `skip-version-bump` label in `dependabot.yml`, exempt `dependabot/*` head branches in CI, and document agent obligations.

## Test plan

- [x] `npm run lint && npm test && npm run verify:dashboard-meta && npm run verify:dashboard-ui`
- [ ] Vercel preview build completes in ~20–30s (install step shows `up to date in 1s`, not `npm ci … 2m`)
- [ ] Open Dependabot PRs (#486–#492) pass `verify` after `skip-version-bump` label (already applied) or branch exemption once merged


Made with [Cursor](https://cursor.com)