### PR TITLE
perf(comms): email deep-link return path + App Check kickoff (#535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.16] — 2026-07-14
+
+### Added
+- **Email deep-link P0 (#535)** — persist intended dashboard path on unauth redirect; eager App Check on dashboard mount; picks-lock CTA includes `?showDate=`; `comms_email_landed` + `picks_page_interactive` funnel events.
+
+---
+
 ## [1.20.15] — 2026-07-14
 
 ### Changed

--- a/docs/comms-triggers/MEASUREMENT_PLAN.md
+++ b/docs/comms-triggers/MEASUREMENT_PLAN.md
@@ -61,6 +61,19 @@ Eligible users → comms_delivered → comms_opened → comms_cta_click → logi
 Eligible → comms_delivered → comms_push_tap → pick submitted before lock
 ```
 
+Email deep-link funnel (#535):
+
+```text
+comms_delivered (email) → comms_email_landed → picks_page_interactive → submit_picks
+```
+
+| Event | When |
+|-------|------|
+| `comms_email_landed` | Picks page mounts with `utm_campaign` (from click host) |
+| `picks_page_interactive` | Picks form finished loading (`!isLoadingPicks`) |
+
+**Bot-filtered click KPI:** ignore `/api/email-click` hits with scanner referrers (e.g. `bing.com`) or sub-second engagement; prefer GA4 funnel above + Firestore first-time lock ground truth over raw click-host pageviews.
+
 Primary metric: **pick submission rate before lock** among reminded users vs holdout (when experiments run).
 
 ### Results (`tour_recap_*`, `post_show_*`)

--- a/functions/commsTemplates.js
+++ b/functions/commsTemplates.js
@@ -26,6 +26,21 @@ function handleOf(p) {
 }
 
 /**
+ * Show-scoped picks CTA (#535). Appends `?showDate=YYYY-MM-DD` when payload has
+ * a calendar date (ignores display labels like "Tonight").
+ *
+ * @param {Record<string, unknown>} p
+ * @returns {string}
+ */
+function picksCtaUrl(p) {
+  const raw = p && typeof p.show_date === "string" ? p.show_date.trim() : "";
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    return `${PICKS_CTA_URL}?showDate=${encodeURIComponent(raw)}`;
+  }
+  return PICKS_CTA_URL;
+}
+
+/**
  * @param {string} venue
  * @param {string} city
  * @returns {string}
@@ -272,12 +287,13 @@ const BUILDERS = {
     const venue = venueLine(p);
     const lockLabel = p.lock_time_local || "7:30 PM";
     const timePhrase = p.time_to_lock ? ` in ${p.time_to_lock}` : "";
+    const ctaUrl = picksCtaUrl(p);
     const assembled = assembleServiceEmail(
       [
         `${handleOf(p)}, ${p.venue_name || "tonight's show"} locks at ${lockLabel} local${timePhrase}.`,
         "You haven't locked picks yet — don't get shut out.",
       ],
-      { ctaUrl: PICKS_CTA_URL, signOff: "See you on tour!" }
+      { ctaUrl, signOff: "See you on tour!" }
     );
     return {
       push: {
@@ -290,7 +306,7 @@ const BUILDERS = {
           : `Lock in your picks${venue ? ` — ${venue}` : ""}`,
         text: assembled.text,
         signOff: assembled.signOff,
-        ctaUrl: PICKS_CTA_URL,
+        ctaUrl,
         ctaLabel: "Make Your Picks",
       },
     };

--- a/functions/commsTemplates.test.js
+++ b/functions/commsTemplates.test.js
@@ -39,6 +39,25 @@ test("inApp payload passes variables through unchanged", async () => {
   assert.deepEqual(out.inApp.payload, payload);
 });
 
+test("picks-lock-reminder email CTA includes showDate when YYYY-MM-DD (#535)", async () => {
+  const out = await renderCommsTemplate("picks-lock-reminder", {
+    handle: "HotDogBilly",
+    show_date: "2026-07-18",
+    venue_name: "MSG",
+    time_to_lock: "3 hours",
+  });
+  assert.match(out.email.ctaUrl, /\/dashboard\/picks\?showDate=2026-07-18/);
+});
+
+test("picks-lock-reminder email CTA omits showDate for display labels", async () => {
+  const out = await renderCommsTemplate("picks-lock-reminder", {
+    handle: "HotDogBilly",
+    show_date: "Tonight",
+    venue_name: "MSG",
+  });
+  assert.equal(out.email.ctaUrl, "https://www.setlistpickem.com/dashboard/picks");
+});
+
 test("unknown template falls back to a generic payload", async () => {
   const out = await renderCommsTemplate("does-not-exist", {});
   assert.ok(out.push.title);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.15",
+  "version": "1.20.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/app/routes/DashboardRoute.jsx
+++ b/src/app/routes/DashboardRoute.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 
 import {
   AuthLoadingScreen,
@@ -8,12 +8,20 @@ import {
 } from '../../features/auth';
 
 import { ShowCalendarProvider } from '../../features/show-calendar';
+import { ensureAppCheckNow } from '../../shared/lib/firebaseAppCheck';
+import { persistDashboardPath } from '../../shared/lib/dashboardLastPath';
 import DashboardLayout from '../layout/DashboardLayout';
 import { decideDashboardRoute } from './profileGuardDecision';
 
 export default function DashboardRoute() {
+  const location = useLocation();
   const { user, userProfile, loading } = useAuth();
   const decision = decideDashboardRoute({ loading, user, userProfile });
+
+  // #535: email deep links need Firestore ASAP — don't wait for idle timeout.
+  useEffect(() => {
+    ensureAppCheckNow();
+  }, []);
 
   // Anomaly signal for the consent-only orphan regression (May 2026).
   // Keyed on uid so a single mount fires once per user, even across
@@ -30,8 +38,14 @@ export default function DashboardRoute() {
     });
   }, [partialProfile, hasConsent, user?.uid]);
 
+  // #535: remember intended path before bounce to splash so post-login lands
+  // on /dashboard/picks (etc.), not generic /dashboard.
+  if (decision.kind === 'redirect-home') {
+    persistDashboardPath(location.pathname, location.search);
+    return <Navigate to="/" replace />;
+  }
+
   if (decision.kind === 'loading') return <AuthLoadingScreen />;
-  if (decision.kind === 'redirect-home') return <Navigate to="/" replace />;
   if (decision.kind === 'redirect-setup') {
     return <Navigate to="/setup" replace />;
   }

--- a/src/features/comms/index.js
+++ b/src/features/comms/index.js
@@ -17,9 +17,9 @@ export {
   logCommsDismissed,
   logCommsCtaClick,
   logCommsPushTap,
+  logCommsEmailLanded,
   logCommsPrefChanged,
 } from './model/commsAnalytics.js';
-
 export {
   SPHERE_2026_RECAP_ID,
   SPHERE_2026_META,

--- a/src/features/comms/model/commsAnalytics.js
+++ b/src/features/comms/model/commsAnalytics.js
@@ -74,6 +74,18 @@ export function logCommsPushTap(meta) {
 }
 
 /**
+ * Email deep-link landed on a dashboard surface (#535).
+ * Prefer calling once with `utm_campaign` / known trigger from the landing URL.
+ *
+ * @param {CommsEventMeta & { surface?: string }} meta
+ */
+export function logCommsEmailLanded(meta) {
+  const params = commsDimensions({ ...meta, channel: COMMS_CHANNEL.email });
+  if (meta?.surface) params.comms_surface = meta.surface;
+  ga4Event('comms_email_landed', params);
+}
+
+/**
  * User changed a notification preference toggle.
  *
  * @param {{ prefKey: string, enabled: boolean }} meta

--- a/src/features/picks/index.js
+++ b/src/features/picks/index.js
@@ -14,3 +14,4 @@ export {
   userHasSubmittedPickEntry,
 } from './model/pickSubmission';
 export { useSetlistLockToast } from './model/useSetlistLockToast';
+export { trackPicksPageInteractive } from './model/picksAnalytics';

--- a/src/features/picks/model/picksAnalytics.js
+++ b/src/features/picks/model/picksAnalytics.js
@@ -13,3 +13,10 @@ export function trackEditPicks({ show_id, tour_date }) {
     tour_date: tour_date ?? '',
   });
 }
+
+/** Picks form ready for input after cold email / deep-link land (#535). */
+export function trackPicksPageInteractive({ show_id, comms_trigger_id } = {}) {
+  const params = { show_id: show_id ?? '' };
+  if (comms_trigger_id) params.comms_trigger_id = comms_trigger_id;
+  ga4Event('picks_page_interactive', params);
+}

--- a/src/pages/picks/PicksPage.jsx
+++ b/src/pages/picks/PicksPage.jsx
@@ -1,10 +1,13 @@
-import React, { useEffect, useId, useState } from 'react';
+import React, { useEffect, useId, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { CheckCircle2, ChevronDown, Lock, Scale } from 'lucide-react';
 
+import { logCommsEmailLanded } from '../../features/comms';
 import {
   PicksFieldsForm,
   PicksSelfRecapSection,
   PicksSubmitButton,
+  trackPicksPageInteractive,
   usePicksForm,
   usePicksSelfRecap,
 } from '../../features/picks';
@@ -14,7 +17,9 @@ import { showOptionLabelCompact } from '../../shared/utils/showOptionLabel';
 import Card from '../../shared/ui/Card';
 import DashboardActionRow from '../../shared/ui/DashboardActionRow';
 import GhostPill from '../../shared/ui/GhostPill';
+
 export default function PicksPage({ user, selectedDate }) {
+  const [searchParams] = useSearchParams();
   const { showDates, showDatesByTour } = useShowCalendar();
   const showForShare = selectedDate ? showDates?.find((s) => s.date === selectedDate) : null;
   const shareShowLabel = showForShare ? showOptionLabelCompact(showForShare) : selectedDate || '';
@@ -34,6 +39,8 @@ export default function PicksPage({ user, selectedDate }) {
 
   const { openScoringRules } = useScoringRulesModal();
   const statusContentId = useId();
+  const landedLoggedRef = useRef(false);
+  const interactiveLoggedRef = useRef(false);
 
   const shouldShowSavedStatus = !isLocked && hasExistingPicks;
   const shouldShowLockedStatus = isLocked;
@@ -45,6 +52,29 @@ export default function PicksPage({ user, selectedDate }) {
     setIsMobileStatusExpanded(shouldShowLockedStatus);
   }, [shouldShowLockedStatus, shouldShowSavedStatus]);
 
+  // #535: email deep-link funnel (utm_campaign from click host / email links)
+  useEffect(() => {
+    if (landedLoggedRef.current) return;
+    const campaign = (searchParams.get('utm_campaign') || '').trim();
+    if (!campaign) return;
+    landedLoggedRef.current = true;
+    logCommsEmailLanded({
+      triggerId: campaign,
+      templateId: campaign.replace(/_/g, '-'),
+      surface: 'dashboard_picks',
+    });
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (interactiveLoggedRef.current) return;
+    if (isLoadingPicks || !selectedDate) return;
+    interactiveLoggedRef.current = true;
+    const campaign = (searchParams.get('utm_campaign') || '').trim();
+    trackPicksPageInteractive({
+      show_id: selectedDate,
+      comms_trigger_id: campaign || undefined,
+    });
+  }, [isLoadingPicks, selectedDate, searchParams]);
   return (
     <div className="max-w-xl mx-auto pb-6 md:pb-12">
       <DashboardActionRow>

--- a/src/shared/lib/firebaseAppCheck.js
+++ b/src/shared/lib/firebaseAppCheck.js
@@ -8,8 +8,12 @@ const APP_CHECK_SITE_KEY = '6LdmOKAsAAAAACN1guy_JoAMDhjN6eljCiLLyMSJ';
 // `whenFirebaseReady()` lets the earliest-path Firestore callers gate their
 // first read on App Check init so prod enforcement doesn't race with boot.
 // (issue #242)
+// Dashboard / email deep links can call `ensureAppCheckNow()` (#535) to skip
+// the idle wait without double-initializing.
 
 let readyPromise = null;
+/** @type {null | (() => void)} */
+let cancelDeferredStart = null;
 
 /** Registered in Firebase Console → App Check → debug tokens (see docs/TESTING.md). */
 const DEV_APPCHECK_DEBUG_TOKEN = '38422efd-029f-45b4-b028-7cf7fcaeeffc';
@@ -37,17 +41,45 @@ function runInitialization() {
 export function initializeAppCheckDeferred() {
   if (readyPromise) return readyPromise;
   readyPromise = new Promise((resolve, reject) => {
+    let started = false;
     const start = () => {
+      if (started) return;
+      started = true;
+      cancelDeferredStart = null;
       runInitialization().then(resolve, reject);
     };
     // `requestIdleCallback` yields to paint + interaction before running.
     // Fall back to `setTimeout(0)` on Safari / tests / SSR.
     if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
-      window.requestIdleCallback(start, { timeout: 2000 });
+      const idleId = window.requestIdleCallback(start, { timeout: 2000 });
+      cancelDeferredStart = () => {
+        if (typeof window.cancelIdleCallback === 'function') {
+          window.cancelIdleCallback(idleId);
+        }
+        start();
+      };
     } else {
-      setTimeout(start, 0);
+      const timeoutId = setTimeout(start, 0);
+      cancelDeferredStart = () => {
+        clearTimeout(timeoutId);
+        start();
+      };
     }
   });
+  return readyPromise;
+}
+
+/**
+ * Start App Check immediately — cancels any pending idle deferral (#535).
+ * Safe to call after `initializeAppCheckDeferred`; shares one init promise.
+ */
+export function ensureAppCheckNow() {
+  if (cancelDeferredStart) {
+    cancelDeferredStart();
+    return readyPromise;
+  }
+  if (readyPromise) return readyPromise;
+  readyPromise = runInitialization();
   return readyPromise;
 }
 


### PR DESCRIPTION
Closes #535

## Summary
- Persist restorable dashboard path before unauth redirect home (post-login → `/dashboard/picks`)
- `ensureAppCheckNow()` cancels idle deferral on dashboard mount
- Picks-lock email CTA includes `?showDate=YYYY-MM-DD`
- Funnel: `comms_email_landed` → `picks_page_interactive` (+ MEASUREMENT_PLAN bot-filter note)

## Out of scope (follow-up)
- Full DashboardRoute chunk diet / skeleton picks shell
- `signInWithRedirect` for in-app browsers

## Test plan
- [x] `cd functions && node --test commsTemplates.test.js`
- [x] `npm run lint`
- [ ] Signed-out hit to `/dashboard/picks` → sign in → lands on picks
- [ ] Mobile Gmail cold tap after promote (TTI still needs device QA)


Made with [Cursor](https://cursor.com)