### PR TITLE
fix(comms): restore venue/location in email copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.8] — 2026-07-14
+
+### Fixed
+- **Comms venue/location missing from email copy** — `parseShowCalendarSnapshotToShows` was dropping `venue` / `city` / tour fields and only keeping date + timezone, so tour rankings ("Next up: [date]"), lock reminders, picks confirmed, and countdown emails shipped without venue. Parser now preserves location metadata; calendar sync also stores a separate `city` field for subject lines after the next show-calendar refresh.
+
+---
+
 ## [1.20.6] — 2026-07-11
 
 ### Fixed

--- a/functions/phishnetLiveSetlistAutomation.js
+++ b/functions/phishnetLiveSetlistAutomation.js
@@ -180,6 +180,22 @@ function candidateShowDates(now = new Date()) {
  * Parse `show_calendar/snapshot` into a list of show date records.
  * Returns `null` if missing, empty, or unreadable (strict — scheduled poller must skip).
  */
+/**
+ * Parse `show_calendar/snapshot` into show records.
+ * Always includes `date` + `timeZone`. Passes through venue / city / tour
+ * fields when present so comms payloads (tour rankings, lock reminders, etc.)
+ * can populate `venue_name` / `next_show_venue` / countdown venue copy.
+ *
+ * @param {import("firebase-admin").firestore.DocumentData | null | undefined} snapshotData
+ * @returns {Array<{
+ *   date: string,
+ *   timeZone: string,
+ *   venue?: string,
+ *   city?: string,
+ *   tour_name?: string,
+ *   tour?: string,
+ * }> | null}
+ */
 function parseShowCalendarSnapshotToShows(snapshotData) {
   if (!snapshotData || typeof snapshotData !== "object") return null;
   const raw = snapshotData.showDates;
@@ -203,7 +219,23 @@ function parseShowCalendarSnapshotToShows(snapshotData) {
             ? item.timezone.trim()
             : ""
         : "";
-    shows.push({ date, timeZone: explicitTz || DEFAULT_SHOW_TIME_ZONE });
+    /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour_name?: string, tour?: string }} */
+    const show = { date, timeZone: explicitTz || DEFAULT_SHOW_TIME_ZONE };
+    if (item && typeof item === "object") {
+      if (typeof item.venue === "string" && item.venue.trim()) {
+        show.venue = item.venue.trim();
+      }
+      if (typeof item.city === "string" && item.city.trim()) {
+        show.city = item.city.trim();
+      }
+      if (typeof item.tour_name === "string" && item.tour_name.trim()) {
+        show.tour_name = item.tour_name.trim();
+      }
+      if (typeof item.tour === "string" && item.tour.trim()) {
+        show.tour = item.tour.trim();
+      }
+    }
+    shows.push(show);
     dedupe.add(date);
   }
   return shows.length > 0 ? shows : null;

--- a/functions/phishnetLiveSetlistAutomation.test.js
+++ b/functions/phishnetLiveSetlistAutomation.test.js
@@ -52,16 +52,34 @@ test("parseShowCalendarSnapshotToDateSet reads flat showDates", () => {
   assert.equal(set.has("2026-07-04"), true);
 });
 
