### PR TITLE
fix(auth): pool invite opens Create account (#577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.21] — 2026-07-15
+
+### Fixed
+- **Pool invite Create account (#577)** — `/join/:code` opens the Create account modal (legal checkbox) so new Google joiners avoid the #406 Sign-in dead end; `/?login=true` still opens Sign in; modals switch Create account ↔ Sign in.
+
+---
+
 ## [1.20.20] — 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 ## [1.20.21] — 2026-07-15
 
 ### Fixed
-- **Pool invite Create account (#577)** — `/join/:code` opens the Create account modal (legal checkbox) so new Google joiners avoid the #406 Sign-in dead end; `/?login=true` still opens Sign in; modals switch Create account ↔ Sign in.
+- **Pool invite Create account (#577)** — `/join/:code` opens the Create account modal (legal checkbox) so new Google joiners avoid the #406 Sign-in dead end; `/?login=true` still opens Sign in; modals switch Create account ↔ Sign in. Join context is a persistent in-modal banner (not a fading toast).
 
 ---
 

--- a/docs/USER_ROUTING_AND_JOURNEYS.md
+++ b/docs/USER_ROUTING_AND_JOURNEYS.md
@@ -94,7 +94,7 @@ If nothing is stored, stored JSON is invalid, or the path is ineligible → **`/
 ### B. First-time user with invite (`/join/:code`)
 
 1. `usePoolInviteInterceptor` (`src/features/pool-invite/model/usePoolInviteInterceptor.js`): valid code → saved under pool-invite storage key → **`navigate('/', { replace: true })`**.
-2. `SplashPage`: if invite code present in storage → toast + open sign-in modal (`src/pages/landing/SplashPage.jsx`).
+2. `SplashPage`: if invite code present in storage → toast + open **Create account** modal (`src/pages/landing/SplashPage.jsx`). Returning invitees can switch to **Sign in** via the modal footer link. (`/?login=true` still opens **Sign in**, and takes priority if both are present.)
 3. After auth → `HomeRoute` → `getDashboardEntryHref` → usually **`/dashboard`** (new device/browser).
 4. `DashboardRoute` → **`/setup`** if no profile; after setup → **`/dashboard`** (then step 5).
 5. `usePendingPoolJoin` (`src/features/pool-invite/model/usePendingPoolJoin.js`) inside `DashboardLayout`: consumes invite code, joins pool → on **`joined`** or **`already-member`** → **`navigate('/dashboard/pools', { replace: true })`**. This **overrides** the URL from step 3–4 for those outcomes.
@@ -116,6 +116,7 @@ If nothing is stored, stored JSON is invalid, or the path is ineligible → **`/
 
 - Last screen was **Profile** (typical sign-out path): Profile is **not** persisted, so restore uses the **previous** eligible tab or **`/dashboard`**.
 - Cleared site data / new browser: no storage → **`/dashboard`**.
+- Deep link **`/?login=true`**: splash opens **Sign in** (password reset, QA, returning users) — not Create account.
 
 ### F. Other entry points
 

--- a/docs/USER_ROUTING_AND_JOURNEYS.md
+++ b/docs/USER_ROUTING_AND_JOURNEYS.md
@@ -94,7 +94,7 @@ If nothing is stored, stored JSON is invalid, or the path is ineligible → **`/
 ### B. First-time user with invite (`/join/:code`)
 
 1. `usePoolInviteInterceptor` (`src/features/pool-invite/model/usePoolInviteInterceptor.js`): valid code → saved under pool-invite storage key → **`navigate('/', { replace: true })`**.
-2. `SplashPage`: if invite code present in storage → toast + open **Create account** modal (`src/pages/landing/SplashPage.jsx`). Returning invitees can switch to **Sign in** via the modal footer link. (`/?login=true` still opens **Sign in**, and takes priority if both are present.)
+2. `SplashPage`: if invite code present in storage → open **Create account** modal with a persistent join banner (`src/pages/landing/SplashPage.jsx`). Returning invitees can switch to **Sign in** via the modal footer link (same banner, sign-in copy). (`/?login=true` still opens **Sign in**, and takes priority if both are present.)
 3. After auth → `HomeRoute` → `getDashboardEntryHref` → usually **`/dashboard`** (new device/browser).
 4. `DashboardRoute` → **`/setup`** if no profile; after setup → **`/dashboard`** (then step 5).
 5. `usePendingPoolJoin` (`src/features/pool-invite/model/usePendingPoolJoin.js`) inside `DashboardLayout`: consumes invite code, joins pool → on **`joined`** or **`already-member`** → **`navigate('/dashboard/pools', { replace: true })`**. This **overrides** the URL from step 3–4 for those outcomes.
@@ -160,4 +160,4 @@ flowchart TD
 | Invite code capture | `src/features/pool-invite/model/usePoolInviteInterceptor.js` |
 | Post-auth join + Pools redirect | `src/features/pool-invite/model/usePendingPoolJoin.js` |
 | Profile completion redirect | `src/features/auth/model/useProfileSetup.js` |
-| Splash + invite toast | `src/pages/landing/SplashPage.jsx` |
+| Splash + invite join banner | `src/pages/landing/SplashPage.jsx` |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.20",
+  "version": "1.20.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/ga4-auth-funnel-report.mjs
+++ b/scripts/ga4-auth-funnel-report.mjs
@@ -194,7 +194,7 @@ async function main() {
     '  - sign_up google ≪ sign_up email for multiple weeks → Google create-account path issue or UX funnel bias',
   );
   console.log(
-    '  - auth_error signin_modal_new_user_blocked ↑ → new users hitting Sign in modal (invite / ?login=true)',
+    '  - auth_error signin_modal_new_user_blocked ↑ → new users hitting Sign in modal (?login=true or switcher; invite opens Create account as of #577)',
   );
   console.log(
     '  - login google with surface=create_account ↑ → existing Google users using Create account (expected after #406)',

--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -87,8 +87,9 @@ Two phases:
 
 **Not covered:** new users who tap Google on the **Sign in** modal — that path is
 intentionally blocked (PR #406) with copy directing them to Create account. Pool
-invite and `?login=true` entry points open Sign in, not Create account — a common
-source of “Google sign-in doesn’t work” reports.
+invite (`/join/:code`) opens **Create account** so new Google joiners see the
+legal checkbox (#577). `/?login=true` still opens **Sign in** (password reset /
+QA / returning deep links).
 
 GA4 funnel readout: `npm run ga4:auth-funnel` (needs `GA4_ACCESS_TOKEN` or
 `gcloud` with `analytics.readonly`). See `docs/AUTH_TELEMETRY_RUNBOOK.md`.

--- a/scripts/qa/auth-scenarios.mjs
+++ b/scripts/qa/auth-scenarios.mjs
@@ -241,21 +241,31 @@ async function main() {
       results,
     );
 
-    // ── ROUTING B: invite link opens sign-in modal ─────────────────────────
+    // ── ROUTING B: invite link opens create-account modal ──────────────────
     await runScenario(
       'UR-B1',
-      '/join/:code stores invite + opens sign-in modal',
+      '/join/:code stores invite + opens create-account modal',
       async () => {
         await signOutViaAccount(page, dev.url);
         await page.goto(`${dev.url}/join/YEM42`, { waitUntil: 'domcontentloaded' });
         await page.waitForURL((url) => url.pathname === '/', { timeout: 30_000 });
-        const dialog = page.getByRole('dialog', { name: /^sign in$/i });
+        const dialog = page.getByRole('dialog', { name: /^create account$/i });
         await dialog.waitFor({ state: 'visible', timeout: 15_000 });
         const stored = await page.evaluate(() =>
           localStorage.getItem('phish_pool_pending_invite'),
         );
         if (stored !== 'YEM42') {
           throw new Error(`expected invite code in storage, got ${stored}`);
+        }
+        // Returning invitee path: switcher opens Sign in without clearing invite.
+        await dialog.getByRole('button', { name: /^sign in$/i }).click();
+        const signIn = page.getByRole('dialog', { name: /^sign in$/i });
+        await signIn.waitFor({ state: 'visible', timeout: 10_000 });
+        const stillStored = await page.evaluate(() =>
+          localStorage.getItem('phish_pool_pending_invite'),
+        );
+        if (stillStored !== 'YEM42') {
+          throw new Error(`invite cleared after switcher, got ${stillStored}`);
         }
       },
       results,

--- a/scripts/qa/auth-scenarios.mjs
+++ b/scripts/qa/auth-scenarios.mjs
@@ -251,6 +251,9 @@ async function main() {
         await page.waitForURL((url) => url.pathname === '/', { timeout: 30_000 });
         const dialog = page.getByRole('dialog', { name: /^create account$/i });
         await dialog.waitFor({ state: 'visible', timeout: 15_000 });
+        await dialog
+          .getByText(/you're joining a pool/i)
+          .waitFor({ state: 'visible', timeout: 5_000 });
         const stored = await page.evaluate(() =>
           localStorage.getItem('phish_pool_pending_invite'),
         );

--- a/src/features/auth/ui/SplashSignInModal.jsx
+++ b/src/features/auth/ui/SplashSignInModal.jsx
@@ -6,7 +6,12 @@ import { StatusBanner } from '../../../shared';
 import SplashAuthModalShell from './SplashAuthModalShell';
 import { useSplashSignIn } from '../model/useSplashSignIn';
 
-export default function SplashSignInModal({ isOpen, onClose, onSwitchToSignUp }) {
+export default function SplashSignInModal({
+  isOpen,
+  onClose,
+  onSwitchToSignUp,
+  poolInvitePending = false,
+}) {
   const [showPassword, setShowPassword] = useState(false);
 
   const {
@@ -23,6 +28,22 @@ export default function SplashSignInModal({ isOpen, onClose, onSwitchToSignUp })
     handleSendPasswordResetEmail,
   } = useSplashSignIn(isOpen, onClose);
 
+  const prependContent =
+    poolInvitePending || error ? (
+      <div className="space-y-3">
+        {poolInvitePending ? (
+          <StatusBanner
+            type="info"
+            message="You're joining a pool — sign in to continue."
+            className="text-left"
+          />
+        ) : null}
+        {error ? (
+          <StatusBanner type="error" message={error} className="text-left" />
+        ) : null}
+      </div>
+    ) : null;
+
   return (
     <SplashAuthModalShell
       isOpen={isOpen}
@@ -30,11 +51,7 @@ export default function SplashSignInModal({ isOpen, onClose, onSwitchToSignUp })
       title="Sign in"
       handleGoogle={handleGoogle}
       busy={busy}
-      prependContent={
-        error ? (
-          <StatusBanner type="error" message={error} className="text-left" />
-        ) : null
-      }
+      prependContent={prependContent}
       closeOnBackdropClick={false}
     >
         <form onSubmit={handleEmailSignIn} className="space-y-4 text-left">

--- a/src/features/auth/ui/SplashSignInModal.jsx
+++ b/src/features/auth/ui/SplashSignInModal.jsx
@@ -6,7 +6,7 @@ import { StatusBanner } from '../../../shared';
 import SplashAuthModalShell from './SplashAuthModalShell';
 import { useSplashSignIn } from '../model/useSplashSignIn';
 
-export default function SplashSignInModal({ isOpen, onClose }) {
+export default function SplashSignInModal({ isOpen, onClose, onSwitchToSignUp }) {
   const [showPassword, setShowPassword] = useState(false);
 
   const {
@@ -154,6 +154,20 @@ export default function SplashSignInModal({ isOpen, onClose }) {
             {busy ? 'Signing in…' : 'Sign in'}
           </Button>
         </form>
+        {typeof onSwitchToSignUp === 'function' ? (
+          <p className="mt-6 text-center text-sm font-semibold text-slate-400">
+            New here?{' '}
+            <Button
+              variant="link"
+              type="button"
+              onClick={onSwitchToSignUp}
+              disabled={busy}
+              className="inline px-0 py-0 text-sm text-teal-300 hover:text-white decoration-teal-500/60"
+            >
+              Create account
+            </Button>
+          </p>
+        ) : null}
     </SplashAuthModalShell>
   );
 }

--- a/src/features/auth/ui/SplashSignUpModal.jsx
+++ b/src/features/auth/ui/SplashSignUpModal.jsx
@@ -8,7 +8,12 @@ import SplashAuthModalShell from './SplashAuthModalShell';
 import { useSplashSignUp } from '../model/useSplashSignUp';
 import { stashSplashResumeAuthModal } from '../utils/splashAuthResumeStorage';
 
-export default function SplashSignUpModal({ isOpen, onClose, onSwitchToSignIn }) {
+export default function SplashSignUpModal({
+  isOpen,
+  onClose,
+  onSwitchToSignIn,
+  poolInvitePending = false,
+}) {
   const {
     email,
     setEmail,
@@ -62,6 +67,19 @@ export default function SplashSignUpModal({ isOpen, onClose, onSwitchToSignIn })
     </label>
   );
 
+  const prependContent = (
+    <div className="space-y-4">
+      {poolInvitePending ? (
+        <StatusBanner
+          type="info"
+          message="You're joining a pool — create an account to continue."
+          className="text-left"
+        />
+      ) : null}
+      {consentBlock}
+    </div>
+  );
+
   return (
     <SplashAuthModalShell
       isOpen={isOpen}
@@ -70,7 +88,7 @@ export default function SplashSignUpModal({ isOpen, onClose, onSwitchToSignIn })
       handleGoogle={handleGoogle}
       busy={busy}
       googleDisabled={busy || !legalAccepted}
-      prependContent={consentBlock}
+      prependContent={prependContent}
       googleFootnote="You'll set your username/handle on the next page. Your email address is never shared or visible to other users."
       closeOnBackdropClick={false}
     >

--- a/src/features/auth/ui/SplashSignUpModal.jsx
+++ b/src/features/auth/ui/SplashSignUpModal.jsx
@@ -8,7 +8,7 @@ import SplashAuthModalShell from './SplashAuthModalShell';
 import { useSplashSignUp } from '../model/useSplashSignUp';
 import { stashSplashResumeAuthModal } from '../utils/splashAuthResumeStorage';
 
-export default function SplashSignUpModal({ isOpen, onClose }) {
+export default function SplashSignUpModal({ isOpen, onClose, onSwitchToSignIn }) {
   const {
     email,
     setEmail,
@@ -131,6 +131,20 @@ export default function SplashSignUpModal({ isOpen, onClose }) {
             {busy ? 'Creating…' : 'Create account'}
           </Button>
         </form>
+        {typeof onSwitchToSignIn === 'function' ? (
+          <p className="mt-6 text-center text-sm font-semibold text-slate-400">
+            Already have an account?{' '}
+            <Button
+              variant="link"
+              type="button"
+              onClick={onSwitchToSignIn}
+              disabled={busy}
+              className="inline px-0 py-0 text-sm text-teal-300 hover:text-white decoration-teal-500/60"
+            >
+              Sign in
+            </Button>
+          </p>
+        ) : null}
     </SplashAuthModalShell>
   );
 }

--- a/src/features/landing/ui/SplashAuthModals.jsx
+++ b/src/features/landing/ui/SplashAuthModals.jsx
@@ -7,6 +7,7 @@ export default function SplashAuthModals({
   closeModal,
   onSwitchToSignIn,
   onSwitchToSignUp,
+  poolInvitePending = false,
 }) {
   return (
     <>
@@ -14,11 +15,13 @@ export default function SplashAuthModals({
         isOpen={authModal === 'signup'}
         onClose={closeModal}
         onSwitchToSignIn={onSwitchToSignIn}
+        poolInvitePending={poolInvitePending}
       />
       <SplashSignInModal
         isOpen={authModal === 'signin'}
         onClose={closeModal}
         onSwitchToSignUp={onSwitchToSignUp}
+        poolInvitePending={poolInvitePending}
       />
     </>
   );

--- a/src/features/landing/ui/SplashAuthModals.jsx
+++ b/src/features/landing/ui/SplashAuthModals.jsx
@@ -2,11 +2,24 @@ import React from 'react';
 
 import { SplashSignInModal, SplashSignUpModal } from '../../auth';
 
-export default function SplashAuthModals({ authModal, closeModal }) {
+export default function SplashAuthModals({
+  authModal,
+  closeModal,
+  onSwitchToSignIn,
+  onSwitchToSignUp,
+}) {
   return (
     <>
-      <SplashSignUpModal isOpen={authModal === 'signup'} onClose={closeModal} />
-      <SplashSignInModal isOpen={authModal === 'signin'} onClose={closeModal} />
+      <SplashSignUpModal
+        isOpen={authModal === 'signup'}
+        onClose={closeModal}
+        onSwitchToSignIn={onSwitchToSignIn}
+      />
+      <SplashSignInModal
+        isOpen={authModal === 'signin'}
+        onClose={closeModal}
+        onSwitchToSignUp={onSwitchToSignUp}
+      />
     </>
   );
 }

--- a/src/pages/landing/SplashPage.jsx
+++ b/src/pages/landing/SplashPage.jsx
@@ -10,7 +10,6 @@ import {
 import { ScoringRulesModalProvider } from '../../features/scoring';
 import { POOL_INVITE_STORAGE_KEY } from '../../shared/config/poolInvite';
 import { getLocalStorageItem } from '../../shared/lib/local-storage';
-import { showSuccessToast } from '../../shared/ui/toast';
 
 /** Dedupes Strict Mode double-invoke / rapid re-renders for the deferred-invite prompt. */
 let lastDeferredPoolInvitePromptAt = 0;
@@ -20,6 +19,10 @@ export default function Splash() {
   const closeModal = useCallback(() => setAuthModal(null), []);
   const openSignUpModal = useCallback(() => setAuthModal('signup'), []);
   const openSignInModal = useCallback(() => setAuthModal('signin'), []);
+  /** Invite is stored before splash mounts; seed once for modal join-context copy. */
+  const [poolInvitePending] = useState(
+    () => Boolean(getLocalStorageItem(POOL_INVITE_STORAGE_KEY)?.trim()),
+  );
 
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -63,15 +66,13 @@ export default function Splash() {
     // Returning / QA deep links keep Sign in; do not overwrite with Create account.
     if (searchParams.get('login') === 'true') return;
 
-    const pending = getLocalStorageItem(POOL_INVITE_STORAGE_KEY)?.trim();
-    if (!pending) return;
+    if (!poolInvitePending) return;
     const now = Date.now();
     if (now - lastDeferredPoolInvitePromptAt < 600) return;
     lastDeferredPoolInvitePromptAt = now;
     // Create account first so new Google joiners get the legal checkbox (#577 / #406).
-    showSuccessToast('Create an account to join the pool!');
     openSignUpModal();
-  }, [openSignUpModal, searchParams]);
+  }, [openSignUpModal, poolInvitePending, searchParams]);
 
   return (
     <ScoringRulesModalProvider>
@@ -94,6 +95,7 @@ export default function Splash() {
         closeModal={closeModal}
         onSwitchToSignIn={openSignInModal}
         onSwitchToSignUp={openSignUpModal}
+        poolInvitePending={poolInvitePending}
       />
     </ScoringRulesModalProvider>
   );

--- a/src/pages/landing/SplashPage.jsx
+++ b/src/pages/landing/SplashPage.jsx
@@ -60,14 +60,18 @@ export default function Splash() {
       return;
     }
 
+    // Returning / QA deep links keep Sign in; do not overwrite with Create account.
+    if (searchParams.get('login') === 'true') return;
+
     const pending = getLocalStorageItem(POOL_INVITE_STORAGE_KEY)?.trim();
     if (!pending) return;
     const now = Date.now();
     if (now - lastDeferredPoolInvitePromptAt < 600) return;
     lastDeferredPoolInvitePromptAt = now;
-    showSuccessToast('Sign in or create an account to join the pool!');
-    openSignInModal();
-  }, [openSignInModal]);
+    // Create account first so new Google joiners get the legal checkbox (#577 / #406).
+    showSuccessToast('Create an account to join the pool!');
+    openSignUpModal();
+  }, [openSignUpModal, searchParams]);
 
   return (
     <ScoringRulesModalProvider>
@@ -85,7 +89,12 @@ export default function Splash() {
         onOpenSignUpModal={openSignUpModal}
         onOpenSignInModal={openSignInModal}
       />
-      <SplashAuthModals authModal={authModal} closeModal={closeModal} />
+      <SplashAuthModals
+        authModal={authModal}
+        closeModal={closeModal}
+        onSwitchToSignIn={openSignInModal}
+        onSwitchToSignUp={openSignUpModal}
+      />
     </ScoringRulesModalProvider>
   );
 }


### PR DESCRIPTION
Closes #577

## Summary
- `/join/:code` (signed out) now opens **Create account** so new Google joiners hit the legal checkbox instead of the #406 Sign-in dead end
- `/?login=true` still opens **Sign in** (password reset / QA / returning deep links) and wins if both apply
- Modal footer switchers: Create account ↔ Sign in without clearing the pending invite
- Docs + `qa:auth-scenarios` UR-B1 updated; PATCH **1.20.21**

## Test plan
- [ ] Signed out → `/join/SOMECODE` → Create account modal + invite in `localStorage`
- [ ] Toast biases to create account; switcher → Sign in keeps invite stored
- [ ] Switcher Create account ← Sign in works both directions
- [ ] `/?login=true` still opens Sign in only
- [ ] New Google on Create account can accept Terms and reach `/setup` (no `signin_modal_new_user_blocked`)
- [ ] Returning Google on Create account still signs in (`login` + `surface=create_account`)
- [ ] `npm test` / `npm run lint` green locally
- [ ] Optional: `npm run qa:auth-scenarios` UR-B1 / UR-E1


Made with [Cursor](https://cursor.com)