### PR TITLE
fix(notifications): remint FCM token for test send from hydrated On state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.3] — 2026-07-08
+
+### Fixed
+- **Push test notification from hydrated "On"** — "Send test notification" no longer dead-ends with _"token was not freshly rotated in this browser session"_ when push status was restored from a persisted token (the #523 hydration path). The canary now remints the FCM token on-demand (deleteToken + getToken) and re-upserts before sending, preserving the freshly-rotated-token guarantee while removing the need to toggle push off/on first.
+
+---
+
 ## [1.20.2] — 2026-07-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.2",
+  "version": "1.20.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/notifications/model/usePushTokenRegistration.js
+++ b/src/features/notifications/model/usePushTokenRegistration.js
@@ -195,31 +195,46 @@ export function usePushTokenRegistration() {
       setDebugState({ phase: 'canary_auth_missing', code: 'no-user', message: 'Missing auth uid in app session.' });
       return;
     }
-    if (!currentFcmToken) {
-      setCanaryStatus('error');
-      setErrorMessage('No in-session FCM token. Tap Enable first to mint a fresh token.');
-      setDebugState({
-        phase: 'canary_missing_token',
-        code: 'missing-token',
-        message: 'currentFcmToken is empty in client state.',
-      });
-      return;
-    }
-    if (!hasFreshRotationInSession) {
-      setCanaryStatus('error');
-      setErrorMessage('Canary blocked: token was not freshly rotated in this browser session.');
-      setDebugState({
-        phase: 'canary_rotation_required',
-        code: 'stale-session-token',
-        message: 'Enable push again to force deleteToken + getToken before canary.',
-      });
-      return;
-    }
     setCanaryStatus('working');
     setErrorMessage('');
     setDebugState({ phase: 'canary_sending', code: '', message: '' });
     try {
-      const res = await sendPushCanary({ token: currentFcmToken });
+      // The canary must send to a token that was freshly reminted in this
+      // browser session — a hydrated/persisted token (status shows "On" after a
+      // reload, via plain getToken) can be stale: FCM accepts it but never
+      // delivers, so the test would falsely report success. If we have not
+      // rotated this session yet (e.g. state came from hydration, not a tap on
+      // Enable), force a deleteToken + getToken remint here before sending.
+      let tokenToSend = currentFcmToken;
+      if (!hasFreshRotationInSession || !tokenToSend) {
+        setDebugState({
+          phase: 'canary_rotating',
+          code: '',
+          message: 'Reminting FCM token before test send.',
+        });
+        const { token } = await refreshFcmDeviceTokenWithDebug();
+        if (!token) {
+          setCanaryStatus('error');
+          setErrorMessage('Could not mint a fresh FCM token for the test notification.');
+          setDebugState({
+            phase: 'canary_token_missing',
+            code: 'token-null',
+            message: 'FCM getToken returned empty during canary remint.',
+          });
+          return;
+        }
+        await upsertFcmTokenForUser({
+          userId: user.uid,
+          token,
+          permission: browserPermissionState(),
+        });
+        setCurrentFcmToken(token);
+        setHasFreshRotationInSession(true);
+        tokenToSend = token;
+        setDebugState({ phase: 'canary_sending', code: '', message: '' });
+      }
+
+      const res = await sendPushCanary({ token: tokenToSend });
       if (!res.ok) {
         throw new Error('Test notification did not report success.');
       }


### PR DESCRIPTION
## Summary

Fixes the staging regression where push status correctly shows **On** (via the #523 hydration fix) but **Send test notification** fails with:

> Canary blocked: token was not freshly rotated in this browser session

**Root cause:** The canary was gated on `hasFreshRotationInSession`, which is only set to `true` inside `enablePush` (a full `deleteToken → getToken` remint). Before #523, the only way to reach `status === 'enabled'` was tapping Enable, so the gate always held. #523's hydration now sets `status = 'enabled'` from a **persisted** token via plain `requestFcmDeviceToken()` (no rotation), leaving `hasFreshRotationInSession = false` — so the button is enabled but the send permanently dead-ends until the user toggles push off/on.

**Fix:** `triggerPushCanary` now remints the FCM token on-demand (`refreshFcmDeviceTokenWithDebug()` → `deleteToken + getToken`) and re-upserts it before sending, but only when it hasn't already rotated this session. This preserves the original guarantee from commit `20ab146` (a canary only ever sends to a token freshly minted in this browser session — a stale token is accepted by FCM but never delivers, falsely reporting success) while removing the dead-end.

## Test plan

- [x] `npm run lint`
- [x] `npm test` (277 passed)
- [ ] Staging PWA, push already **On** from a prior session (hydrated): tap **Send test notification** → device receives the alert; no "not freshly rotated" error
- [ ] Tap **Send test notification** again in the same session → still delivers
- [ ] Fresh **Enable** → **Send test notification** → still works (unchanged path)
- [ ] **Disable** → button hidden/disabled as before

Closes the follow-up to #523.

Made with [Cursor](https://cursor.com)