-test("parseShowCalendarSnapshotToShows reads date + timezone records", () => {
+test("parseShowCalendarSnapshotToShows reads date + timezone + venue/city/tour", () => {
   const shows = parseShowCalendarSnapshotToShows({
     showDates: [
-      { date: "2026-07-03", venue: "A", timeZone: "America/Chicago" },
-      { date: "2026-07-04", venue: "B" },
+      {
+        date: "2026-07-03",
+        venue: "Kohl Center, Madison, WI",
+        city: "Madison, WI",
+        tour_name: "2026 Summer Tour",
+        timeZone: "America/Chicago",
+      },
+      { date: "2026-07-04", venue: "United Center, Chicago, IL" },
+      "2026-07-05",
     ],
   });
   assert.deepEqual(shows, [
-    { date: "2026-07-03", timeZone: "America/Chicago" },
-    { date: "2026-07-04", timeZone: "America/Los_Angeles" },
+    {
+      date: "2026-07-03",
+      timeZone: "America/Chicago",
+      venue: "Kohl Center, Madison, WI",
+      city: "Madison, WI",
+      tour_name: "2026 Summer Tour",
+    },
+    {
+      date: "2026-07-04",
+      timeZone: "America/Los_Angeles",
+      venue: "United Center, Chicago, IL",
+    },
+    { date: "2026-07-05", timeZone: "America/Los_Angeles" },
   ]);
 });
 

--- a/functions/phishnetShowCalendar.js
+++ b/functions/phishnetShowCalendar.js
@@ -270,13 +270,13 @@ function buildApiNamedTourByDate(shows) {
 
 /**
  * Regroup flat shows when per-date tour strings may differ from Phish.net clustering.
- * @param {{ date: string, venue: string, timeZone: string }[]} flatSorted
+ * @param {{ date: string, venue: string, city?: string, timeZone: string }[]} flatSorted
  * @param {(date: string) => string} tourFor
  */
 function regroupConsecutiveTours(flatSorted, tourFor) {
-  /** @type {{ tour: string, shows: { date: string, venue: string, timeZone: string }[] }[]} */
+  /** @type {{ tour: string, shows: { date: string, venue: string, city: string, timeZone: string }[] }[]} */
   const out = [];
-  let cur = /** @type {{ tour: string, shows: { date: string, venue: string, timeZone: string }[] } | null} */ (
+  let cur = /** @type {{ tour: string, shows: { date: string, venue: string, city: string, timeZone: string }[] } | null} */ (
     null
   );
   for (const s of flatSorted) {
@@ -286,7 +286,12 @@ function regroupConsecutiveTours(flatSorted, tourFor) {
       cur = { tour: label, shows: [] };
       out.push(cur);
     }
-    cur.shows.push({ date: s.date, venue: s.venue, timeZone: s.timeZone });
+    cur.shows.push({
+      date: s.date,
+      venue: s.venue,
+      city: typeof s.city === "string" ? s.city : "",
+      timeZone: s.timeZone,
+    });
   }
   return out;
 }
@@ -310,7 +315,12 @@ function mergeToursWithSnapshotPreservation(
 ) {
   const computedByDate = computedTourByDateFromGroups(computedGroups);
   const apiNamedByDate = buildApiNamedTourByDate(shows);
-  const flat = shows.map((s) => ({ date: s.date, venue: s.venue, timeZone: s.timeZone }));
+  const flat = shows.map((s) => ({
+    date: s.date,
+    venue: s.venue,
+    city: typeof s.city === "string" ? s.city : "",
+    timeZone: s.timeZone,
+  }));
 
   function tourFor(date) {
     if (overridesByDate.has(date)) return /** @type {string} */ (overridesByDate.get(date));
@@ -427,11 +437,26 @@ async function fetchShowsForYear(year, apiKey) {
 }
 
 /**
+ * @param {Record<string, unknown>} row
+ * @returns {string}
+ */
+function buildCityLine(row) {
+  const city = String(row.city ?? "").trim();
+  const state = String(row.state ?? "").trim();
+  const country = String(row.country ?? "").trim();
+  if (city && state) return `${city}, ${state}`;
+  if (city && country && country.toUpperCase() !== "USA") {
+    return `${city}, ${country}`;
+  }
+  return city;
+}
+
+/**
  * @param {Record<string, unknown>[]} rawRows
- * @returns {{ date: string, venue: string, tour_name: string, timeZone: string }[]}
+ * @returns {{ date: string, venue: string, city: string, tour_name: string, timeZone: string }[]}
  */
 function normalizePhishShows(rawRows) {
-  /** @type {Map<string, { date: string, venue: string, tour_name: string, timeZone: string }>} */
+  /** @type {Map<string, { date: string, venue: string, city: string, tour_name: string, timeZone: string }>} */
   const byDate = new Map();
 
   for (const row of rawRows) {
@@ -441,6 +466,7 @@ function normalizePhishShows(rawRows) {
     const date = String(row.showdate ?? "").trim();
     if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) continue;
     const venue = buildVenueLine(row);
+    const city = buildCityLine(row);
     const tour_name = String(row.tour_name ?? "").trim() || GENERIC_TOUR;
     const timeZone = deriveTimeZoneFromLocationParts({
       state: row.state,
@@ -448,22 +474,22 @@ function normalizePhishShows(rawRows) {
       city: row.city,
       venue,
     });
-    byDate.set(date, { date, venue, tour_name, timeZone });
+    byDate.set(date, { date, venue, city, tour_name, timeZone });
   }
 
   return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
 }
 
 /**
- * @param {{ date: string, venue: string, tour_name: string, timeZone: string }[]} shows
- * @returns {{ tour: string, shows: { date: string, venue: string, timeZone: string }[] }[]}
+ * @param {{ date: string, venue: string, city?: string, tour_name: string, timeZone: string }[]} shows
+ * @returns {{ tour: string, shows: { date: string, venue: string, city: string, timeZone: string }[] }[]}
  */
 function buildShowDatesByTour(shows) {
   if (shows.length === 0) return [];
 
   /** @type {string[]} */
   const orderedKeys = [];
-  /** @type {Map<string, { tour: string, shows: { date: string, venue: string, timeZone: string }[], firstDate: string, lastDate: string, isGeneric: boolean }>} */
+  /** @type {Map<string, { tour: string, shows: { date: string, venue: string, city: string, timeZone: string }[], firstDate: string, lastDate: string, isGeneric: boolean }>} */
   const map = new Map();
 
   let prev = /** @type {typeof shows[0] | null} */ (null);
@@ -498,7 +524,12 @@ function buildShowDatesByTour(shows) {
 
     const g = map.get(key);
     if (!g) continue;
-    g.shows.push({ date: s.date, venue: s.venue, timeZone: s.timeZone });
+    g.shows.push({
+      date: s.date,
+      venue: s.venue,
+      city: typeof s.city === "string" ? s.city : "",
+      timeZone: s.timeZone,
+    });
     g.lastDate = s.date;
 
     prev = s;

--- a/functions/phishnetShowCalendar.test.js
+++ b/functions/phishnetShowCalendar.test.js
@@ -240,5 +240,8 @@ test("normalizePhishShows: stamps per-show IANA timezone from location", () => {
   ]);
 
   assert.equal(out[0].timeZone, "America/Cancun");
+  assert.equal(out[0].city, "Cancun, Mexico");
   assert.equal(out[1].timeZone, "America/Chicago");
+  assert.equal(out[1].city, "Madison, WI");
+  assert.equal(out[1].venue, "Kohl Center, Madison, WI");
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.6",
+  "version": "1.20.8",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- `parseShowCalendarSnapshotToShows` was dropping `venue` / `city` / tour fields and only keeping date + timezone, so tour rankings (“Next up: [date]”), lock reminders, picks confirmed, and countdown emails shipped without venue.
- Parser now preserves location metadata; calendar sync also stores a separate `city` field for subject lines after the next show-calendar refresh.
- Bumps to **1.20.8** (patch).

## Test plan
- [x] Unit tests: `phishnetLiveSetlistAutomation`, `phishnetShowCalendar`, `picksLockReminder`
- [x] Local canary tour-rankings previews reviewed in inbox (venue present in “Next up”)
- [ ] CI `verify` + `functions` green
- [ ] After merge + promote: deploy comms (+ optional calendar refresh for `city` field)


Made with [Cursor](https://cursor.com)