### PR TITLE
fix(comms): honest CTA labels and standings#self-recap deep links (#551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.10] — 2026-07-14
+
+### Fixed
+- **Comms CTA / route honesty (#551)** — show recap inbox CTA no longer promises a “full recap” while linking only to standings; labels and destinations aligned (picks → `/dashboard/picks`, recap/score → `/dashboard/standings#self-recap`). Email CTAs and CTA click measurement (`comms_destination`) updated; audit matrix in `docs/comms-triggers/CTA_ROUTE_AUDIT.md`.
+
+---
+
 ## [1.20.9] — 2026-07-14
 
 ### Fixed

--- a/docs/comms-triggers/CTA_ROUTE_AUDIT.md
+++ b/docs/comms-triggers/CTA_ROUTE_AUDIT.md
@@ -1,0 +1,53 @@
+# Comms CTA / route audit (#551)
+
+Matrix of shipped / registry CTAs vs intended landing. Updated with Sprint 7 train.
+
+Label rule: **never promise a surface the href does not deliver.** Inbox cards stay short teases; graded “your night” detail lives on Standings (`StandingsSelfRecapCard`, `#self-recap`).
+
+## In-app registry (`commsTemplateRegistry.jsx`)
+
+| templateId | CTA label | href | Intent match | Notes |
+|------------|-----------|------|--------------|-------|
+| `account-welcome` | Make your first picks | `/dashboard/picks` | yes | Was `/dashboard` |
+| `tour-countdown` | varies by T-n | `/dashboard/picks` | yes | |
+| `picks-confirmed` | Review your picks | `/dashboard/picks` | yes | Was `/dashboard` |
+| `score-first-points` | Watch it live | `/dashboard/standings` | yes | Was `/dashboard` |
+| `score-leader` | Defend your lead | `/dashboard/standings` | yes | Was `/dashboard` |
+| `show-recap` | See standings | `/dashboard/standings#self-recap` | yes | Was “See full recap” → standings (mismatch) |
+| `tour-rankings-daily` | See standings | `/dashboard/standings#self-recap` | yes | Scrolls to self-recap card |
+| `picks-lock-reminder` | Make your picks | `/dashboard/picks` | yes | |
+| `tour-engagement-reminder` | Make picks for next show | `/dashboard/picks` | yes | |
+| `sphere-2026-inaugural` | (bespoke) | — | n/a | Legacy Sphere edition |
+
+## Email (`functions/commsTemplates.js`)
+
+| templateId | Primary CTA URL | Notes |
+|------------|-----------------|-------|
+| `account-welcome` | `/dashboard` | Generic app open OK for welcome |
+| `tour-countdown` | `/dashboard/picks` | |
+| `picks-confirmed` | `/dashboard` default | Prefer picks in a follow-up if still shipping |
+| `show-recap` | `/dashboard/standings#self-recap` | Rare (email folded into morning send #451) |
+| `tour-rankings_daily` | `/dashboard/picks` | Catalog: “Make picks for next show” |
+| `picks-lock-reminder` | `/dashboard/picks` | |
+
+## Push deep links
+
+Prefers inbox (`/dashboard/profile/notifications`) for night-of show_recap tease; standings for tour rankings. Align when editing FCM payloads in delivery workers.
+
+## Measurement & periodic review
+
+Already coded (no new pipeline required for v1):
+
+| Layer | What |
+|-------|------|
+| Server | `comms_delivered` (+ GA4 MP when secrets bound) |
+| Client | `comms_opened`, `comms_cta_click` (`comms_cta` + `comms_destination`), `comms_push_tap` |
+| Cadence | Weekly (show weeks) + monthly full catalog — `MEASUREMENT_PLAN.md` §4 |
+
+**Recap-specific review (analyst):** each Monday of a show week, filter GA4 for `comms_trigger_id` ∈ `{show_recap, tour_rankings_daily}` — deliver / open / CTA rates and top `comms_destination` values. File a note under the issue or `#comms` channel if CTA→bounce patterns appear.
+
+## Deferred (product)
+
+- Dedicated written `/dashboard/.../recap` route beyond Standings self-recap card → #510 / future IA
+- Email/auth return-URL latency → #535
+- Dynamic View/Edit picks CTA → #509

--- a/docs/comms-triggers/MEASUREMENT_PLAN.md
+++ b/docs/comms-triggers/MEASUREMENT_PLAN.md
@@ -13,7 +13,7 @@ Client engagement events use `ga4Event` via `src/features/comms/model/commsAnaly
 | `comms_delivered` | Server wrote inbox row, sent FCM, or sent email (per channel) | `comms_trigger_id`, `comms_template_id`, `comms_channel`, `comms_variant` (MP + logs; `user_id` = Firebase uid on MP) |
 | `comms_opened` | User opens inbox message or expands bell item | `trigger_id`, `template_id`, `channel`, `message_id` |
 | `comms_dismissed` | User dismisses without reading | `trigger_id`, `template_id`, `message_id` |
-| `comms_cta_click` | User taps CTA in message | `trigger_id`, `template_id`, `cta`, `destination` |
+| `comms_cta_click` | User taps CTA in message | `comms_trigger_id`, `comms_template_id`, `comms_cta`, `comms_destination` (href) |
 | `comms_push_tap` | Notification click opens app | `trigger_id`, `template_id`, `message_id` |
 | `comms_pref_changed` | User toggles notification pref | `pref_key`, `enabled` |
 
@@ -32,6 +32,7 @@ Admin → Property → Custom definitions → Event-scoped. Event parameter name
 | Comms channel | `comms_channel` |
 | Comms variant | `comms_variant` |
 | Comms CTA | `comms_cta` |
+| Comms destination | `comms_destination` |
 
 Also register auth dimensions from #291 (`method`, `error_code`) in the same Admin pass.
 
@@ -72,9 +73,11 @@ Eligible → comms_delivered → comms_opened → dashboard visit within 24h
 
 | Cadence | Report |
 |---------|--------|
-| Weekly (show weeks) | Picks-lock funnel, push tap rate, pref opt-out rate |
+| Weekly (show weeks) | Picks-lock funnel, push tap rate, pref opt-out rate; **recap slice** (`show_recap` + `tour_rankings_daily`) deliver/open/CTA + top `comms_destination` |
 | Monthly | Full catalog review: deliver/open/CTA by `trigger_id` |
 | Per experiment | Variant comparison per EXPERIMENT_PLAYBOOK.md |
+
+Recap CTA honesty audit: `docs/comms-triggers/CTA_ROUTE_AUDIT.md` (#551). Cadence is **analyst-scheduled** against existing GA4 events — no separate Cloud Function required for v1.
 
 ### Data sources
 

--- a/docs/comms-triggers/README.md
+++ b/docs/comms-triggers/README.md
@@ -11,6 +11,7 @@ This directory is the **canonical home** for triggered, templated communications
 | [TRIGGER_CATALOG.md](./TRIGGER_CATALOG.md) | Human-readable v1 trigger inventory (status, channels, prefs, dedup) |
 | [catalog.json](./catalog.json) | Machine-readable trigger specs for agents and future orchestration |
 | [MEASUREMENT_PLAN.md](./MEASUREMENT_PLAN.md) | GA4 comms events, dimensions, funnels |
+| [CTA_ROUTE_AUDIT.md](./CTA_ROUTE_AUDIT.md) | In-app/email CTA label ↔ destination matrix (#551) |
 | [EXPERIMENT_PLAYBOOK.md](./EXPERIMENT_PLAYBOOK.md) | A/B rules, variant assignment, ship/kill criteria |
 | [EMAIL_INBOX_BADGE.md](./EMAIL_INBOX_BADGE.md) | Inbox sender badge (BIMI/DMARC) vs in-body email logo (#498) |
 | [COMMERCIAL_PHASE3.md](./COMMERCIAL_PHASE3.md) | Sponsor / affiliate / offer gates (Phase 3) |

--- a/docs/comms-triggers/TRIGGER_CATALOG.md
+++ b/docs/comms-triggers/TRIGGER_CATALOG.md
@@ -350,7 +350,7 @@ Scores update live during the show. Check back tonight.
 
 Tonight's top score was {{top_score}} points — {{top_scorer_handle}} led the room.
 
-**CTA:** `Full standings →`
+**CTA:** `See standings →` → `/dashboard/standings#self-recap`
 
 *(No email template — the "your night" content below now ships inside `tour_rankings_daily`'s email, see #451.)*
 
@@ -389,7 +389,7 @@ Tonight's top score was {{top_score}} points — {{top_scorer_handle}} led the r
 
 Up next: {{next_show_venue}} on {{next_show_date}}. Picks open now.
 
-**CTA:** `Full tour standings →`
+**CTA:** `See standings →` → `/dashboard/standings#self-recap`
 
 #### Template — Email
 

--- a/functions/commsTemplates.js
+++ b/functions/commsTemplates.js
@@ -18,6 +18,7 @@ const { buildTourRankingsDailyParagraphs } = require("./tourRankingsDailyCore");
 const SITE_URL = "https://www.setlistpickem.com";
 const APP_CTA_URL = `${SITE_URL}/dashboard`;
 const PICKS_CTA_URL = `${SITE_URL}/dashboard/picks`;
+const STANDINGS_CTA_URL = `${SITE_URL}/dashboard/standings#self-recap`;
 
 function handleOf(p) {
   const h = p && typeof p.handle === "string" ? p.handle.trim() : "";
@@ -207,7 +208,8 @@ const BUILDERS = {
         p.global_rank != null
           ? `Global rank: #${p.global_rank}${p.global_total_pickers != null ? ` of ${p.global_total_pickers}` : ""}.`
           : "",
-      ].filter(Boolean)
+      ].filter(Boolean),
+      { ctaUrl: STANDINGS_CTA_URL }
     );
     return {
       push: {
@@ -218,7 +220,7 @@ const BUILDERS = {
         subject: p.venue_name ? `Your recap: ${p.venue_name}` : "Your show recap",
         text: assembled.text,
         signOff: assembled.signOff,
-        ctaUrl: assembled.ctaUrl,
+        ctaUrl: STANDINGS_CTA_URL,
       },
     };
   },
@@ -236,7 +238,9 @@ const BUILDERS = {
     ].filter(Boolean);
 
     const tourParas = buildTourRankingsDailyParagraphs(p);
-    const assembled = assembleServiceEmail([...nightOf, "", ...tourParas].filter(Boolean));
+    const assembled = assembleServiceEmail([...nightOf, "", ...tourParas].filter(Boolean), {
+      ctaUrl: PICKS_CTA_URL,
+    });
 
     const pushRank =
       p.tour_rank != null
@@ -258,7 +262,8 @@ const BUILDERS = {
           : "Your show recap + tour standings",
         text: assembled.text,
         signOff: assembled.signOff,
-        ctaUrl: assembled.ctaUrl,
+        ctaUrl: PICKS_CTA_URL,
+        ctaLabel: "Make picks for next show",
       },
     };
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.9",
+  "version": "1.20.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/comms/model/commsAnalytics.js
+++ b/src/features/comms/model/commsAnalytics.js
@@ -59,11 +59,12 @@ export function logCommsDismissed(meta) {
 /**
  * User clicked the message's primary CTA.
  *
- * @param {CommsEventMeta & { cta?: string }} meta
+ * @param {CommsEventMeta & { cta?: string, destination?: string }} meta
  */
 export function logCommsCtaClick(meta) {
   const params = commsDimensions(meta);
   if (meta?.cta) params.comms_cta = meta.cta;
+  if (meta?.destination) params.comms_destination = meta.destination;
   ga4Event('comms_cta_click', params);
 }
 

--- a/src/features/notifications/ui/CommsInboxSection.jsx
+++ b/src/features/notifications/ui/CommsInboxSection.jsx
@@ -76,15 +76,14 @@ export default function CommsInboxSection() {
     [messages, markRead],
   );
 
-  const handleCtaClick = useCallback(
-    (row) => {
-      logCommsCtaClick({
-        triggerId: triggerIdForTemplate(row.templateId),
-        templateId: row.templateId,
-      });
-    },
-    [],
-  );
+  const handleCtaClick = useCallback((row, cta) => {
+    logCommsCtaClick({
+      triggerId: triggerIdForTemplate(row.templateId),
+      templateId: row.templateId,
+      cta: typeof cta?.label === 'string' ? cta.label : undefined,
+      destination: typeof cta?.href === 'string' ? cta.href : undefined,
+    });
+  }, []);
 
   return (
     <section
@@ -192,7 +191,7 @@ export default function CommsInboxSection() {
                         <CommsMessageBody
                           templateId={m.templateId}
                           payload={m.payload}
-                          onCtaClick={() => handleCtaClick(m)}
+                          onCtaClick={(cta) => handleCtaClick(m, cta)}
                         />
                         <div className="mt-4 flex items-center justify-end gap-2">
                           <button

--- a/src/features/notifications/ui/commsTemplates/CommsTemplateBody.jsx
+++ b/src/features/notifications/ui/commsTemplates/CommsTemplateBody.jsx
@@ -14,7 +14,7 @@ import React from 'react';
  *   paragraphs?: string[],
  *   stats?: { label: string, value: React.ReactNode }[],
  *   cta?: { label: string, href?: string },
- *   onCtaClick?: () => void,
+ *   onCtaClick?: (cta: { label: string, href?: string }) => void,
  * }} props
  */
 export default function CommsTemplateBody({
@@ -71,7 +71,7 @@ export default function CommsTemplateBody({
         <div className="pt-2">
           <a
             href={cta.href || '#'}
-            onClick={onCtaClick}
+            onClick={() => onCtaClick?.(cta)}
             className="inline-flex items-center justify-center rounded-lg border border-brand-primary/40 bg-brand-primary/10 px-4 py-2 text-xs font-black uppercase tracking-widest text-brand-primary transition-colors hover:border-brand-primary hover:bg-brand-primary/20"
           >
             {cta.label}

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
@@ -118,7 +118,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           ? `Your next chance to play: ${venueLine(p, { dateKey: 'next_show_date', venueKey: 'next_show_venue', cityKey: '__none' })}.`
           : 'Head to the dashboard, make your first set of picks, and you’re on the board.',
       ],
-      cta: { label: 'Make your first picks', href: '/dashboard' },
+      cta: { label: 'Make your first picks', href: '/dashboard/picks' },
     }),
     samples: [
       {
@@ -232,7 +232,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           'Sit back — we’ll score them live as the setlist comes in.',
         ],
         stats: picks.map(([label, value]) => ({ label, value })),
-        cta: { label: 'Review your picks', href: '/dashboard' },
+        cta: { label: 'Review your picks', href: '/dashboard/picks' },
       };
     },
     samples: [
@@ -270,7 +270,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
         p.current_score != null ? { label: 'Score', value: p.current_score } : null,
         p.global_rank != null ? { label: 'Rank', value: `#${p.global_rank}` } : null,
       ].filter(Boolean),
-      cta: { label: 'Watch it live', href: '/dashboard' },
+      cta: { label: 'Watch it live', href: '/dashboard/standings' },
     }),
     samples: [
       {
@@ -305,7 +305,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
         p.current_score != null ? { label: 'Score', value: p.current_score } : null,
         p.lead_margin != null ? { label: 'Lead', value: `+${p.lead_margin}` } : null,
       ].filter(Boolean),
-      cta: { label: 'Defend your lead', href: '/dashboard' },
+      cta: { label: 'Defend your lead', href: '/dashboard/standings' },
     }),
     samples: [
       {
@@ -341,7 +341,8 @@ export const COMMS_TEMPLATE_REGISTRY = {
           ? { label: p.pool_name, value: `#${p.pool_rank}` }
           : null,
       ].filter(Boolean),
-      cta: { label: 'See full recap', href: '/dashboard/standings' },
+      // Inbox card is the tease; graded self-recap lives on Standings (#551).
+      cta: { label: 'See standings', href: '/dashboard/standings#self-recap' },
     }),
     samples: [
       {
@@ -389,7 +390,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           p.tour_points != null ? { label: 'Tour points', value: p.tour_points } : null,
           p.shows_played != null ? { label: 'Shows', value: p.shows_played } : null,
         ].filter(Boolean),
-        cta: { label: 'See standings', href: '/dashboard/standings' },
+        cta: { label: 'See standings', href: '/dashboard/standings#self-recap' },
       };
     },
     samples: [

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.test.js
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.test.js
@@ -80,6 +80,23 @@ describe('comms template registry', () => {
     });
   });
 
