### PR TITLE
fix(install): teach iOS Chrome Share → A2HS (#539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.18] — 2026-07-15
+
+### Fixed
+- **iOS Chrome A2HS copy (#539)** — stop claiming Chrome can’t install; teach Share → Add to Home Screen with Chrome steps (toolbar or ··· → Share).
+
+---
+
 ## [1.20.17] — 2026-07-14
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.17",
+  "version": "1.20.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/install/model/installCopy.js
+++ b/src/features/install/model/installCopy.js
@@ -60,25 +60,25 @@ export function getInstallLeadCopy(branch) {
     case 'ios_safari':
       return {
         eyebrow: 'iPhone · Safari',
-        body: "Use Safari's Share sheet to Add to Home Screen — required for reliable show-night push.",
+        body: "Use Safari's Share sheet to Add to Home Screen — best path for full-screen + show-night push.",
         ctaLabel: null,
       };
     case 'ios_non_safari':
       return {
-        eyebrow: 'Open in Safari',
-        body: "On iPhone, Chrome and other browsers can't install this app. Open setlistpickem.com in Safari, then use Share → Add to Home Screen.",
+        eyebrow: 'iPhone · Add to Home Screen',
+        body: "Chrome can Add to Home Screen too — use Share → Add to Home Screen (same as Safari). Open from the home icon for show-night push.",
         ctaLabel: null,
       };
     default:
       return {
         eyebrow: 'Install app',
-        body: "Install is not available in this browser yet. On iPhone, open Setlist Pick 'Em in Safari and use Add to Home Screen.",
+        body: "Install is not available in this browser yet. On iPhone, use Share → Add to Home Screen in Safari or Chrome.",
         ctaLabel: null,
       };
   }
 }
 
-/** Ordered Safari A2HS steps — Share toolbar, not Chrome ⋮ (#539). */
+/** Ordered Safari A2HS steps — Share toolbar (#539). */
 export const IOS_SAFARI_INSTALL_STEPS = Object.freeze([
   {
     id: 'share',
@@ -107,6 +107,42 @@ export const IOS_SAFARI_INSTALL_STEPS = Object.freeze([
       { text: ' (or the ', bold: false },
       { text: '+', bold: true },
       { text: ') to confirm.', bold: false },
+    ],
+  },
+]);
+
+/**
+ * Chrome / Edge / Firefox on iOS — A2HS via Share (iOS 17+), not “open Safari” (#539 follow-up).
+ * Share may live in the toolbar or under More (···).
+ */
+export const IOS_CHROME_INSTALL_STEPS = Object.freeze([
+  {
+    id: 'share',
+    prefix: '1. ',
+    parts: [
+      { text: 'Tap ', bold: false },
+      { text: 'Share', bold: true },
+      { text: ' (square with arrow) — in the toolbar, or ', bold: false },
+      { text: '···', bold: true },
+      { text: ' → Share.', bold: false },
+    ],
+  },
+  {
+    id: 'a2hs',
+    prefix: '2. ',
+    parts: [
+      { text: 'Scroll and tap ', bold: false },
+      { text: 'Add to Home Screen', bold: true },
+      { text: '.', bold: false },
+    ],
+  },
+  {
+    id: 'add',
+    prefix: '3. ',
+    parts: [
+      { text: 'Tap ', bold: false },
+      { text: 'Add', bold: true },
+      { text: ' to confirm.', bold: false },
     ],
   },
 ]);

--- a/src/features/install/model/installCopy.test.js
+++ b/src/features/install/model/installCopy.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getInstallLeadCopy,
+  IOS_CHROME_INSTALL_STEPS,
   IOS_SAFARI_INSTALL_STEPS,
   isAndroidLike,
   resolveInstallCopyBranch,
@@ -42,5 +43,20 @@ describe('installCopy (#539)', () => {
     expect(joined.toLowerCase()).toContain('toolbar');
     expect(joined.toLowerCase()).not.toContain('three-dot');
     expect(joined).not.toContain('...');
+  });
+
+  it('iOS Chrome copy teaches A2HS in Chrome (does not claim install is impossible)', () => {
+    const copy = getInstallLeadCopy('ios_non_safari');
+    expect(copy.body.toLowerCase()).toContain('chrome');
+    expect(copy.body.toLowerCase()).toContain('add to home screen');
+    expect(copy.body.toLowerCase()).not.toContain("can't install");
+    expect(copy.body.toLowerCase()).not.toContain('cannot install');
+    expect(copy.eyebrow.toLowerCase()).not.toContain('open in safari');
+  });
+
+  it('iOS Chrome steps use Share → Add to Home Screen', () => {
+    const joined = IOS_CHROME_INSTALL_STEPS.flatMap((s) => s.parts.map((p) => p.text)).join('');
+    expect(joined.toLowerCase()).toContain('share');
+    expect(joined.toLowerCase()).toContain('add to home screen');
   });
 });

