### PR TITLE
Cloud dev environment setup: verify + correct AGENTS.md caveats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,16 +5,18 @@
 ### Environment
 
 - **Node.js 24** is needed for Cloud Functions (`engines.node: "24"`). `nvm install 24` provides it. Caveat: a daemon-managed `node` at `/exec-daemon/node` (Node 22) sits ahead of `nvm` on `PATH`, so a bare `node` is v22. For Functions work prepend the nvm bin first: `export PATH="$HOME/.nvm/versions/node/v24.17.0/bin:$PATH"`. Root web app (Vite 4 / Vitest) runs fine on Node 22 too; only deploy/Functions strictly want 24.
-- **Package manager:** npm (lockfile: `package-lock.json`). Two install targets: root (`/workspace`) and `functions/` — both have their own lockfile.
+- **Package manager:** npm (lockfile: `package-lock.json`). Three install targets, each with its own lockfile: root (`/workspace`), `functions/`, and `emails/`. The Cloud update script runs `npm ci` in all three.
+- **Node for functions:** `cd functions && npm test` runs fine under the VM-default Node 22, but deploy (`engines.node: "24"`) wants Node 24 — see the version caveat below.
+- **Playwright browser:** the Chromium binary is **not** preinstalled. Anything that drives a real browser (`npm run qa:cache`, `npm run qa:chunks`, ad-hoc Playwright scripts) needs `npx playwright install chromium` first, or it fails with a missing-executable error.
 - **`.env`** is gitignored. Copy `.env.example` to `.env` for local dev. The `VITE_FIREBASE_*` config plus `QA_TEST_EMAIL` / `QA_TEST_PASSWORD` are injected as Cloud Agent secrets (env vars) and Vite picks them up automatically — you do not need to add them to `.env`.
 
 ### Running the application
 
 - **Dev server:** `npm run dev` — Vite on `http://localhost:5173` (`strictPort: true`; free that port or it will fail).
 - The app connects to the **remote Firebase project** (Firestore, Auth, Storage). There is no local emulator-first workflow for the SPA.
-- **App Check is NOT actually disabled in dev.** `src/shared/lib/firebaseAppCheck.js` sets `self.FIREBASE_APPCHECK_DEBUG_TOKEN = true`, which makes Firebase mint a fresh, *unregistered* debug token → the App Check exchange returns **403** and Firestore/Auth-backed flows (sign-in, sign-up, picks, pools) fail. To make signed-in flows work on localhost, seed the **pre-registered** debug token (`38422efd-029f-45b4-b028-7cf7fcaeeffc`, from `docs/TESTING.md`) into IndexedDB once, then reload: load the page, then in DevTools console run
-  `indexedDB.open('firebase-app-check-database',1).onsuccess=e=>{const tx=e.target.result.transaction('firebase-app-check-store','readwrite');tx.objectStore('firebase-app-check-store').put({compositeKey:'debug-token',value:'38422efd-029f-45b4-b028-7cf7fcaeeffc'});}`
-  and reload. The token persists in that browser profile. (The `true` branch reuses an IndexedDB-stored token if one exists, so seeding wins.)
+- **App Check works out-of-the-box on the localhost dev server — no IndexedDB seeding needed.** `src/shared/lib/firebaseAppCheck.js` now sets `self.FIREBASE_APPCHECK_DEBUG_TOKEN` to the **pre-registered** UUID `38422efd-029f-45b4-b028-7cf7fcaeeffc` (not `true`) whenever `import.meta.env.DEV`, so signed-in flows (sign-in, picks, pools) succeed on `http://localhost:5173` with no extra setup. (Verified: signed in with the QA account and locked in picks against prod Firestore straight from `npm run dev`.)
+- **Production/`vite preview` builds strip that DEV branch**, so headless Playwright against a preview must inject the token itself before the bundle runs (`self.FIREBASE_APPCHECK_DEBUG_TOKEN = '38422efd-...'` via `context.addInitScript`, as `scripts/qa/_lib/qaBrowserInit.mjs` does — set `QA_APPCHECK_DEBUG_TOKEN` to the registered UUID for the QA runners).
+- **Browser automation gotcha:** once signed in, Firestore keeps a long-lived WebChannel open, so `page.goto(url, { waitUntil: 'networkidle' })` / `waitForLoadState('networkidle')` **after** login never settles and times out. Wait on concrete elements/text instead.
 - **Test account:** sign in with `QA_TEST_EMAIL` / `QA_TEST_PASSWORD` (injected secrets) instead of creating throwaway accounts you cannot delete (the cleanup protocol in `docs/TESTING.md` needs Firebase Console access).
 - **Firebase Storage `song-catalog.json` returns 402 (Payment Required)** on the current project (billing state). This is non-blocking: the song-search autocomplete falls back to the bundled static catalog, and Firestore (the actual game data) is unaffected. Ignore 402s from `firebasestorage.googleapis.com`; only worry about non-200s from `firestore.googleapis.com`.
 
