### PR TITLE
fix(perf): Safari dashboard tab navigation hangs on Loading…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.18.6] — 2026-07-04
+
+### Fixed
+- **Safari dashboard tab navigation** — stop remounting the lazy route tree on every `/dashboard/*` pathname change (`shellTransitionKey` in `RootAppShell`); prefetch sibling route chunks on idle and nav interaction; eager-load the tiny Profile cluster shell to avoid nested Suspense on Profile.
+
+---
+
 ## [1.18.5] — 2026-07-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 ## [1.18.6] — 2026-07-04
 
 ### Fixed
-- **Safari dashboard tab navigation** — stop remounting the lazy route tree on every `/dashboard/*` pathname change (`shellTransitionKey` in `RootAppShell`); prefetch sibling route chunks on idle and nav interaction; eager-load the tiny Profile cluster shell to avoid nested Suspense on Profile.
+- **Safari dashboard tab navigation** — stop remounting the lazy route tree on every `/dashboard/*` pathname change (`shellTransitionKey` in `RootAppShell`); static-import primary nav tabs (Picks, Pools, Standings, Profile) so tab switches never hit Suspense; keep Admin / Pool Hub / Account / Messages lazy with per-route boundaries and eager prefetch on dashboard mount.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.18.5",
+  "version": "1.18.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -7,31 +7,15 @@ import { useScrollDirection } from '../../shared/hooks/useScrollDirection';
 import RouteSuspenseFallback from '../../shared/ui/RouteSuspenseFallback';
 import {
   DASHBOARD_NAV_PRELOAD_BY_PATH,
-  dashboardRouteImport,
+  dashboardLazyRouteImport,
   prefetchDashboardRoutes,
 } from './model/dashboardRouteModules';
 import ProfileClusterLayout from './ui/ProfileClusterLayout';
 
