### PR TITLE
fix(install): distinct Chrome vs Safari A2HS copy (#539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.14] — 2026-07-14
+
+### Changed
+- **A2HS copy by platform (#539)** — Android Chrome / desktop Chromium / iOS Safari lead copy and Safari Share-toolbar steps are shared across the dashboard banner and Profile install card; telemetry uses `android_chrome` / `desktop_chromium` / `ios_safari` / `ios_non_safari`.
+
+---
+
 ## [1.20.13] — 2026-07-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.13",
+  "version": "1.20.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/install/model/installCopy.js
+++ b/src/features/install/model/installCopy.js
@@ -1,0 +1,116 @@
+/**
+ * Platform-specific A2HS lead copy + Safari steps (#539).
+ * Shared by DashboardInstallEngageBanner and InstallAppCard.
+ */
+
+/** @typedef {'android_chrome' | 'desktop_chromium' | 'ios_safari' | 'ios_non_safari' | 'unsupported'} InstallCopyBranch */
+
+/**
+ * @param {PickNavigator} [nav]
+ * @returns {boolean}
+ */
+export function isAndroidLike(nav = typeof navigator !== 'undefined' ? navigator : undefined) {
+  if (!nav || typeof nav.userAgent !== 'string') return false;
+  return /Android/i.test(nav.userAgent);
+}
+
+/**
+ * Telemetry + copy branch for install CTAs (#539).
+ *
+ * @param {{
+ *   canPrompt?: boolean,
+ *   shouldShowIosFlow?: boolean,
+ *   shouldShowIosNonSafariFlow?: boolean,
+ *   nav?: PickNavigator,
+ * }} opts
+ * @returns {InstallCopyBranch}
+ */
+export function resolveInstallCopyBranch({
+  canPrompt = false,
+  shouldShowIosFlow = false,
+  shouldShowIosNonSafariFlow = false,
+  nav = typeof navigator !== 'undefined' ? navigator : undefined,
+} = {}) {
+  if (shouldShowIosNonSafariFlow) return 'ios_non_safari';
+  if (shouldShowIosFlow) return 'ios_safari';
+  if (canPrompt) {
+    return isAndroidLike(nav) ? 'android_chrome' : 'desktop_chromium';
+  }
+  return 'unsupported';
+}
+
+/**
+ * @param {InstallCopyBranch} branch
+ * @returns {{ eyebrow: string, body: string, ctaLabel: string | null }}
+ */
+export function getInstallLeadCopy(branch) {
+  switch (branch) {
+    case 'android_chrome':
+      return {
+        eyebrow: 'One-tap install',
+        body: 'Tap below, then confirm Install in Chrome for quick access on show night.',
+        ctaLabel: 'Add to Home Screen',
+      };
+    case 'desktop_chromium':
+      return {
+        eyebrow: 'Install this site',
+        body: "Add Setlist Pick 'Em as an app shortcut for a faster full-screen dashboard.",
+        ctaLabel: 'Install app',
+      };
+    case 'ios_safari':
+      return {
+        eyebrow: 'iPhone · Safari',
+        body: "Use Safari's Share sheet to Add to Home Screen — required for reliable show-night push.",
+        ctaLabel: null,
+      };
+    case 'ios_non_safari':
+      return {
+        eyebrow: 'Open in Safari',
+        body: "On iPhone, Chrome and other browsers can't install this app. Open setlistpickem.com in Safari, then use Share → Add to Home Screen.",
+        ctaLabel: null,
+      };
+    default:
+      return {
+        eyebrow: 'Install app',
+        body: "Install is not available in this browser yet. On iPhone, open Setlist Pick 'Em in Safari and use Add to Home Screen.",
+        ctaLabel: null,
+      };
+  }
+}
+
+/** Ordered Safari A2HS steps — Share toolbar, not Chrome ⋮ (#539). */
+export const IOS_SAFARI_INSTALL_STEPS = Object.freeze([
+  {
+    id: 'share',
+    prefix: '1. ',
+    parts: [
+      { text: 'Tap the ', bold: false },
+      { text: 'Share', bold: true },
+      { text: ' button in Safari’s toolbar (square with an arrow).', bold: false },
+    ],
+  },
+  {
+    id: 'a2hs',
+    prefix: '2. ',
+    parts: [
+      { text: 'Scroll and tap ', bold: false },
+      { text: 'Add to Home Screen', bold: true },
+      { text: '.', bold: false },
+    ],
+  },
+  {
+    id: 'add',
+    prefix: '3. ',
+    parts: [
+      { text: 'Tap ', bold: false },
+      { text: 'Add', bold: true },
+      { text: ' (or the ', bold: false },
+      { text: '+', bold: true },
+      { text: ') to confirm.', bold: false },
+    ],
+  },
+]);
+
+/**
+ * @typedef {{ userAgent?: string }} PickNavigator
+ */

--- a/src/features/install/model/installCopy.test.js
+++ b/src/features/install/model/installCopy.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getInstallLeadCopy,
+  IOS_SAFARI_INSTALL_STEPS,
+  isAndroidLike,
+  resolveInstallCopyBranch,
+} from './installCopy';
+
+describe('installCopy (#539)', () => {
+  it('detects Android UA', () => {
+    expect(isAndroidLike({ userAgent: 'Mozilla/5.0 (Linux; Android 14) Chrome/120' })).toBe(true);
+    expect(isAndroidLike({ userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X)' })).toBe(false);
+  });
+
+  it('resolves telemetry branches', () => {
+    expect(
+      resolveInstallCopyBranch({
+        canPrompt: true,
+        nav: { userAgent: 'Mozilla/5.0 (Linux; Android 14) Chrome/120' },
+      }),
+    ).toBe('android_chrome');
+    expect(
+      resolveInstallCopyBranch({
+        canPrompt: true,
+        nav: { userAgent: 'Mozilla/5.0 (Windows NT 10.0) Chrome/120' },
+      }),
+    ).toBe('desktop_chromium');
+    expect(resolveInstallCopyBranch({ shouldShowIosFlow: true })).toBe('ios_safari');
+    expect(resolveInstallCopyBranch({ shouldShowIosNonSafariFlow: true })).toBe('ios_non_safari');
+  });
+
+  it('android lead copy references Chrome install, not Safari Share', () => {
+    const copy = getInstallLeadCopy('android_chrome');
+    expect(copy.body.toLowerCase()).toContain('chrome');
+    expect(copy.body.toLowerCase()).not.toContain('share');
+  });
+
+  it('Safari steps reference Share toolbar, not three-dot menu', () => {
+    const joined = IOS_SAFARI_INSTALL_STEPS.flatMap((s) => s.parts.map((p) => p.text)).join('');
+    expect(joined.toLowerCase()).toContain('share');
+    expect(joined.toLowerCase()).toContain('toolbar');
+    expect(joined.toLowerCase()).not.toContain('three-dot');
+    expect(joined).not.toContain('...');
+  });
+});

--- a/src/features/install/model/useInstallPrompt.js
+++ b/src/features/install/model/useInstallPrompt.js
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { ga4Event } from '../../../shared/lib/ga4';
+import { resolveInstallCopyBranch } from './installCopy';
 import {
   isInstalled,
   isIosNonSafariBrowser,
@@ -130,11 +131,13 @@ export function useInstallPrompt() {
 
   useEffect(() => {
     if (!shouldShowCard) return;
-    let platform = 'ios_safari';
-    if (canPrompt) platform = 'chromium';
-    else if (isIosNonSafari) platform = 'ios_non_safari';
+    const platform = resolveInstallCopyBranch({
+      canPrompt,
+      shouldShowIosFlow,
+      shouldShowIosNonSafariFlow,
+    });
     ga4Event('a2hs_cta_shown', { platform });
-  }, [shouldShowCard, canPrompt, isIosNonSafari]);
+  }, [shouldShowCard, canPrompt, shouldShowIosFlow, shouldShowIosNonSafariFlow]);
 
   const dismissIos = useCallback(() => {
     setIosDismissedStorage(true);
@@ -163,10 +166,11 @@ export function useInstallPrompt() {
   const promptInstall = useCallback(async () => {
     if (!deferredPrompt) return false;
 
-    ga4Event('a2hs_cta_clicked', { platform: 'chromium' });
+    const platform = resolveInstallCopyBranch({ canPrompt: true });
+    ga4Event('a2hs_cta_clicked', { platform });
     deferredPrompt.prompt();
     const choice = await deferredPrompt.userChoice;
-    ga4Event('a2hs_prompt_result', { outcome: choice?.outcome ?? 'unknown' });
+    ga4Event('a2hs_prompt_result', { outcome: choice?.outcome ?? 'unknown', platform });
     setDeferredPrompt(null);
     return choice?.outcome === 'accepted';
   }, [deferredPrompt]);

--- a/src/features/install/ui/DashboardInstallEngageBanner.jsx
+++ b/src/features/install/ui/DashboardInstallEngageBanner.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { Bell, Download, Share2 } from 'lucide-react';
 
@@ -7,9 +7,11 @@ import {
   isProfileClusterPath,
 } from '../../../shared/config/dashboardRoutes';
 import { ga4Event } from '../../../shared/lib/ga4';
+import { getInstallLeadCopy, resolveInstallCopyBranch } from '../model/installCopy';
 import { useDashboardPushNudge } from '../model/useDashboardPushNudge';
 import { useInstallPrompt } from '../model/useInstallPrompt';
 import IosInstallScreenshotGallery from './IosInstallScreenshotGallery.jsx';
+import IosSafariInstallSteps from './IosSafariInstallSteps.jsx';
 
 /**
  * Routes where the compact install + push nudge may appear (#334). Profile
@@ -48,6 +50,21 @@ function DashboardInstallEngageBannerLoaded({ userId }) {
   const showInstall = install.shouldShowDashboardInstallBanner;
   const showPush = push.shouldShowPushNudge;
 
+  const branch = useMemo(
+    () =>
+      resolveInstallCopyBranch({
+        canPrompt: install.canPrompt,
+        shouldShowIosFlow: install.shouldShowIosFlow,
+        shouldShowIosNonSafariFlow: install.shouldShowIosNonSafariFlow,
+      }),
+    [
+      install.canPrompt,
+      install.shouldShowIosFlow,
+      install.shouldShowIosNonSafariFlow,
+    ],
+  );
+  const lead = getInstallLeadCopy(branch);
+
   if (!showInstall && !showPush) return null;
 
   return (
@@ -55,11 +72,9 @@ function DashboardInstallEngageBannerLoaded({ userId }) {
       {showInstall ? (
         <div className="rounded-2xl border border-border-subtle bg-surface-panel px-4 py-3 shadow-inset-glass md:px-5">
           <p className="text-[11px] font-black uppercase tracking-widest text-brand-primary">
-            Faster launch &amp; full screen
+            {lead.eyebrow}
           </p>
-          <p className="mt-1 text-xs font-bold leading-snug text-content-secondary">
-            Add Setlist Pick &apos;Em to your home screen for quick access on show night.
-          </p>
+          <p className="mt-1 text-xs font-bold leading-snug text-content-secondary">{lead.body}</p>
 
           {install.canPrompt ? (
             <button
@@ -68,7 +83,7 @@ function DashboardInstallEngageBannerLoaded({ userId }) {
               className="mt-3 flex w-full items-center justify-center gap-2 rounded-xl border-2 border-brand-primary/45 bg-brand-primary/10 py-2.5 text-xs font-black uppercase tracking-widest text-brand-primary transition-colors hover:border-brand-primary hover:bg-brand-primary/20"
             >
               <Download className="h-4 w-4 shrink-0" aria-hidden />
-              Add to Home Screen
+              {lead.ctaLabel || 'Add to Home Screen'}
             </button>
           ) : null}
 
@@ -82,23 +97,11 @@ function DashboardInstallEngageBannerLoaded({ userId }) {
                 className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-border-subtle bg-surface-field py-2.5 text-xs font-black uppercase tracking-widest text-white transition-colors hover:border-brand-primary/50 hover:bg-surface-panel"
               >
                 <Share2 className="h-4 w-4 shrink-0" aria-hidden />
-                {install.showIosGuide ? 'Hide steps' : 'iPhone: Add to Home Screen'}
+                {install.showIosGuide ? 'Hide steps' : 'Show Safari steps'}
               </button>
               {install.showIosGuide ? (
                 <div className="space-y-2">
-                  <ol className="space-y-1.5 rounded-xl border border-border-muted bg-surface-inset p-3 text-xs text-content-secondary">
-                    <li>
-                      1. Tap the three-dot menu <span className="font-bold text-white">(...)</span>, then tap{' '}
-                      <span className="font-bold text-white">Share</span> (share icon).
-                    </li>
-                    <li>
-                      2. Scroll down and tap{' '}
-                      <span className="font-bold text-white">Add to Home Screen</span>.
-                    </li>
-                    <li>
-                      3. Tap the <span className="font-bold text-white">+</span> icon.
-                    </li>
-                  </ol>
+                  <IosSafariInstallSteps compact />
                   <IosInstallScreenshotGallery compact />
                 </div>
               ) : null}
@@ -115,9 +118,7 @@ function DashboardInstallEngageBannerLoaded({ userId }) {
           {install.shouldShowIosNonSafariFlow ? (
             <div className="mt-3 space-y-2">
               <p className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-3 text-xs font-bold leading-relaxed text-content-secondary">
-                On iPhone, <span className="text-white">Chrome and other browsers can&apos;t install</span> this
-                app. Open <span className="text-white">setlistpickem.com</span> in{' '}
-                <span className="text-white">Safari</span>, then use Share → Add to Home Screen.
+                {lead.body}
               </p>
               <button
                 type="button"

--- a/src/features/install/ui/DashboardInstallEngageBanner.jsx
+++ b/src/features/install/ui/DashboardInstallEngageBanner.jsx
@@ -74,7 +74,9 @@ function DashboardInstallEngageBannerLoaded({ userId }) {
           <p className="text-[11px] font-black uppercase tracking-widest text-brand-primary">
             {lead.eyebrow}
           </p>
-          <p className="mt-1 text-xs font-bold leading-snug text-content-secondary">{lead.body}</p>
+          {install.canPrompt || install.shouldShowIosFlow ? (
+            <p className="mt-1 text-xs font-bold leading-snug text-content-secondary">{lead.body}</p>
+          ) : null}
 
           {install.canPrompt ? (
             <button

--- a/src/features/install/ui/InstallAppCard.jsx
+++ b/src/features/install/ui/InstallAppCard.jsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Download, Share2 } from 'lucide-react';
 
+import { getInstallLeadCopy, resolveInstallCopyBranch } from '../model/installCopy';
 import { useInstallPrompt } from '../model/useInstallPrompt';
 import IosInstallScreenshotGallery from './IosInstallScreenshotGallery.jsx';
+import IosSafariInstallSteps from './IosSafariInstallSteps.jsx';
 
 export default function InstallAppCard() {
   const {
@@ -17,17 +19,28 @@ export default function InstallAppCard() {
     shouldShowIosNonSafariFlow,
   } = useInstallPrompt();
 
+  const branch = useMemo(
+    () =>
+      resolveInstallCopyBranch({
+        canPrompt,
+        shouldShowIosFlow,
+        shouldShowIosNonSafariFlow,
+      }),
+    [canPrompt, shouldShowIosFlow, shouldShowIosNonSafariFlow],
+  );
+  const lead = getInstallLeadCopy(branch);
+
   if (isInstalled) return null;
 
   return (
     <section className="mt-8 rounded-3xl border border-border-subtle bg-surface-panel p-6 shadow-inset-glass">
       <h3 className="text-sm font-black uppercase tracking-widest text-content-secondary">
-        Install app
+        {lead.eyebrow}
       </h3>
-      <p className="mt-2 text-sm leading-relaxed text-content-secondary">
-        Get faster launch and a cleaner full-screen dashboard by adding Setlist Pick &apos;Em to your
-        home screen.
-      </p>
+
+      {canPrompt || shouldShowIosFlow ? (
+        <p className="mt-2 text-sm leading-relaxed text-content-secondary">{lead.body}</p>
+      ) : null}
 
       {canPrompt ? (
         <button
@@ -36,7 +49,7 @@ export default function InstallAppCard() {
           className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border-2 border-brand-primary/45 bg-brand-primary/10 py-3.5 text-sm font-black uppercase tracking-widest text-brand-primary transition-colors hover:border-brand-primary hover:bg-brand-primary/20"
         >
           <Download className="h-4 w-4 shrink-0" aria-hidden />
-          Add to Home Screen
+          {lead.ctaLabel || 'Add to Home Screen'}
         </button>
       ) : null}
 
@@ -48,24 +61,12 @@ export default function InstallAppCard() {
             className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border-2 border-border-subtle bg-surface-field py-3.5 text-sm font-black uppercase tracking-widest text-white transition-colors hover:border-brand-primary/50 hover:bg-surface-panel"
           >
             <Share2 className="h-4 w-4 shrink-0" aria-hidden />
-            {showIosGuide ? 'Hide iPhone install steps' : 'Show iPhone install steps'}
+            {showIosGuide ? 'Hide Safari steps' : 'Show Safari steps'}
           </button>
 
           {showIosGuide ? (
             <div className="mt-4 space-y-3">
-              <ol className="space-y-2 rounded-2xl border border-border-muted bg-surface-inset p-4 text-sm text-content-secondary">
-                <li>
-                  1. Tap the three-dot menu <span className="font-bold text-white">(...)</span>, then tap{' '}
-                  <span className="font-bold text-white">Share</span> (share icon).
-                </li>
-                <li>
-                  2. Scroll down and tap{' '}
-                  <span className="font-bold text-white">Add to Home Screen</span>.
-                </li>
-                <li>
-                  3. Tap the <span className="font-bold text-white">+</span> icon to confirm.
-                </li>
-              </ol>
+              <IosSafariInstallSteps />
               <IosInstallScreenshotGallery />
             </div>
           ) : null}
@@ -83,9 +84,7 @@ export default function InstallAppCard() {
       {shouldShowIosNonSafariFlow ? (
         <>
           <p className="mt-4 rounded-2xl border border-amber-500/35 bg-amber-500/5 p-4 text-sm font-bold leading-relaxed text-content-secondary">
-            On iPhone, <span className="text-white">Chrome and other browsers can&apos;t install</span>{' '}
-            this app. Open <span className="text-white">setlistpickem.com</span> in{' '}
-            <span className="text-white">Safari</span>, then use Share → Add to Home Screen.
+            {lead.body}
           </p>
           <button
             type="button"
@@ -99,9 +98,7 @@ export default function InstallAppCard() {
 
       {!canPrompt && !shouldShowIosFlow && !shouldShowIosNonSafariFlow ? (
         <p className="mt-4 rounded-2xl border border-border-muted bg-surface-inset p-4 text-sm leading-relaxed text-content-secondary">
-          Install is not available in this browser yet. For the best install experience on iPhone,
-          open Setlist Pick &apos;Em in <span className="font-bold text-white">Safari</span> and use
-          Add to Home Screen.
+          {lead.body}
         </p>
       ) : null}
     </section>

--- a/src/features/install/ui/IosSafariInstallSteps.jsx
+++ b/src/features/install/ui/IosSafariInstallSteps.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { IOS_SAFARI_INSTALL_STEPS } from '../model/installCopy';
+
+/**
+ * Shared ordered Safari A2HS steps (#539).
+ *
+ * @param {{ className?: string, compact?: boolean }} props
+ */
+export default function IosSafariInstallSteps({ className = '', compact = false }) {
+  const listClass = compact
+    ? 'space-y-1.5 rounded-xl border border-border-muted bg-surface-inset p-3 text-xs text-content-secondary'
+    : 'space-y-2 rounded-2xl border border-border-muted bg-surface-inset p-4 text-sm text-content-secondary';
+
+  return (
+    <ol className={`${listClass} ${className}`.trim()}>
+      {IOS_SAFARI_INSTALL_STEPS.map((step) => (
+        <li key={step.id}>
+          {step.prefix}
+          {step.parts.map((part, i) =>
+            part.bold ? (
+              <span key={`${step.id}-${i}`} className="font-bold text-white">
+                {part.text}
+              </span>
+            ) : (
+              <span key={`${step.id}-${i}`}>{part.text}</span>
+            ),
+          )}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/features/install/ui/iosInstallScreenshots.js
+++ b/src/features/install/ui/iosInstallScreenshots.js
@@ -5,8 +5,8 @@
 export const IOS_INSTALL_SCREENSHOT_STEPS = Object.freeze([
   {
     src: '/images/iphone-add-to-homescreen/1.png',
-    alt: 'Safari: open the menu, then tap Share',
-    caption: 'Step 1: Menu (…) → Share',
+    alt: "Safari toolbar: tap Share (square with arrow)",
+    caption: 'Step 1: Share (toolbar)',
   },
   {
     src: '/images/iphone-add-to-homescreen/2.png',

--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link, useOutletContext } from 'react-router-dom';
 import { ExternalLink } from 'lucide-react';
 
+import { InstallAppCard } from '../../features/install';
 import { ProfileEditForm, useUserProfile } from '../../features/profile';
 import { dashboardPageTitleGradientClasses } from '../../shared/config/dashboardHeadingTypography';
 import DashboardActionRow from '../../shared/ui/DashboardActionRow';
@@ -60,6 +61,9 @@ export default function ProfilePage({ user: userProp }) {
         isLoading={isLoading}
         message={message}
       />
+
+      {/* Remounted for #539 — shares installCopy with dashboard banner */}
+      <InstallAppCard />
     </div>
   );
 }


### PR DESCRIPTION
Closes #539

## Summary
- Platform-specific lead copy via shared `installCopy` (Android Chrome / desktop Chromium / iOS Safari / iOS non-Safari)
- Safari steps + screenshot captions use Share toolbar (not Chrome ⋮)
- Remount `InstallAppCard` on Profile so banner + card stay in sync
- Telemetry `platform`: `android_chrome` | `desktop_chromium` | `ios_safari` | `ios_non_safari`

## Test plan
- [x] `npm test -- --run src/features/install`
- [ ] Localhost: Profile + dashboard banner on Chromium vs iOS Safari (simulator/device)
- [ ] Confirm iOS Chrome still shows open-in-Safari amber copy


Made with [Cursor](https://cursor.com)