### PR TITLE
perf(standings): React Query cache for show-scoped standings (#507)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.11] — 2026-07-14
+
+### Fixed
+- **Safari/PWA standings loading (#507)** — show-scoped standings use React Query (60s stale) so tab revisits skip the full-page spinner; LIVE listeners still apply after snapshot seed; calendar snapshot reference churn no longer restarts the fetch.
+
+---
+
 ## [1.20.10] — 2026-07-14
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.10",
+  "version": "1.20.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/scoring/model/useStandings.js
+++ b/src/features/scoring/model/useStandings.js
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 import { getShowStatus } from '../../../shared/utils/timeLogic.js';
 import {
@@ -11,66 +12,81 @@ import {
 /** Tab hidden → tear down LIVE Firestore listeners after this delay (#311). */
 const LIVE_LISTENER_HIDE_DEBOUNCE_MS = 60_000;
 
+/**
+ * Stable fingerprint so calendar snapshot reference churn does not re-trigger
+ * standings work when date/TZ membership is unchanged (#507).
+ *
+ * @param {Array<{ date?: string, timeZone?: string } | string> | null | undefined} showDates
+ */
+export function showDatesStatusKey(showDates) {
+  if (!Array.isArray(showDates) || showDates.length === 0) return '';
+  return showDates
+    .map((s) => {
+      if (typeof s === 'string') return s.trim();
+      const date = typeof s?.date === 'string' ? s.date.trim() : '';
+      const tz = typeof s?.timeZone === 'string' ? s.timeZone.trim() : '';
+      return date ? `${date}@${tz}` : '';
+    })
+    .filter(Boolean)
+    .join('|');
+}
+
+/**
+ * Show-scoped standings (#507). Snapshot path uses React Query (default
+ * staleTime 60s from `main.jsx`) so Safari/PWA tab revisits skip the full-page
+ * spinner. LIVE shows still attach visibility-gated Firestore listeners after
+ * the initial snapshot seed.
+ *
+ * @param {string} showDate
+ * @param {Array<{ date?: string, timeZone?: string } | string> | null | undefined} showDates
+ */
 export function useStandings(showDate, showDates) {
-  const [picks, setPicks] = useState([]);
-  const [actualSetlist, setActualSetlist] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const statusKey = useMemo(() => showDatesStatusKey(showDates), [showDates]);
+  const showStatus = useMemo(() => {
+    if (!showDate || !statusKey) return 'FUTURE';
+    return Array.isArray(showDates) && showDates.length > 0
+      ? getShowStatus(showDate, showDates)
+      : 'FUTURE';
+  }, [showDate, showDates, statusKey]);
+
+  const enabled = Boolean(showDate) && showStatus !== 'FUTURE';
+
+  const query = useQuery({
+    queryKey: ['standings-show', showDate],
+    enabled,
+    queryFn: async () => {
+      const [picks, actualSetlist] = await Promise.all([
+        fetchPicksForShowDate(showDate),
+        fetchOfficialSetlistForShow(showDate),
+      ]);
+      return { picks, actualSetlist };
+    },
+  });
+
+  const [livePicks, setLivePicks] = useState(
+    /** @type {Array<Record<string, unknown>> | null} */ (null)
+  );
+  const [liveSetlist, setLiveSetlist] = useState(
+    /** @type {Record<string, unknown> | null | undefined} */ (undefined)
+  );
 
   useEffect(() => {
-    if (!showDate) {
-      setPicks([]);
-      setActualSetlist(null);
-      setLoading(false);
-      setError(null);
-      return;
+    if (query.isError) {
+      console.error('useStandings query error:', query.error);
     }
+  }, [query.isError, query.error]);
 
-    const showStatus =
-      Array.isArray(showDates) && showDates.length > 0
-        ? getShowStatus(showDate, showDates)
-        : 'FUTURE';
-
-    if (showStatus === 'FUTURE') {
-      setPicks([]);
-      setActualSetlist(null);
-      setLoading(false);
-      setError(null);
-      return;
+  useEffect(() => {
+    if (showStatus !== 'LIVE' || !showDate) {
+      setLivePicks(null);
+      setLiveSetlist(undefined);
+      return undefined;
     }
 
     let cancelled = false;
-
-    if (showStatus !== 'LIVE') {
-      setLoading(true);
-      setError(null);
-
-      (async () => {
-        try {
-          const [fetchedPicks, setlist] = await Promise.all([
-            fetchPicksForShowDate(showDate),
-            fetchOfficialSetlistForShow(showDate),
-          ]);
-          if (!cancelled) {
-            setPicks(fetchedPicks);
-            setActualSetlist(setlist);
-          }
-        } catch (err) {
-          if (!cancelled) {
-            setError(err);
-            console.error('Error fetching standings data:', err);
-          }
-        } finally {
-          if (!cancelled) setLoading(false);
-        }
-      })();
-
-      return () => {
-        cancelled = true;
-      };
-    }
-
+    /** @type {Array<() => void>} */
     let unsubscribers = [];
+    /** @type {ReturnType<typeof setTimeout> | null} */
     let hideTimer = null;
 
     const clearHideTimer = () => {
@@ -91,7 +107,6 @@ export function useStandings(showDate, showDates) {
 
       const onErr = (err) => {
         if (!cancelled) {
-          setError(err);
           console.error('useStandings live listener error:', err);
         }
       };
@@ -100,7 +115,7 @@ export function useStandings(showDate, showDates) {
         subscribePicksForShowDate(
           showDate,
           (nextPicks) => {
-            if (!cancelled) setPicks(nextPicks);
+            if (!cancelled) setLivePicks(nextPicks);
           },
           onErr
         )
@@ -109,7 +124,7 @@ export function useStandings(showDate, showDates) {
         subscribeOfficialSetlistForShow(
           showDate,
           (nextSetlist) => {
-            if (!cancelled) setActualSetlist(nextSetlist);
+            if (!cancelled) setLiveSetlist(nextSetlist);
           },
           onErr
         )
@@ -131,43 +146,39 @@ export function useStandings(showDate, showDates) {
     };
 
     document.addEventListener('visibilitychange', onVisibilityChange);
-
-    setLoading(true);
-    setError(null);
-
-    (async () => {
-      try {
-        const [fetchedPicks, setlist] = await Promise.all([
-          fetchPicksForShowDate(showDate),
-          fetchOfficialSetlistForShow(showDate),
-        ]);
-        if (!cancelled) {
-          setPicks(fetchedPicks);
-          setActualSetlist(setlist);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError(err);
-          console.error('Error fetching standings data:', err);
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-
-      if (cancelled) return;
-
-      if (document.visibilityState === 'visible') {
-        attachLiveListeners();
-      }
-    })();
+    if (document.visibilityState === 'visible') {
+      attachLiveListeners();
+    }
 
     return () => {
       cancelled = true;
       document.removeEventListener('visibilitychange', onVisibilityChange);
       clearHideTimer();
       tearDownListeners();
+      setLivePicks(null);
+      setLiveSetlist(undefined);
     };
-  }, [showDate, showDates]);
+  }, [showDate, showStatus]);
 
-  return { picks, actualSetlist, loading, error };
+  if (!enabled) {
+    return { picks: [], actualSetlist: null, loading: false, error: null };
+  }
+
+  const picks = livePicks ?? query.data?.picks ?? [];
+  const actualSetlist =
+    liveSetlist !== undefined
+      ? liveSetlist
+      : (query.data?.actualSetlist ?? null);
+
+  return {
+    picks,
+    actualSetlist,
+    // Full-page / card spinners only on first miss — not background refetch (#507).
+    loading: query.isPending,
+    error: query.isError
+      ? query.error instanceof Error
+        ? query.error
+        : new Error('Failed to load standings.')
+      : null,
+  };
 }

--- a/src/features/scoring/model/useStandings.test.js
+++ b/src/features/scoring/model/useStandings.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+
+import { showDatesStatusKey } from './useStandings';
+
+function createIsolatedClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60_000,
+        gcTime: 5 * 60_000,
+        refetchOnWindowFocus: false,
+        retry: 0,
+      },
+    },
+  });
+}
+
+describe('showDatesStatusKey', () => {
+  it('is stable across new array references with the same membership', () => {
+    const a = [
+      { date: '2026-07-07', timeZone: 'America/Chicago', venue: 'Kohl' },
+      { date: '2026-07-08', timeZone: 'America/Chicago', venue: 'Kohl' },
+    ];
+    const b = a.map((row) => ({ ...row }));
+    expect(showDatesStatusKey(a)).toBe(showDatesStatusKey(b));
+  });
+
+  it('changes when a date or timezone changes', () => {
+    const a = [{ date: '2026-07-07', timeZone: 'America/Chicago' }];
+    const b = [{ date: '2026-07-07', timeZone: 'America/New_York' }];
+    expect(showDatesStatusKey(a)).not.toBe(showDatesStatusKey(b));
+  });
+});
+
+describe('standings-show query cache (#507)', () => {
+  it('reuses cached picks+setlist within staleTime for the same showDate', async () => {
+    const client = createIsolatedClient();
+    const fetchPair = vi.fn(async () => ({
+      picks: [{ userId: 'u1', picks: { opener: 'Tweezer' } }],
+      actualSetlist: { s1o: 'Tweezer' },
+    }));
+
+    await client.fetchQuery({
+      queryKey: ['standings-show', '2026-07-07'],
+      queryFn: fetchPair,
+    });
+    const second = await client.fetchQuery({
+      queryKey: ['standings-show', '2026-07-07'],
+      queryFn: fetchPair,
+    });
+
+    expect(fetchPair).toHaveBeenCalledTimes(1);
+    expect(second.picks[0].userId).toBe('u1');
+  });
+
+  it('busts the cache when showDate changes', async () => {
+    const client = createIsolatedClient();
+    const fetchPair = vi
+      .fn()
+      .mockResolvedValueOnce({ picks: [{ userId: 'a' }], actualSetlist: null })
+      .mockResolvedValueOnce({ picks: [{ userId: 'b' }], actualSetlist: null });
+
+    await client.fetchQuery({
+      queryKey: ['standings-show', '2026-07-07'],
+      queryFn: fetchPair,
+    });
+    const next = await client.fetchQuery({
+      queryKey: ['standings-show', '2026-07-08'],
+      queryFn: fetchPair,
+    });
+
+    expect(fetchPair).toHaveBeenCalledTimes(2);
+    expect(next.picks[0].userId).toBe('b');
+  });
+});

--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -88,6 +88,8 @@ export function useStandingsScreen(selectedDate, options = {}) {
     isNextShowView && user?.uid
       ? userHasSubmittedPickEntry(picks, user.uid)
       : false;
+  // Card spinner only while the show-scoped query has no data yet (#507).
+  // Cached revisits keep `loading` false so this cannot stick indefinitely.
   const picksStatusLoading = isNextShowView && loading;
 
   useStandingsLeaderboardView(selectedDate, loading, showDates);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -13,9 +13,9 @@ import './index.css'
 
 initGa4()
 
-// Shared client for the React Query caches added in #243 (profile season
-// stats + tour standings). Defaults are tuned for read-heavy stats hooks
-// where back-navigation should reuse data within the session.
+// Shared client for React Query caches (#243 profile/tour standings, #507
+// show-scoped standings). Defaults tuned for read-heavy dashboard hooks
+// where tab revisits should reuse data within the session.
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {


### PR DESCRIPTION
Closes #507

## Summary
- Show-scoped standings use React Query (shared 60s `staleTime`) so Safari/PWA tab revisits skip the full-page spinner.
- LIVE shows still attach visibility-gated Firestore listeners after snapshot seed.
- Calendar snapshot reference churn stabilized via `showDatesStatusKey`.
- Patch **1.20.11** (Sprint 7 train → staging).

## Test plan
- [x] Unit tests: `useStandings.test.js` cache + fingerprint
- [ ] CI green
- [ ] Desktop Network: single fetch per show on first visit; revisit within 60s no full-page Loading
- [ ] iOS Safari/PWA smoke after promote (not a PR blocker)


Made with [Cursor](https://cursor.com)