### PR TITLE
chore(release): promote staging to main (v1.18.7) — Safari dashboard fixes

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -84,6 +84,7 @@ This repo follows **Semantic Versioning 2.0.0** (https://semver.org). The public
 4. **Update `docs/API.md`** if any declared surface changed (new route, renamed field, new callable, etc.).
 5. **Never tag a release commit** — tagging `vX.Y.Z` on `main` is a human step done after the staging→main merge.
 6. **Never modify a tagged version** — if a mistake is found in a released version, ship a new version.
+7. **Dependabot PRs are exempt** — do not bump `package.json` on `dependabot/*` branches. They ship with `skip-version-bump` (see `.github/dependabot.yml`). If CI still fails the SemVer gate on an open Dependabot PR, add the `skip-version-bump` label and re-run `verify`.
 
 ### Naming and format
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -85,6 +85,7 @@ This repo follows **Semantic Versioning 2.0.0** (https://semver.org). The public
 5. **Never tag a release commit** — tagging `vX.Y.Z` on `main` is a human step done after the staging→main merge.
 6. **Never modify a tagged version** — if a mistake is found in a released version, ship a new version.
 7. **Dependabot PRs are exempt** — do not bump `package.json` on `dependabot/*` branches. They ship with `skip-version-bump` (see `.github/dependabot.yml`). If CI still fails the SemVer gate on an open Dependabot PR, add the `skip-version-bump` label and re-run `verify`.
+8. **Dependabot first-run / ops reset** — read **`docs/DEPENDABOT_OPERATIONS.md`** before enabling or triaging Dependabot. Never ship `dependabot.yml` without `target-branch: staging`. After first enable, expect an **immediate** PR wave (not Monday). Do not `@dependabot rebase` all open dep PRs at once. To clear a flooded queue: close PRs, set `open-pull-requests-limit: 0`, document in CHANGELOG.
 
 ### Naming and format
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+      - skip-version-bump
     groups:
       root-production:
         dependency-type: production
@@ -27,6 +28,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+      - skip-version-bump
     groups:
       functions-production:
         dependency-type: production
@@ -41,3 +43,4 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - dependencies
+      - skip-version-bump

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 # Dependabot — weekly npm updates for the SPA and Cloud Functions (#414).
-# Grouped PRs reduce noise; triage notes in AGENTS.md.
+# Grouped PRs reduce noise; triage + first-run runbook: docs/DEPENDABOT_OPERATIONS.md
 # PRs target `staging` (repo PR base), not `main`.
+#
+# PAUSED 2026-07-04: open-pull-requests-limit 0 after v1.18 enablement-wave flood.
+# Human re-enable: restore limits (5/5/3) per docs/DEPENDABOT_OPERATIONS.md § Re-enabling.
 version: 2
 updates:
   - package-ecosystem: npm
@@ -9,7 +12,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     labels:
       - dependencies
       - skip-version-bump
@@ -25,7 +28,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     labels:
       - dependencies
       - skip-version-bump
@@ -40,7 +43,10 @@ updates:
     target-branch: "staging"
     schedule:
       interval: monthly
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0
     labels:
       - dependencies
       - skip-version-bump
+    groups:
+      actions-all:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         # last release. Skipped on push/schedule where github.base_ref is empty
         # (so `!= 'main'` was accidentally true) and package.json legitimately
         # equals the last release tag once a release has been cut.
-        if: github.event_name == 'pull_request' && github.base_ref != 'main' && !contains(github.event.pull_request.labels.*.name, 'skip-version-bump')
+        if: github.event_name == 'pull_request' && github.base_ref != 'main' && !contains(github.event.pull_request.labels.*.name, 'skip-version-bump') && !startsWith(github.head_ref, 'dependabot/')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Core local commands:
 
 ### Dependabot / npm audit (#414)
 
-- **Dependabot** (`.github/dependabot.yml`) opens weekly grouped PRs for root and `functions/` npm deps, plus monthly GitHub Actions updates. Base branch is the repo default; retarget to `staging` if GitHub opens against `main` only.
+- **Dependabot** (`.github/dependabot.yml`) opens weekly grouped PRs for root and `functions/` npm deps, plus monthly GitHub Actions updates. Base branch is `staging`. New Dependabot PRs get the **`skip-version-bump`** label automatically; CI also skips the SemVer gate for `dependabot/*` head branches. Agents must **not** bump `package.json` on Dependabot PRs — triage and merge (or close) as dependency maintenance only.
 - **CI `npm audit`** on the `verify` job is **informational** (`continue-on-error: true`). It does not block merge.
 - **Triage:** Critical/high in **production** deps → fix or upgrade in a normal PR. Dev-only / low noise → defer or group into a maintenance PR. Do not mass-upgrade without running `npm test` and `cd functions && npm test`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,9 @@ Core local commands:
 
 ### Dependabot / npm audit (#414)
 
-- **Dependabot** (`.github/dependabot.yml`) opens weekly grouped PRs for root and `functions/` npm deps, plus monthly GitHub Actions updates. Base branch is `staging`. New Dependabot PRs get the **`skip-version-bump`** label automatically; CI also skips the SemVer gate for `dependabot/*` head branches. Agents must **not** bump `package.json` on Dependabot PRs — triage and merge (or close) as dependency maintenance only.
+- **Runbook:** **`docs/DEPENDABOT_OPERATIONS.md`** — first-enable timeline, ops-reset procedure, re-enable steps. Read before touching `dependabot.yml` or triaging dep PRs.
+- **Dependabot** (`.github/dependabot.yml`) — **paused** (`open-pull-requests-limit: 0`) after 2026-07-04 enablement-wave reset. When active: weekly grouped npm PRs + monthly Actions; base `staging`; auto `skip-version-bump`; CI exempts `dependabot/*`. Agents must **not** bump `package.json` on Dependabot PRs.
+- **Vercel:** `ignoreCommand` → `scripts/vercel-should-build.sh` skips previews for Actions/functions-only dep PRs.
 - **CI `npm audit`** on the `verify` job is **informational** (`continue-on-error: true`). It does not block merge.
 - **Triage:** Critical/high in **production** deps → fix or upgrade in a normal PR. Dev-only / low noise → defer or group into a maintenance PR. Do not mass-upgrade without running `npm test` and `cd functions && npm test`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.18.6] — 2026-07-04
+
+### Fixed
+- **Safari dashboard tab navigation** — stop remounting the lazy route tree on every `/dashboard/*` pathname change (`shellTransitionKey` in `RootAppShell`); static-import primary nav tabs (Picks, Pools, Standings, Profile) so tab switches never hit Suspense; keep Admin / Pool Hub / Account / Messages lazy with per-route boundaries and eager prefetch on dashboard mount.
+
+---
+
 ## [1.18.5] — 2026-07-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.18.7] — 2026-07-04
+
+### Fixed
+- **Standings "Checking your picks…" spinner stuck on Safari** — derive next-show pick status from the standings picks query instead of a redundant `getDoc`; harden `useNextShowPicksStatus` against effect cancellation races (Pools / Pool Hub).
+
+---
+
 ## [1.18.6] — 2026-07-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.18.4] — 2026-07-04
+
+### Fixed
+- **Vercel build time** — drop explicit `npm ci` install command so Vercel restores its dependency cache (`up to date in 1s`) instead of reinstalling 685 packages (~2 min). `.npmrc` `legacy-peer-deps` retains the v1.18.1 peer-resolution fix.
+
+### Changed
+- **Dependabot CI** — auto-apply `skip-version-bump` label and exempt `dependabot/*` branches from the SemVer gate (dependency-only PRs do not bump `package.json`).
+
+---
+
 ## [1.18.3] — 2026-07-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.18.5] — 2026-07-04
+
+### Fixed
+- **PR queue stabilization** — pause Dependabot (`open-pull-requests-limit: 0`) after v1.18 enablement-wave; add Vercel `ignoreCommand` to skip SPA previews for CI/functions-only dependency PRs.
+
+### Added
+- **`docs/DEPENDABOT_OPERATIONS.md`** — definitive enablement timeline, agent triage table, ops-reset procedure, re-enable checklist.
+
+---
+
 ## [1.18.4] — 2026-07-04
 
 ### Fixed

--- a/docs/DEPENDABOT_OPERATIONS.md
+++ b/docs/DEPENDABOT_OPERATIONS.md
@@ -1,0 +1,93 @@
+# Dependabot operations (agent + human)
+
+**Purpose:** Prevent post-release PR-queue floods. Injected into agent context via `AGENTS.md` and `.cursorrules`.
+
+---
+
+## What happened (2026-07-03 — definitive timeline)
+
+| UTC | Event |
+|-----|--------|
+| 22:32 | [#476](https://github.com/pat792/set-picks/pull/476) merges — **first-ever** `.github/dependabot.yml` lands on `staging` (**no `target-branch`**) |
+| 22:45 | Dependabot **immediate first scan** (not Monday schedule) opens **#479–#485** targeting **`main`** (repo default) |
+| 22:57 | `378f41a` adds `target-branch: staging` → **#479–#485 closed**, **#486–#492 opened** (duplicate wave) |
+| 22:58–23:00 | Seven Dependabot PRs sit open; each triggers full GitHub CI + Vercel preview |
+| 23:30–23:33 | Sprint 6 train PRs **#493–#495** opened manually (separate from Dependabot, same evening) |
+
+**Root cause:** Dependabot was enabled in the v1.18.0 train without (1) correct `target-branch` on day one, (2) SemVer exemption, (3) Vercel ignore for non-SPA PRs, or (4) a first-run agent runbook. The “clean slate after v1.18” lasted **~13 minutes** until the first Dependabot scan.
+
+This is **not** recurring weekly noise — it was a **one-time enablement avalanche** plus same-evening Sprint 6 queueing.
+
+---
+
+## Current policy (post ops-reset 2026-07-04)
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| `open-pull-requests-limit` | **0** (all ecosystems) | Paused until human sets limits back |
+| SemVer gate | Skips `dependabot/*` + `skip-version-bump` label | Deps PRs never bump `package.json` |
+| Vercel | `ignoreCommand` → `scripts/vercel-should-build.sh` | No SPA preview for Actions/functions-only bumps |
+
+### Re-enabling Dependabot (human step)
+
+1. Restore limits in `.github/dependabot.yml` (e.g. `5` root/functions, `3` actions).
+2. Merge to `staging`; wait for **one** weekly wave — do **not** open parallel manual dep PRs same day.
+3. Triage with table below; max **1–2 merges per week**, never batch-merge `#492`-class toolchain bombs.
+
+---
+
+## Agent obligations
+
+### On the same PR / release that adds or edits `dependabot.yml`
+
+- [ ] `target-branch: staging` on **every** `updates` entry (repo default is `main`).
+- [ ] `skip-version-bump` label on every entry.
+- [ ] Document first-scan behavior in this file + `CHANGELOG.md`.
+- [ ] Set `open-pull-requests-limit: 0` initially; file a follow-up issue to raise limits after first triage.
+
+### When Dependabot PRs appear
+
+| PR type | Agent action |
+|---------|----------------|
+| `dependabot/github_actions/*` | Triage together; merge only if `verify` green; never bump version |
+| Root production group | Run `npm test`; merge if patch/minor only |
+| Root **development** group | **Defer** if vite/eslint/tailwind major jumps bundled |
+| `functions/*` production | Run `cd functions && npm test`; merge individually |
+| `functions/*` development | Low priority; merge when functions CI green |
+
+### Never
+
+- `@dependabot rebase` on **all** open PRs at once (N× CI + Vercel).
+- Leave enablement-wave PRs open “until green” without owner triage.
+- Open Sprint train feature PRs in the same hour as Dependabot first-scan.
+
+### Ops reset (clear slate)
+
+If the PR queue becomes unmanageable:
+
+```bash
+# Close Dependabot backlog (branches preserved)
+for pr in $(gh pr list --author app/dependabot --json number -q '.[].number'); do
+  gh pr close "$pr" --comment "Ops reset — see docs/DEPENDABOT_OPERATIONS.md"
+done
+```
+
+Set `open-pull-requests-limit: 0` in `dependabot.yml` until re-enable.
+
+---
+
+## Triage quick reference
+
+| PR class | Merge? | Notes |
+|----------|--------|-------|
+| Actions only (#486-class) | Optional batch | CI-only; Vercel skip |
+| Root prod patch bumps | Yes, one PR/week | `npm test` |
+| Root dev (vite 8, tailwind 4) | **No** | Dedicated upgrade issue |
+| Functions prod | Case-by-case | `functions` job must pass |
+| Functions dev | Low priority | Test-only dep |
+
+---
+
+## Maintenance
+
+Update this file when `dependabot.yml`, SemVer gate, or Vercel ignore logic changes.

--- a/docs/GITHUB_AUTOMATION_CONTEXT.md
+++ b/docs/GITHUB_AUTOMATION_CONTEXT.md
@@ -99,6 +99,14 @@ Name **existing** domains when known (e.g. `pools`, `picks`, `scoring`, `auth`, 
 
 ---
 
+## Dependabot (paused 2026-07-04)
+
+- **Runbook:** **`docs/DEPENDABOT_OPERATIONS.md`** — enablement-wave root cause, agent triage, ops-reset, re-enable checklist.
+- **First enable dumps PRs immediately** (not weekly schedule). Ship `target-branch: staging` on day one or Dependabot opens against `main`.
+- **`open-pull-requests-limit: 0`** until human restores limits after triage.
+
+---
+
 ## Maintenance
 
 When architecture or automation behavior changes, update **this file** and keep **`.cursorrules`** and **`docs/DASHBOARD_IA.md`** aligned. If **`public/branding/`** or **`src/shared/config/branding.js`** changes materially, refresh **`docs/design.md`** §7 so automation and humans share the same contract.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.18.5",
+  "version": "1.18.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.18.4",
+  "version": "1.18.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.18.3",
+  "version": "1.18.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/vercel-should-build.sh
+++ b/scripts/vercel-should-build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Vercel Ignored Build Step (wired from vercel.json ignoreCommand).
+# Exit 0 → skip deploy; exit 1 → build.
+#
+# Skips previews for dependency/CI-only PRs that do not touch SPA artifacts.
+
+set -euo pipefail
+
+# Dependabot CI-only branches never change the Vite app.
+if [[ "${VERCEL_GIT_COMMIT_REF:-}" == dependabot/github_actions/* ]]; then
+  exit 0
+fi
+
+# Functions-only lockfile bumps (no root package / src change).
+if [[ "${VERCEL_GIT_COMMIT_REF:-}" == dependabot/npm_and_yarn/functions/* ]]; then
+  exit 0
+fi
+
+# Build only when SPA-relevant paths changed vs parent commit.
+if git diff HEAD^ HEAD --quiet -- \
+  package.json \
+  package-lock.json \
+  src/ \
+  public/ \
+  api/ \
+  vite.config.js \
+  vercel.json \
+  index.html
+then
+  exit 0
+fi
+
+exit 1

--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -5,28 +5,17 @@ import { usePendingPoolJoin } from '../../features/pool-invite';
 import { useShowCalendar } from '../../features/show-calendar';
 import { useScrollDirection } from '../../shared/hooks/useScrollDirection';
 import RouteSuspenseFallback from '../../shared/ui/RouteSuspenseFallback';
+import {
+  DASHBOARD_NAV_PRELOAD_BY_PATH,
+  dashboardLazyRouteImport,
+  prefetchDashboardRoutes,
+} from './model/dashboardRouteModules';
+import ProfileClusterLayout from './ui/ProfileClusterLayout';
 
-import { ListMusic, Users, Medal, User as UserIcon, Settings } from 'lucide-react';
-
-// Lazy-load each dashboard page so a direct hit on e.g. `/dashboard/profile`
-// doesn't pay the download cost for Admin / Pools / Standings / Picks /
-// PoolHub. Static imports here would defeat the route-level code splitting
-// at the top level (`App.jsx`), because they'd all collapse back into the
-// DashboardRoute chunk. The inner `<Suspense>` below reuses the shared
-// brand loading fallback.
-const PicksPage = lazy(() => import('../../pages/picks/PicksPage'));
-const AdminPage = lazy(() => import('../../pages/admin/AdminPage'));
-const StandingsPage = lazy(() => import('../../pages/standings/StandingsPage'));
-const ProfilePage = lazy(() => import('../../pages/profile/ProfilePage'));
-const AccountPage = lazy(() => import('../../pages/profile/AccountPage'));
-const PoolsPage = lazy(() => import('../../pages/pools/PoolsPage'));
-const PoolHubPage = lazy(() => import('../../pages/pools/PoolHubPage'));
-const NotificationsPage = lazy(() => import('../../pages/notifications/NotificationsPage'));
-const ProfileClusterLayout = lazy(() => import('./ui/ProfileClusterLayout'));
-
-// `ScoringRulesModalProvider` must stay eager — it wraps the whole dashboard
-// and owns the modal portal state; lazy-loading it would Suspense-flash the
-// entire dashboard chrome.
+import PicksPage from '../../pages/picks/PicksPage';
+import PoolsPage from '../../pages/pools/PoolsPage';
+import StandingsPage from '../../pages/standings/StandingsPage';
+import ProfilePage from '../../pages/profile/ProfilePage';
 import { ScoringRulesModalProvider } from '../../features/scoring';
 import {
   NAV_LABEL_ADMIN,
@@ -48,7 +37,6 @@ import {
 } from '../../shared/utils/showOptionLabel.js';
 import { PastShowLockBanner, TooEarlyBanner, useSetlistLockToast } from '../../features/picks';
 import { DashboardInstallEngageBanner } from '../../features/install';
-
 import {
   CommsInboxProvider,
   DashboardNotificationsBell,
@@ -64,9 +52,35 @@ import {
   dashboardTourDateSelectChromeDesktopWrap,
 } from '../../shared/config/dashboardHeadingTypography';
 import { getDashboardPageMeta } from './model/dashboardPageMeta';
+import { usePrefetchDashboardRoutes } from './model/usePrefetchDashboardRoutes';
 import DashboardMobileBrandBar from './ui/DashboardMobileBrandBar';
 import DashboardMobileContextBar from './ui/DashboardMobileContextBar';
 import DashboardPageHeading from './ui/DashboardPageHeading';
+
+import { ListMusic, Users, Medal, User as UserIcon, Settings } from 'lucide-react';
+
+// Primary nav tabs are static imports so tab switches never hit Suspense
+// (lazy + single boundary unmounts the old route before the new chunk resolves).
+// Secondary / deep routes stay lazy to keep the DashboardRoute chunk lean.
+const AdminPage = lazy(dashboardLazyRouteImport.admin);
+const AccountPage = lazy(dashboardLazyRouteImport.account);
+const PoolHubPage = lazy(dashboardLazyRouteImport.poolHub);
+const NotificationsPage = lazy(dashboardLazyRouteImport.notifications);
+
+function LazyDashboardRoute({ children }) {
+  return <Suspense fallback={<RouteSuspenseFallback />}>{children}</Suspense>;
+}
+
+function navPrefetchHandlers(path) {
+  const keys = DASHBOARD_NAV_PRELOAD_BY_PATH[path];
+  if (!keys?.length) return undefined;
+  const warm = () => prefetchDashboardRoutes(keys);
+  return {
+    onMouseEnter: warm,
+    onFocus: warm,
+    onTouchStart: warm,
+  };
+}
 
 export default function DashboardLayout() {
   const location = useLocation();
@@ -74,8 +88,9 @@ export default function DashboardLayout() {
   const { user, isAdmin } = useAuth();
   const { showDates, showDatesByTour } = useShowCalendar();
   usePendingPoolJoin(showDates);
-  
-  const scrollDirection = useScrollDirection(); 
+  usePrefetchDashboardRoutes(location.pathname);
+
+  const scrollDirection = useScrollDirection();
 
   const [selectedDate, setSelectedDate] = useState(() =>
     getNextShow(FALLBACK_SHOW_DATES).date
@@ -174,7 +189,12 @@ export default function DashboardLayout() {
                 (location.pathname === item.path ||
                   (item.path === '/dashboard' && location.pathname === '/dashboard/')));
             return (
-              <Link key={item.name} to={item.path} className={`flex items-center gap-3 rounded-xl px-4 py-3 font-bold transition-all ${isActive ? 'bg-brand-primary/10 text-brand-primary' : 'text-content-secondary hover:bg-surface-inset hover:text-white'}`}>
+              <Link
+                key={item.name}
+                to={item.path}
+                {...navPrefetchHandlers(item.path)}
+                className={`flex items-center gap-3 rounded-xl px-4 py-3 font-bold transition-all ${isActive ? 'bg-brand-primary/10 text-brand-primary' : 'text-content-secondary hover:bg-surface-inset hover:text-white'}`}
+              >
                 {/* Render the Lucide icon instead of text */}
                 <Icon className="w-5 h-5 shrink-0" />
                 {item.name}
@@ -255,57 +275,80 @@ export default function DashboardLayout() {
             <DashboardPageHeading title={meta.layoutDesktopHeading} tone={isWarRoomRoute ? 'warRoom' : 'default'} />
           )}
 
-          <Suspense fallback={<RouteSuspenseFallback />}>
-            <Routes>
-              <Route index element={<PicksPage user={user} selectedDate={selectedDate} />} />
-              <Route
-                path="picks"
-                element={<PicksPage user={user} selectedDate={selectedDate} />}
-              />
-              <Route
-                path="scoring"
-                element={<Navigate to="/dashboard?scoringRules=1" replace />}
-              />
-              <Route
-                path="standings"
-                element={
-                  <StandingsPage
-                    selectedDate={selectedDate}
-                    onSelectShowDate={setSelectedDate}
-                  />
-                }
-              />
-              <Route
-                path="admin"
-                element={<AdminPage user={user} selectedDate={selectedDate} />}
-              />
-              <Route path="profile" element={<ProfileClusterLayout user={user} />}>
-                <Route index element={<ProfilePage />} />
-                <Route path="notifications" element={<NotificationsPage />} />
-                <Route path="account" element={<AccountPage />} />
-              </Route>
-              <Route
-                path="account-security"
-                element={
-                  <Navigate
-                    to={`${PROFILE_CLUSTER_PATHS.account}${location.search}`}
-                    replace
-                  />
-                }
-              />
+          <Routes>
+            <Route index element={<PicksPage user={user} selectedDate={selectedDate} />} />
+            <Route
+              path="picks"
+              element={<PicksPage user={user} selectedDate={selectedDate} />}
+            />
+            <Route
+              path="scoring"
+              element={<Navigate to="/dashboard?scoringRules=1" replace />}
+            />
+            <Route
+              path="standings"
+              element={
+                <StandingsPage
+                  selectedDate={selectedDate}
+                  onSelectShowDate={setSelectedDate}
+                />
+              }
+            />
+            <Route
+              path="admin"
+              element={
+                <LazyDashboardRoute>
+                  <AdminPage user={user} selectedDate={selectedDate} />
+                </LazyDashboardRoute>
+              }
+            />
+            <Route path="profile" element={<ProfileClusterLayout user={user} />}>
+              <Route index element={<ProfilePage />} />
               <Route
                 path="notifications"
                 element={
-                  <Navigate
-                    to={`${PROFILE_CLUSTER_PATHS.notifications}${location.search}`}
-                    replace
-                  />
+                  <LazyDashboardRoute>
+                    <NotificationsPage />
+                  </LazyDashboardRoute>
                 }
               />
-              <Route path="pools" element={<PoolsPage user={user} />} />
-              <Route path="pool/:poolId" element={<PoolHubPage user={user} />} />
-            </Routes>
-          </Suspense>
+              <Route
+                path="account"
+                element={
+                  <LazyDashboardRoute>
+                    <AccountPage />
+                  </LazyDashboardRoute>
+                }
+              />
+            </Route>
+            <Route
+              path="account-security"
+              element={
+                <Navigate
+                  to={`${PROFILE_CLUSTER_PATHS.account}${location.search}`}
+                  replace
+                />
+              }
+            />
+            <Route
+              path="notifications"
+              element={
+                <Navigate
+                  to={`${PROFILE_CLUSTER_PATHS.notifications}${location.search}`}
+                  replace
+                />
+              }
+            />
+            <Route path="pools" element={<PoolsPage user={user} />} />
+            <Route
+              path="pool/:poolId"
+              element={
+                <LazyDashboardRoute>
+                  <PoolHubPage user={user} />
+                </LazyDashboardRoute>
+              }
+            />
+          </Routes>
         </div>
       </main>
 
@@ -332,6 +375,7 @@ export default function DashboardLayout() {
               <Link
                 key={item.name}
                 to={item.path}
+                {...navPrefetchHandlers(item.path)}
                 className={`flex h-[calc(100%-10px)] min-h-0 w-full flex-col items-center justify-center space-y-1 self-center rounded-xl transition-colors ${
                   isActive
                     ? 'text-brand-primary bg-brand-primary/[0.14] ring-1 ring-inset ring-brand-primary/30 shadow-[inset_0_1px_0_0_rgb(255_255_255_/_0.06)]'

--- a/src/app/layout/RootAppShell.jsx
+++ b/src/app/layout/RootAppShell.jsx
@@ -5,6 +5,7 @@ import { useServiceWorkerUpdate } from '../../shared/lib/useServiceWorkerUpdate'
 import AppBackground from '../../shared/ui/AppBackground';
 import RouteSuspenseFallback from '../../shared/ui/RouteSuspenseFallback';
 import UpdateAvailableBanner from '../../shared/ui/UpdateAvailableBanner';
+import { shellTransitionKey } from './model/shellTransitionKey';
 
 /**
  * Global chrome: ambient background + top-level route outlet with enter animation.
@@ -14,16 +15,20 @@ import UpdateAvailableBanner from '../../shared/ui/UpdateAvailableBanner';
  * setup, public profile, pool-invite, etc.), so we only need one boundary at
  * this level. Nested boundaries exist inside `DashboardLayout` for its child
  * pages.
+ *
+ * The enter-animation wrapper uses {@link shellTransitionKey} — not raw
+ * `pathname` — so dashboard tab switches do not remount the lazy route tree.
  */
 export default function RootAppShell() {
   const { pathname } = useLocation();
+  const transitionKey = shellTransitionKey(pathname);
   const { updateAvailable, applyUpdate } = useServiceWorkerUpdate();
 
   return (
     <>
       <AppBackground />
       <div className="relative z-[1] min-h-screen">
-        <div key={pathname} className="min-h-screen animate-page-enter">
+        <div key={transitionKey} className="min-h-screen animate-page-enter">
           <Suspense fallback={<RouteSuspenseFallback />}>
             <Outlet />
           </Suspense>

--- a/src/app/layout/model/dashboardRouteModules.js
+++ b/src/app/layout/model/dashboardRouteModules.js
@@ -1,0 +1,74 @@
+import { isProfileClusterPath } from '../../../shared/config/dashboardRoutes';
+
+/**
+ * Dynamic import factories for **secondary** dashboard routes only.
+ *
+ * Primary nav tabs (Picks, Pools, Standings, Profile) are static imports in
+ * `DashboardLayout` so `<Routes>` tab switches never unmount into an empty
+ * Suspense boundary — Safari shows "Loading…" on every lazy swap otherwise.
+ *
+ * Keep specifiers in sync with `lazy()` usage in `DashboardLayout.jsx`.
+ */
+export const dashboardLazyRouteImport = {
+  admin: () => import('../../../pages/admin/AdminPage'),
+  account: () => import('../../../pages/profile/AccountPage'),
+  poolHub: () => import('../../../pages/pools/PoolHubPage'),
+  notifications: () => import('../../../pages/notifications/NotificationsPage'),
+};
+
+/** Nav path → lazy route keys to warm before navigation. */
+export const DASHBOARD_NAV_PRELOAD_BY_PATH = Object.freeze({
+  '/dashboard/admin': ['admin'],
+});
+
+const started = new Set();
+
+/**
+ * @param {string | string[]} keys
+ */
+export function prefetchDashboardRoutes(keys) {
+  if (typeof window === 'undefined') return;
+  const list = Array.isArray(keys) ? keys : [keys];
+  for (const key of list) {
+    if (started.has(key)) continue;
+    const load = dashboardLazyRouteImport[key];
+    if (!load) continue;
+    started.add(key);
+    load().catch(() => {
+      started.delete(key);
+    });
+  }
+}
+
+/**
+ * @param {string} pathname
+ * @returns {string[]}
+ */
+export function dashboardLazyRouteKeysForPathname(pathname) {
+  const path = pathname.replace(/\/+$/, '') || '/dashboard';
+  if (path.startsWith('/dashboard/pool/')) return ['poolHub'];
+  if (path === '/dashboard/admin') return ['admin'];
+  if (isProfileClusterPath(path)) {
+    const keys = [];
+    if (path.includes('/notifications')) keys.push('notifications');
+    if (path.includes('/account')) keys.push('account');
+    return keys;
+  }
+  return [];
+}
+
+/**
+ * Warm every lazy dashboard route chunk except those already on screen.
+ *
+ * @param {string} pathname
+ */
+export function prefetchIdleDashboardRoutes(pathname) {
+  const exclude = new Set(dashboardLazyRouteKeysForPathname(pathname));
+  const keys = Object.keys(dashboardLazyRouteImport).filter((key) => !exclude.has(key));
+  prefetchDashboardRoutes(keys);
+}
+
+/** Eagerly warm all lazy dashboard chunks (secondary routes). */
+export function prefetchAllLazyDashboardRoutes() {
+  prefetchDashboardRoutes(Object.keys(dashboardLazyRouteImport));
+}

--- a/src/app/layout/model/dashboardRouteModules.test.js
+++ b/src/app/layout/model/dashboardRouteModules.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DASHBOARD_NAV_PRELOAD_BY_PATH,
+  dashboardLazyRouteImport,
+  dashboardLazyRouteKeysForPathname,
+} from './dashboardRouteModules';
+
+describe('dashboardRouteModules', () => {
+  it('defines lazy import factories only for secondary dashboard routes', () => {
+    expect(Object.keys(dashboardLazyRouteImport).sort()).toEqual(
+      ['account', 'admin', 'notifications', 'poolHub'].sort()
+    );
+  });
+
+  it('maps admin nav to preload keys', () => {
+    expect(DASHBOARD_NAV_PRELOAD_BY_PATH['/dashboard/admin']).toEqual(['admin']);
+  });
+
+  it('derives active lazy route keys from pathname', () => {
+    expect(dashboardLazyRouteKeysForPathname('/dashboard/pools')).toEqual([]);
+    expect(dashboardLazyRouteKeysForPathname('/dashboard/pool/abc123')).toEqual(['poolHub']);
+    expect(dashboardLazyRouteKeysForPathname('/dashboard/profile/account')).toEqual(['account']);
+  });
+});

--- a/src/app/layout/model/shellTransitionKey.js
+++ b/src/app/layout/model/shellTransitionKey.js
@@ -1,0 +1,18 @@
+/**
+ * Stable React key for `RootAppShell`'s enter-animation wrapper.
+ *
+ * Must not change on nested navigations within the same top-level route
+ * (e.g. `/dashboard` → `/dashboard/profile`). A pathname-level key remounts
+ * lazy route trees and re-triggers `<Suspense>` — Safari tab switches then
+ * hang on the shared "Loading…" fallback.
+ *
+ * @param {string} pathname
+ * @returns {string}
+ */
+export function shellTransitionKey(pathname) {
+  const path = (pathname || '').replace(/\/+$/, '') || '/';
+  if (path.startsWith('/dashboard')) return '/dashboard';
+  if (path.startsWith('/join/')) return '/join/:code';
+  if (path.startsWith('/user/')) return '/user/:userId';
+  return path;
+}

--- a/src/app/layout/model/shellTransitionKey.test.js
+++ b/src/app/layout/model/shellTransitionKey.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { shellTransitionKey } from './shellTransitionKey';
+
+describe('shellTransitionKey', () => {
+  it('keeps dashboard nested paths on one key', () => {
+    expect(shellTransitionKey('/dashboard')).toBe('/dashboard');
+    expect(shellTransitionKey('/dashboard/')).toBe('/dashboard');
+    expect(shellTransitionKey('/dashboard/profile')).toBe('/dashboard');
+    expect(shellTransitionKey('/dashboard/profile/account')).toBe('/dashboard');
+    expect(shellTransitionKey('/dashboard/pools')).toBe('/dashboard');
+    expect(shellTransitionKey('/dashboard/pool/abc123')).toBe('/dashboard');
+  });
+
+  it('changes key across top-level routes', () => {
+    expect(shellTransitionKey('/')).not.toBe(shellTransitionKey('/dashboard'));
+    expect(shellTransitionKey('/how-it-works')).not.toBe(shellTransitionKey('/privacy'));
+  });
+
+  it('groups pool invite deep links', () => {
+    expect(shellTransitionKey('/join/POOL1')).toBe('/join/:code');
+    expect(shellTransitionKey('/join/abc/')).toBe('/join/:code');
+  });
+});

--- a/src/app/layout/model/usePrefetchDashboardRoutes.js
+++ b/src/app/layout/model/usePrefetchDashboardRoutes.js
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+import {
+  prefetchAllLazyDashboardRoutes,
+  prefetchIdleDashboardRoutes,
+} from './dashboardRouteModules';
+
+/**
+ * After the dashboard shell mounts, prefetch secondary (lazy) route chunks.
+ * Primary nav tabs are static imports — no Suspense on tab switch.
+ */
+export function usePrefetchDashboardRoutes(pathname) {
+  useEffect(() => {
+    prefetchAllLazyDashboardRoutes();
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const run = () => prefetchIdleDashboardRoutes(pathname);
+
+    if (typeof window.requestIdleCallback === 'function') {
+      const id = window.requestIdleCallback(run, { timeout: 1500 });
+      return () => window.cancelIdleCallback(id);
+    }
+
+    const timer = window.setTimeout(run, 200);
+    return () => window.clearTimeout(timer);
+  }, [pathname]);
+}

--- a/src/features/picks/api/picksApi.js
+++ b/src/features/picks/api/picksApi.js
@@ -11,6 +11,7 @@ import {
 } from 'firebase/firestore';
 
 import { db } from '../../../shared/lib/firebase';
+import { hasNonEmptyPicksObject } from '../model/pickSubmission';
 
 /** Firestore rejects `undefined` anywhere in document data; strip from shallow objects. */
 function omitUndefinedShallow(record) {
@@ -26,15 +27,6 @@ export function getPickDocumentId(selectedDate, userId) {
 /**
  * Load the user's pick map for a show (field id → song string).
  */
-function hasNonEmptyPicksObject(picks) {
-  if (picks == null || typeof picks !== 'object' || Array.isArray(picks)) {
-    return false;
-  }
-  return Object.values(picks).some(
-    (v) => v != null && String(v).trim() !== ''
-  );
-}
-
 export async function fetchPickDoc(selectedDate, userId) {
   if (!userId || !selectedDate) return {};
 

--- a/src/features/picks/index.js
+++ b/src/features/picks/index.js
@@ -7,4 +7,9 @@ export { default as PicksSelfRecapSection } from './ui/PicksSelfRecapSection';
 export { default as usePicksForm } from './model/usePicksForm';
 export { usePicksSelfRecap } from './model/usePicksSelfRecap';
 export { useNextShowPicksStatus } from './model/useNextShowPicksStatus';
+export {
+  hasNonEmptyPicksObject,
+  pickEntryHasSubmission,
+  userHasSubmittedPickEntry,
+} from './model/pickSubmission';
 export { useSetlistLockToast } from './model/useSetlistLockToast';

--- a/src/features/picks/model/pickSubmission.js
+++ b/src/features/picks/model/pickSubmission.js
@@ -1,0 +1,32 @@
+import { FORM_FIELDS } from '../../../shared/data/gameConfig';
+
+export function hasNonEmptyPicksObject(picks) {
+  if (picks == null || typeof picks !== 'object' || Array.isArray(picks)) {
+    return false;
+  }
+  return Object.values(picks).some(
+    (v) => v != null && String(v).trim() !== ''
+  );
+}
+
+/** Whether a picks query row (or flat legacy doc) counts as submitted. */
+export function pickEntryHasSubmission(entry) {
+  if (!entry || typeof entry !== 'object') return false;
+  if (entry.picks && typeof entry.picks === 'object') {
+    return hasNonEmptyPicksObject(entry.picks);
+  }
+  return FORM_FIELDS.some((f) => {
+    const v = entry[f.id];
+    return v != null && String(v).trim() !== '';
+  });
+}
+
+/**
+ * @param {Array<{ userId?: string, uid?: string } & Record<string, unknown>> | null | undefined} pickEntries
+ * @param {string | null | undefined} userId
+ */
+export function userHasSubmittedPickEntry(pickEntries, userId) {
+  if (!userId || !Array.isArray(pickEntries)) return false;
+  const entry = pickEntries.find((p) => (p.userId || p.uid) === userId);
+  return pickEntryHasSubmission(entry);
+}

--- a/src/features/picks/model/pickSubmission.test.js
+++ b/src/features/picks/model/pickSubmission.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  hasNonEmptyPicksObject,
+  pickEntryHasSubmission,
+  userHasSubmittedPickEntry,
+} from './pickSubmission';
+
+describe('pickSubmission', () => {
+  it('detects non-empty picks maps', () => {
+    expect(hasNonEmptyPicksObject({ opener: 'Tweezer' })).toBe(true);
+    expect(hasNonEmptyPicksObject({ opener: '  ' })).toBe(false);
+    expect(hasNonEmptyPicksObject(null)).toBe(false);
+  });
+
+  it('reads submission from pick query rows', () => {
+    const rows = [
+      { userId: 'u1', picks: { opener: 'Fluffhead' } },
+      { userId: 'u2', picks: {} },
+    ];
+    expect(userHasSubmittedPickEntry(rows, 'u1')).toBe(true);
+    expect(userHasSubmittedPickEntry(rows, 'u2')).toBe(false);
+    expect(userHasSubmittedPickEntry(rows, 'u3')).toBe(false);
+  });
+
+  it('supports legacy flat pick fields on entries', () => {
+    expect(pickEntryHasSubmission({ userId: 'u1', s1o: 'Wilson' })).toBe(true);
+  });
+});

--- a/src/features/picks/model/useNextShowPicksStatus.js
+++ b/src/features/picks/model/useNextShowPicksStatus.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useAuth } from '../../auth';
 import { hasSubmittedPicksForShow } from '../api/picksApi';
@@ -15,18 +15,21 @@ export function useNextShowPicksStatus(showDate) {
   const [hasSubmittedPicksForNextShow, setHasSubmittedPicksForNextShow] =
     useState(false);
   const [error, setError] = useState(null);
+  const requestIdRef = useRef(0);
 
   useEffect(() => {
+    const requestId = ++requestIdRef.current;
+
     if (authLoading) {
       setLoading(true);
-      return;
+      return undefined;
     }
 
     let cancelled = false;
 
     const run = async () => {
       if (!showDate || !user?.uid) {
-        if (!cancelled) {
+        if (!cancelled && requestId === requestIdRef.current) {
           setHasSubmittedPicksForNextShow(false);
           setError(null);
           setLoading(false);
@@ -34,17 +37,19 @@ export function useNextShowPicksStatus(showDate) {
         return;
       }
 
-      setLoading(true);
-      setError(null);
+      if (requestId === requestIdRef.current) {
+        setLoading(true);
+        setError(null);
+      }
 
       try {
         const submitted = await hasSubmittedPicksForShow(showDate, user.uid);
-        if (!cancelled) {
+        if (!cancelled && requestId === requestIdRef.current) {
           setHasSubmittedPicksForNextShow(submitted);
         }
       } catch (err) {
         console.error('useNextShowPicksStatus:', err);
-        if (!cancelled) {
+        if (!cancelled && requestId === requestIdRef.current) {
           setHasSubmittedPicksForNextShow(false);
           setError(
             err?.message != null
@@ -53,7 +58,7 @@ export function useNextShowPicksStatus(showDate) {
           );
         }
       } finally {
-        if (!cancelled) {
+        if (!cancelled && requestId === requestIdRef.current) {
           setLoading(false);
         }
       }

--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../../auth';
-import { useNextShowPicksStatus } from '../../picks';
+import { userHasSubmittedPickEntry } from '../../picks';
 import { useUserPools } from '../../pools';
 import { useShowCalendar } from '../../show-calendar';
 import { FORM_FIELDS } from '../../../shared/data/gameConfig';
@@ -81,14 +81,14 @@ export function useStandingsScreen(selectedDate, options = {}) {
   );
   const { openScoringRules } = useScoringRulesModal();
 
-  // Only fetch pick-status for the "Now picking" active-show card — NEXT is
-  // the only status where users can still enter picks (see timeLogic.js).
-  // For PAST / LIVE, picks are already in `picks` and no extra read is
-  // needed; for FUTURE (a listed show beyond NEXT), picks aren't yet open.
-  const picksStatusTarget =
-    view === 'show' && showStatus === 'NEXT' ? selectedDate : undefined;
-  const { hasSubmittedPicksForNextShow, loading: picksStatusLoading } =
-    useNextShowPicksStatus(picksStatusTarget);
+  const isNextShowView = view === 'show' && showStatus === 'NEXT';
+  // Reuse standings picks already loaded for this date — avoids a redundant
+  // getDoc that can race/cancel on Safari tab switches (#505 follow-up).
+  const hasSubmittedPicksForNextShow =
+    isNextShowView && user?.uid
+      ? userHasSubmittedPickEntry(picks, user.uid)
+      : false;
+  const picksStatusLoading = isNextShowView && loading;
 
   useStandingsLeaderboardView(selectedDate, loading, showDates);
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "installCommand": "npm ci",
   "functions": {
     "api/invite/[code].js": {
       "includeFiles": "dist/index.html"

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "bash scripts/vercel-should-build.sh",
   "functions": {
     "api/invite/[code].js": {
       "includeFiles": "dist/index.html"


### PR DESCRIPTION
## Summary
- Promote `staging` → `main` at **v1.18.7** (production baseline **v1.18.3** auth hotfix).
- Delivers Safari dashboard tab navigation fix (#505) and Standings picks-status spinner fix (#506).
- Also rolls up: Dependabot pause + PR queue stabilization (1.18.5), Vercel install cache restore (1.18.4), build/CI Dependabot SemVer exempt.

## Test plan
- [x] #505 merged to staging — Safari tab switch no longer remounts lazy dashboard tree
- [x] #506 merged to staging — NEXT show card picks-status no longer stuck
- [x] `verify` on staging PRs
- [ ] Post-merge: smoke Safari sign-in + dashboard tab switch on production
- [ ] Post-merge: tag `v1.18.7` + GitHub Release (human step)
- [ ] Follow-up: #507 — React Query cache + decouple standings spinners (not in this promote)


Made with [Cursor](https://cursor.com)