### PR TITLE
chore(ops): pause Dependabot and stabilize PR queue post-v1.18

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -85,6 +85,7 @@ This repo follows **Semantic Versioning 2.0.0** (https://semver.org). The public
 5. **Never tag a release commit** — tagging `vX.Y.Z` on `main` is a human step done after the staging→main merge.
 6. **Never modify a tagged version** — if a mistake is found in a released version, ship a new version.
 7. **Dependabot PRs are exempt** — do not bump `package.json` on `dependabot/*` branches. They ship with `skip-version-bump` (see `.github/dependabot.yml`). If CI still fails the SemVer gate on an open Dependabot PR, add the `skip-version-bump` label and re-run `verify`.
+8. **Dependabot first-run / ops reset** — read **`docs/DEPENDABOT_OPERATIONS.md`** before enabling or triaging Dependabot. Never ship `dependabot.yml` without `target-branch: staging`. After first enable, expect an **immediate** PR wave (not Monday). Do not `@dependabot rebase` all open dep PRs at once. To clear a flooded queue: close PRs, set `open-pull-requests-limit: 0`, document in CHANGELOG.
 
 ### Naming and format
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 # Dependabot — weekly npm updates for the SPA and Cloud Functions (#414).
-# Grouped PRs reduce noise; triage notes in AGENTS.md.
+# Grouped PRs reduce noise; triage + first-run runbook: docs/DEPENDABOT_OPERATIONS.md
 # PRs target `staging` (repo PR base), not `main`.
+#
+# PAUSED 2026-07-04: open-pull-requests-limit 0 after v1.18 enablement-wave flood.
+# Human re-enable: restore limits (5/5/3) per docs/DEPENDABOT_OPERATIONS.md § Re-enabling.
 version: 2
 updates:
   - package-ecosystem: npm
@@ -9,7 +12,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     labels:
       - dependencies
       - skip-version-bump
@@ -25,7 +28,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     labels:
       - dependencies
       - skip-version-bump
@@ -40,7 +43,10 @@ updates:
     target-branch: "staging"
     schedule:
       interval: monthly
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0
     labels:
       - dependencies
       - skip-version-bump
+    groups:
+      actions-all:
+        patterns: ["*"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,9 @@ Core local commands:
 
 ### Dependabot / npm audit (#414)
 
-- **Dependabot** (`.github/dependabot.yml`) opens weekly grouped PRs for root and `functions/` npm deps, plus monthly GitHub Actions updates. Base branch is `staging`. New Dependabot PRs get the **`skip-version-bump`** label automatically; CI also skips the SemVer gate for `dependabot/*` head branches. Agents must **not** bump `package.json` on Dependabot PRs — triage and merge (or close) as dependency maintenance only.
+- **Runbook:** **`docs/DEPENDABOT_OPERATIONS.md`** — first-enable timeline, ops-reset procedure, re-enable steps. Read before touching `dependabot.yml` or triaging dep PRs.
+- **Dependabot** (`.github/dependabot.yml`) — **paused** (`open-pull-requests-limit: 0`) after 2026-07-04 enablement-wave reset. When active: weekly grouped npm PRs + monthly Actions; base `staging`; auto `skip-version-bump`; CI exempts `dependabot/*`. Agents must **not** bump `package.json` on Dependabot PRs.
+- **Vercel:** `ignoreCommand` → `scripts/vercel-should-build.sh` skips previews for Actions/functions-only dep PRs.
 - **CI `npm audit`** on the `verify` job is **informational** (`continue-on-error: true`). It does not block merge.
 - **Triage:** Critical/high in **production** deps → fix or upgrade in a normal PR. Dev-only / low noise → defer or group into a maintenance PR. Do not mass-upgrade without running `npm test` and `cd functions && npm test`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.18.5] — 2026-07-04
+
+### Fixed
+- **PR queue stabilization** — pause Dependabot (`open-pull-requests-limit: 0`) after v1.18 enablement-wave; add Vercel `ignoreCommand` to skip SPA previews for CI/functions-only dependency PRs.
+
+### Added
+- **`docs/DEPENDABOT_OPERATIONS.md`** — definitive enablement timeline, agent triage table, ops-reset procedure, re-enable checklist.
+
+---
+
 ## [1.18.4] — 2026-07-04
 
 ### Fixed

--- a/docs/DEPENDABOT_OPERATIONS.md
+++ b/docs/DEPENDABOT_OPERATIONS.md
@@ -1,0 +1,93 @@
+# Dependabot operations (agent + human)
+
+**Purpose:** Prevent post-release PR-queue floods. Injected into agent context via `AGENTS.md` and `.cursorrules`.
+
+---
+
+## What happened (2026-07-03 — definitive timeline)
+
+| UTC | Event |
+|-----|--------|
+| 22:32 | [#476](https://github.com/pat792/set-picks/pull/476) merges — **first-ever** `.github/dependabot.yml` lands on `staging` (**no `target-branch`**) |
+| 22:45 | Dependabot **immediate first scan** (not Monday schedule) opens **#479–#485** targeting **`main`** (repo default) |
+| 22:57 | `378f41a` adds `target-branch: staging` → **#479–#485 closed**, **#486–#492 opened** (duplicate wave) |
+| 22:58–23:00 | Seven Dependabot PRs sit open; each triggers full GitHub CI + Vercel preview |
+| 23:30–23:33 | Sprint 6 train PRs **#493–#495** opened manually (separate from Dependabot, same evening) |
+
+**Root cause:** Dependabot was enabled in the v1.18.0 train without (1) correct `target-branch` on day one, (2) SemVer exemption, (3) Vercel ignore for non-SPA PRs, or (4) a first-run agent runbook. The “clean slate after v1.18” lasted **~13 minutes** until the first Dependabot scan.
+
+This is **not** recurring weekly noise — it was a **one-time enablement avalanche** plus same-evening Sprint 6 queueing.
+
+---
+
+## Current policy (post ops-reset 2026-07-04)
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| `open-pull-requests-limit` | **0** (all ecosystems) | Paused until human sets limits back |
+| SemVer gate | Skips `dependabot/*` + `skip-version-bump` label | Deps PRs never bump `package.json` |
+| Vercel | `ignoreCommand` → `scripts/vercel-should-build.sh` | No SPA preview for Actions/functions-only bumps |
+
+### Re-enabling Dependabot (human step)
+
+1. Restore limits in `.github/dependabot.yml` (e.g. `5` root/functions, `3` actions).
+2. Merge to `staging`; wait for **one** weekly wave — do **not** open parallel manual dep PRs same day.
+3. Triage with table below; max **1–2 merges per week**, never batch-merge `#492`-class toolchain bombs.
+
+---
+
+## Agent obligations
+
+### On the same PR / release that adds or edits `dependabot.yml`
+
+- [ ] `target-branch: staging` on **every** `updates` entry (repo default is `main`).
+- [ ] `skip-version-bump` label on every entry.
+- [ ] Document first-scan behavior in this file + `CHANGELOG.md`.
+- [ ] Set `open-pull-requests-limit: 0` initially; file a follow-up issue to raise limits after first triage.
+
+### When Dependabot PRs appear
+
+| PR type | Agent action |
+|---------|----------------|
+| `dependabot/github_actions/*` | Triage together; merge only if `verify` green; never bump version |
+| Root production group | Run `npm test`; merge if patch/minor only |
+| Root **development** group | **Defer** if vite/eslint/tailwind major jumps bundled |
+| `functions/*` production | Run `cd functions && npm test`; merge individually |
+| `functions/*` development | Low priority; merge when functions CI green |
+
+### Never
+
+- `@dependabot rebase` on **all** open PRs at once (N× CI + Vercel).
+- Leave enablement-wave PRs open “until green” without owner triage.
+- Open Sprint train feature PRs in the same hour as Dependabot first-scan.
+
+### Ops reset (clear slate)
+
+If the PR queue becomes unmanageable:
+
+```bash
+# Close Dependabot backlog (branches preserved)
+for pr in $(gh pr list --author app/dependabot --json number -q '.[].number'); do
+  gh pr close "$pr" --comment "Ops reset — see docs/DEPENDABOT_OPERATIONS.md"
+done
+```
+
+Set `open-pull-requests-limit: 0` in `dependabot.yml` until re-enable.
+
+---
+
+## Triage quick reference
+
+| PR class | Merge? | Notes |
+|----------|--------|-------|
+| Actions only (#486-class) | Optional batch | CI-only; Vercel skip |
+| Root prod patch bumps | Yes, one PR/week | `npm test` |
+| Root dev (vite 8, tailwind 4) | **No** | Dedicated upgrade issue |
+| Functions prod | Case-by-case | `functions` job must pass |
+| Functions dev | Low priority | Test-only dep |
+
+---
+
+## Maintenance
+
+Update this file when `dependabot.yml`, SemVer gate, or Vercel ignore logic changes.

--- a/docs/GITHUB_AUTOMATION_CONTEXT.md
+++ b/docs/GITHUB_AUTOMATION_CONTEXT.md
@@ -99,6 +99,14 @@ Name **existing** domains when known (e.g. `pools`, `picks`, `scoring`, `auth`, 
 
 ---
 
+## Dependabot (paused 2026-07-04)
+
+- **Runbook:** **`docs/DEPENDABOT_OPERATIONS.md`** — enablement-wave root cause, agent triage, ops-reset, re-enable checklist.
+- **First enable dumps PRs immediately** (not weekly schedule). Ship `target-branch: staging` on day one or Dependabot opens against `main`.
+- **`open-pull-requests-limit: 0`** until human restores limits after triage.
+
+---
+
 ## Maintenance
 
 When architecture or automation behavior changes, update **this file** and keep **`.cursorrules`** and **`docs/DASHBOARD_IA.md`** aligned. If **`public/branding/`** or **`src/shared/config/branding.js`** changes materially, refresh **`docs/design.md`** §7 so automation and humans share the same contract.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.18.4",
+  "version": "1.18.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/vercel-should-build.sh
+++ b/scripts/vercel-should-build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Vercel Ignored Build Step (wired from vercel.json ignoreCommand).
+# Exit 0 → skip deploy; exit 1 → build.
+#
+# Skips previews for dependency/CI-only PRs that do not touch SPA artifacts.
+
+set -euo pipefail
+
+# Dependabot CI-only branches never change the Vite app.
+if [[ "${VERCEL_GIT_COMMIT_REF:-}" == dependabot/github_actions/* ]]; then
+  exit 0
+fi
+
+# Functions-only lockfile bumps (no root package / src change).
+if [[ "${VERCEL_GIT_COMMIT_REF:-}" == dependabot/npm_and_yarn/functions/* ]]; then
+  exit 0
+fi
+
+# Build only when SPA-relevant paths changed vs parent commit.
+if git diff HEAD^ HEAD --quiet -- \
+  package.json \
+  package-lock.json \
+  src/ \
+  public/ \
+  api/ \
+  vite.config.js \
+  vercel.json \
+  index.html
+then
+  exit 0
+fi
+
+exit 1

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "bash scripts/vercel-should-build.sh",
   "functions": {
     "api/invite/[code].js": {
       "includeFiles": "dist/index.html"


### PR DESCRIPTION
## Summary

- **Paused Dependabot** (`open-pull-requests-limit: 0`) after the Jul 3 enablement-wave flooded the PR queue with 11 open PRs
- Added **`docs/DEPENDABOT_OPERATIONS.md`** — definitive timeline, agent triage, ops-reset, re-enable checklist
- **Vercel `ignoreCommand`** skips SPA previews for Actions/functions-only dependency PRs
- Grouped future GitHub Actions bumps into one PR (`actions-all`)
- Updated agent context: `AGENTS.md`, `.cursorrules`, `GITHUB_AUTOMATION_CONTEXT.md`

Closed PRs #486–#501 with ops-reset comments (branches preserved).

## Test plan

- [x] `npm run lint && npm test && npm run verify:dashboard-meta && npm run verify:dashboard-ui`
- [x] Open PR count is 0
- [ ] After merge: no new Dependabot PRs until limits restored


Made with [Cursor](https://cursor.com)