### PR TITLE
feat(comms): View / Edit picks CTA when picks_secured (#509)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.13] — 2026-07-14
+
+### Added
+- **In-app picks CTA honesty (#509)** — `tour_countdown`, `picks_lock_reminder`, and `tour_engagement_reminder` switch to **View / Edit picks** when payload `picks_secured` is true; adapters enrich countdown/engagement from picks for the target show.
+
+---
+
 ## [1.20.12] — 2026-07-14
 
 ### Fixed

--- a/docs/comms-triggers/CTA_ROUTE_AUDIT.md
+++ b/docs/comms-triggers/CTA_ROUTE_AUDIT.md
@@ -9,14 +9,14 @@ Label rule: **never promise a surface the href does not deliver.** Inbox cards s
 | templateId | CTA label | href | Intent match | Notes |
 |------------|-----------|------|--------------|-------|
 | `account-welcome` | Make your first picks | `/dashboard/picks` | yes | Was `/dashboard` |
-| `tour-countdown` | varies by T-n | `/dashboard/picks` | yes | |
+| `tour-countdown` | varies by T-n / `picks_secured` | `/dashboard/picks` | yes | T-5/3/1 → **View / Edit picks** when secured (#509) |
 | `picks-confirmed` | Review your picks | `/dashboard/picks` | yes | Was `/dashboard` |
 | `score-first-points` | Watch it live | `/dashboard/standings` | yes | Was `/dashboard` |
 | `score-leader` | Defend your lead | `/dashboard/standings` | yes | Was `/dashboard` |
 | `show-recap` | See standings | `/dashboard/standings#self-recap` | yes | Was “See full recap” → standings (mismatch) |
 | `tour-rankings-daily` | See standings | `/dashboard/standings#self-recap` | yes | Scrolls to self-recap card |
-| `picks-lock-reminder` | Make your picks | `/dashboard/picks` | yes | |
-| `tour-engagement-reminder` | Make picks for next show | `/dashboard/picks` | yes | |
+| `picks-lock-reminder` | Make your picks / View / Edit picks | `/dashboard/picks` | yes | Prod skips secured users; secured CTA for preview (#509) |
+| `tour-engagement-reminder` | Make picks for next show / View / Edit picks | `/dashboard/picks` | yes | Branches on next-show `picks_secured` (#509) |
 | `sphere-2026-inaugural` | (bespoke) | — | n/a | Legacy Sphere edition |
 
 ## Email (`functions/commsTemplates.js`)

--- a/docs/comms-triggers/TRIGGER_CATALOG.md
+++ b/docs/comms-triggers/TRIGGER_CATALOG.md
@@ -145,7 +145,15 @@ Every template draws from this shared set. Each trigger declares the subset it u
 
 #### Variables used
 
-`{{handle}}`, `{{tour_name}}`, `{{days_remaining}}`, `{{first_show_date}}`, `{{first_show_venue}}`, `{{first_show_city}}`
+`{{handle}}`, `{{tour_name}}`, `{{days_remaining}}`, `{{first_show_date}}`, `{{first_show_venue}}`, `{{first_show_city}}`, `{{picks_secured}}`
+
+#### In-app CTA by picks state (#509)
+
+| Days | No picks | `picks_secured === true` |
+|------|----------|--------------------------|
+| `10` | `View upcoming shows` | unchanged (`View upcoming shows`) |
+| `5` / `3` | `Make picks for show 1` | `View / Edit picks` |
+| `1` | `Lock in your picks` | `View / Edit picks` |
 
 #### Template variants by `{{days_remaining}}`
 
@@ -423,7 +431,11 @@ Up next: {{next_show_venue}} on {{next_show_date}}. Picks open now.
 
 #### Variables used
 
-`{{handle}}`, `{{show_date}}`, `{{venue_name}}`, `{{venue_city}}`, `{{time_to_lock}}`, `{{lock_time_local}}`
+`{{handle}}`, `{{show_date}}`, `{{venue_name}}`, `{{venue_city}}`, `{{time_to_lock}}`, `{{lock_time_local}}`, `{{picks_secured}}` (preview/edge; production fanout already skips users with picks)
+
+#### Product choice (#509)
+
+Production `picks_lock_reminder` **skips** users with non-empty picks for tonight (`users_no_picks_tonight`). In-app registry still branches CTA/body on `picks_secured` for `/comms-preview` and any edge payload.
 
 #### Template — Push
 
@@ -437,7 +449,7 @@ Up next: {{next_show_venue}} on {{next_show_date}}. Picks open now.
 
 **Body:** Picks for {{venue_name}} close at {{lock_time_local}} — {{time_to_lock}} from now. You're not on the board yet for {{show_date}}.
 
-**CTA:** `Make picks now →`
+**CTA:** `Make your picks` (or `View / Edit picks` when `picks_secured`)
 
 #### Template — Email
 
@@ -466,7 +478,14 @@ Up next: {{next_show_venue}} on {{next_show_date}}. Picks open now.
 
 #### Variables used
 
-`{{handle}}`, `{{show_score}}`, `{{global_rank}}`, `{{global_total_pickers}}`, `{{tour_name}}`, `{{shows_remaining}}`, `{{next_show_date}}`, `{{next_show_venue}}`
+`{{handle}}`, `{{show_score}}`, `{{global_rank}}`, `{{global_total_pickers}}`, `{{tour_name}}`, `{{shows_remaining}}`, `{{next_show_date}}`, `{{next_show_venue}}`, `{{picks_secured}}` (next show)
+
+#### In-app CTA by picks state (#509)
+
+| State | CTA |
+|-------|-----|
+| No picks for next show | `Make picks for next show` |
+| `picks_secured === true` | `View / Edit picks` |
 
 #### Template — Push
 
@@ -482,7 +501,7 @@ Up next: {{next_show_venue}} on {{next_show_date}}. Picks open now.
 
 The more shows you pick, the better your tour rank. Don't let the tour slip by.
 
-**CTA:** `Make picks for next show →` → `/dashboard/picks`
+**CTA:** `Make picks for next show` / `View / Edit picks` → `/dashboard/picks`
 
 #### Template — Email
 

--- a/docs/comms-triggers/catalog.json
+++ b/docs/comms-triggers/catalog.json
@@ -45,7 +45,7 @@
       "githubIssue": null,
       "variants": ["t10", "t5", "t3", "t1"],
       "inAppDeepLink": "/dashboard/picks",
-      "note": "In-app CTA label varies by days_remaining (see TRIGGER_CATALOG.md §2). Push/email use open-app phrasing.",
+      "note": "In-app CTA label varies by days_remaining; T-5/T-3/T-1 switch to View / Edit picks when picks_secured (#509). Push/email use open-app phrasing.",
       "variables": [
         { "name": "handle", "source": "users/{uid}.handle", "fallback": "Picker" },
         { "name": "tour_name", "source": "tour metadata", "fallback": null },
@@ -53,7 +53,8 @@
         { "name": "first_show_date", "source": "tour first show", "fallback": null },
         { "name": "first_show_venue", "source": "tour first show venue", "fallback": null },
         { "name": "first_show_city", "source": "tour first show city", "fallback": null },
-        { "name": "lock_time_local", "source": "computed (19:30 venue-local)", "fallback": "7:30 PM" }
+        { "name": "lock_time_local", "source": "computed (19:30 venue-local)", "fallback": "7:30 PM" },
+        { "name": "picks_secured", "source": "picks where showDate=first_show + hasNonEmptyPicksObject", "fallback": false }
       ]
     },
     {
@@ -241,14 +242,15 @@
       "templateId": "picks-lock-reminder",
       "implementationModule": "functions/picksLockReminder.js",
       "githubIssue": 524,
-      "note": "Email is transactional (CAN-SPAM): bypasses reminders pref but respects email_suppression. Push/in-app still use reminders pref.",
+      "note": "Email is transactional (CAN-SPAM): bypasses reminders pref but respects email_suppression. Push/in-app still use reminders pref. Audience excludes users with picks; in-app registry still branches on picks_secured for preview (#509).",
       "variables": [
         { "name": "handle", "source": "users/{uid}.handle", "fallback": "Picker" },
         { "name": "show_date", "source": "show_calendar", "fallback": null },
         { "name": "venue_name", "source": "show_calendar", "fallback": null },
         { "name": "venue_city", "source": "show_calendar", "fallback": null },
         { "name": "time_to_lock", "source": "computed at send time", "fallback": null },
-        { "name": "lock_time_local", "source": "computed (19:30 venue-local)", "fallback": "7:30 PM" }
+        { "name": "lock_time_local", "source": "computed (19:30 venue-local)", "fallback": "7:30 PM" },
+        { "name": "picks_secured", "source": "preview/edge only — production fanout skips users with picks", "fallback": false }
       ]
     },
     {
@@ -267,7 +269,7 @@
       "templateId": "tour-engagement-reminder",
       "inAppDeepLink": "/dashboard/picks",
       "implementationModule": "functions/commsEventAdapters.js",
-      "githubIssue": null,
+      "githubIssue": 509,
       "variables": [
         { "name": "handle", "source": "users/{uid}.handle", "fallback": "Picker" },
         { "name": "show_score", "source": "graded show total", "fallback": null },
@@ -276,7 +278,8 @@
         { "name": "tour_name", "source": "tour metadata", "fallback": null },
         { "name": "shows_remaining", "source": "tour calendar", "fallback": null },
         { "name": "next_show_date", "source": "show_calendar", "fallback": null },
-        { "name": "next_show_venue", "source": "show_calendar", "fallback": null }
+        { "name": "next_show_venue", "source": "show_calendar", "fallback": null },
+        { "name": "picks_secured", "source": "picks where showDate=next_show + hasNonEmptyPicksObject", "fallback": false }
       ]
     },
     {

--- a/functions/commsEventAdapters.js
+++ b/functions/commsEventAdapters.js
@@ -43,6 +43,35 @@ function handleFromUser(data) {
 }
 
 /**
+ * Build showDate → Set(uid) for users with non-empty picks (#509).
+ *
+ * @param {import("firebase-admin").firestore.Firestore} db
+ * @param {string[]} showDates
+ * @returns {Promise<Map<string, Set<string>>>}
+ */
+async function loadUserIdsWithPicksForShowDates(db, showDates) {
+  const unique = [...new Set(showDates.filter((d) => typeof d === "string" && d.trim()))];
+  /** @type {Map<string, Set<string>>} */
+  const byDate = new Map();
+  for (const d of unique) byDate.set(d, new Set());
+  if (unique.length === 0) return byDate;
+
+  for (let i = 0; i < unique.length; i += FIRESTORE_IN_QUERY_LIMIT) {
+    const chunk = unique.slice(i, i + FIRESTORE_IN_QUERY_LIMIT);
+    // eslint-disable-next-line no-await-in-loop
+    const snap = await db.collection("picks").where("showDate", "in", chunk).get();
+    for (const doc of snap.docs) {
+      const data = doc.data() || {};
+      const sd = typeof data.showDate === "string" ? data.showDate.trim() : "";
+      const uid = typeof data.userId === "string" ? data.userId.trim() : "";
+      if (!uid || !byDate.has(sd)) continue;
+      if (hasNonEmptyPicksObject(data.picks)) byDate.get(sd).add(uid);
+    }
+  }
+  return byDate;
+}
+
+/**
  * Fire when a user doc gains a non-empty handle (profile setup complete).
  *
  * @param {object | null | undefined} before
@@ -290,10 +319,21 @@ async function deliverPostRollupComms({
   if (!picksSnap || picksSnap.empty) return null;
 
   const calSnap = await db.collection("show_calendar").doc("snapshot").get();
-  const shows = parseShowCalendarSnapshotToShows(calSnap.exists ? calSnap.data() : null);
+  const calData = calSnap.exists ? calSnap.data() : null;
+  const shows = parseShowCalendarSnapshotToShows(calData);
   const meta = findShowMeta(shows, showDate) || {};
   const ranks = computeGlobalRankByUid(picksSnap.docs, newScoresById);
   const runtime = createCommsAdapterRuntime({ db, admin, resendApiKey, logger });
+
+  const tourDates = tourKey ? tourDatesForKey(showDatesByTour, tourKey) : [];
+  const nextDate = nextTourShowDate(tourDates, showDate);
+  const nextMeta = nextDate ? findShowMeta(shows, nextDate) || {} : {};
+  const showsRemaining =
+    tourDates.length > 0 ? tourDates.filter((d) => d > showDate).length : null;
+  const securedByNextShow = nextDate
+    ? await loadUserIdsWithPicksForShowDates(db, [nextDate])
+    : new Map();
+  const nextShowSecuredUids = nextDate ? securedByNextShow.get(nextDate) || new Set() : new Set();
 
   /** @type {Array<{ uid: string, userData?: object, payload: object, vars: object }>} */
   const recapRecipients = [];
@@ -337,9 +377,16 @@ async function deliverPostRollupComms({
           userData,
           payload: {
             handle: handleFromUser(userData),
+            show_score: score,
             global_rank: rankInfo.rank,
+            global_total_pickers: rankInfo.total,
+            tour_name: tourKey,
             tourId: tourKey,
-            shows_remaining: null,
+            shows_remaining: showsRemaining,
+            next_show_date: nextDate || "",
+            next_show_venue: nextMeta.venue || "",
+            // #509: next-show picks (not the graded show just rolled up)
+            picks_secured: nextDate ? nextShowSecuredUids.has(uid) : false,
           },
           vars: { uid, tourId: tourKey },
         });
@@ -507,7 +554,15 @@ async function runScheduledTourCountdown({ db, admin, resendApiKey, logger, now 
   /** @type {import("./commsDelivery").deliverCommsTrigger extends (...args: infer A) => any ? A[0]["recipients"] : never} */
   const recipients = [];
 
+  // #509: batch picks lookup per first-show date so CTA can say View / Edit
+  const securedByShow = await loadUserIdsWithPicksForShowDates(
+    db,
+    targets.map((t) => t.first_show_date || t.firstShowDate)
+  );
+
   for (const target of targets) {
+    const firstShow = target.first_show_date || target.firstShowDate || "";
+    const securedUids = securedByShow.get(firstShow) || new Set();
     for (const userDoc of usersSnap.docs) {
       const userData = userDoc.data() || {};
       if (!handleFromUser(userData)) continue;
@@ -522,6 +577,7 @@ async function runScheduledTourCountdown({ db, admin, resendApiKey, logger, now 
           first_show_venue: target.first_show_venue,
           first_show_city: target.first_show_city,
           lock_time_local: target.lock_time_local,
+          picks_secured: firstShow ? securedUids.has(userDoc.id) : false,
         },
         vars: {
           uid: userDoc.id,
@@ -686,6 +742,7 @@ module.exports = {
   findShowMeta,
   computeGlobalRankByUid,
   findTourCountdownTargets,
+  loadUserIdsWithPicksForShowDates,
   handleAccountWelcome,
   handlePicksConfirmed,
   deliverPostRollupComms,

--- a/functions/commsEventAdapters.test.js
+++ b/functions/commsEventAdapters.test.js
@@ -8,6 +8,7 @@ const {
   shouldDeliverPicksConfirmed,
   computeGlobalRankByUid,
   findTourCountdownTargets,
+  loadUserIdsWithPicksForShowDates,
   leaderUidFromScores,
 } = require("./commsEventAdapters");
 const { isCommsEventAdaptersEnabled } = require("./commsAdapterRuntime");
@@ -162,4 +163,42 @@ test("leaderUidFromScores returns sole leader only", () => {
     leaderUidFromScores(new Map([["p1", 5], ["p2", 5]]), picksSnap),
     null
   );
+});
+
+test("loadUserIdsWithPicksForShowDates indexes non-empty picks (#509)", async () => {
+  const db = {
+    collection: () => ({
+      where: () => ({
+        get: async () => ({
+          docs: [
+            {
+              data: () => ({
+                showDate: "2026-07-18",
+                userId: "u1",
+                picks: { opener: "Tweezer" },
+              }),
+            },
+            {
+              data: () => ({
+                showDate: "2026-07-18",
+                userId: "u2",
+                picks: {},
+              }),
+            },
+            {
+              data: () => ({
+                showDate: "2026-07-20",
+                userId: "u3",
+                picks: { closer: "Slave" },
+              }),
+            },
+          ],
+        }),
+      }),
+    }),
+  };
+  const map = await loadUserIdsWithPicksForShowDates(db, ["2026-07-18", "2026-07-20"]);
+  assert.equal(map.get("2026-07-18").has("u1"), true);
+  assert.equal(map.get("2026-07-18").has("u2"), false);
+  assert.equal(map.get("2026-07-20").has("u3"), true);
 });

--- a/functions/tourCountdownRecoveryDelivery.js
+++ b/functions/tourCountdownRecoveryDelivery.js
@@ -11,6 +11,7 @@
 const { deliverCommsTrigger, buildDefaultWorkers } = require("./commsDelivery");
 const { createCommsEmailWorker, buildResendClient } = require("./commsEmailWorker");
 const { ymdInTimeZone } = require("./phishnetLiveSetlistAutomation");
+const { hasNonEmptyPicksObject } = require("./rollupSeasonAggregates");
 
 const TRIGGER_ID = "tour_countdown";
 const DEFAULT_SHOW_TIME_ZONE = "America/Los_Angeles";
@@ -194,6 +195,21 @@ async function deliverTourCountdownRecovery({
     };
   }
 
+  // #509: mirror scheduled countdown — mark recipients who already have first-show picks
+  const firstShow =
+    typeof target.first_show_date === "string" ? target.first_show_date.trim() : "";
+  /** @type {Set<string>} */
+  const securedUids = new Set();
+  if (firstShow) {
+    const picksSnap = await db.collection("picks").where("showDate", "==", firstShow).get();
+    for (const doc of picksSnap.docs) {
+      const d = doc.data() || {};
+      const uid = typeof d.userId === "string" ? d.userId.trim() : "";
+      if (!uid) continue;
+      if (hasNonEmptyPicksObject(d.picks)) securedUids.add(uid);
+    }
+  }
+
   /** @type {import("./commsDelivery").deliverCommsTrigger extends (...args: infer A) => any ? A[0]["recipients"] : never} */
   const recipients = audience.map(({ uid, userData }) => ({
     uid,
@@ -206,6 +222,7 @@ async function deliverTourCountdownRecovery({
       first_show_venue: target.first_show_venue,
       first_show_city: target.first_show_city,
       lock_time_local: target.lock_time_local,
+      picks_secured: firstShow ? securedUids.has(uid) : false,
     },
     vars: {
       uid,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.12",
+  "version": "1.20.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
@@ -72,9 +72,20 @@ function venueLine(payload, { dateKey = 'show_date', venueKey = 'venue_name', ci
 }
 
 const PICKS_HREF = '/dashboard/picks';
+/** Matches dashboard StandingsActiveShowCard / PoolHubActiveShow (#509). */
+const VIEW_EDIT_PICKS_CTA = { label: 'View / Edit picks', href: PICKS_HREF };
+
+/**
+ * @param {Record<string, unknown>} p
+ * @returns {boolean}
+ */
+function isPicksSecured(p) {
+  return p?.picks_secured === true || p?.picks_secured === 'true';
+}
 
 /**
  * In-app CTA for tour countdown — varies by `days_remaining` (TRIGGER_CATALOG.md §2).
+ * When `picks_secured`, T-5/T-3/T-1 switch to View / Edit picks (#509). T-10 stays exploratory.
  * Push/email may use "open the app" phrasing; in-app users are already in the app.
  * @param {Record<string, unknown>} p
  */
@@ -82,6 +93,9 @@ function tourCountdownInAppCta(p) {
   const days = Number(p.days_remaining);
   if (days === 10) {
     return { label: 'View upcoming shows', href: PICKS_HREF };
+  }
+  if (isPicksSecured(p)) {
+    return { ...VIEW_EDIT_PICKS_CTA };
   }
   if (days === 5 || days === 3) {
     return { label: 'Make picks for show 1', href: PICKS_HREF };
@@ -207,6 +221,31 @@ export const COMMS_TEMPLATE_REGISTRY = {
           first_show_date: 'Jul 18',
           first_show_venue: 'MSG',
           first_show_city: 'New York, NY',
+        },
+      },
+      {
+        name: 'T-3 picks secured',
+        payload: {
+          handle: 'ArmenianMan',
+          tour_name: 'Summer Tour 2026',
+          days_remaining: 3,
+          first_show_date: 'Jul 7',
+          first_show_venue: 'Kohl Center',
+          first_show_city: 'Madison, WI',
+          lock_time_local: '7:30 PM',
+          picks_secured: true,
+        },
+      },
+      {
+        name: 'T-1 picks secured',
+        payload: {
+          handle: 'ArmenianMan',
+          tour_name: 'Summer Tour 2026',
+          days_remaining: 1,
+          first_show_date: 'Jul 18',
+          first_show_venue: 'MSG',
+          first_show_city: 'New York, NY',
+          picks_secured: true,
         },
       },
     ],
@@ -555,9 +594,13 @@ export const COMMS_TEMPLATE_REGISTRY = {
         `${handleOf(p)}, ${venueLine(p) || "tonight's show"} locks at ${p.lock_time_local || '7:30 PM'} local${
           p.time_to_lock ? ` — about ${p.time_to_lock} away` : ''
         }.`,
-        "You haven't locked picks yet. Don't get shut out of the night.",
+        isPicksSecured(p)
+          ? 'Your picks are on the board — open them any time before lock to tweak.'
+          : "You haven't locked picks yet. Don't get shut out of the night.",
       ],
-      cta: { label: 'Make your picks', href: '/dashboard/picks' },
+      cta: isPicksSecured(p)
+        ? { ...VIEW_EDIT_PICKS_CTA }
+        : { label: 'Make your picks', href: PICKS_HREF },
     }),
     samples: [
       {
@@ -569,6 +612,18 @@ export const COMMS_TEMPLATE_REGISTRY = {
           venue_city: 'New York, NY',
           time_to_lock: '3 hours',
           lock_time_local: '7:30 PM',
+        },
+      },
+      {
+        name: 'Lock reminder — secured',
+        payload: {
+          handle: 'HotDogBilly',
+          show_date: 'Tonight',
+          venue_name: 'MSG',
+          venue_city: 'New York, NY',
+          time_to_lock: '3 hours',
+          lock_time_local: '7:30 PM',
+          picks_secured: true,
         },
       },
     ],
@@ -593,7 +648,9 @@ export const COMMS_TEMPLATE_REGISTRY = {
           ? `Next up: ${venueLine(p, { dateKey: 'next_show_date', venueKey: 'next_show_venue', cityKey: '__none' })}.`
           : '',
       ].filter(Boolean),
-      cta: { label: 'Make picks for next show', href: PICKS_HREF },
+      cta: isPicksSecured(p)
+        ? { ...VIEW_EDIT_PICKS_CTA }
+        : { label: 'Make picks for next show', href: PICKS_HREF },
     }),
     samples: [
       {
@@ -607,6 +664,20 @@ export const COMMS_TEMPLATE_REGISTRY = {
           shows_remaining: 8,
           next_show_date: 'Jul 20',
           next_show_venue: 'MSG',
+        },
+      },
+      {
+        name: 'After first show — next show secured',
+        payload: {
+          handle: 'I have the book',
+          show_score: 65,
+          global_rank: 18,
+          global_total_pickers: 312,
+          tour_name: 'Summer Tour 2026',
+          shows_remaining: 8,
+          next_show_date: 'Jul 20',
+          next_show_venue: 'MSG',
+          picks_secured: true,
         },
       },
     ],

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.test.js
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.test.js
@@ -72,12 +72,40 @@ describe('comms template registry', () => {
     expect(entry.build({ days_remaining: 1 }).cta.label).toBe('Lock in your picks');
   });
 
+  it('tour countdown T-5/T-3/T-1 uses View / Edit picks when picks_secured (#509)', () => {
+    const entry = getCommsTemplateEntry('tour-countdown');
+    expect(entry.build({ days_remaining: 5, picks_secured: true }).cta).toEqual({
+      label: 'View / Edit picks',
+      href: '/dashboard/picks',
+    });
+    expect(entry.build({ days_remaining: 3, picks_secured: true }).cta.label).toBe(
+      'View / Edit picks',
+    );
+    expect(entry.build({ days_remaining: 1, picks_secured: true }).cta.label).toBe(
+      'View / Edit picks',
+    );
+    // T-10 stays exploratory even if secured
+    expect(entry.build({ days_remaining: 10, picks_secured: true }).cta.label).toBe(
+      'View upcoming shows',
+    );
+  });
+
   it('tour engagement reminder uses in-app picks CTA (not "Open the app")', () => {
     const entry = getCommsTemplateEntry('tour-engagement-reminder');
     expect(entry.build({}).cta).toEqual({
       label: 'Make picks for next show',
       href: '/dashboard/picks',
     });
+    expect(entry.build({ picks_secured: true }).cta).toEqual({
+      label: 'View / Edit picks',
+      href: '/dashboard/picks',
+    });
+  });
+
+  it('picks-lock-reminder CTA switches when picks_secured (#509)', () => {
+    const entry = getCommsTemplateEntry('picks-lock-reminder');
+    expect(entry.build({}).cta.label).toBe('Make your picks');
+    expect(entry.build({ picks_secured: true }).cta.label).toBe('View / Edit picks');
   });
 
   it('show_recap CTA is honest about standings destination (#551)', () => {


### PR DESCRIPTION
Closes #509

## Summary
- In-app registry: T-5/T-3/T-1 countdown, lock reminder, and engagement switch to **View / Edit picks** when `picks_secured`
- Adapters enrich `tour_countdown` (+ recovery) and `tour_engagement_reminder` from non-empty picks for first/next show
- `picks_lock_reminder` keeps skip-if-picks audience; secured CTA covered in `/comms-preview` samples
- Catalog + CTA audit docs updated

## Test plan
- [x] `npm test -- --run src/features/notifications/ui/commsTemplates/commsTemplateRegistry.test.js`
- [x] `cd functions && node --test commsEventAdapters.test.js`
- [ ] Localhost: http://localhost:5173/comms-preview — confirm secured samples show **View / Edit picks**
- [ ] Leave issue open until promote; AC checkboxes tracked on issue comment


Made with [Cursor](https://cursor.com)