### PR TITLE
feat(notifications): PWA-first push disable gate (#532)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.15] — 2026-07-14
+
+### Changed
+- **PWA-first push disable (#532)** — Messages **Disable** is only shown in standalone/installed context; browser tabs get install/Settings copy instead. Desktop Chrome tabs follow the same rule.
+
+---
+
 ## [1.20.14] — 2026-07-14
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.14",
+  "version": "1.20.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/install/index.js
+++ b/src/features/install/index.js
@@ -3,3 +3,4 @@ export {
   default as DashboardInstallEngageBanner,
   dashboardRouteShowsInstallEngage,
 } from './ui/DashboardInstallEngageBanner.jsx';
+export { isInstalled } from './model/installPromptPlatform';

--- a/src/features/notifications/model/pushDisablePolicy.js
+++ b/src/features/notifications/model/pushDisablePolicy.js
@@ -1,0 +1,32 @@
+/**
+ * PWA-first push disable policy (#532).
+ *
+ * Product decision (Sprint 7): in-app **Disable** is only available when the
+ * app is installed (standalone / navigator.standalone). Desktop Chrome tabs
+ * follow the same rule — revoke via system Settings or install first.
+ */
+
+/**
+ * @param {{ isInstalled?: boolean }} opts
+ * @returns {boolean}
+ */
+export function canShowPushDisable({ isInstalled = false } = {}) {
+  return Boolean(isInstalled);
+}
+
+/**
+ * Copy shown when Disable is hidden (browser tab / non-PWA).
+ *
+ * @param {{ isInstalled?: boolean, permission?: string }} opts
+ * @returns {string | null}
+ */
+export function pushDisableUnavailableCopy({
+  isInstalled = false,
+  permission = 'default',
+} = {}) {
+  if (isInstalled) return null;
+  if (permission === 'granted') {
+    return 'Push is managed by this browser. Add Setlist Pick \'Em to your home screen to turn it off in-app, or revoke in system Settings.';
+  }
+  return 'Add Setlist Pick \'Em to your home screen for reliable show-night push — then Enable here. Disable is available in the installed app.';
+}

--- a/src/features/notifications/model/pushDisablePolicy.test.js
+++ b/src/features/notifications/model/pushDisablePolicy.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { canShowPushDisable, pushDisableUnavailableCopy } from './pushDisablePolicy';
+
+describe('pushDisablePolicy (#532)', () => {
+  it('allows Disable only when installed', () => {
+    expect(canShowPushDisable({ isInstalled: true })).toBe(true);
+    expect(canShowPushDisable({ isInstalled: false })).toBe(false);
+    expect(canShowPushDisable({})).toBe(false);
+  });
+
+  it('explains non-PWA when Disable is hidden', () => {
+    const copy = pushDisableUnavailableCopy({ isInstalled: false, permission: 'default' });
+    expect(copy).toMatch(/home screen/i);
+    expect(pushDisableUnavailableCopy({ isInstalled: true })).toBeNull();
+    expect(pushDisableUnavailableCopy({ isInstalled: false, permission: 'granted' })).toMatch(
+      /system Settings/i,
+    );
+  });
+});

--- a/src/features/notifications/ui/NotificationsPrototypeScreen.jsx
+++ b/src/features/notifications/ui/NotificationsPrototypeScreen.jsx
@@ -3,10 +3,15 @@ import { useSearchParams } from 'react-router-dom';
 import { Bell, ChevronDown, Mail, Smartphone } from 'lucide-react';
 
 import { dashboardPageTitleGradientClasses } from '../../../shared/config/dashboardHeadingTypography';
+import { isInstalled } from '../../install';
 import { logCommsPrefChanged } from '../../comms';
 import CommsInboxSection from './CommsInboxSection.jsx';
 import { useCommsEmailStatus } from '../model/useCommsEmailStatus';
 import { useNotificationPrefs } from '../model/useNotificationPrefs';
+import {
+  canShowPushDisable,
+  pushDisableUnavailableCopy,
+} from '../model/pushDisablePolicy';
 import { usePushTokenRegistration } from '../model/usePushTokenRegistration';
 
 function ChannelToggle({ description, disabled, checked, label, onChange }) {
@@ -125,6 +130,15 @@ export default function NotificationsPrototypeScreen() {
     triggerPushCanary,
     canaryStatus,
   } = usePushTokenRegistration();
+
+  const installed =
+    typeof window !== 'undefined' && isInstalled(window, navigator);
+  const showPushDisable = canShowPushDisable({ isInstalled: installed });
+  const disableUnavailableCopy = pushDisableUnavailableCopy({
+    isInstalled: installed,
+    permission,
+  });
+
   const {
     prefs,
     setField,
@@ -273,27 +287,42 @@ export default function NotificationsPrototypeScreen() {
           onToggle={() => handleAccordion('push')}
         >
           <p className="text-sm font-bold leading-relaxed text-content-secondary">
-            Get lock reminders, score updates, and recap drops on your phone. Add Setlist Pick
-            &apos;Em to your home screen, then tap Enable and allow notifications.
+            {installed
+              ? 'Get lock reminders, score updates, and recap drops on this device. Tap Enable and allow notifications when prompted.'
+              : 'Get lock reminders, score updates, and recap drops on your phone. Add Setlist Pick \'Em to your home screen for reliable push, then tap Enable and allow notifications.'}
           </p>
+          {!showPushDisable && disableUnavailableCopy ? (
+            <p className="mt-3 rounded-xl border border-border-muted bg-surface-inset/60 px-3 py-2 text-xs font-bold leading-relaxed text-content-secondary">
+              {disableUnavailableCopy}
+            </p>
+          ) : null}
           <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
             <span className="text-xs font-bold uppercase tracking-wider text-content-secondary">
               {pushStatusLabel}
             </span>
             <div className="flex flex-wrap items-center gap-2">
-              <button
-                type="button"
-                onClick={status === 'enabled' ? disablePush : enablePush}
-                disabled={status === 'working'}
-                className={`rounded-lg border px-3 py-1.5 text-xs font-black uppercase tracking-widest transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
-                  status === 'enabled'
-                    ? 'border-amber-500/40 bg-amber-500/10 text-amber-200 hover:border-amber-500 hover:bg-amber-500/20'
-                    : 'border-brand-primary/40 bg-brand-primary/10 text-brand-primary hover:border-brand-primary hover:bg-brand-primary/20'
-                }`}
-                aria-label={status === 'enabled' ? 'Disable push notifications' : 'Enable push notifications'}
-              >
-                {status === 'enabled' ? 'Disable' : status === 'working' ? 'Working...' : 'Enable'}
-              </button>
+              {status === 'enabled' && showPushDisable ? (
+                <button
+                  type="button"
+                  onClick={disablePush}
+                  disabled={status === 'working'}
+                  className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs font-black uppercase tracking-widest text-amber-200 transition-colors hover:border-amber-500 hover:bg-amber-500/20 disabled:cursor-not-allowed disabled:opacity-60"
+                  aria-label="Disable push notifications"
+                >
+                  Disable
+                </button>
+              ) : null}
+              {status !== 'enabled' ? (
+                <button
+                  type="button"
+                  onClick={enablePush}
+                  disabled={status === 'working'}
+                  className="rounded-lg border border-brand-primary/40 bg-brand-primary/10 px-3 py-1.5 text-xs font-black uppercase tracking-widest text-brand-primary transition-colors hover:border-brand-primary hover:bg-brand-primary/20 disabled:cursor-not-allowed disabled:opacity-60"
+                  aria-label="Enable push notifications"
+                >
+                  {status === 'working' ? 'Working...' : 'Enable'}
+                </button>
+              ) : null}
               <button
                 type="button"
                 onClick={triggerPushCanary}
@@ -307,6 +336,9 @@ export default function NotificationsPrototypeScreen() {
           </div>
           <p className="mt-2 text-xs text-content-secondary">
             Browser permission: <span className="font-bold text-white">{permission}</span>
+            {' · '}
+            Surface:{' '}
+            <span className="font-bold text-white">{installed ? 'PWA' : 'browser'}</span>
           </p>
               {canaryStatus === 'sent' ? (
                 <p className="mt-2 text-xs text-emerald-300">


### PR DESCRIPTION
Closes #532

## Summary
- Messages **Disable** only when `isInstalled()` (standalone / navigator.standalone)
- Non-PWA copy points at A2HS or system Settings
- **Product decision:** desktop Chrome tabs also hide Disable (PWA-only disable everywhere)
- Enable + category prefs unchanged; no silent permission prompt

## Test plan
- [x] `pushDisablePolicy` unit tests
- [x] `npm run lint`
- [ ] Localhost Messages: browser tab = no Disable; after A2HS standalone = Disable available
- [ ] Confirm Enable still prompts on explicit tap


Made with [Cursor](https://cursor.com)