### PR TITLE
fix(comms): bump branded email type for mobile Gmail (#536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.12] — 2026-07-14
+
+### Fixed
+- **Service email mobile typography (#536)** — branded email shell adds viewport meta and bumps body/CTA/footer sizes so Gmail iOS no longer shrinks copy into illegible text.
+
+---
+
 ## [1.20.11] — 2026-07-14
 
 ### Fixed

--- a/functions/commsEmailWorker.js
+++ b/functions/commsEmailWorker.js
@@ -228,8 +228,10 @@ function buildBrandedEmailHtml({ siteUrl, bodyText, ctaUrl, settingsUrl, ctaLabe
     .filter(Boolean)
     .map((line) => escapeHtml(line))
     .join("<br />");
+  // #536 — mobile Gmail readable type: body ≥16px, CTA ≥16px, footer ≥13px;
+  // viewport meta so fixed-width cards are not scaled down into illegible text.
   const paragraphs = bodyLines
-    ? `<p style="margin:0 0 20px 0;font-size:15px;line-height:1.6;color:#1a1a2e;">${bodyLines}</p>`
+    ? `<p style="margin:0 0 20px 0;font-size:16px;line-height:1.6;color:#1a1a2e;">${bodyLines}</p>`
     : "";
   const signOffHtml = signOffLine
     ? `<p style="margin:0 0 20px 0;font-size:15px;line-height:1.5;color:#64748b;font-style:italic;">${escapeHtml(signOffLine)}</p>`
@@ -246,14 +248,20 @@ function buildBrandedEmailHtml({ siteUrl, bodyText, ctaUrl, settingsUrl, ctaLabe
   ].join(";");
 
   return `<!DOCTYPE html>
-<html>
-  <body style="margin:0;padding:0;background-color:#0b0b14;">
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#0b0b14;padding:32px 16px;">
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="x-apple-disable-message-reformatting" />
+    <title>Setlist Pick'em</title>
+  </head>
+  <body style="margin:0;padding:0;background-color:#0b0b14;-webkit-text-size-adjust:100%;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#0b0b14;padding:24px 12px;">
       <tr>
         <td align="center">
           <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width:480px;width:100%;background-color:#ffffff;border-radius:16px;overflow:hidden;border-top:${EMAIL_SHELL_ACCENT_BORDER_PX}px solid ${EMAIL_BRAND_PRIMARY};">
             <tr>
-              <td style="padding:20px 32px 12px 32px;text-align:center;">
+              <td style="padding:16px 24px 8px 24px;text-align:center;">
                 <!--[if mso]>
                 <img src="${escapeHtml(resolvedWordmarkSrc)}" width="${EMAIL_SHELL_WORDMARK_WIDTH_PX}" height="${EMAIL_SHELL_WORDMARK_HEIGHT_PX}" alt="Setlist Pick'em" style="display:block;margin:0 auto;max-width:${EMAIL_SHELL_WORDMARK_WIDTH_PX}px;width:100%;height:auto;border:0;" />
                 <![endif]-->
@@ -263,18 +271,18 @@ function buildBrandedEmailHtml({ siteUrl, bodyText, ctaUrl, settingsUrl, ctaLabe
               </td>
             </tr>
             <tr>
-              <td style="padding:8px 32px 8px 32px;font-family:-apple-system,Helvetica,Arial,sans-serif;">
+              <td style="padding:8px 24px 8px 24px;font-family:-apple-system,Helvetica,Arial,sans-serif;">
                 ${paragraphs}
                 ${signOffHtml}
-                <a href="${escapeHtml(ctaUrl)}" style="display:inline-block;margin-top:8px;padding:12px 24px;background-color:${EMAIL_BRAND_PRIMARY};color:${EMAIL_BRAND_BG_DEEP};text-decoration:none;border-radius:12px;font-weight:700;font-size:14px;">${escapeHtml(buttonLabel)}</a>
+                <a href="${escapeHtml(ctaUrl)}" style="display:inline-block;margin-top:8px;padding:14px 28px;background-color:${EMAIL_BRAND_PRIMARY};color:${EMAIL_BRAND_BG_DEEP};text-decoration:none;border-radius:12px;font-weight:700;font-size:16px;">${escapeHtml(buttonLabel)}</a>
               </td>
             </tr>
             <tr>
-              <td style="padding:24px 32px;border-top:1px solid #eeeeee;text-align:center;font-family:-apple-system,Helvetica,Arial,sans-serif;">
-                <p style="margin:0 0 8px 0;font-size:12px;color:#888888;">
+              <td style="padding:20px 24px;border-top:1px solid #eeeeee;text-align:center;font-family:-apple-system,Helvetica,Arial,sans-serif;">
+                <p style="margin:0 0 8px 0;font-size:13px;line-height:1.5;color:#888888;">
                   You&apos;re receiving this because you have a Setlist Pick&apos;em account.
                 </p>
-                <p style="margin:0;font-size:12px;color:#888888;">
+                <p style="margin:0;font-size:13px;line-height:1.5;color:#888888;">
                   <a href="${escapeHtml(settingsUrl)}" style="color:${EMAIL_BRAND_PRIMARY_STRONG};text-decoration:underline;">Manage preferences</a>
                   &nbsp;&middot;&nbsp;
                   <a href="${escapeHtml(settingsUrl)}" style="color:${EMAIL_BRAND_PRIMARY_STRONG};text-decoration:underline;">Unsubscribe</a>

--- a/functions/commsEmailWorker.test.js
+++ b/functions/commsEmailWorker.test.js
@@ -343,6 +343,11 @@ test("buildBrandedEmailHtml renders gradient wordmark, sign-off, teal CTA, and t
   assert.match(html, /Make Your Picks/);
   assert.match(html, /See you on tour!/);
   assert.ok(!html.includes("web-app-manifest-512x512.png"), "vinyl logo removed from shell header");
+  // #536 mobile readability
+  assert.match(html, /name="viewport"[^>]*content="width=device-width, initial-scale=1"/);
+  assert.match(html, /font-size:16px;line-height:1\.6;color:#1a1a2e/);
+  assert.match(html, /font-weight:700;font-size:16px/);
+  assert.match(html, /font-size:13px;line-height:1\.5;color:#888888/);
 });
 
 test("buildBrandedEmailHtml joins multi-line bodies into a single <p> with <br> breaks", () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.11",
+  "version": "1.20.12",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #536

## Summary
- Add viewport meta + `-webkit-text-size-adjust` to branded service email shell
- Bump body/CTA to 16px and footer to 13px so Gmail iOS stops shrinking copy
- Cover with `commsEmailWorker` assertions; preview sent to `pat@road2media.com`

## Test plan
- [x] `cd functions && node --test commsEmailWorker.test.js`
- [x] Local Resend preview: `--picks-lock-reminder --send`
- [ ] Confirm on phone Gmail (iOS) after staging deploy of functions / next service email
- [ ] Leave issue open until promote+deploy; update AC checkboxes in issue comment


Made with [Cursor](https://cursor.com)