### PR TITLE
feat(comms): Sprint 6 wrap — v1.18.8 in-app CTAs, email branding, Dependabot (#504)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,8 @@
 # Grouped PRs reduce noise; triage + first-run runbook: docs/DEPENDABOT_OPERATIONS.md
 # PRs target `staging` (repo PR base), not `main`.
 #
-# PAUSED 2026-07-04: open-pull-requests-limit 0 after v1.18 enablement-wave flood.
-# Human re-enable: restore limits (5/5/3) per docs/DEPENDABOT_OPERATIONS.md § Re-enabling.
+# Re-enabled 2026-07-05 (Sprint 6 wrap, #504) after v1.18 enablement-wave ops reset.
+# Triage: docs/DEPENDABOT_OPERATIONS.md — max 1–2 merges/week; never batch-rebase all PRs.
 version: 2
 updates:
   - package-ecosystem: npm
@@ -12,7 +12,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 5
     labels:
       - dependencies
       - skip-version-bump
@@ -28,7 +28,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 5
     labels:
       - dependencies
       - skip-version-bump
@@ -43,7 +43,7 @@ updates:
     target-branch: "staging"
     schedule:
       interval: monthly
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 3
     labels:
       - dependencies
       - skip-version-bump

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.18.8] — 2026-07-05
+
+### Changed
+- **Dependabot re-enabled (#504)** — restore `open-pull-requests-limit` to 5/5/3 after v1.18 enablement-wave ops reset; triage per `docs/DEPENDABOT_OPERATIONS.md`.
+- **Email branding (#498)** — keep large vinyl in-body logo (`web-app-manifest-512x512.png`); centralize URLs in `comms/emailBranding.cjs`; document inbox sender badge (BIMI/DMARC) separately from in-body HTML.
+- **In-app comms CTAs** — `tour-countdown` and `tour-engagement-reminder` use contextual picks deep links instead of generic “Open the app”; document in-app vs push/email CTA rules in `TRIGGER_CATALOG.md`.
+
+### Added
+- **`comms/emailBranding.cjs`** — shared in-body email logo URL helper.
+- **`docs/comms-triggers/EMAIL_INBOX_BADGE.md`** — runbook for inbox sender badge (BIMI/DMARC) vs in-body logo (#498).
+- **`scripts/send-local-email-preview.mjs`** — local Resend preview helper for branded email shells.
+- **`vercel.json`** — rewrite `/favicon.ico` → `/favicon/favicon.ico` for domain-root favicon fetchers.
+
+---
+
 ## [1.18.7] — 2026-07-04
 
 ### Fixed

--- a/comms/emailBranding.cjs
+++ b/comms/emailBranding.cjs
@@ -1,0 +1,38 @@
+'use strict';
+
+/**
+ * Email branding assets — two layers, do not conflate:
+ *
+ * 1. **In-body header** (`EMAIL_IN_BODY_LOGO_PATH`) — large vinyl mark inside the opened
+ *    email HTML. Controlled by `buildEmailInBodyLogoUrl()` in templates.
+ *
+ * 2. **Inbox sender badge** — small avatar beside the sender name in Gmail/Apple Mail list
+ *    views. NOT driven by the HTML `<img>`. Requires BIMI + DMARC (primary) and/or domain
+ *    favicon at the From host (fallback). See docs/comms-triggers/EMAIL_INBOX_BADGE.md (#498).
+ */
+const EMAIL_IN_BODY_LOGO_PATH = '/favicon/web-app-manifest-512x512.png';
+/** Hint for BIMI / domain-favicon ops — not injected into email HTML. */
+const EMAIL_INBOX_BADGE_FAVICON_PATH = '/favicon/favicon-96x96.png';
+const DEFAULT_SITE_URL = 'https://www.setlistpickem.com';
+
+/**
+ * Absolute URL for the large in-body header logo (opened email).
+ * @param {string} [siteUrl]
+ * @returns {string}
+ */
+function buildEmailInBodyLogoUrl(siteUrl = DEFAULT_SITE_URL) {
+  const base = String(siteUrl || DEFAULT_SITE_URL).replace(/\/+$/, '');
+  return `${base}${EMAIL_IN_BODY_LOGO_PATH}`;
+}
+
+/** @deprecated Use buildEmailInBodyLogoUrl — kept for call-site stability. */
+function buildEmailLogoUrl(siteUrl = DEFAULT_SITE_URL) {
+  return buildEmailInBodyLogoUrl(siteUrl);
+}
+
+module.exports = {
+  EMAIL_IN_BODY_LOGO_PATH,
+  EMAIL_INBOX_BADGE_FAVICON_PATH,
+  buildEmailInBodyLogoUrl,
+  buildEmailLogoUrl,
+};

--- a/docs/DEPENDABOT_OPERATIONS.md
+++ b/docs/DEPENDABOT_OPERATIONS.md
@@ -24,7 +24,7 @@ This is **not** recurring weekly noise — it was a **one-time enablement avalan
 
 | Setting | Value | Why |
 |---------|-------|-----|
-| `open-pull-requests-limit` | **0** (all ecosystems) | Paused until human sets limits back |
+| `open-pull-requests-limit` | **5** root/functions, **3** actions (re-enabled 2026-07-05, #504) | Was **0** during ops reset; triage max 1–2 merges/week |
 | SemVer gate | Skips `dependabot/*` + `skip-version-bump` label | Deps PRs never bump `package.json` |
 | Vercel | `ignoreCommand` → `scripts/vercel-should-build.sh` | No SPA preview for Actions/functions-only bumps |
 

--- a/docs/comms-triggers/EMAIL_INBOX_BADGE.md
+++ b/docs/comms-triggers/EMAIL_INBOX_BADGE.md
@@ -1,0 +1,89 @@
+# Email inbox sender badge (BIMI / domain favicon)
+
+**Issue:** [#498](https://github.com/pat792/set-picks/issues/498)
+
+## Two different logos (do not conflate)
+
+| Layer | What you see | Controlled by | Asset |
+|-------|--------------|---------------|-------|
+| **In-body header** | Large vinyl mark when the email is **open** | HTML `<img>` in `MarketingLayout` / `buildBrandedEmailHtml` | `comms/emailBranding.cjs` → `/favicon/web-app-manifest-512x512.png` |
+| **Inbox sender badge** | Small circle beside **Setlist Pick'em** in the **inbox list** | BIMI + DMARC (Gmail), domain favicon fallback — **not** the email template | DNS / certificates (#498 ops) |
+
+**Typical symptom (see QA screenshot):** opened email shows the vinyl logo correctly; inbox list shows a **generic blue person icon**. That means in-body branding works and only the **inbox badge** layer is missing.
+
+Changing the in-body `<img>` URL will **not** fix the inbox circle. Gmail does not use the HTML header image for the list avatar.
+
+---
+
+## In-body logo (working — keep separate)
+
+- Shared helper: `comms/emailBranding.cjs` → `buildEmailInBodyLogoUrl()`
+- Marketing: `emails/src/components/MarketingLayout.jsx`
+- Service comms: `functions/commsEmailWorker.js` → `buildBrandedEmailHtml()`
+- Display size in template: 48×48 CSS pixels; source is the 512×512 vinyl PNG
+
+---
+
+## Inbox badge — what actually fixes the blue circle
+
+### Primary: BIMI (Gmail, Yahoo)
+
+Gmail shows a verified brand mark in the inbox list only when **BIMI** is fully configured:
+
+1. **DMARC** on `setlistpickem.com` at `p=quarantine` or `p=reject`, with SPF/DKIM alignment for `updates@setlistpickem.com` (Resend verified domain).
+2. **BIMI DNS** — publish `default._bimi.setlistpickem.com` TXT referencing an **SVG** logo URL + **VMC** (Verified Mark Certificate from an approved CA).
+3. **Logo asset** — simple square SVG (BIMI spec limits complexity; not the 854 KB `favicon.svg`).
+4. **Enrollment** — register with mailbox providers; propagation can take days.
+
+This is **DNS + certificate ops**, not an app deploy. Track on #498.
+
+### Partial fallback: domain favicon
+
+Some clients (not reliably Gmail) fetch `https://<from-domain>/favicon.ico` when BIMI is absent.
+
+| Check | URL |
+|-------|-----|
+| www (Vercel rewrite) | `https://www.setlistpickem.com/favicon.ico` → `/favicon/favicon.ico` |
+| Nested ICO | `https://www.setlistpickem.com/favicon/favicon.ico` |
+| Apex | `https://setlistpickem.com/favicon.ico` — confirm apex DNS/hosting matches `From` domain |
+
+Candidate badge asset for BIMI prep: `EMAIL_INBOX_BADGE_FAVICON_PATH` in `comms/emailBranding.cjs` (`/favicon/favicon-96x96.png`).
+
+---
+
+## DNS audit commands (human)
+
+```bash
+# DMARC (required before BIMI)
+dig +short TXT _dmarc.setlistpickem.com
+
+# SPF on sending domain
+dig +short TXT setlistpickem.com | grep spf
+
+# BIMI (after VMC obtained)
+dig +short TXT default._bimi.setlistpickem.com
+
+# Favicon reachability
+curl -sI https://www.setlistpickem.com/favicon.ico | head -5
+curl -sI https://setlistpickem.com/favicon.ico | head -5
+```
+
+Resend dashboard: confirm `setlistpickem.com` verified, DKIM active, `updates@setlistpickem.com` sender identity matches DMARC alignment.
+
+---
+
+## QA checklist
+
+- [ ] **Opened email** — large vinyl logo in header (regression guard)
+- [ ] **Gmail inbox list** — brand icon instead of blue person circle (#498 AC)
+- [ ] Gmail web + iOS
+- [ ] Apple Mail inbox list
+- [ ] Service comms from `updates@setlistpickem.com` — same badge
+
+---
+
+## Related
+
+- #456 branded HTML shell (in-body — working)
+- #497 closed as duplicate (mis-scoped in-body bug)
+- `vercel.json` `/favicon.ico` rewrite (domain favicon fallback only)

--- a/docs/comms-triggers/README.md
+++ b/docs/comms-triggers/README.md
@@ -12,6 +12,7 @@ This directory is the **canonical home** for triggered, templated communications
 | [catalog.json](./catalog.json) | Machine-readable trigger specs for agents and future orchestration |
 | [MEASUREMENT_PLAN.md](./MEASUREMENT_PLAN.md) | GA4 comms events, dimensions, funnels |
 | [EXPERIMENT_PLAYBOOK.md](./EXPERIMENT_PLAYBOOK.md) | A/B rules, variant assignment, ship/kill criteria |
+| [EMAIL_INBOX_BADGE.md](./EMAIL_INBOX_BADGE.md) | Inbox sender badge (BIMI/DMARC) vs in-body email logo (#498) |
 | [COMMERCIAL_PHASE3.md](./COMMERCIAL_PHASE3.md) | Sponsor / affiliate / offer gates (Phase 3) |
 
 ## Related repo paths
@@ -28,6 +29,7 @@ This directory is the **canonical home** for triggered, templated communications
 | `users/{uid}/commsInbox/{messageId}` | In-app channel worker (Admin SDK) |
 | `functions/commsPushWorker.js` / `functions/fcmMessagingCore.js` | Push channel worker (FCM) |
 | `functions/commsEmailWorker.js` | Email channel worker (Resend, #442) |
+| `comms/emailBranding.cjs` | Shared in-body email logo URL |
 | `fcm_notification_log` | Shared delivery / dedup log |
 
 ## Delivery model

--- a/docs/comms-triggers/TRIGGER_CATALOG.md
+++ b/docs/comms-triggers/TRIGGER_CATALOG.md
@@ -17,6 +17,18 @@ All production triggers are one of these two. There are no admin-initiated or ma
 
 ---
 
+## In-app vs push/email CTAs
+
+| Channel | User context | CTA pattern |
+|---------|--------------|-------------|
+| **In-app** (`commsInbox`) | Already in the app | Action label + deep link (e.g. `Make picks for show 1` → `/dashboard/picks`). **Never** `Open the app`. |
+| **Push** | Lock screen / notification shade | Short teaser body; tap deep-links into the app (may say "Open the app" in body copy). |
+| **Email** | Mail client | Branded button + plain-text `Open the app: <url>` footer. |
+
+Registry implementation: `src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx`.
+
+---
+
 ## Variables — common pool
 
 Every template draws from this shared set. Each trigger declares the subset it uses.

--- a/docs/comms-triggers/catalog.json
+++ b/docs/comms-triggers/catalog.json
@@ -44,6 +44,8 @@
       "implementationModule": "functions/commsEventAdapters.js",
       "githubIssue": null,
       "variants": ["t10", "t5", "t3", "t1"],
+      "inAppDeepLink": "/dashboard/picks",
+      "note": "In-app CTA label varies by days_remaining (see TRIGGER_CATALOG.md §2). Push/email use open-app phrasing.",
       "variables": [
         { "name": "handle", "source": "users/{uid}.handle", "fallback": "Picker" },
         { "name": "tour_name", "source": "tour metadata", "fallback": null },
@@ -257,6 +259,7 @@
       "prefKeys": ["lifecycle"],
       "dedupKey": "tour_engage:{uid}:{tourId}",
       "templateId": "tour-engagement-reminder",
+      "inAppDeepLink": "/dashboard/picks",
       "implementationModule": "functions/commsEventAdapters.js",
       "githubIssue": null,
       "variables": [

--- a/emails/src/components/MarketingLayout.jsx
+++ b/emails/src/components/MarketingLayout.jsx
@@ -11,6 +11,8 @@ import {
   Text,
 } from "@react-email/components";
 
+import { buildEmailLogoUrl } from "../../../comms/emailBranding.cjs";
+
 const styles = {
   body: {
     margin: 0,
@@ -72,7 +74,7 @@ export function MarketingLayout({
   children,
 }) {
   const base = siteUrl.replace(/\/+$/, "");
-  const logoUrl = `${base}/favicon/web-app-manifest-512x512.png`;
+  const logoUrl = buildEmailLogoUrl(base);
   const prefsUrl = settingsUrl || `${base}/dashboard/profile/notifications`;
 
   return (

--- a/functions/commsEmailWorker.js
+++ b/functions/commsEmailWorker.js
@@ -36,6 +36,7 @@
 const { isEmailSuppressed } = require("./commsEmailSuppression");
 const { buildOneClickUnsubscribeUrl } = require("./commsEmailUnsubscribe");
 const { reserveEmailDailyCapSlot } = require("./commsEmailDailyCap");
+const { buildEmailLogoUrl } = require("../comms/emailBranding.cjs");
 
 const DEFAULT_FROM = "Setlist Pick'em <updates@setlistpickem.com>";
 const DEFAULT_SITE_URL = "https://www.setlistpickem.com";
@@ -147,7 +148,7 @@ function stripRedundantCtaLine(text) {
  */
 function buildBrandedEmailHtml({ siteUrl, bodyText, ctaUrl, settingsUrl }) {
   const base = (siteUrl || DEFAULT_SITE_URL).replace(/\/+$/, "");
-  const logoUrl = `${base}/favicon/web-app-manifest-512x512.png`;
+  const logoUrl = buildEmailLogoUrl(base);
   // A stack of several short, single-line <p> blocks is a well-known trigger
   // for Gmail's content-folding heuristic (it renders a clickable "..." pill
   // in place of the text, which most recipients never think to expand). A

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.18.7",
+  "version": "1.18.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/send-local-email-preview.mjs
+++ b/scripts/send-local-email-preview.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Render email HTML from **local** sources and optionally send via Resend.
+ *
+ * Usage:
+ *   node scripts/send-local-email-preview.mjs                    # render only (opens HTML)
+ *   node scripts/send-local-email-preview.mjs --send pat@you.com # render + send (needs RESEND_API_KEY)
+ *   node scripts/send-local-email-preview.mjs --service          # service branded shell sample
+ *
+ * RESEND_API_KEY: export in shell or add to .env (this script loads .env).
+ * Inbox sender badge (Gmail list avatar) is NOT controlled by HTML — see docs/comms-triggers/EMAIL_INBOX_BADGE.md.
+ */
+
+import { createRequire } from 'node:module';
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const require = createRequire(import.meta.url);
+
+// Load .env (gitignored) without overwriting existing env.
+const envPath = resolve(root, '.env');
+try {
+  for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+    const m = line.match(/^([^#=]+)=(.*)$/);
+    if (!m) continue;
+    const key = m[1].trim();
+    if (process.env[key] == null || process.env[key] === '') {
+      process.env[key] = m[2].trim().replace(/^"|"$/g, '');
+    }
+  }
+} catch {
+  // optional
+}
+
+const args = process.argv.slice(2);
+const sendTo = args.includes('--send') ? args[args.indexOf('--send') + 1] : null;
+const serviceOnly = args.includes('--service');
+
+const outDir = resolve(root, 'emails/preview');
+mkdirSync(outDir, { recursive: true });
+
+const siteUrl = 'https://www.setlistpickem.com';
+
+/** @type {{ label: string, file: string, subject: string, html: string, text: string }[]} */
+const variants = [];
+
+if (!serviceOnly) {
+  execSync('npm run build', { cwd: resolve(root, 'emails'), stdio: 'inherit' });
+  const bundlePath = resolve(root, 'functions/emails/renderSummerTour2026Launch.cjs');
+  delete require.cache[require.resolve(bundlePath)];
+  const { renderSummerTour2026LaunchEmail } = require(bundlePath);
+  const { html, text, subject } = await renderSummerTour2026LaunchEmail({
+    greetingName: 'Pat',
+    audienceSegment: 'sphere_alum',
+    openerLabel: 'Tuesday, July 7',
+    inviteCode: 'DEMO1',
+    siteUrl,
+    settingsUrl: `${siteUrl}/dashboard/profile/notifications`,
+  });
+  variants.push({
+    label: 'Marketing — Summer Tour 2026 (local render)',
+    file: 'local-marketing-summer-tour.html',
+    subject: subject || "Bring your crew → Summer Tour starts Tuesday, July 7.",
+    html,
+    text: text || 'Summer Tour preview (see HTML)',
+  });
+}
+
+{
+  const { buildBrandedEmailHtml } = require(resolve(root, 'functions/commsEmailWorker.js'));
+  const html = buildBrandedEmailHtml({
+    siteUrl,
+    bodyText: [
+      'Hi Pat,',
+      '',
+      'This is a local preview of the service comms branded shell (account welcome, recap, etc.).',
+      '',
+      '— Setlist Pick\'em',
+    ].join('\n'),
+    ctaUrl: `${siteUrl}/dashboard`,
+    settingsUrl: `${siteUrl}/dashboard/profile/notifications`,
+  });
+  variants.push({
+    label: 'Service — branded shell (local render)',
+    file: 'local-service-branded-shell.html',
+    subject: '[LOCAL PREVIEW] Setlist Pick\'em branded service email',
+    html,
+    text: 'Local preview of service comms shell.',
+  });
+}
+
+for (const v of variants) {
+  const outFile = resolve(outDir, v.file);
+  writeFileSync(outFile, v.html, 'utf8');
+  console.log(`✓ ${v.label}\n  ${outFile}`);
+  if (v.html.includes('web-app-manifest-512x512.png')) {
+    console.log('  Logo: web-app-manifest-512x512.png (large vinyl in-body)');
+  }
+}
+
+const primary = resolve(outDir, variants[0].file);
+if (!sendTo && process.platform === 'darwin') {
+  execSync(`open "${primary}"`);
+}
+
+const resendKey = process.env.RESEND_API_KEY;
+if (sendTo) {
+  if (!resendKey || !resendKey.startsWith('re_')) {
+    console.error('\n✗ --send requires RESEND_API_KEY in .env or environment.');
+    console.error('  Get it from Firebase Secret Manager / Resend dashboard, then:');
+    console.error('  RESEND_API_KEY=re_xxx node scripts/send-local-email-preview.mjs --send pat@road2media.com');
+    process.exit(1);
+  }
+  const pick = variants[0];
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${resendKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: "Setlist Pick'em <updates@setlistpickem.com>",
+      to: [sendTo],
+      subject: `[LOCAL PREVIEW] ${pick.subject}`,
+      html: pick.html,
+      text: pick.text,
+    }),
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    console.error('\n✗ Resend error:', res.status, JSON.stringify(json, null, 2));
+    process.exit(1);
+  }
+  console.log(`\n✓ Sent to ${sendTo} (id: ${json.id || 'unknown'})`);
+  console.log('  Note: inbox list badge may still show blue circle until BIMI (#498).');
+}

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
@@ -60,7 +60,26 @@ function venueLine(payload, { dateKey = 'show_date', venueKey = 'venue_name', ci
   return place || payload?.[dateKey] || '';
 }
 
-const DASHBOARD_CTA = { label: 'Open the app', href: '/dashboard' };
+const PICKS_HREF = '/dashboard/picks';
+
+/**
+ * In-app CTA for tour countdown — varies by `days_remaining` (TRIGGER_CATALOG.md §2).
+ * Push/email may use "open the app" phrasing; in-app users are already in the app.
+ * @param {Record<string, unknown>} p
+ */
+function tourCountdownInAppCta(p) {
+  const days = Number(p.days_remaining);
+  if (days === 10) {
+    return { label: 'View upcoming shows', href: PICKS_HREF };
+  }
+  if (days === 5 || days === 3) {
+    return { label: 'Make picks for show 1', href: PICKS_HREF };
+  }
+  if (days === 1) {
+    return { label: 'Lock in your picks', href: PICKS_HREF };
+  }
+  return { label: 'Make your picks', href: PICKS_HREF };
+}
 
 /**
  * @typedef {object} CommsTemplateEntry
@@ -128,7 +147,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
             : 'Get your picks ready before the first downbeat.',
           `Picks lock at ${p.lock_time_local || '7:55 PM'} local on show night — don't get shut out.`,
         ],
-        cta: DASHBOARD_CTA,
+        cta: tourCountdownInAppCta(p),
       };
     },
     samples: [
@@ -437,7 +456,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           ? `Next up: ${venueLine(p, { dateKey: 'next_show_date', venueKey: 'next_show_venue', cityKey: '__none' })}.`
           : '',
       ].filter(Boolean),
-      cta: DASHBOARD_CTA,
+      cta: { label: 'Make picks for next show', href: PICKS_HREF },
     }),
     samples: [
       {

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.test.js
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.test.js
@@ -61,6 +61,25 @@ describe('comms template registry', () => {
     }
   });
 
+  it('tour countdown in-app CTA varies by days_remaining (never "Open the app")', () => {
+    const entry = getCommsTemplateEntry('tour-countdown');
+    expect(entry.build({ days_remaining: 10 }).cta).toEqual({
+      label: 'View upcoming shows',
+      href: '/dashboard/picks',
+    });
+    expect(entry.build({ days_remaining: 5 }).cta.label).toBe('Make picks for show 1');
+    expect(entry.build({ days_remaining: 3 }).cta.label).toBe('Make picks for show 1');
+    expect(entry.build({ days_remaining: 1 }).cta.label).toBe('Lock in your picks');
+  });
+
+  it('tour engagement reminder uses in-app picks CTA (not "Open the app")', () => {
+    const entry = getCommsTemplateEntry('tour-engagement-reminder');
+    expect(entry.build({}).cta).toEqual({
+      label: 'Make picks for next show',
+      href: '/dashboard/picks',
+    });
+  });
+
   it('maps templateId → catalog triggerId', () => {
     expect(triggerIdForTemplate('show-recap')).toBe('show_recap');
     expect(triggerIdForTemplate('account-welcome')).toBe('account_welcome');

--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,10 @@
       "destination": "https://set-picks.firebaseapp.com/__/auth/$1"
     },
     {
+      "source": "/favicon.ico",
+      "destination": "/favicon/favicon.ico"
+    },
+    {
       "source": "/join/:code",
       "destination": "/api/invite/:code"
     },


### PR DESCRIPTION
## Summary

- **Closes #504** — re-enable Dependabot (`open-pull-requests-limit` 5/5/3) after v1.18 enablement-wave ops reset; update `DEPENDABOT_OPERATIONS.md`.
- **In-app comms CTAs** — `tour-countdown` and `tour-engagement-reminder` use contextual picks deep links (`/dashboard/picks`) instead of generic “Open the app”; document in-app vs push/email CTA rules in `TRIGGER_CATALOG.md` + `catalog.json`.
- **Email branding prep (#498)** — `comms/emailBranding.cjs` centralizes in-body logo URL; `EMAIL_INBOX_BADGE.md` documents BIMI/DMARC vs HTML logo; `send-local-email-preview.mjs` for local Resend previews.
- **`vercel.json`** — rewrite `/favicon.ico` → `/favicon/favicon.ico`.
- **PATCH bump** to `1.18.8` + CHANGELOG.
- Includes **staging ← main sync** promote commit (`v1.18.7` Safari fixes) so `staging` matches released `main`.

## Test plan

- [x] `npm test` (272 passed)
- [ ] `npm run verify` (lint + dashboard meta/ui scripts)
- [ ] `/comms-preview` — tour-countdown T-10/5/3/1 and tour-engagement CTAs are picks deep links (no “Open the app”)
- [ ] After deploy: `https://www.setlistpickem.com/favicon.ico` resolves (Vercel rewrite)
- [ ] Post-merge: watch first Dependabot wave; triage max 1–2 merges/week per runbook


Made with [Cursor](https://cursor.com)