### PR TITLE
fix(standings): unstick Safari "Checking your picks…" spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.18.7] — 2026-07-04
+
+### Fixed
+- **Standings "Checking your picks…" spinner stuck on Safari** — derive next-show pick status from the standings picks query instead of a redundant `getDoc`; harden `useNextShowPicksStatus` against effect cancellation races (Pools / Pool Hub).
+
+---
+
 ## [1.18.6] — 2026-07-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/picks/api/picksApi.js
+++ b/src/features/picks/api/picksApi.js
@@ -11,6 +11,7 @@ import {
 } from 'firebase/firestore';
 
 import { db } from '../../../shared/lib/firebase';
+import { hasNonEmptyPicksObject } from '../model/pickSubmission';
 
 /** Firestore rejects `undefined` anywhere in document data; strip from shallow objects. */
 function omitUndefinedShallow(record) {
@@ -26,15 +27,6 @@ export function getPickDocumentId(selectedDate, userId) {
 /**
  * Load the user's pick map for a show (field id → song string).
  */
-function hasNonEmptyPicksObject(picks) {
-  if (picks == null || typeof picks !== 'object' || Array.isArray(picks)) {
-    return false;
-  }
-  return Object.values(picks).some(
-    (v) => v != null && String(v).trim() !== ''
-  );
-}
-
 export async function fetchPickDoc(selectedDate, userId) {
   if (!userId || !selectedDate) return {};
 

--- a/src/features/picks/index.js
+++ b/src/features/picks/index.js
@@ -7,4 +7,9 @@ export { default as PicksSelfRecapSection } from './ui/PicksSelfRecapSection';
 export { default as usePicksForm } from './model/usePicksForm';
 export { usePicksSelfRecap } from './model/usePicksSelfRecap';
 export { useNextShowPicksStatus } from './model/useNextShowPicksStatus';
+export {
+  hasNonEmptyPicksObject,
+  pickEntryHasSubmission,
+  userHasSubmittedPickEntry,
+} from './model/pickSubmission';
 export { useSetlistLockToast } from './model/useSetlistLockToast';

--- a/src/features/picks/model/pickSubmission.js
+++ b/src/features/picks/model/pickSubmission.js
@@ -1,0 +1,32 @@
+import { FORM_FIELDS } from '../../../shared/data/gameConfig';
+
+export function hasNonEmptyPicksObject(picks) {
+  if (picks == null || typeof picks !== 'object' || Array.isArray(picks)) {
+    return false;
+  }
+  return Object.values(picks).some(
+    (v) => v != null && String(v).trim() !== ''
+  );
+}
+
+/** Whether a picks query row (or flat legacy doc) counts as submitted. */
+export function pickEntryHasSubmission(entry) {
+  if (!entry || typeof entry !== 'object') return false;
+  if (entry.picks && typeof entry.picks === 'object') {
+    return hasNonEmptyPicksObject(entry.picks);
+  }
+  return FORM_FIELDS.some((f) => {
+    const v = entry[f.id];
+    return v != null && String(v).trim() !== '';
+  });
+}
+
+/**
+ * @param {Array<{ userId?: string, uid?: string } & Record<string, unknown>> | null | undefined} pickEntries
+ * @param {string | null | undefined} userId
+ */
+export function userHasSubmittedPickEntry(pickEntries, userId) {
+  if (!userId || !Array.isArray(pickEntries)) return false;
+  const entry = pickEntries.find((p) => (p.userId || p.uid) === userId);
+  return pickEntryHasSubmission(entry);
+}

--- a/src/features/picks/model/pickSubmission.test.js
+++ b/src/features/picks/model/pickSubmission.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  hasNonEmptyPicksObject,
+  pickEntryHasSubmission,
+  userHasSubmittedPickEntry,
+} from './pickSubmission';
+
+describe('pickSubmission', () => {
+  it('detects non-empty picks maps', () => {
+    expect(hasNonEmptyPicksObject({ opener: 'Tweezer' })).toBe(true);
+    expect(hasNonEmptyPicksObject({ opener: '  ' })).toBe(false);
+    expect(hasNonEmptyPicksObject(null)).toBe(false);
+  });
+
+  it('reads submission from pick query rows', () => {
+    const rows = [
+      { userId: 'u1', picks: { opener: 'Fluffhead' } },
+      { userId: 'u2', picks: {} },
+    ];
+    expect(userHasSubmittedPickEntry(rows, 'u1')).toBe(true);
+    expect(userHasSubmittedPickEntry(rows, 'u2')).toBe(false);
+    expect(userHasSubmittedPickEntry(rows, 'u3')).toBe(false);
+  });
+
+  it('supports legacy flat pick fields on entries', () => {
+    expect(pickEntryHasSubmission({ userId: 'u1', s1o: 'Wilson' })).toBe(true);
+  });
+});

--- a/src/features/picks/model/useNextShowPicksStatus.js
+++ b/src/features/picks/model/useNextShowPicksStatus.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useAuth } from '../../auth';
 import { hasSubmittedPicksForShow } from '../api/picksApi';
@@ -15,18 +15,21 @@ export function useNextShowPicksStatus(showDate) {
   const [hasSubmittedPicksForNextShow, setHasSubmittedPicksForNextShow] =
     useState(false);
   const [error, setError] = useState(null);
+  const requestIdRef = useRef(0);
 
   useEffect(() => {
+    const requestId = ++requestIdRef.current;
+
     if (authLoading) {
       setLoading(true);
-      return;
+      return undefined;
     }
 
     let cancelled = false;
 
     const run = async () => {
       if (!showDate || !user?.uid) {
-        if (!cancelled) {
+        if (!cancelled && requestId === requestIdRef.current) {
           setHasSubmittedPicksForNextShow(false);
           setError(null);
           setLoading(false);
@@ -34,17 +37,19 @@ export function useNextShowPicksStatus(showDate) {
         return;
       }
 
-      setLoading(true);
-      setError(null);
+      if (requestId === requestIdRef.current) {
+        setLoading(true);
+        setError(null);
+      }
 
       try {
         const submitted = await hasSubmittedPicksForShow(showDate, user.uid);
-        if (!cancelled) {
+        if (!cancelled && requestId === requestIdRef.current) {
           setHasSubmittedPicksForNextShow(submitted);
         }
       } catch (err) {
         console.error('useNextShowPicksStatus:', err);
-        if (!cancelled) {
+        if (!cancelled && requestId === requestIdRef.current) {
           setHasSubmittedPicksForNextShow(false);
           setError(
             err?.message != null
@@ -53,7 +58,7 @@ export function useNextShowPicksStatus(showDate) {
           );
         }
       } finally {
-        if (!cancelled) {
+        if (!cancelled && requestId === requestIdRef.current) {
           setLoading(false);
         }
       }

--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../../auth';
-import { useNextShowPicksStatus } from '../../picks';
+import { userHasSubmittedPickEntry } from '../../picks';
 import { useUserPools } from '../../pools';
 import { useShowCalendar } from '../../show-calendar';
 import { FORM_FIELDS } from '../../../shared/data/gameConfig';
@@ -81,14 +81,14 @@ export function useStandingsScreen(selectedDate, options = {}) {
   );
   const { openScoringRules } = useScoringRulesModal();
 
-  // Only fetch pick-status for the "Now picking" active-show card — NEXT is
-  // the only status where users can still enter picks (see timeLogic.js).
-  // For PAST / LIVE, picks are already in `picks` and no extra read is
-  // needed; for FUTURE (a listed show beyond NEXT), picks aren't yet open.
-  const picksStatusTarget =
-    view === 'show' && showStatus === 'NEXT' ? selectedDate : undefined;
-  const { hasSubmittedPicksForNextShow, loading: picksStatusLoading } =
-    useNextShowPicksStatus(picksStatusTarget);
+  const isNextShowView = view === 'show' && showStatus === 'NEXT';
+  // Reuse standings picks already loaded for this date — avoids a redundant
+  // getDoc that can race/cancel on Safari tab switches (#505 follow-up).
+  const hasSubmittedPicksForNextShow =
+    isNextShowView && user?.uid
+      ? userHasSubmittedPickEntry(picks, user.uid)
+      : false;
+  const picksStatusLoading = isNextShowView && loading;
 
   useStandingsLeaderboardView(selectedDate, loading, showDates);
 


### PR DESCRIPTION
## Summary

- **Root cause:** Standings Show view fired a redundant `getDoc` via `useNextShowPicksStatus` while the standings query already loaded all picks for the date. Effect cancellation on Safari could leave `loading: true` forever — the active-show card stuck on "Checking your picks for this show…" even with the leaderboard visible.
- **Fix:** Derive secured state from the existing `picks` array on NEXT show tab; harden `useNextShowPicksStatus` with request-id guards for Pools / Pool Hub.

## Test plan

- [x] `npm test` / `npm run lint`
- [ ] Safari staging: Standings → NEXT show — card shows Make picks / View picks (no infinite spinner)
- [ ] Pools / Pool Hub — picks secured badge still resolves

Made with [Cursor](https://cursor.com)