@@ -39,6 +41,8 @@ Core local commands:
 | Firestore rules tests | `npm run test:rules` |
 | QA runners | `npm run qa:chunks && npm run qa:cache` |
 | Build | `npm run build` |
+
+> **Functions tests need the email artifact first.** `cd functions && npm test` includes `marketingCommsTemplates.test.js`, which `require`s `functions/emails/renderSummerTour2026Launch.cjs` — a **gitignored** esbuild bundle. Run `npm run emails:build` once (needs `emails/` deps, which the update script installs) before the functions suite, or that test fails with `Cannot find module './emails/renderSummerTour2026Launch.cjs'`.
 
 ### Dependabot / npm audit (#414)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified the Cloud dev environment for this Vite + React SPA (root) and its Firebase Cloud Functions (`functions/`) + React Email templates (`emails/`). Only doc changes are committed; the rest is environment/update-script config.

Corrected/added a few **non-obvious** `AGENTS.md` caveats discovered during setup:
- **App Check dev note was stale** — `firebaseAppCheck.js` now injects the *registered* debug UUID (`38422efd-…`) in DEV, so signed-in flows work on `localhost:5173` with **no IndexedDB seeding** (the old note claimed a 403 + manual seed step). Verified by signing in and locking in picks against prod Firestore.
- **Functions tests need `npm run emails:build` first** — `marketingCommsTemplates.test.js` requires the gitignored esbuild bundle `functions/emails/renderSummerTour2026Launch.cjs`.
- **Three install targets** now (`/`, `functions/`, `emails/`); update script runs `npm ci` in each.
- **Playwright Chromium isn't preinstalled** (`npx playwright install chromium` for QA runners / browser tests).
- **Browser automation gotcha:** post-login `networkidle` never settles (long-lived Firestore WebChannel).

## Environment

- Root deps: `npm ci`; Functions deps: `npm ci --prefix functions`; Emails deps: `npm ci --prefix emails`.
- Node 22 (VM default) runs web app lint/test/build and functions tests; Node 24 installed via nvm for Functions deploy parity.

## Hello-world verification

Signed in with the QA test account and **locked in a full set of picks** (You Enjoy Myself / Divided Sky / Run Like an Antelope / David Bowie / AC/DC Bag / Foam) for the 2026-07-08 — Kohl Center show, confirmed by the "Picks locked in successfully!" banner.

<a href="https://cursor.com/agents/bc-dc0be408-4e56-41b6-a99e-4d6a508de169/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_signin_and_make_picks.webm"><img src="https://cursor.com/artifacts/c/art-31a4cff5-1a26-46ea-87a9-97d800e037d3" alt="hello_world_signin_and_make_picks.webm" /></a>

![Signed-in Picks dashboard](https://cursor.com/artifacts/c/art-9a0b215e-eef7-4f78-9b00-ab7f9a3ac43a)
![Picks locked in successfully](https://cursor.com/artifacts/c/art-936f5b90-d302-457f-b608-50a2bebe36d8)

## Test plan

- ✅ `npm run lint`
- ✅ `npm test` (272 passed)
- ✅ `npm run verify:dashboard-meta` / `npm run verify:dashboard-ui`
- ✅ `cd functions && npm test` (283 passed, after `npm run emails:build`)
- ✅ `npm run build`
- ✅ `npm run dev` + end-to-end sign-in and pick submission (see video)

[verify_matrix.log](https://cursor.com/artifacts/c/art-8186bb47-d0c5-48d7-9392-48d61f8a7d47)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc0be408-4e56-41b6-a99e-4d6a508de169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc0be408-4e56-41b6-a99e-4d6a508de169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