+  it('show_recap CTA is honest about standings destination (#551)', () => {
+    const entry = getCommsTemplateEntry('show-recap');
+    expect(entry.build({}).cta).toEqual({
+      label: 'See standings',
+      href: '/dashboard/standings#self-recap',
+    });
+  });
+
+  it('welcome + picks-confirmed CTAs deep-link to picks (#551)', () => {
+    expect(getCommsTemplateEntry('account-welcome').build({}).cta.href).toBe(
+      '/dashboard/picks',
+    );
+    expect(getCommsTemplateEntry('picks-confirmed').build({}).cta.href).toBe(
+      '/dashboard/picks',
+    );
+  });
+
   it('maps templateId → catalog triggerId', () => {
     expect(triggerIdForTemplate('show-recap')).toBe('show_recap');
     expect(triggerIdForTemplate('account-welcome')).toBe('account_welcome');

--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../../auth';
@@ -193,6 +193,18 @@ export function useStandingsScreen(selectedDate, options = {}) {
     view === 'pools' ? activePoolName || 'This pool' : 'Everyone';
 
   const isShowToday = selectedDate === todayYmd();
+
+  // Comms deep links use `/dashboard/standings#self-recap` (#551).
+  useEffect(() => {
+    if (location.hash !== '#self-recap') return;
+    if (!selfStandingsRecap || loading) return;
+    const el = document.getElementById('self-recap');
+    if (!el) return;
+    const t = window.setTimeout(() => {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }, 50);
+    return () => window.clearTimeout(t);
+  }, [location.hash, selfStandingsRecap, loading]);
 
   const onOpenPoolHub = useCallback(() => {
     if (view !== 'pools' || !poolId) return;

--- a/src/features/scoring/ui/StandingsSelfRecapCard.jsx
+++ b/src/features/scoring/ui/StandingsSelfRecapCard.jsx
@@ -204,6 +204,7 @@ export default function StandingsSelfRecapCard({
   if (useCollapsible) {
     return (
       <details
+        id="self-recap"
         className={`group ${shellClass}`}
         defaultOpen
         aria-label="Your rank and score. Expand for show details, jump link, and share."
@@ -223,7 +224,7 @@ export default function StandingsSelfRecapCard({
   }
 
   return (
-    <div className={shellClass}>
+    <div id={bodyOnly ? undefined : 'self-recap'} className={shellClass}>
       {!bodyOnly ? (
         <>
           {primaryRow}


### PR DESCRIPTION
Closes #551

## Summary
- Show-recap inbox CTA: **See standings** → `/dashboard/standings#self-recap` (no longer promises a “full recap”).
- Welcome / picks-confirmed → `/dashboard/picks`; score CTAs → standings.
- Email CTAs aligned; CTA clicks log `comms_destination`.
- Audit matrix + weekly recap review notes in `docs/comms-triggers/CTA_ROUTE_AUDIT.md`.
- Patch **1.20.10** (Sprint 7 train → staging).

## Test plan
- [x] Localhost `/comms-preview` — labels + clicks verified
- [x] Unit tests: registry + commsTemplates
- [ ] CI green
- [ ] Merge to staging (hold promote)


Made with [Cursor](https://cursor.com)