--- a/src/features/install/model/installPromptPlatform.js
+++ b/src/features/install/model/installPromptPlatform.js
@@ -22,8 +22,9 @@ export function isIosDevice(nav = navigator) {
 }
 
 /**
- * iPhone/iPad in Chrome, Firefox, Edge, etc. Install + reliable push require
- * opening the site in **Safari** (#334).
+ * iPhone/iPad in Chrome, Firefox, Edge, etc.
+ * A2HS works via Share on modern iOS; show Chrome-oriented steps (#539 follow-up).
+ * Reliable show-night push still requires opening from the home-screen icon (standalone).
  */
 export function isIosNonSafariBrowser(nav = navigator) {
   if (!isIosDevice(nav)) return false;

--- a/src/features/install/ui/DashboardInstallEngageBanner.jsx
+++ b/src/features/install/ui/DashboardInstallEngageBanner.jsx
@@ -74,7 +74,7 @@ function DashboardInstallEngageBannerLoaded({ userId }) {
           <p className="text-[11px] font-black uppercase tracking-widest text-brand-primary">
             {lead.eyebrow}
           </p>
-          {install.canPrompt || install.shouldShowIosFlow ? (
+          {install.canPrompt || install.shouldShowIosFlow || install.shouldShowIosNonSafariFlow ? (
             <p className="mt-1 text-xs font-bold leading-snug text-content-secondary">{lead.body}</p>
           ) : null}
 
@@ -103,7 +103,7 @@ function DashboardInstallEngageBannerLoaded({ userId }) {
               </button>
               {install.showIosGuide ? (
                 <div className="space-y-2">
-                  <IosSafariInstallSteps compact />
+                  <IosSafariInstallSteps compact variant="safari" />
                   <IosInstallScreenshotGallery compact />
                 </div>
               ) : null}
@@ -119,9 +119,21 @@ function DashboardInstallEngageBannerLoaded({ userId }) {
 
           {install.shouldShowIosNonSafariFlow ? (
             <div className="mt-3 space-y-2">
-              <p className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-3 text-xs font-bold leading-relaxed text-content-secondary">
-                {lead.body}
-              </p>
+              <button
+                type="button"
+                onClick={() =>
+                  install.showIosGuide ? install.closeIosGuide() : install.openIosGuide()
+                }
+                className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-border-subtle bg-surface-field py-2.5 text-xs font-black uppercase tracking-widest text-white transition-colors hover:border-brand-primary/50 hover:bg-surface-panel"
+              >
+                <Share2 className="h-4 w-4 shrink-0" aria-hidden />
+                {install.showIosGuide ? 'Hide steps' : 'Show Chrome steps'}
+              </button>
+              {install.showIosGuide ? (
+                <div className="space-y-2">
+                  <IosSafariInstallSteps compact variant="chrome" />
+                </div>
+              ) : null}
               <button
                 type="button"
                 onClick={() => install.dismissIos()}

--- a/src/features/install/ui/InstallAppCard.jsx
+++ b/src/features/install/ui/InstallAppCard.jsx
@@ -38,7 +38,7 @@ export default function InstallAppCard() {
         {lead.eyebrow}
       </h3>
 
-      {canPrompt || shouldShowIosFlow ? (
+      {canPrompt || shouldShowIosFlow || shouldShowIosNonSafariFlow ? (
         <p className="mt-2 text-sm leading-relaxed text-content-secondary">{lead.body}</p>
       ) : null}
 
@@ -66,7 +66,7 @@ export default function InstallAppCard() {
 
           {showIosGuide ? (
             <div className="mt-4 space-y-3">
-              <IosSafariInstallSteps />
+              <IosSafariInstallSteps variant="safari" />
               <IosInstallScreenshotGallery />
             </div>
           ) : null}
@@ -83,9 +83,21 @@ export default function InstallAppCard() {
 
       {shouldShowIosNonSafariFlow ? (
         <>
-          <p className="mt-4 rounded-2xl border border-amber-500/35 bg-amber-500/5 p-4 text-sm font-bold leading-relaxed text-content-secondary">
-            {lead.body}
-          </p>
+          <button
+            type="button"
+            onClick={showIosGuide ? closeIosGuide : openIosGuide}
+            className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border-2 border-border-subtle bg-surface-field py-3.5 text-sm font-black uppercase tracking-widest text-white transition-colors hover:border-brand-primary/50 hover:bg-surface-panel"
+          >
+            <Share2 className="h-4 w-4 shrink-0" aria-hidden />
+            {showIosGuide ? 'Hide Chrome steps' : 'Show Chrome steps'}
+          </button>
+
+          {showIosGuide ? (
+            <div className="mt-4 space-y-3">
+              <IosSafariInstallSteps variant="chrome" />
+            </div>
+          ) : null}
+
           <button
             type="button"
             onClick={dismissIos}

--- a/src/features/install/ui/IosSafariInstallSteps.jsx
+++ b/src/features/install/ui/IosSafariInstallSteps.jsx
@@ -1,21 +1,30 @@
 import React from 'react';
 
-import { IOS_SAFARI_INSTALL_STEPS } from '../model/installCopy';
+import { IOS_CHROME_INSTALL_STEPS, IOS_SAFARI_INSTALL_STEPS } from '../model/installCopy';
 
 /**
- * Shared ordered Safari A2HS steps (#539).
+ * Shared ordered iOS A2HS steps (#539).
  *
- * @param {{ className?: string, compact?: boolean }} props
+ * @param {{
+ *   className?: string,
+ *   compact?: boolean,
+ *   variant?: 'safari' | 'chrome',
+ * }} props
  */
-export default function IosSafariInstallSteps({ className = '', compact = false }) {
+export default function IosSafariInstallSteps({
+  className = '',
+  compact = false,
+  variant = 'safari',
+}) {
+  const steps = variant === 'chrome' ? IOS_CHROME_INSTALL_STEPS : IOS_SAFARI_INSTALL_STEPS;
   const listClass = compact
     ? 'space-y-1.5 rounded-xl border border-border-muted bg-surface-inset p-3 text-xs text-content-secondary'
     : 'space-y-2 rounded-2xl border border-border-muted bg-surface-inset p-4 text-sm text-content-secondary';
 
   return (
     <ol className={`${listClass} ${className}`.trim()}>
-      {IOS_SAFARI_INSTALL_STEPS.map((step) => (
-        <li key={step.id}>
+      {steps.map((step) => (
+        <li key={`${variant}-${step.id}`}>
           {step.prefix}
           {step.parts.map((part, i) =>
             part.bold ? (


### PR DESCRIPTION
## Summary
Staging smoke showed iOS Chrome with outdated “can’t install / open Safari” copy. Chrome (and other iOS browsers) **can** Add to Home Screen via Share.

- New lead copy + expandable **Chrome steps** (Share in toolbar or ··· → Share)
- Safari path unchanged (Share toolbar steps + screenshots)
- Soft note: open from home icon for show-night push

Land before promote [#569](https://github.com/pat792/set-picks/pull/569) so main ships **1.20.18**.

## Test plan
- [x] `npm test -- --run src/features/install`
- [x] lint
- [ ] Re-check staging Chrome iOS: no “can’t install”; Show Chrome steps works
- [ ] Safari still gets Safari steps


Made with [Cursor](https://cursor.com)