-import { ListMusic, Users, Medal, User as UserIcon, Settings } from 'lucide-react';
-
-// Lazy-load each dashboard page so a direct hit on e.g. `/dashboard/profile`
-// doesn't pay the download cost for Admin / Pools / Standings / Picks /
-// PoolHub. Static imports here would defeat the route-level code splitting
-// at the top level (`App.jsx`), because they'd all collapse back into the
-// DashboardRoute chunk. Import factories live in `dashboardRouteModules`
-// so idle/hover prefetch warms the same module cache before navigation.
-const PicksPage = lazy(dashboardRouteImport.picks);
-const AdminPage = lazy(dashboardRouteImport.admin);
-const StandingsPage = lazy(dashboardRouteImport.standings);
-const ProfilePage = lazy(dashboardRouteImport.profile);
-const AccountPage = lazy(dashboardRouteImport.account);
-const PoolsPage = lazy(dashboardRouteImport.pools);
-const PoolHubPage = lazy(dashboardRouteImport.poolHub);
-const NotificationsPage = lazy(dashboardRouteImport.notifications);
-
-// `ScoringRulesModalProvider` must stay eager — it wraps the whole dashboard
-// and owns the modal portal state; lazy-loading it would Suspense-flash the
-// entire dashboard chrome.
+import PicksPage from '../../pages/picks/PicksPage';
+import PoolsPage from '../../pages/pools/PoolsPage';
+import StandingsPage from '../../pages/standings/StandingsPage';
+import ProfilePage from '../../pages/profile/ProfilePage';
 import { ScoringRulesModalProvider } from '../../features/scoring';
 import {
   NAV_LABEL_ADMIN,
@@ -53,7 +37,6 @@ import {
 } from '../../shared/utils/showOptionLabel.js';
 import { PastShowLockBanner, TooEarlyBanner, useSetlistLockToast } from '../../features/picks';
 import { DashboardInstallEngageBanner } from '../../features/install';
-
 import {
   CommsInboxProvider,
   DashboardNotificationsBell,
@@ -74,6 +57,20 @@ import DashboardMobileBrandBar from './ui/DashboardMobileBrandBar';
 import DashboardMobileContextBar from './ui/DashboardMobileContextBar';
 import DashboardPageHeading from './ui/DashboardPageHeading';
 
+import { ListMusic, Users, Medal, User as UserIcon, Settings } from 'lucide-react';
+
+// Primary nav tabs are static imports so tab switches never hit Suspense
+// (lazy + single boundary unmounts the old route before the new chunk resolves).
+// Secondary / deep routes stay lazy to keep the DashboardRoute chunk lean.
+const AdminPage = lazy(dashboardLazyRouteImport.admin);
+const AccountPage = lazy(dashboardLazyRouteImport.account);
+const PoolHubPage = lazy(dashboardLazyRouteImport.poolHub);
+const NotificationsPage = lazy(dashboardLazyRouteImport.notifications);
+
+function LazyDashboardRoute({ children }) {
+  return <Suspense fallback={<RouteSuspenseFallback />}>{children}</Suspense>;
+}
+
 function navPrefetchHandlers(path) {
   const keys = DASHBOARD_NAV_PRELOAD_BY_PATH[path];
   if (!keys?.length) return undefined;
@@ -93,7 +90,7 @@ export default function DashboardLayout() {
   usePendingPoolJoin(showDates);
   usePrefetchDashboardRoutes(location.pathname);
 
-  const scrollDirection = useScrollDirection(); 
+  const scrollDirection = useScrollDirection();
 
   const [selectedDate, setSelectedDate] = useState(() =>
     getNextShow(FALLBACK_SHOW_DATES).date
@@ -278,57 +275,80 @@ export default function DashboardLayout() {
             <DashboardPageHeading title={meta.layoutDesktopHeading} tone={isWarRoomRoute ? 'warRoom' : 'default'} />
           )}
 
-          <Suspense fallback={<RouteSuspenseFallback />}>
-            <Routes>
-              <Route index element={<PicksPage user={user} selectedDate={selectedDate} />} />
-              <Route
-                path="picks"
-                element={<PicksPage user={user} selectedDate={selectedDate} />}
-              />
-              <Route
-                path="scoring"
-                element={<Navigate to="/dashboard?scoringRules=1" replace />}
-              />
-              <Route
-                path="standings"
-                element={
-                  <StandingsPage
-                    selectedDate={selectedDate}
-                    onSelectShowDate={setSelectedDate}
-                  />
-                }
-              />
-              <Route
-                path="admin"
-                element={<AdminPage user={user} selectedDate={selectedDate} />}
-              />
-              <Route path="profile" element={<ProfileClusterLayout user={user} />}>
-                <Route index element={<ProfilePage />} />
-                <Route path="notifications" element={<NotificationsPage />} />
-                <Route path="account" element={<AccountPage />} />
-              </Route>
-              <Route
-                path="account-security"
-                element={
-                  <Navigate
-                    to={`${PROFILE_CLUSTER_PATHS.account}${location.search}`}
-                    replace
-                  />
-                }
-              />
+          <Routes>
+            <Route index element={<PicksPage user={user} selectedDate={selectedDate} />} />
+            <Route
+              path="picks"
+              element={<PicksPage user={user} selectedDate={selectedDate} />}
+            />
+            <Route
+              path="scoring"
+              element={<Navigate to="/dashboard?scoringRules=1" replace />}
+            />
+            <Route
+              path="standings"
+              element={
+                <StandingsPage
+                  selectedDate={selectedDate}
+                  onSelectShowDate={setSelectedDate}
+                />
+              }
+            />
+            <Route
+              path="admin"
+              element={
+                <LazyDashboardRoute>
+                  <AdminPage user={user} selectedDate={selectedDate} />
+                </LazyDashboardRoute>
+              }
+            />
+            <Route path="profile" element={<ProfileClusterLayout user={user} />}>
+              <Route index element={<ProfilePage />} />
               <Route
                 path="notifications"
                 element={
-                  <Navigate
-                    to={`${PROFILE_CLUSTER_PATHS.notifications}${location.search}`}
-                    replace
-                  />
+                  <LazyDashboardRoute>
+                    <NotificationsPage />
+                  </LazyDashboardRoute>
                 }
               />
-              <Route path="pools" element={<PoolsPage user={user} />} />
-              <Route path="pool/:poolId" element={<PoolHubPage user={user} />} />
-            </Routes>
-          </Suspense>
+              <Route
+                path="account"
+                element={
+                  <LazyDashboardRoute>
+                    <AccountPage />
+                  </LazyDashboardRoute>
+                }
+              />
+            </Route>
+            <Route
+              path="account-security"
+              element={
+                <Navigate
+                  to={`${PROFILE_CLUSTER_PATHS.account}${location.search}`}
+                  replace
+                />
+              }
+            />
+            <Route
+              path="notifications"
+              element={
+                <Navigate
+                  to={`${PROFILE_CLUSTER_PATHS.notifications}${location.search}`}
+                  replace
+                />
+              }
+            />
+            <Route path="pools" element={<PoolsPage user={user} />} />
+            <Route
+              path="pool/:poolId"
+              element={
+                <LazyDashboardRoute>
+                  <PoolHubPage user={user} />
+                </LazyDashboardRoute>
+              }
+            />
+          </Routes>
         </div>
       </main>
 

--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -5,6 +5,12 @@ import { usePendingPoolJoin } from '../../features/pool-invite';
 import { useShowCalendar } from '../../features/show-calendar';
 import { useScrollDirection } from '../../shared/hooks/useScrollDirection';
 import RouteSuspenseFallback from '../../shared/ui/RouteSuspenseFallback';
+import {
+  DASHBOARD_NAV_PRELOAD_BY_PATH,
+  dashboardRouteImport,
+  prefetchDashboardRoutes,
+} from './model/dashboardRouteModules';
+import ProfileClusterLayout from './ui/ProfileClusterLayout';
 
 import { ListMusic, Users, Medal, User as UserIcon, Settings } from 'lucide-react';
 
@@ -12,17 +18,16 @@ import { ListMusic, Users, Medal, User as UserIcon, Settings } from 'lucide-reac
 // doesn't pay the download cost for Admin / Pools / Standings / Picks /
 // PoolHub. Static imports here would defeat the route-level code splitting
 // at the top level (`App.jsx`), because they'd all collapse back into the
-// DashboardRoute chunk. The inner `<Suspense>` below reuses the shared
-// brand loading fallback.
-const PicksPage = lazy(() => import('../../pages/picks/PicksPage'));
-const AdminPage = lazy(() => import('../../pages/admin/AdminPage'));
-const StandingsPage = lazy(() => import('../../pages/standings/StandingsPage'));
-const ProfilePage = lazy(() => import('../../pages/profile/ProfilePage'));
-const AccountPage = lazy(() => import('../../pages/profile/AccountPage'));
-const PoolsPage = lazy(() => import('../../pages/pools/PoolsPage'));
-const PoolHubPage = lazy(() => import('../../pages/pools/PoolHubPage'));
-const NotificationsPage = lazy(() => import('../../pages/notifications/NotificationsPage'));
-const ProfileClusterLayout = lazy(() => import('./ui/ProfileClusterLayout'));
+// DashboardRoute chunk. Import factories live in `dashboardRouteModules`
+// so idle/hover prefetch warms the same module cache before navigation.
+const PicksPage = lazy(dashboardRouteImport.picks);
+const AdminPage = lazy(dashboardRouteImport.admin);
+const StandingsPage = lazy(dashboardRouteImport.standings);
+const ProfilePage = lazy(dashboardRouteImport.profile);
+const AccountPage = lazy(dashboardRouteImport.account);
+const PoolsPage = lazy(dashboardRouteImport.pools);
+const PoolHubPage = lazy(dashboardRouteImport.poolHub);
+const NotificationsPage = lazy(dashboardRouteImport.notifications);
 
 // `ScoringRulesModalProvider` must stay eager — it wraps the whole dashboard
 // and owns the modal portal state; lazy-loading it would Suspense-flash the
@@ -64,9 +69,21 @@ import {
   dashboardTourDateSelectChromeDesktopWrap,
 } from '../../shared/config/dashboardHeadingTypography';
 import { getDashboardPageMeta } from './model/dashboardPageMeta';
+import { usePrefetchDashboardRoutes } from './model/usePrefetchDashboardRoutes';
 import DashboardMobileBrandBar from './ui/DashboardMobileBrandBar';
 import DashboardMobileContextBar from './ui/DashboardMobileContextBar';
 import DashboardPageHeading from './ui/DashboardPageHeading';
+
+function navPrefetchHandlers(path) {
+  const keys = DASHBOARD_NAV_PRELOAD_BY_PATH[path];
+  if (!keys?.length) return undefined;
+  const warm = () => prefetchDashboardRoutes(keys);
+  return {
+    onMouseEnter: warm,
+    onFocus: warm,
+    onTouchStart: warm,
+  };
+}
 
 export default function DashboardLayout() {
   const location = useLocation();
@@ -74,7 +91,8 @@ export default function DashboardLayout() {
   const { user, isAdmin } = useAuth();
   const { showDates, showDatesByTour } = useShowCalendar();
   usePendingPoolJoin(showDates);
-  
+  usePrefetchDashboardRoutes(location.pathname);
+
   const scrollDirection = useScrollDirection(); 
 
   const [selectedDate, setSelectedDate] = useState(() =>
@@ -174,7 +192,12 @@ export default function DashboardLayout() {
                 (location.pathname === item.path ||
                   (item.path === '/dashboard' && location.pathname === '/dashboard/')));
             return (
-              <Link key={item.name} to={item.path} className={`flex items-center gap-3 rounded-xl px-4 py-3 font-bold transition-all ${isActive ? 'bg-brand-primary/10 text-brand-primary' : 'text-content-secondary hover:bg-surface-inset hover:text-white'}`}>
+              <Link
+                key={item.name}
+                to={item.path}
+                {...navPrefetchHandlers(item.path)}
+                className={`flex items-center gap-3 rounded-xl px-4 py-3 font-bold transition-all ${isActive ? 'bg-brand-primary/10 text-brand-primary' : 'text-content-secondary hover:bg-surface-inset hover:text-white'}`}
+              >
                 {/* Render the Lucide icon instead of text */}
                 <Icon className="w-5 h-5 shrink-0" />
                 {item.name}
@@ -332,6 +355,7 @@ export default function DashboardLayout() {
               <Link
                 key={item.name}
                 to={item.path}
+                {...navPrefetchHandlers(item.path)}
                 className={`flex h-[calc(100%-10px)] min-h-0 w-full flex-col items-center justify-center space-y-1 self-center rounded-xl transition-colors ${
                   isActive
                     ? 'text-brand-primary bg-brand-primary/[0.14] ring-1 ring-inset ring-brand-primary/30 shadow-[inset_0_1px_0_0_rgb(255_255_255_/_0.06)]'

--- a/src/app/layout/RootAppShell.jsx
+++ b/src/app/layout/RootAppShell.jsx
@@ -5,6 +5,7 @@ import { useServiceWorkerUpdate } from '../../shared/lib/useServiceWorkerUpdate'
 import AppBackground from '../../shared/ui/AppBackground';
 import RouteSuspenseFallback from '../../shared/ui/RouteSuspenseFallback';
 import UpdateAvailableBanner from '../../shared/ui/UpdateAvailableBanner';
+import { shellTransitionKey } from './model/shellTransitionKey';
 
 /**
  * Global chrome: ambient background + top-level route outlet with enter animation.
@@ -14,16 +15,20 @@ import UpdateAvailableBanner from '../../shared/ui/UpdateAvailableBanner';
  * setup, public profile, pool-invite, etc.), so we only need one boundary at
  * this level. Nested boundaries exist inside `DashboardLayout` for its child
  * pages.
+ *
+ * The enter-animation wrapper uses {@link shellTransitionKey} — not raw
+ * `pathname` — so dashboard tab switches do not remount the lazy route tree.
  */
 export default function RootAppShell() {
   const { pathname } = useLocation();
+  const transitionKey = shellTransitionKey(pathname);
   const { updateAvailable, applyUpdate } = useServiceWorkerUpdate();
 
   return (
     <>
       <AppBackground />
       <div className="relative z-[1] min-h-screen">
-        <div key={pathname} className="min-h-screen animate-page-enter">
+        <div key={transitionKey} className="min-h-screen animate-page-enter">
           <Suspense fallback={<RouteSuspenseFallback />}>
             <Outlet />
           </Suspense>

--- a/src/app/layout/model/dashboardRouteModules.js
+++ b/src/app/layout/model/dashboardRouteModules.js
@@ -1,0 +1,81 @@
+import { isProfileClusterPath } from '../../../shared/config/dashboardRoutes';
+
+/**
+ * Dynamic import factories for dashboard nested routes. Shared by
+ * `DashboardLayout`'s `lazy()` wrappers and idle/hover prefetch so the
+ * module loader cache is warm before the user navigates (Safari SPA nav).
+ *
+ * Keep specifiers in sync with any `lazy()` usage in `DashboardLayout.jsx`.
+ */
+export const dashboardRouteImport = {
+  picks: () => import('../../../pages/picks/PicksPage'),
+  admin: () => import('../../../pages/admin/AdminPage'),
+  standings: () => import('../../../pages/standings/StandingsPage'),
+  profile: () => import('../../../pages/profile/ProfilePage'),
+  account: () => import('../../../pages/profile/AccountPage'),
+  pools: () => import('../../../pages/pools/PoolsPage'),
+  poolHub: () => import('../../../pages/pools/PoolHubPage'),
+  notifications: () => import('../../../pages/notifications/NotificationsPage'),
+};
+
+/** Nav path → route module keys to warm before navigation. */
+export const DASHBOARD_NAV_PRELOAD_BY_PATH = Object.freeze({
+  '/dashboard': ['picks'],
+  '/dashboard/pools': ['pools'],
+  '/dashboard/standings': ['standings'],
+  '/dashboard/profile': ['profile'],
+  '/dashboard/admin': ['admin'],
+});
+
+const started = new Set();
+
+/**
+ * @param {string | string[]} keys
+ */
+export function prefetchDashboardRoutes(keys) {
+  if (typeof window === 'undefined') return;
+  const list = Array.isArray(keys) ? keys : [keys];
+  for (const key of list) {
+    if (started.has(key)) continue;
+    const load = dashboardRouteImport[key];
+    if (!load) continue;
+    started.add(key);
+    load().catch(() => {
+      started.delete(key);
+    });
+  }
+}
+
+/**
+ * Keys for the currently mounted dashboard nested route (for idle prefetch
+ * exclusion so we don't re-fetch the active tab's chunk).
+ *
+ * @param {string} pathname
+ * @returns {string[]}
+ */
+export function dashboardRouteKeysForPathname(pathname) {
+  const path = pathname.replace(/\/+$/, '') || '/dashboard';
+  if (path === '/dashboard' || path === '/dashboard/picks') return ['picks'];
+  if (path === '/dashboard/pools') return ['pools'];
+  if (path.startsWith('/dashboard/pool/')) return ['poolHub'];
+  if (path === '/dashboard/standings') return ['standings'];
+  if (path === '/dashboard/admin') return ['admin'];
+  if (isProfileClusterPath(path)) {
+    const keys = ['profile'];
+    if (path.includes('/notifications')) keys.push('notifications');
+    if (path.includes('/account')) keys.push('account');
+    return keys;
+  }
+  return [];
+}
+
+/**
+ * Warm every dashboard route chunk except those already on screen.
+ *
+ * @param {string} pathname
+ */
+export function prefetchIdleDashboardRoutes(pathname) {
+  const exclude = new Set(dashboardRouteKeysForPathname(pathname));
+  const keys = Object.keys(dashboardRouteImport).filter((key) => !exclude.has(key));
+  prefetchDashboardRoutes(keys);
+}

--- a/src/app/layout/model/dashboardRouteModules.js
+++ b/src/app/layout/model/dashboardRouteModules.js
@@ -1,29 +1,23 @@
 import { isProfileClusterPath } from '../../../shared/config/dashboardRoutes';
 
 /**
- * Dynamic import factories for dashboard nested routes. Shared by
- * `DashboardLayout`'s `lazy()` wrappers and idle/hover prefetch so the
- * module loader cache is warm before the user navigates (Safari SPA nav).
+ * Dynamic import factories for **secondary** dashboard routes only.
  *
- * Keep specifiers in sync with any `lazy()` usage in `DashboardLayout.jsx`.
+ * Primary nav tabs (Picks, Pools, Standings, Profile) are static imports in
+ * `DashboardLayout` so `<Routes>` tab switches never unmount into an empty
+ * Suspense boundary — Safari shows "Loading…" on every lazy swap otherwise.
+ *
+ * Keep specifiers in sync with `lazy()` usage in `DashboardLayout.jsx`.
  */
-export const dashboardRouteImport = {
-  picks: () => import('../../../pages/picks/PicksPage'),
+export const dashboardLazyRouteImport = {
   admin: () => import('../../../pages/admin/AdminPage'),
-  standings: () => import('../../../pages/standings/StandingsPage'),
-  profile: () => import('../../../pages/profile/ProfilePage'),
   account: () => import('../../../pages/profile/AccountPage'),
-  pools: () => import('../../../pages/pools/PoolsPage'),
   poolHub: () => import('../../../pages/pools/PoolHubPage'),
   notifications: () => import('../../../pages/notifications/NotificationsPage'),
 };
 
-/** Nav path → route module keys to warm before navigation. */
+/** Nav path → lazy route keys to warm before navigation. */
 export const DASHBOARD_NAV_PRELOAD_BY_PATH = Object.freeze({
-  '/dashboard': ['picks'],
-  '/dashboard/pools': ['pools'],
-  '/dashboard/standings': ['standings'],
-  '/dashboard/profile': ['profile'],
   '/dashboard/admin': ['admin'],
 });
 
@@ -37,7 +31,7 @@ export function prefetchDashboardRoutes(keys) {
   const list = Array.isArray(keys) ? keys : [keys];
   for (const key of list) {
     if (started.has(key)) continue;
-    const load = dashboardRouteImport[key];
+    const load = dashboardLazyRouteImport[key];
     if (!load) continue;
     started.add(key);
     load().catch(() => {
@@ -47,21 +41,15 @@ export function prefetchDashboardRoutes(keys) {
 }
 
 /**
- * Keys for the currently mounted dashboard nested route (for idle prefetch
- * exclusion so we don't re-fetch the active tab's chunk).
- *
  * @param {string} pathname
  * @returns {string[]}
  */
-export function dashboardRouteKeysForPathname(pathname) {
+export function dashboardLazyRouteKeysForPathname(pathname) {
   const path = pathname.replace(/\/+$/, '') || '/dashboard';
-  if (path === '/dashboard' || path === '/dashboard/picks') return ['picks'];
-  if (path === '/dashboard/pools') return ['pools'];
   if (path.startsWith('/dashboard/pool/')) return ['poolHub'];
-  if (path === '/dashboard/standings') return ['standings'];
   if (path === '/dashboard/admin') return ['admin'];
   if (isProfileClusterPath(path)) {
-    const keys = ['profile'];
+    const keys = [];
     if (path.includes('/notifications')) keys.push('notifications');
     if (path.includes('/account')) keys.push('account');
     return keys;
@@ -70,12 +58,17 @@ export function dashboardRouteKeysForPathname(pathname) {
 }
 
 /**
- * Warm every dashboard route chunk except those already on screen.
+ * Warm every lazy dashboard route chunk except those already on screen.
  *
  * @param {string} pathname
  */
 export function prefetchIdleDashboardRoutes(pathname) {
-  const exclude = new Set(dashboardRouteKeysForPathname(pathname));
-  const keys = Object.keys(dashboardRouteImport).filter((key) => !exclude.has(key));
+  const exclude = new Set(dashboardLazyRouteKeysForPathname(pathname));
+  const keys = Object.keys(dashboardLazyRouteImport).filter((key) => !exclude.has(key));
   prefetchDashboardRoutes(keys);
+}
+
+/** Eagerly warm all lazy dashboard chunks (secondary routes). */
+export function prefetchAllLazyDashboardRoutes() {
+  prefetchDashboardRoutes(Object.keys(dashboardLazyRouteImport));
 }

--- a/src/app/layout/model/dashboardRouteModules.test.js
+++ b/src/app/layout/model/dashboardRouteModules.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DASHBOARD_NAV_PRELOAD_BY_PATH,
+  dashboardRouteImport,
+  dashboardRouteKeysForPathname,
+} from './dashboardRouteModules';
+
+describe('dashboardRouteModules', () => {
+  it('defines a dynamic import factory for every dashboard lazy route', () => {
+    expect(Object.keys(dashboardRouteImport).sort()).toEqual(
+      [
+        'account',
+        'admin',
+        'notifications',
+        'picks',
+        'poolHub',
+        'pools',
+        'profile',
+        'standings',
+      ].sort()
+    );
+  });
+
+  it('maps primary nav paths to preload keys', () => {
+    expect(DASHBOARD_NAV_PRELOAD_BY_PATH['/dashboard']).toEqual(['picks']);
+    expect(DASHBOARD_NAV_PRELOAD_BY_PATH['/dashboard/profile']).toEqual(['profile']);
+  });
+
+  it('derives active route keys from pathname', () => {
+    expect(dashboardRouteKeysForPathname('/dashboard/')).toEqual(['picks']);
+    expect(dashboardRouteKeysForPathname('/dashboard/pools')).toEqual(['pools']);
+    expect(dashboardRouteKeysForPathname('/dashboard/pool/abc')).toEqual(['poolHub']);
+    expect(dashboardRouteKeysForPathname('/dashboard/profile/account')).toEqual([
+      'profile',
+      'account',
+    ]);
+  });
+});

--- a/src/app/layout/model/dashboardRouteModules.test.js
+++ b/src/app/layout/model/dashboardRouteModules.test.js
@@ -2,38 +2,24 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DASHBOARD_NAV_PRELOAD_BY_PATH,
-  dashboardRouteImport,
-  dashboardRouteKeysForPathname,
+  dashboardLazyRouteImport,
+  dashboardLazyRouteKeysForPathname,
 } from './dashboardRouteModules';
 
 describe('dashboardRouteModules', () => {
-  it('defines a dynamic import factory for every dashboard lazy route', () => {
-    expect(Object.keys(dashboardRouteImport).sort()).toEqual(
-      [
-        'account',
-        'admin',
-        'notifications',
-        'picks',
-        'poolHub',
-        'pools',
-        'profile',
-        'standings',
-      ].sort()
+  it('defines lazy import factories only for secondary dashboard routes', () => {
+    expect(Object.keys(dashboardLazyRouteImport).sort()).toEqual(
+      ['account', 'admin', 'notifications', 'poolHub'].sort()
     );
   });
 
-  it('maps primary nav paths to preload keys', () => {
-    expect(DASHBOARD_NAV_PRELOAD_BY_PATH['/dashboard']).toEqual(['picks']);
-    expect(DASHBOARD_NAV_PRELOAD_BY_PATH['/dashboard/profile']).toEqual(['profile']);
+  it('maps admin nav to preload keys', () => {
+    expect(DASHBOARD_NAV_PRELOAD_BY_PATH['/dashboard/admin']).toEqual(['admin']);
   });
 
-  it('derives active route keys from pathname', () => {
-    expect(dashboardRouteKeysForPathname('/dashboard/')).toEqual(['picks']);
-    expect(dashboardRouteKeysForPathname('/dashboard/pools')).toEqual(['pools']);
-    expect(dashboardRouteKeysForPathname('/dashboard/pool/abc')).toEqual(['poolHub']);
-    expect(dashboardRouteKeysForPathname('/dashboard/profile/account')).toEqual([
-      'profile',
-      'account',
-    ]);
+  it('derives active lazy route keys from pathname', () => {
+    expect(dashboardLazyRouteKeysForPathname('/dashboard/pools')).toEqual([]);
+    expect(dashboardLazyRouteKeysForPathname('/dashboard/pool/abc123')).toEqual(['poolHub']);
+    expect(dashboardLazyRouteKeysForPathname('/dashboard/profile/account')).toEqual(['account']);
   });
 });

--- a/src/app/layout/model/shellTransitionKey.js
+++ b/src/app/layout/model/shellTransitionKey.js
@@ -1,0 +1,18 @@
+/**
+ * Stable React key for `RootAppShell`'s enter-animation wrapper.
+ *
+ * Must not change on nested navigations within the same top-level route
+ * (e.g. `/dashboard` → `/dashboard/profile`). A pathname-level key remounts
+ * lazy route trees and re-triggers `<Suspense>` — Safari tab switches then
+ * hang on the shared "Loading…" fallback.
+ *
+ * @param {string} pathname
+ * @returns {string}
+ */
+export function shellTransitionKey(pathname) {
+  const path = (pathname || '').replace(/\/+$/, '') || '/';
+  if (path.startsWith('/dashboard')) return '/dashboard';
+  if (path.startsWith('/join/')) return '/join/:code';
+  if (path.startsWith('/user/')) return '/user/:userId';
+  return path;
+}

--- a/src/app/layout/model/shellTransitionKey.test.js
+++ b/src/app/layout/model/shellTransitionKey.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { shellTransitionKey } from './shellTransitionKey';
+
+describe('shellTransitionKey', () => {
+  it('keeps dashboard nested paths on one key', () => {
+    expect(shellTransitionKey('/dashboard')).toBe('/dashboard');
+    expect(shellTransitionKey('/dashboard/')).toBe('/dashboard');
+    expect(shellTransitionKey('/dashboard/profile')).toBe('/dashboard');
+    expect(shellTransitionKey('/dashboard/profile/account')).toBe('/dashboard');
+    expect(shellTransitionKey('/dashboard/pools')).toBe('/dashboard');
+    expect(shellTransitionKey('/dashboard/pool/abc123')).toBe('/dashboard');
+  });
+
+  it('changes key across top-level routes', () => {
+    expect(shellTransitionKey('/')).not.toBe(shellTransitionKey('/dashboard'));
+    expect(shellTransitionKey('/how-it-works')).not.toBe(shellTransitionKey('/privacy'));
+  });
+
+  it('groups pool invite deep links', () => {
+    expect(shellTransitionKey('/join/POOL1')).toBe('/join/:code');
+    expect(shellTransitionKey('/join/abc/')).toBe('/join/:code');
+  });
+});

--- a/src/app/layout/model/usePrefetchDashboardRoutes.js
+++ b/src/app/layout/model/usePrefetchDashboardRoutes.js
@@ -1,23 +1,30 @@
 import { useEffect } from 'react';
 
-import { prefetchIdleDashboardRoutes } from './dashboardRouteModules';
+import {
+  prefetchAllLazyDashboardRoutes,
+  prefetchIdleDashboardRoutes,
+} from './dashboardRouteModules';
 
 /**
- * After the dashboard shell paints, prefetch sibling route chunks on an idle
- * tick so Safari/mobile tab switches don't block on dynamic import RTT.
+ * After the dashboard shell mounts, prefetch secondary (lazy) route chunks.
+ * Primary nav tabs are static imports — no Suspense on tab switch.
  */
 export function usePrefetchDashboardRoutes(pathname) {
+  useEffect(() => {
+    prefetchAllLazyDashboardRoutes();
+  }, []);
+
   useEffect(() => {
     if (typeof window === 'undefined') return undefined;
 
     const run = () => prefetchIdleDashboardRoutes(pathname);
 
     if (typeof window.requestIdleCallback === 'function') {
-      const id = window.requestIdleCallback(run, { timeout: 2500 });
+      const id = window.requestIdleCallback(run, { timeout: 1500 });
       return () => window.cancelIdleCallback(id);
     }
 
-    const timer = window.setTimeout(run, 400);
+    const timer = window.setTimeout(run, 200);
     return () => window.clearTimeout(timer);
   }, [pathname]);
 }

--- a/src/app/layout/model/usePrefetchDashboardRoutes.js
+++ b/src/app/layout/model/usePrefetchDashboardRoutes.js
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+
+import { prefetchIdleDashboardRoutes } from './dashboardRouteModules';
+
+/**
+ * After the dashboard shell paints, prefetch sibling route chunks on an idle
+ * tick so Safari/mobile tab switches don't block on dynamic import RTT.
+ */
+export function usePrefetchDashboardRoutes(pathname) {
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const run = () => prefetchIdleDashboardRoutes(pathname);
+
+    if (typeof window.requestIdleCallback === 'function') {
+      const id = window.requestIdleCallback(run, { timeout: 2500 });
+      return () => window.cancelIdleCallback(id);
+    }
+
+    const timer = window.setTimeout(run, 400);
+    return () => window.clearTimeout(timer);
+  }, [pathname]);
+}


### PR DESCRIPTION
## Summary

- **Root cause:** `RootAppShell` keyed its enter-animation wrapper on the full `pathname`, remounting the lazy `DashboardRoute` tree on every dashboard tab switch and re-triggering top-level `<Suspense>` (visible as the shared "Loading…" spinner — worst on Profile with nested lazy chunks).
- **`shellTransitionKey`:** Dashboard nested paths share one stable key (`/dashboard`) so tab switches no longer remount the route tree; enter animation still runs for true top-level route changes.
- **Prefetch + Profile shell:** Idle/touch/hover prefetch warms sibling route chunks; `ProfileClusterLayout` (~1 kB) is eager to avoid a nested lazy boundary on Profile.

## Test plan

- [ ] `npm test` — layout model tests pass
- [ ] `npm run lint`
- [ ] Safari (staging preview): sign in → Picks → tap Profile — no full-screen Loading hang
- [ ] Safari: switch Pools / Standings / Profile repeatedly — no remount flash, selected date persists
- [ ] Desktop Chrome: confirm enter animation still plays on `/` → `/dashboard` and marketing route changes

Made with [Cursor](https://cursor.com)