### PR TITLE
feat(standings): live setlist + official pick-slots card (#552)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.22] — 2026-07-15
+
+### Added
+- **Standings live setlist card (#552)** — collapsible set-broken official setlist + six-slot official board (wildcard blank) on Standings; reuses existing `official_setlists` subscription (no extra listeners).
+
+---
+
 ## [1.20.21] — 2026-07-15
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.21",
+  "version": "1.20.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -5,7 +5,9 @@ export {
 export { default as Leaderboard } from './ui/Leaderboard';
 export { default as GradedPicksShareBar } from './ui/GradedPicksShareBar';
 export { default as StandingsSelfRecapCard } from './ui/StandingsSelfRecapCard';
+export { default as StandingsOfficialSetlistCard } from './ui/StandingsOfficialSetlistCard';
 export { computeStandingsSelfRecap } from './model/standingsSelfRecap';
+export { groupOfficialSetlistBySet } from './model/groupOfficialSetlistBySet';
 export { computeShowWinnerOfTheNight } from './model/useShowWinnerOfTheNight';
 export {
   GRADED_PICKS_SHARE_DOMAIN,

--- a/src/features/scoring/model/groupOfficialSetlistBySet.js
+++ b/src/features/scoring/model/groupOfficialSetlistBySet.js
@@ -1,0 +1,87 @@
+/**
+ * Group a normalized `official_setlists` payload into Set 1 / Set 2 / Encore
+ * for fan-facing standings display (#552).
+ *
+ * Firestore stores a flat `officialSetlist` (all titles in play order) plus
+ * slot markers and optional `encoreSongs`. Set breaks are inferred from
+ * `s2o` and encore markers — imperfect mid-show until those land.
+ *
+ * @param {null | Record<string, unknown>} actualSetlist — from
+ *   `normalizeOfficialSetlistDocData` / `useStandings`
+ * @returns {{
+ *   set1: string[],
+ *   set2: string[],
+ *   encore: string[],
+ *   hasSongs: boolean,
+ *   hasOfficialSlots: boolean,
+ * }}
+ */
+export function groupOfficialSetlistBySet(actualSetlist) {
+  if (!actualSetlist || typeof actualSetlist !== 'object') {
+    return {
+      set1: [],
+      set2: [],
+      encore: [],
+      hasSongs: false,
+      hasOfficialSlots: false,
+    };
+  }
+
+  const list = Array.isArray(actualSetlist.officialSetlist)
+    ? actualSetlist.officialSetlist
+        .map((t) => String(t ?? '').trim())
+        .filter(Boolean)
+    : [];
+
+  const encoreSongs = Array.isArray(actualSetlist.encoreSongs)
+    ? actualSetlist.encoreSongs
+        .map((t) => String(t ?? '').trim())
+        .filter(Boolean)
+    : [];
+
+  const s2o = String(actualSetlist.s2o ?? '').trim();
+  const enc = String(actualSetlist.enc ?? '').trim();
+
+  const lowerEq = (a, b) => a.toLowerCase() === b.toLowerCase();
+
+  let mainList = list;
+  let encoreFromList = [];
+
+  if (encoreSongs.length > 0) {
+    const firstEncIdx = list.findIndex((t) => lowerEq(t, encoreSongs[0]));
+    if (firstEncIdx >= 0) {
+      mainList = list.slice(0, firstEncIdx);
+      encoreFromList = list.slice(firstEncIdx);
+    }
+  } else if (enc) {
+    const encIdx = list.findIndex((t) => lowerEq(t, enc));
+    if (encIdx >= 0) {
+      mainList = list.slice(0, encIdx);
+      encoreFromList = list.slice(encIdx);
+    }
+  }
+
+  const encore = encoreSongs.length > 0 ? encoreSongs : encoreFromList;
+
+  let set1 = [];
+  let set2 = [];
+  if (s2o) {
+    const s2Idx = mainList.findIndex((t) => lowerEq(t, s2o));
+    if (s2Idx >= 0) {
+      set1 = mainList.slice(0, s2Idx);
+      set2 = mainList.slice(s2Idx);
+    } else {
+      set1 = mainList;
+    }
+  } else {
+    set1 = mainList;
+  }
+
+  const hasSongs = set1.length + set2.length + encore.length > 0;
+  const slotIds = ['s1o', 's1c', 's2o', 's2c', 'enc'];
+  const hasOfficialSlots = slotIds.some(
+    (id) => String(actualSetlist[id] ?? '').trim().length > 0,
+  );
+
+  return { set1, set2, encore, hasSongs, hasOfficialSlots };
+}

--- a/src/features/scoring/model/groupOfficialSetlistBySet.test.js
+++ b/src/features/scoring/model/groupOfficialSetlistBySet.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { groupOfficialSetlistBySet } from './groupOfficialSetlistBySet';
+
+describe('groupOfficialSetlistBySet', () => {
+  it('returns empty groups for null/invalid', () => {
+    expect(groupOfficialSetlistBySet(null)).toEqual({
+      set1: [],
+      set2: [],
+      encore: [],
+      hasSongs: false,
+      hasOfficialSlots: false,
+    });
+    expect(groupOfficialSetlistBySet(undefined).hasSongs).toBe(false);
+  });
+
+  it('keeps early-show songs in set 1 before s2o lands', () => {
+    const grouped = groupOfficialSetlistBySet({
+      s1o: 'Martian Monster',
+      officialSetlist: ['Martian Monster', 'Free', 'Bathtub Gin'],
+    });
+    expect(grouped.set1).toEqual(['Martian Monster', 'Free', 'Bathtub Gin']);
+    expect(grouped.set2).toEqual([]);
+    expect(grouped.encore).toEqual([]);
+    expect(grouped.hasSongs).toBe(true);
+    expect(grouped.hasOfficialSlots).toBe(true);
+  });
+
+  it('splits on s2o and pulls encore from encoreSongs', () => {
+    const grouped = groupOfficialSetlistBySet({
+      s1o: 'Martian Monster',
+      s1c: 'Bathtub Gin',
+      s2o: 'Down with Disease',
+      s2c: 'Harry Hood',
+      enc: 'First Tube',
+      officialSetlist: [
+        'Martian Monster',
+        'Free',
+        'Bathtub Gin',
+        'Down with Disease',
+        'Light',
+        'Harry Hood',
+        'First Tube',
+      ],
+      encoreSongs: ['First Tube'],
+    });
+    expect(grouped.set1).toEqual(['Martian Monster', 'Free', 'Bathtub Gin']);
+    expect(grouped.set2).toEqual(['Down with Disease', 'Light', 'Harry Hood']);
+    expect(grouped.encore).toEqual(['First Tube']);
+  });
+
+  it('falls back to enc slot when encoreSongs is missing', () => {
+    const grouped = groupOfficialSetlistBySet({
+      s2o: 'Down with Disease',
+      enc: 'Character Zero',
+      officialSetlist: [
+        'Martian Monster',
+        'Down with Disease',
+        'Harry Hood',
+        'Character Zero',
+      ],
+    });
+    expect(grouped.set1).toEqual(['Martian Monster']);
+    expect(grouped.set2).toEqual(['Down with Disease', 'Harry Hood']);
+    expect(grouped.encore).toEqual(['Character Zero']);
+  });
+
+  it('prefers encoreSongs list over list slice when songs already split', () => {
+    const grouped = groupOfficialSetlistBySet({
+      s2o: 'Tweezer',
+      enc: 'Tweezer Reprise',
+      officialSetlist: ['Chalk Dust Torture', 'Tweezer', 'Tweezer Reprise'],
+      encoreSongs: ['Tweezer Reprise', 'First Tube'],
+    });
+    expect(grouped.set1).toEqual(['Chalk Dust Torture']);
+    expect(grouped.set2).toEqual(['Tweezer']);
+    expect(grouped.encore).toEqual(['Tweezer Reprise', 'First Tube']);
+  });
+
+  it('flags hasOfficialSlots when only slots exist', () => {
+    const grouped = groupOfficialSetlistBySet({
+      s1o: 'Sample in a Jar',
+      officialSetlist: [],
+    });
+    expect(grouped.hasSongs).toBe(false);
+    expect(grouped.hasOfficialSlots).toBe(true);
+  });
+});

--- a/src/features/scoring/ui/OfficialPickSlotsGrid.jsx
+++ b/src/features/scoring/ui/OfficialPickSlotsGrid.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { FORM_FIELDS } from '../../../shared/data/gameConfig';
+
+/** Official pick-slot board — wildcard stays blank by design (#552). */
+export default function OfficialPickSlotsGrid({ actualSetlist }) {
+  return (
+    <div
+      className="grid grid-cols-2 gap-2 sm:gap-3"
+      role="list"
+      aria-label="Official pick slots"
+    >
+      {FORM_FIELDS.map((field) => {
+        const isWild = field.id === 'wild';
+        const raw = isWild ? '' : String(actualSetlist?.[field.id] ?? '').trim();
+        const value = isWild ? null : raw || null;
+
+        return (
+          <div
+            key={field.id}
+            role="listitem"
+            className="flex flex-col gap-1 rounded-xl border border-border-muted bg-surface-inset p-3"
+          >
+            <span className="text-[8px] font-bold uppercase tracking-wider text-content-secondary">
+              {field.label}
+            </span>
+            {isWild ? (
+              <span className="text-xs font-bold text-content-secondary/80">
+                — <span className="font-semibold">personal pick</span>
+              </span>
+            ) : (
+              <span
+                className={`text-xs font-bold truncate ${
+                  value ? 'text-white' : 'text-content-secondary'
+                }`}
+              >
+                {value || '—'}
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
+++ b/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { ChevronDown, ListMusic } from 'lucide-react';
+
+import Card from '../../../shared/ui/Card';
+import { groupOfficialSetlistBySet } from '../model/groupOfficialSetlistBySet';
+import OfficialPickSlotsGrid from './OfficialPickSlotsGrid';
+
+function SetSongList({ label, songs }) {
+  if (!songs.length) return null;
+  return (
+    <div>
+      <p className="mb-1.5 text-[10px] font-black uppercase tracking-widest text-brand-primary">
+        {label}
+      </p>
+      <ol className="space-y-1">
+        {songs.map((title, idx) => (
+          <li
+            key={`${label}-${idx}-${title}`}
+            className="flex gap-2 text-sm font-bold leading-snug text-slate-100"
+          >
+            <span className="w-5 shrink-0 tabular-nums text-content-secondary">
+              {idx + 1}.
+            </span>
+            <span className="min-w-0">{title}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+/**
+ * Collapsible live / official setlist + official pick-slot board for Standings (#552).
+ * Presentational only — consumes `actualSetlist` already loaded by `useStandings`.
+ *
+ * @param {object} props
+ * @param {object} props.actualSetlist
+ * @param {string} [props.showLabel]
+ * @param {string} [props.showStatus] — NEXT | LIVE | PAST | FUTURE
+ * @param {string} [props.className]
+ */
+export default function StandingsOfficialSetlistCard({
+  actualSetlist,
+  showLabel = '',
+  showStatus = '',
+  className = '',
+}) {
+  const grouped = groupOfficialSetlistBySet(actualSetlist);
+
+  if (!actualSetlist || (!grouped.hasSongs && !grouped.hasOfficialSlots)) {
+    return null;
+  }
+
+  const isLive = showStatus === 'LIVE';
+  const statusLabel = isLive ? 'Live' : showStatus === 'PAST' ? 'Final' : 'Official';
+
+  return (
+    <Card
+      as="section"
+      variant="default"
+      padding="sm"
+      className={`mb-3 md:p-5 ${className}`.trim()}
+    >
+      <details className="group" defaultOpen={isLive}>
+        <summary className="flex cursor-pointer list-none items-start justify-between gap-3 [&::-webkit-details-marker]:hidden">
+          <div className="min-w-0 space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <ListMusic
+                className="h-4 w-4 shrink-0 text-brand-primary"
+                aria-hidden
+              />
+              <p className="text-[10px] font-black uppercase tracking-widest text-brand-primary">
+                Setlist
+              </p>
+              <span
+                className={`rounded-md border px-1.5 py-0.5 text-[9px] font-black uppercase tracking-wider ${
+                  isLive
+                    ? 'border-brand-primary/40 bg-brand-primary/15 text-brand-primary'
+                    : 'border-border-subtle bg-surface-inset text-content-secondary'
+                }`}
+              >
+                {statusLabel}
+              </span>
+            </div>
+            {showLabel ? (
+              <p className="truncate font-display text-base font-bold text-white sm:text-lg">
+                {showLabel}
+              </p>
+            ) : (
+              <p className="font-display text-base font-bold text-white sm:text-lg">
+                Official setlist
+              </p>
+            )}
+          </div>
+          <ChevronDown
+            className="mt-1 h-5 w-5 shrink-0 text-content-secondary transition-transform group-open:rotate-180"
+            aria-hidden
+          />
+        </summary>
+
+        <div className="mt-4 space-y-5 border-t border-border-subtle pt-4">
+          {grouped.hasSongs ? (
+            <div className="space-y-4">
+              <SetSongList label="Set 1" songs={grouped.set1} />
+              <SetSongList label="Set 2" songs={grouped.set2} />
+              <SetSongList label="Encore" songs={grouped.encore} />
+            </div>
+          ) : (
+            <p className="text-sm font-bold text-content-secondary">
+              Slot picks are in — full song order lands as the setlist builds.
+            </p>
+          )}
+
+          <div>
+            <p className="mb-2 text-[10px] font-black uppercase tracking-widest text-content-secondary">
+              Official pick slots
+            </p>
+            <OfficialPickSlotsGrid actualSetlist={actualSetlist} />
+          </div>
+        </div>
+      </details>
+    </Card>
+  );
+}

--- a/src/features/scoring/ui/StandingsShowOrPoolView.jsx
+++ b/src/features/scoring/ui/StandingsShowOrPoolView.jsx
@@ -4,6 +4,7 @@ import { Inbox, Loader2, Music } from 'lucide-react';
 import Card from '../../../shared/ui/Card';
 import PageTitle from '../../../shared/ui/PageTitle';
 import StandingsSelfRecapCard from './StandingsSelfRecapCard';
+import StandingsOfficialSetlistCard from './StandingsOfficialSetlistCard';
 import Leaderboard from './Leaderboard';
 import StandingsActiveShowCard from './StandingsActiveShowCard';
 import StandingsBannerWaitingSetlist from './StandingsBannerWaitingSetlist';
@@ -115,6 +116,13 @@ export default function StandingsShowOrPoolView({ screen }) {
           <div className="mt-4 md:mt-6">
             {!actualSetlist && picks.length > 0 ? (
               <StandingsBannerWaitingSetlist />
+            ) : null}
+            {actualSetlist ? (
+              <StandingsOfficialSetlistCard
+                actualSetlist={actualSetlist}
+                showLabel={showLabel}
+                showStatus={showStatus}
+              />
             ) : null}
             {selfStandingsRecap ? (
               <StandingsSelfRecapCard
@@ -229,6 +237,14 @@ export default function StandingsShowOrPoolView({ screen }) {
 
       {!actualSetlist && picks.length > 0 ? (
         <StandingsBannerWaitingSetlist />
+      ) : null}
+
+      {actualSetlist ? (
+        <StandingsOfficialSetlistCard
+          actualSetlist={actualSetlist}
+          showLabel={showLabel}
+          showStatus={showStatus}
+        />
       ) : null}
 
       {displayedPicks.length === 0 ? (


### PR DESCRIPTION
Closes #552

## Summary
- Collapsible Standings card with set-broken official setlist (Set 1 / Set 2 / Encore)
- Six-slot official board (s1/s2 opener/closer + encore); **wildcard blank** by design
- Open by default while `LIVE`; collapsed for past shows
- Reuses existing `useStandings` `official_setlists` data — **no extra Firestore listeners** (#507-safe)
- PATCH **1.20.22**

## Test plan
- [ ] Standings → pick a **past** show with setlist → card appears (collapsed); expand shows sets + slot grid; wild is “personal pick”
- [ ] During a **LIVE** show (or War Room–populated LIVE doc) → card open by default; songs/slots update without refresh
- [ ] Pre-setlist show still shows waiting banner; card appears once setlist/slots land
- [ ] Safari/PWA: no spin-forever / extra lag vs prior standings
- [ ] `npm test` / `npm run lint` green


Made with [Cursor](https://cursor.com)