### PR TITLE
fix(comms): tour countdown uses showDatesByTour (#514)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.9] — 2026-07-14
+
+### Fixed
+- **Tour countdown multi-tour no-op (#514)** — `scheduledTourCountdownComms` now resolves first-show targets from `showDatesByTour` so past tours on the calendar no longer collapse every show into one pseudo-tour and skip T-10/T-5/T-3/T-1.
+
+---
+
 ## [1.20.8] — 2026-07-14
 
 ### Fixed

--- a/functions/commsEventAdapters.js
+++ b/functions/commsEventAdapters.js
@@ -10,6 +10,7 @@
 
 const {
   parseShowCalendarSnapshotToShows,
+  parseShowCalendarSnapshotToShowsByTour,
   ymdInTimeZone,
 } = require("./phishnetLiveSetlistAutomation");
 const { hasNonEmptyPicksObject, resolveTourKeyForDate } = require("./rollupSeasonAggregates");
@@ -493,7 +494,11 @@ async function runScheduledTourCountdown({ db, admin, resendApiKey, logger, now 
   if (!isCommsEventAdaptersEnabled()) return null;
 
   const calSnap = await db.collection("show_calendar").doc("snapshot").get();
-  const shows = parseShowCalendarSnapshotToShows(calSnap.exists ? calSnap.data() : null);
+  // #514: per-tour first show from showDatesByTour — flat showDates collapses
+  // every tour into one pseudo-tour keyed "tour" (earliest legacy opener wins).
+  const shows = parseShowCalendarSnapshotToShowsByTour(
+    calSnap.exists ? calSnap.data() : null
+  );
   const targets = findTourCountdownTargets(shows, now);
   if (targets.length === 0) return { processed: 0, delivered: 0 };
 

--- a/functions/commsEventAdapters.test.js
+++ b/functions/commsEventAdapters.test.js
@@ -94,6 +94,59 @@ test("findTourCountdownTargets hits T-3 for Summer Tour Jul 7 kickoff", () => {
   assert.equal(hits[0].tourId, "Summer Tour 2026");
 });
 
+test("findTourCountdownTargets: multi-tour snapshot hits Summer T-1 only (#514)", () => {
+  // Flat showDates without tour labels collapses to earliest past opener → 0 hits.
+  // With per-tour labels (showDatesByTour expansion), Summer T-1 still fires.
+  const now = new Date("2026-07-06T16:00:00Z");
+  const shows = [
+    {
+      date: "2026-04-16",
+      venue: "Sphere",
+      timeZone: "America/Los_Angeles",
+      tour: "Sphere Run 2026",
+      tour_name: "Sphere Run 2026",
+    },
+    {
+      date: "2026-04-26",
+      venue: "Sphere",
+      timeZone: "America/Los_Angeles",
+      tour: "Sphere Run 2026",
+      tour_name: "Sphere Run 2026",
+    },
+    {
+      date: "2026-07-07",
+      venue: "Kohl Center",
+      city: "Madison, WI",
+      timeZone: "America/Chicago",
+      tour: "Summer Tour 2026",
+      tour_name: "Summer Tour 2026",
+    },
+    {
+      date: "2026-07-08",
+      venue: "Kohl Center",
+      city: "Madison, WI",
+      timeZone: "America/Chicago",
+      tour: "Summer Tour 2026",
+      tour_name: "Summer Tour 2026",
+    },
+  ];
+  const hits = findTourCountdownTargets(shows, now);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].tourId, "Summer Tour 2026");
+  assert.equal(hits[0].days_remaining, 1);
+  assert.equal(hits[0].first_show_date, "2026-07-07");
+});
+
+test("findTourCountdownTargets: unlabeled flat list with past dates is a no-op (#514)", () => {
+  const now = new Date("2026-07-06T16:00:00Z");
+  const flatCollapsed = [
+    { date: "2026-04-16", timeZone: "America/Los_Angeles" },
+    { date: "2026-07-07", timeZone: "America/Chicago" },
+  ];
+  const hits = findTourCountdownTargets(flatCollapsed, now);
+  assert.equal(hits.length, 0);
+});
+
 test("leaderUidFromScores returns sole leader only", () => {
   const picksSnap = {
     docs: [

--- a/functions/phishnetLiveSetlistAutomation.js
+++ b/functions/phishnetLiveSetlistAutomation.js
@@ -242,6 +242,82 @@ function parseShowCalendarSnapshotToShows(snapshotData) {
 }
 
 /**
+ * Expand `show_calendar/snapshot.showDatesByTour` into show records with
+ * per-tour labels. Used by tour countdown so each tour's first show is
+ * independent of older tours also present on the flat `showDates` list (#514).
+ *
+ * Falls back to flat `parseShowCalendarSnapshotToShows` when `showDatesByTour`
+ * is missing/empty (legacy snapshots).
+ *
+ * @param {import("firebase-admin").firestore.DocumentData | null | undefined} snapshotData
+ * @returns {Array<{
+ *   date: string,
+ *   timeZone: string,
+ *   venue?: string,
+ *   city?: string,
+ *   tour?: string,
+ *   tour_name?: string,
+ * }> | null}
+ */
+function parseShowCalendarSnapshotToShowsByTour(snapshotData) {
+  if (!snapshotData || typeof snapshotData !== "object") return null;
+  const groups = snapshotData.showDatesByTour;
+  if (!Array.isArray(groups) || groups.length === 0) {
+    return parseShowCalendarSnapshotToShows(snapshotData);
+  }
+
+  /** @type {Array<{ date: string, timeZone: string, venue?: string, city?: string, tour?: string, tour_name?: string }>} */
+  const shows = [];
+  for (const group of groups) {
+    if (!group || typeof group !== "object") continue;
+    const rawShows = Array.isArray(group.shows) ? group.shows : [];
+    /** @type {string[]} */
+    const groupDates = [];
+    for (const item of rawShows) {
+      const date =
+        item && typeof item === "object" && typeof item.date === "string"
+          ? item.date.trim()
+          : "";
+      if (/^\d{4}-\d{2}-\d{2}$/.test(date)) groupDates.push(date);
+    }
+    groupDates.sort();
+    const namedTour =
+      typeof group.tour === "string" && group.tour.trim() ? group.tour.trim() : "";
+    // Untitled / NPT clusters still need a stable unique key so they do not
+    // collapse into the same pseudo-tour as every other unlabeled group.
+    const tourKey = namedTour || (groupDates[0] ? `run:${groupDates[0]}` : "");
+    if (!tourKey) continue;
+
+    for (const item of rawShows) {
+      if (!item || typeof item !== "object") continue;
+      const date = typeof item.date === "string" ? item.date.trim() : "";
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) continue;
+      const explicitTz =
+        typeof item.timeZone === "string" && item.timeZone.trim()
+          ? item.timeZone.trim()
+          : typeof item.timezone === "string" && item.timezone.trim()
+            ? item.timezone.trim()
+            : "";
+      /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour?: string, tour_name?: string }} */
+      const show = {
+        date,
+        timeZone: explicitTz || DEFAULT_SHOW_TIME_ZONE,
+        tour: tourKey,
+        tour_name: namedTour || tourKey,
+      };
+      if (typeof item.venue === "string" && item.venue.trim()) {
+        show.venue = item.venue.trim();
+      }
+      if (typeof item.city === "string" && item.city.trim()) {
+        show.city = item.city.trim();
+      }
+      shows.push(show);
+    }
+  }
+  return shows.length > 0 ? shows : parseShowCalendarSnapshotToShows(snapshotData);
+}
+
+/**
  * Back-compat parser used by tests/consumers that only need date membership.
  * @param {import("firebase-admin").firestore.DocumentData | null | undefined} snapshotData
  */
@@ -1074,6 +1150,7 @@ module.exports = {
   normalizeSetlistRows,
   parseShowCalendarSnapshotToDateSet,
   parseShowCalendarSnapshotToShows,
+  parseShowCalendarSnapshotToShowsByTour,
   pollSingleShowDate,
   randomScheduledPollDelayMs,
   scheduledCandidateShowDates,

--- a/functions/phishnetLiveSetlistAutomation.test.js
+++ b/functions/phishnetLiveSetlistAutomation.test.js
@@ -20,6 +20,7 @@ const {
   normalizeSetlistRows,
   parseShowCalendarSnapshotToDateSet,
   parseShowCalendarSnapshotToShows,
+  parseShowCalendarSnapshotToShowsByTour,
   pollSingleShowDate,
   randomScheduledPollDelayMs,
   scheduledCandidateShowDates,
@@ -81,6 +82,39 @@ test("parseShowCalendarSnapshotToShows reads date + timezone + venue/city/tour",
     },
     { date: "2026-07-05", timeZone: "America/Los_Angeles" },
   ]);
+});
+
+test("parseShowCalendarSnapshotToShowsByTour stamps tour from showDatesByTour (#514)", () => {
+  const shows = parseShowCalendarSnapshotToShowsByTour({
+    showDates: [
+      { date: "2026-04-16", venue: "Sphere" },
+      { date: "2026-07-07", venue: "Kohl Center" },
+    ],
+    showDatesByTour: [
+      {
+        tour: "Sphere Run 2026",
+        shows: [
+          { date: "2026-04-16", venue: "Sphere", timeZone: "America/Los_Angeles" },
+        ],
+      },
+      {
+        tour: "Summer Tour 2026",
+        shows: [
+          {
+            date: "2026-07-07",
+            venue: "Kohl Center",
+            city: "Madison, WI",
+            timeZone: "America/Chicago",
+          },
+        ],
+      },
+    ],
+  });
+  assert.ok(shows);
+  assert.equal(shows.length, 2);
+  assert.equal(shows[0].tour, "Sphere Run 2026");
+  assert.equal(shows[1].tour, "Summer Tour 2026");
+  assert.equal(shows[1].city, "Madison, WI");
 });
 
 test("parseShowCalendarSnapshotToDateSet accepts string dates", () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.8",
+  "version": "1.20.9",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #514

## Summary
- `scheduledTourCountdownComms` now expands `showDatesByTour` so each tour’s first show is independent of legacy tours on the flat calendar.
- Untitled/NPT groups get stable `run:{firstDate}` keys so they do not collapse either.
- Regression tests cover multi-tour T-1 + unlabeled flat no-op.
- Patch bump **1.20.9** (Sprint 7 release train → staging).

## Test plan
- [x] `node --test commsEventAdapters.test.js phishnetLiveSetlistAutomation.test.js` (functions)
- [ ] CI `verify` + `functions` green
- [ ] Deploy `scheduledTourCountdownComms` with train promote (not blocking merge to staging)


Made with [Cursor](https://cursor.com)