### PR TITLE
chore(release): promote staging to main (v1.20.4 song autocomplete rank)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.4] — 2026-07-08
+
+### Fixed
+- **Song autocomplete ranking** — pick/admin suggestions now sort by lowest catalog gap, then most times played, and dedupe duplicate Phish.net rows so common titles like **Light** surface in the top 10 instead of being buried by alphabetical catalog order.
+
+---
+
 ## [1.20.3] — 2026-07-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.3",
+  "version": "1.20.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/shared/lib/rankCatalogSongMatches.js
+++ b/src/shared/lib/rankCatalogSongMatches.js
@@ -1,0 +1,75 @@
+/**
+ * @param {unknown} value
+ * @returns {number | null}
+ */
+function parseCatalogStat(value) {
+  if (value == null) return null;
+  const s = String(value).trim();
+  if (!s || s === '—' || s === 'N/A') return null;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * @param {string | { name?: string, total?: string, gap?: string, last?: string }} song
+ * @returns {string}
+ */
+function catalogSongName(song) {
+  if (typeof song === 'string') return song;
+  return song?.name != null ? String(song.name) : '';
+}
+
+/**
+ * Sort key for autocomplete: lowest gap first, then most times played.
+ *
+ * @param {string | { name?: string, total?: string, gap?: string, last?: string }} a
+ * @param {string | { name?: string, total?: string, gap?: string, last?: string }} b
+ * @returns {number}
+ */
+export function compareCatalogSongsByGapAndPlays(a, b) {
+  const gapA = parseCatalogStat(typeof a === 'string' ? null : a.gap);
+  const gapB = parseCatalogStat(typeof b === 'string' ? null : b.gap);
+  const gapSortA = gapA ?? Number.POSITIVE_INFINITY;
+  const gapSortB = gapB ?? Number.POSITIVE_INFINITY;
+  if (gapSortA !== gapSortB) return gapSortA - gapSortB;
+
+  const totalA = parseCatalogStat(typeof a === 'string' ? null : a.total);
+  const totalB = parseCatalogStat(typeof b === 'string' ? null : b.total);
+  const totalSortA = totalA ?? Number.NEGATIVE_INFINITY;
+  const totalSortB = totalB ?? Number.NEGATIVE_INFINITY;
+  if (totalSortA !== totalSortB) return totalSortB - totalSortA;
+
+  return catalogSongName(a).localeCompare(catalogSongName(b));
+}
+
+/**
+ * Substring filter + dedupe by title + rank by gap/total for autocomplete.
+ *
+ * @param {Array<string | { name?: string, total?: string, gap?: string, last?: string }>} songs
+ * @param {string} query
+ * @param {{ excludeTitlesLower?: Set<string>, limit?: number }} [opts]
+ * @returns {Array<string | { name?: string, total?: string, gap?: string, last?: string }>}
+ */
+export function rankCatalogSongMatches(songs, query, opts = {}) {
+  const { excludeTitlesLower = new Set(), limit = 10 } = opts;
+  const q = String(query ?? '').trim().toLowerCase();
+  if (!q || !Array.isArray(songs)) return [];
+
+  /** @type {Map<string, string | { name?: string, total?: string, gap?: string, last?: string }>} */
+  const bestByName = new Map();
+
+  for (const song of songs) {
+    const name = catalogSongName(song);
+    const n = name.trim().toLowerCase();
+    if (!n || excludeTitlesLower.has(n) || !n.includes(q)) continue;
+
+    const prev = bestByName.get(n);
+    if (!prev || compareCatalogSongsByGapAndPlays(song, prev) < 0) {
+      bestByName.set(n, song);
+    }
+  }
+
+  return Array.from(bestByName.values())
+    .sort(compareCatalogSongsByGapAndPlays)
+    .slice(0, limit);
+}

--- a/src/shared/lib/rankCatalogSongMatches.test.js
+++ b/src/shared/lib/rankCatalogSongMatches.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  compareCatalogSongsByGapAndPlays,
+  rankCatalogSongMatches,
+} from './rankCatalogSongMatches.js';
+
+describe('compareCatalogSongsByGapAndPlays', () => {
+  it('ranks lower gap first', () => {
+    expect(
+      compareCatalogSongsByGapAndPlays(
+        { name: 'A', gap: '1', total: '10' },
+        { name: 'B', gap: '5', total: '10' },
+      ),
+    ).toBeLessThan(0);
+  });
+
+  it('breaks gap ties by higher total', () => {
+    expect(
+      compareCatalogSongsByGapAndPlays(
+        { name: 'A', gap: '2', total: '200' },
+        { name: 'B', gap: '2', total: '50' },
+      ),
+    ).toBeLessThan(0);
+  });
+
+  it('sorts missing gap/total after numeric values', () => {
+    expect(
+      compareCatalogSongsByGapAndPlays(
+        { name: 'A', gap: '—', total: '—' },
+        { name: 'B', gap: '3', total: '10' },
+      ),
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe('rankCatalogSongMatches', () => {
+  const songs = [
+    { name: 'The Silver Light', total: '1', gap: '203' },
+    { name: 'Slave to the Traffic Light', total: '296', gap: '0' },
+    { name: 'Shine a Light', total: '30', gap: '15' },
+    { name: 'Midnight Moonlight', total: '1', gap: '1255' },
+    { name: 'Midnight Moonlight', total: '1', gap: '400' },
+    { name: 'Light Up Or Leave Me Alone', total: '19', gap: '561' },
+    { name: 'Light', total: '135', gap: '8' },
+  ];
+
+  it('surfaces lowest-gap, highest-played matches first for "light"', () => {
+    const matches = rankCatalogSongMatches(songs, 'light');
+    expect(matches.map((s) => s.name)).toEqual([
+      'Slave to the Traffic Light',
+      'Light',
+      'Shine a Light',
+      'The Silver Light',
+      'Midnight Moonlight',
+      'Light Up Or Leave Me Alone',
+    ]);
+  });
+
+  it('dedupes catalog rows by title keeping the best-ranked row', () => {
+    const matches = rankCatalogSongMatches(songs, 'moonlight');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].gap).toBe('400');
+  });
+
+  it('respects excluded titles', () => {
+    const matches = rankCatalogSongMatches(songs, 'light', {
+      excludeTitlesLower: new Set(['light']),
+    });
+    expect(matches.some((s) => s.name === 'Light')).toBe(false);
+  });
+
+  it('honors limit', () => {
+    const matches = rankCatalogSongMatches(songs, 'light', { limit: 3 });
+    expect(matches).toHaveLength(3);
+  });
+});

--- a/src/shared/ui/SongAutocomplete.jsx
+++ b/src/shared/ui/SongAutocomplete.jsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { PHISH_SONGS } from '../data/phishSongs.js';
+import { rankCatalogSongMatches } from '../lib/rankCatalogSongMatches.js';
 import { resolveCatalogSongTitle } from '../lib/resolveCatalogSongTitle.js';
 import Input from './Input';
 
@@ -36,18 +37,11 @@ export default function SongAutocomplete({
   );
 
   const filterCatalog = useCallback(
-    (query) => {
-      const q = String(query ?? '').trim().toLowerCase();
-      if (!q) return [];
-      return songs
-        .filter((song) => {
-          const name = typeof song === 'string' ? song : song.name;
-          const n = String(name ?? '').trim().toLowerCase();
-          if (!n || excludedLower.has(n)) return false;
-          return n.includes(q);
-        })
-        .slice(0, 10);
-    },
+    (query) =>
+      rankCatalogSongMatches(songs, query, {
+        excludeTitlesLower: excludedLower,
+        limit: 10,
+      }),
     [songs, excludedLower],
   );
   const [isOpen, setIsOpen] = useState(false);


### PR DESCRIPTION
## Summary
- Promote staging → main for **v1.20.4**
- Song autocomplete ranks suggestions by lowest gap, then most times played (#541)

## Test plan
- [x] PR #541 merged to staging with green CI (verify, Vercel, qa-runners)
- [ ] Staging deployment smoke: picks autocomplete shows **Light** for query `light`
- [ ] Production Vercel deploy succeeds after merge


Made with [Cursor](https://cursor.com)