### PR TITLE
chore(release): promote staging → main (v1.20.22) — live setlist + join Create account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.21] — 2026-07-15
+
+### Fixed
+- **Pool invite Create account (#577)** — `/join/:code` opens the Create account modal (legal checkbox) so new Google joiners avoid the #406 Sign-in dead end; `/?login=true` still opens Sign in; modals switch Create account ↔ Sign in. Join context is a persistent in-modal banner (not a fading toast).
+
+---
+
 ## [1.20.20] — 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.22] — 2026-07-15
+
+### Added
+- **Standings live setlist card (#552)** — collapsible set-broken official setlist + six-slot official board (wildcard blank) on Standings; reuses existing `official_setlists` subscription (no extra listeners).
+
+---
+
 ## [1.20.21] — 2026-07-15
 
 ### Fixed

--- a/docs/USER_ROUTING_AND_JOURNEYS.md
+++ b/docs/USER_ROUTING_AND_JOURNEYS.md
@@ -94,7 +94,7 @@ If nothing is stored, stored JSON is invalid, or the path is ineligible → **`/
 ### B. First-time user with invite (`/join/:code`)
 
 1. `usePoolInviteInterceptor` (`src/features/pool-invite/model/usePoolInviteInterceptor.js`): valid code → saved under pool-invite storage key → **`navigate('/', { replace: true })`**.
-2. `SplashPage`: if invite code present in storage → toast + open sign-in modal (`src/pages/landing/SplashPage.jsx`).
+2. `SplashPage`: if invite code present in storage → open **Create account** modal with a persistent join banner (`src/pages/landing/SplashPage.jsx`). Returning invitees can switch to **Sign in** via the modal footer link (same banner, sign-in copy). (`/?login=true` still opens **Sign in**, and takes priority if both are present.)
 3. After auth → `HomeRoute` → `getDashboardEntryHref` → usually **`/dashboard`** (new device/browser).
 4. `DashboardRoute` → **`/setup`** if no profile; after setup → **`/dashboard`** (then step 5).
 5. `usePendingPoolJoin` (`src/features/pool-invite/model/usePendingPoolJoin.js`) inside `DashboardLayout`: consumes invite code, joins pool → on **`joined`** or **`already-member`** → **`navigate('/dashboard/pools', { replace: true })`**. This **overrides** the URL from step 3–4 for those outcomes.
@@ -116,6 +116,7 @@ If nothing is stored, stored JSON is invalid, or the path is ineligible → **`/
 
 - Last screen was **Profile** (typical sign-out path): Profile is **not** persisted, so restore uses the **previous** eligible tab or **`/dashboard`**.
 - Cleared site data / new browser: no storage → **`/dashboard`**.
+- Deep link **`/?login=true`**: splash opens **Sign in** (password reset, QA, returning users) — not Create account.
 
 ### F. Other entry points
 
@@ -159,4 +160,4 @@ flowchart TD
 | Invite code capture | `src/features/pool-invite/model/usePoolInviteInterceptor.js` |
 | Post-auth join + Pools redirect | `src/features/pool-invite/model/usePendingPoolJoin.js` |
 | Profile completion redirect | `src/features/auth/model/useProfileSetup.js` |
-| Splash + invite toast | `src/pages/landing/SplashPage.jsx` |
+| Splash + invite join banner | `src/pages/landing/SplashPage.jsx` |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.20",
+  "version": "1.20.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.21",
+  "version": "1.20.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/ga4-auth-funnel-report.mjs
+++ b/scripts/ga4-auth-funnel-report.mjs
@@ -194,7 +194,7 @@ async function main() {
     '  - sign_up google ≪ sign_up email for multiple weeks → Google create-account path issue or UX funnel bias',
   );
   console.log(
-    '  - auth_error signin_modal_new_user_blocked ↑ → new users hitting Sign in modal (invite / ?login=true)',
+    '  - auth_error signin_modal_new_user_blocked ↑ → new users hitting Sign in modal (?login=true or switcher; invite opens Create account as of #577)',
   );
   console.log(
     '  - login google with surface=create_account ↑ → existing Google users using Create account (expected after #406)',

--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -87,8 +87,9 @@ Two phases:
 
 **Not covered:** new users who tap Google on the **Sign in** modal — that path is
 intentionally blocked (PR #406) with copy directing them to Create account. Pool
-invite and `?login=true` entry points open Sign in, not Create account — a common
-source of “Google sign-in doesn’t work” reports.
+invite (`/join/:code`) opens **Create account** so new Google joiners see the
+legal checkbox (#577). `/?login=true` still opens **Sign in** (password reset /
+QA / returning deep links).
 
 GA4 funnel readout: `npm run ga4:auth-funnel` (needs `GA4_ACCESS_TOKEN` or
 `gcloud` with `analytics.readonly`). See `docs/AUTH_TELEMETRY_RUNBOOK.md`.

--- a/scripts/qa/auth-scenarios.mjs
+++ b/scripts/qa/auth-scenarios.mjs
@@ -241,21 +241,34 @@ async function main() {
       results,
     );
 
-    // ── ROUTING B: invite link opens sign-in modal ─────────────────────────
+    // ── ROUTING B: invite link opens create-account modal ──────────────────
     await runScenario(
       'UR-B1',
-      '/join/:code stores invite + opens sign-in modal',
+      '/join/:code stores invite + opens create-account modal',
       async () => {
         await signOutViaAccount(page, dev.url);
         await page.goto(`${dev.url}/join/YEM42`, { waitUntil: 'domcontentloaded' });
         await page.waitForURL((url) => url.pathname === '/', { timeout: 30_000 });
-        const dialog = page.getByRole('dialog', { name: /^sign in$/i });
+        const dialog = page.getByRole('dialog', { name: /^create account$/i });
         await dialog.waitFor({ state: 'visible', timeout: 15_000 });
+        await dialog
+          .getByText(/you're joining a pool/i)
+          .waitFor({ state: 'visible', timeout: 5_000 });
         const stored = await page.evaluate(() =>
           localStorage.getItem('phish_pool_pending_invite'),
         );
         if (stored !== 'YEM42') {
           throw new Error(`expected invite code in storage, got ${stored}`);
+        }
+        // Returning invitee path: switcher opens Sign in without clearing invite.
+        await dialog.getByRole('button', { name: /^sign in$/i }).click();
+        const signIn = page.getByRole('dialog', { name: /^sign in$/i });
+        await signIn.waitFor({ state: 'visible', timeout: 10_000 });
+        const stillStored = await page.evaluate(() =>
+          localStorage.getItem('phish_pool_pending_invite'),
+        );
+        if (stillStored !== 'YEM42') {
+          throw new Error(`invite cleared after switcher, got ${stillStored}`);
         }
       },
       results,

--- a/src/features/auth/ui/SplashSignInModal.jsx
+++ b/src/features/auth/ui/SplashSignInModal.jsx
@@ -6,7 +6,12 @@ import { StatusBanner } from '../../../shared';
 import SplashAuthModalShell from './SplashAuthModalShell';
 import { useSplashSignIn } from '../model/useSplashSignIn';
 
-export default function SplashSignInModal({ isOpen, onClose }) {
+export default function SplashSignInModal({
+  isOpen,
+  onClose,
+  onSwitchToSignUp,
+  poolInvitePending = false,
+}) {
   const [showPassword, setShowPassword] = useState(false);
 
   const {
@@ -23,6 +28,22 @@ export default function SplashSignInModal({ isOpen, onClose }) {
     handleSendPasswordResetEmail,
   } = useSplashSignIn(isOpen, onClose);
 
+  const prependContent =
+    poolInvitePending || error ? (
+      <div className="space-y-3">
+        {poolInvitePending ? (
+          <StatusBanner
+            type="info"
+            message="You're joining a pool — sign in to continue."
+            className="text-left"
+          />
+        ) : null}
+        {error ? (
+          <StatusBanner type="error" message={error} className="text-left" />
+        ) : null}
+      </div>
+    ) : null;
+
   return (
     <SplashAuthModalShell
       isOpen={isOpen}
@@ -30,11 +51,7 @@ export default function SplashSignInModal({ isOpen, onClose }) {
       title="Sign in"
       handleGoogle={handleGoogle}
       busy={busy}
-      prependContent={
-        error ? (
-          <StatusBanner type="error" message={error} className="text-left" />
-        ) : null
-      }
+      prependContent={prependContent}
       closeOnBackdropClick={false}
     >
         <form onSubmit={handleEmailSignIn} className="space-y-4 text-left">
@@ -154,6 +171,20 @@ export default function SplashSignInModal({ isOpen, onClose }) {
             {busy ? 'Signing in…' : 'Sign in'}
           </Button>
         </form>
+        {typeof onSwitchToSignUp === 'function' ? (
+          <p className="mt-6 text-center text-sm font-semibold text-slate-400">
+            New here?{' '}
+            <Button
+              variant="link"
+              type="button"
+              onClick={onSwitchToSignUp}
+              disabled={busy}
+              className="inline px-0 py-0 text-sm text-teal-300 hover:text-white decoration-teal-500/60"
+            >
+              Create account
+            </Button>
+          </p>
+        ) : null}
     </SplashAuthModalShell>
   );
 }

--- a/src/features/auth/ui/SplashSignUpModal.jsx
+++ b/src/features/auth/ui/SplashSignUpModal.jsx
@@ -8,7 +8,12 @@ import SplashAuthModalShell from './SplashAuthModalShell';
 import { useSplashSignUp } from '../model/useSplashSignUp';
 import { stashSplashResumeAuthModal } from '../utils/splashAuthResumeStorage';
 
-export default function SplashSignUpModal({ isOpen, onClose }) {
+export default function SplashSignUpModal({
+  isOpen,
+  onClose,
+  onSwitchToSignIn,
+  poolInvitePending = false,
+}) {
   const {
     email,
     setEmail,
@@ -62,6 +67,19 @@ export default function SplashSignUpModal({ isOpen, onClose }) {
     </label>
   );
 
+  const prependContent = (
+    <div className="space-y-4">
+      {poolInvitePending ? (
+        <StatusBanner
+          type="info"
+          message="You're joining a pool — create an account to continue."
+          className="text-left"
+        />
+      ) : null}
+      {consentBlock}
+    </div>
+  );
+
   return (
     <SplashAuthModalShell
       isOpen={isOpen}
@@ -70,7 +88,7 @@ export default function SplashSignUpModal({ isOpen, onClose }) {
       handleGoogle={handleGoogle}
       busy={busy}
       googleDisabled={busy || !legalAccepted}
-      prependContent={consentBlock}
+      prependContent={prependContent}
       googleFootnote="You'll set your username/handle on the next page. Your email address is never shared or visible to other users."
       closeOnBackdropClick={false}
     >
@@ -131,6 +149,20 @@ export default function SplashSignUpModal({ isOpen, onClose }) {
             {busy ? 'Creating…' : 'Create account'}
           </Button>
         </form>
+        {typeof onSwitchToSignIn === 'function' ? (
+          <p className="mt-6 text-center text-sm font-semibold text-slate-400">
+            Already have an account?{' '}
+            <Button
+              variant="link"
+              type="button"
+              onClick={onSwitchToSignIn}
+              disabled={busy}
+              className="inline px-0 py-0 text-sm text-teal-300 hover:text-white decoration-teal-500/60"
+            >
+              Sign in
+            </Button>
+          </p>
+        ) : null}
     </SplashAuthModalShell>
   );
 }

--- a/src/features/landing/ui/SplashAuthModals.jsx
+++ b/src/features/landing/ui/SplashAuthModals.jsx
@@ -2,11 +2,27 @@ import React from 'react';
 
 import { SplashSignInModal, SplashSignUpModal } from '../../auth';
 
-export default function SplashAuthModals({ authModal, closeModal }) {
+export default function SplashAuthModals({
+  authModal,
+  closeModal,
+  onSwitchToSignIn,
+  onSwitchToSignUp,
+  poolInvitePending = false,
+}) {
   return (
     <>
-      <SplashSignUpModal isOpen={authModal === 'signup'} onClose={closeModal} />
-      <SplashSignInModal isOpen={authModal === 'signin'} onClose={closeModal} />
+      <SplashSignUpModal
+        isOpen={authModal === 'signup'}
+        onClose={closeModal}
+        onSwitchToSignIn={onSwitchToSignIn}
+        poolInvitePending={poolInvitePending}
+      />
+      <SplashSignInModal
+        isOpen={authModal === 'signin'}
+        onClose={closeModal}
+        onSwitchToSignUp={onSwitchToSignUp}
+        poolInvitePending={poolInvitePending}
+      />
     </>
   );
 }

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -5,7 +5,9 @@ export {
 export { default as Leaderboard } from './ui/Leaderboard';
 export { default as GradedPicksShareBar } from './ui/GradedPicksShareBar';
 export { default as StandingsSelfRecapCard } from './ui/StandingsSelfRecapCard';
+export { default as StandingsOfficialSetlistCard } from './ui/StandingsOfficialSetlistCard';
 export { computeStandingsSelfRecap } from './model/standingsSelfRecap';
+export { groupOfficialSetlistBySet } from './model/groupOfficialSetlistBySet';
 export { computeShowWinnerOfTheNight } from './model/useShowWinnerOfTheNight';
 export {
   GRADED_PICKS_SHARE_DOMAIN,

--- a/src/features/scoring/model/groupOfficialSetlistBySet.js
+++ b/src/features/scoring/model/groupOfficialSetlistBySet.js
@@ -1,0 +1,87 @@
+/**
+ * Group a normalized `official_setlists` payload into Set 1 / Set 2 / Encore
+ * for fan-facing standings display (#552).
+ *
+ * Firestore stores a flat `officialSetlist` (all titles in play order) plus
+ * slot markers and optional `encoreSongs`. Set breaks are inferred from
+ * `s2o` and encore markers — imperfect mid-show until those land.
+ *
+ * @param {null | Record<string, unknown>} actualSetlist — from
+ *   `normalizeOfficialSetlistDocData` / `useStandings`
+ * @returns {{
+ *   set1: string[],
+ *   set2: string[],
+ *   encore: string[],
+ *   hasSongs: boolean,
+ *   hasOfficialSlots: boolean,
+ * }}
+ */
+export function groupOfficialSetlistBySet(actualSetlist) {
+  if (!actualSetlist || typeof actualSetlist !== 'object') {
+    return {
+      set1: [],
+      set2: [],
+      encore: [],
+      hasSongs: false,
+      hasOfficialSlots: false,
+    };
+  }
+
+  const list = Array.isArray(actualSetlist.officialSetlist)
+    ? actualSetlist.officialSetlist
+        .map((t) => String(t ?? '').trim())
+        .filter(Boolean)
+    : [];
+
+  const encoreSongs = Array.isArray(actualSetlist.encoreSongs)
+    ? actualSetlist.encoreSongs
+        .map((t) => String(t ?? '').trim())
+        .filter(Boolean)
+    : [];
+
+  const s2o = String(actualSetlist.s2o ?? '').trim();
+  const enc = String(actualSetlist.enc ?? '').trim();
+
+  const lowerEq = (a, b) => a.toLowerCase() === b.toLowerCase();
+
+  let mainList = list;
+  let encoreFromList = [];
+
+  if (encoreSongs.length > 0) {
+    const firstEncIdx = list.findIndex((t) => lowerEq(t, encoreSongs[0]));
+    if (firstEncIdx >= 0) {
+      mainList = list.slice(0, firstEncIdx);
+      encoreFromList = list.slice(firstEncIdx);
+    }
+  } else if (enc) {
+    const encIdx = list.findIndex((t) => lowerEq(t, enc));
+    if (encIdx >= 0) {
+      mainList = list.slice(0, encIdx);
+      encoreFromList = list.slice(encIdx);
+    }
+  }
+
+  const encore = encoreSongs.length > 0 ? encoreSongs : encoreFromList;
+
+  let set1 = [];
+  let set2 = [];
+  if (s2o) {
+    const s2Idx = mainList.findIndex((t) => lowerEq(t, s2o));
+    if (s2Idx >= 0) {
+      set1 = mainList.slice(0, s2Idx);
+      set2 = mainList.slice(s2Idx);
+    } else {
+      set1 = mainList;
+    }
+  } else {
+    set1 = mainList;
+  }
+
+  const hasSongs = set1.length + set2.length + encore.length > 0;
+  const slotIds = ['s1o', 's1c', 's2o', 's2c', 'enc'];
+  const hasOfficialSlots = slotIds.some(
+    (id) => String(actualSetlist[id] ?? '').trim().length > 0,
+  );
+
+  return { set1, set2, encore, hasSongs, hasOfficialSlots };
+}

--- a/src/features/scoring/model/groupOfficialSetlistBySet.test.js
+++ b/src/features/scoring/model/groupOfficialSetlistBySet.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { groupOfficialSetlistBySet } from './groupOfficialSetlistBySet';
+
+describe('groupOfficialSetlistBySet', () => {
+  it('returns empty groups for null/invalid', () => {
+    expect(groupOfficialSetlistBySet(null)).toEqual({
+      set1: [],
+      set2: [],
+      encore: [],
+      hasSongs: false,
+      hasOfficialSlots: false,
+    });
+    expect(groupOfficialSetlistBySet(undefined).hasSongs).toBe(false);
+  });
+
+  it('keeps early-show songs in set 1 before s2o lands', () => {
+    const grouped = groupOfficialSetlistBySet({
+      s1o: 'Martian Monster',
+      officialSetlist: ['Martian Monster', 'Free', 'Bathtub Gin'],
+    });
+    expect(grouped.set1).toEqual(['Martian Monster', 'Free', 'Bathtub Gin']);
+    expect(grouped.set2).toEqual([]);
+    expect(grouped.encore).toEqual([]);
+    expect(grouped.hasSongs).toBe(true);
+    expect(grouped.hasOfficialSlots).toBe(true);
+  });
+
+  it('splits on s2o and pulls encore from encoreSongs', () => {
+    const grouped = groupOfficialSetlistBySet({
+      s1o: 'Martian Monster',
+      s1c: 'Bathtub Gin',
+      s2o: 'Down with Disease',
+      s2c: 'Harry Hood',
+      enc: 'First Tube',
+      officialSetlist: [
+        'Martian Monster',
+        'Free',
+        'Bathtub Gin',
+        'Down with Disease',
+        'Light',
+        'Harry Hood',
+        'First Tube',
+      ],
+      encoreSongs: ['First Tube'],
+    });
+    expect(grouped.set1).toEqual(['Martian Monster', 'Free', 'Bathtub Gin']);
+    expect(grouped.set2).toEqual(['Down with Disease', 'Light', 'Harry Hood']);
+    expect(grouped.encore).toEqual(['First Tube']);
+  });
+
+  it('falls back to enc slot when encoreSongs is missing', () => {
+    const grouped = groupOfficialSetlistBySet({
+      s2o: 'Down with Disease',
+      enc: 'Character Zero',
+      officialSetlist: [
+        'Martian Monster',
+        'Down with Disease',
+        'Harry Hood',
+        'Character Zero',
+      ],
+    });
+    expect(grouped.set1).toEqual(['Martian Monster']);
+    expect(grouped.set2).toEqual(['Down with Disease', 'Harry Hood']);
+    expect(grouped.encore).toEqual(['Character Zero']);
+  });
+
+  it('prefers encoreSongs list over list slice when songs already split', () => {
+    const grouped = groupOfficialSetlistBySet({
+      s2o: 'Tweezer',
+      enc: 'Tweezer Reprise',
+      officialSetlist: ['Chalk Dust Torture', 'Tweezer', 'Tweezer Reprise'],
+      encoreSongs: ['Tweezer Reprise', 'First Tube'],
+    });
+    expect(grouped.set1).toEqual(['Chalk Dust Torture']);
+    expect(grouped.set2).toEqual(['Tweezer']);
+    expect(grouped.encore).toEqual(['Tweezer Reprise', 'First Tube']);
+  });
+
+  it('flags hasOfficialSlots when only slots exist', () => {
+    const grouped = groupOfficialSetlistBySet({
+      s1o: 'Sample in a Jar',
+      officialSetlist: [],
+    });
+    expect(grouped.hasSongs).toBe(false);
+    expect(grouped.hasOfficialSlots).toBe(true);
+  });
+});

--- a/src/features/scoring/ui/OfficialPickSlotsGrid.jsx
+++ b/src/features/scoring/ui/OfficialPickSlotsGrid.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { FORM_FIELDS } from '../../../shared/data/gameConfig';
+
+/** Official pick-slot board — wildcard stays blank by design (#552). */
+export default function OfficialPickSlotsGrid({ actualSetlist }) {
+  return (
+    <div
+      className="grid grid-cols-2 gap-2 sm:gap-3"
+      role="list"
+      aria-label="Official pick slots"
+    >
+      {FORM_FIELDS.map((field) => {
+        const isWild = field.id === 'wild';
+        const raw = isWild ? '' : String(actualSetlist?.[field.id] ?? '').trim();
+        const value = isWild ? null : raw || null;
+
+        return (
+          <div
+            key={field.id}
+            role="listitem"
+            className="flex flex-col gap-1 rounded-xl border border-border-muted bg-surface-inset p-3"
+          >
+            <span className="text-[8px] font-bold uppercase tracking-wider text-content-secondary">
+              {field.label}
+            </span>
+            {isWild ? (
+              <span className="text-xs font-bold text-content-secondary/80">
+                — <span className="font-semibold">personal pick</span>
+              </span>
+            ) : (
+              <span
+                className={`text-xs font-bold truncate ${
+                  value ? 'text-white' : 'text-content-secondary'
+                }`}
+              >
+                {value || '—'}
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
+++ b/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { ChevronDown, ListMusic } from 'lucide-react';
+
+import Card from '../../../shared/ui/Card';
+import { groupOfficialSetlistBySet } from '../model/groupOfficialSetlistBySet';
+import OfficialPickSlotsGrid from './OfficialPickSlotsGrid';
+
+function SetSongList({ label, songs }) {
+  if (!songs.length) return null;
+  return (
+    <div>
+      <p className="mb-1.5 text-[10px] font-black uppercase tracking-widest text-brand-primary">
+        {label}
+      </p>
+      <ol className="space-y-1">
+        {songs.map((title, idx) => (
+          <li
+            key={`${label}-${idx}-${title}`}
+            className="flex gap-2 text-sm font-bold leading-snug text-slate-100"
+          >
+            <span className="w-5 shrink-0 tabular-nums text-content-secondary">
+              {idx + 1}.
+            </span>
+            <span className="min-w-0">{title}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+/**
+ * Collapsible live / official setlist + official pick-slot board for Standings (#552).
+ * Presentational only — consumes `actualSetlist` already loaded by `useStandings`.
+ *
+ * @param {object} props
+ * @param {object} props.actualSetlist
+ * @param {string} [props.showLabel]
+ * @param {string} [props.showStatus] — NEXT | LIVE | PAST | FUTURE
+ * @param {string} [props.className]
+ */
+export default function StandingsOfficialSetlistCard({
+  actualSetlist,
+  showLabel = '',
+  showStatus = '',
+  className = '',
+}) {
+  const grouped = groupOfficialSetlistBySet(actualSetlist);
+
+  if (!actualSetlist || (!grouped.hasSongs && !grouped.hasOfficialSlots)) {
+    return null;
+  }
+
+  const isLive = showStatus === 'LIVE';
+  const statusLabel = isLive ? 'Live' : showStatus === 'PAST' ? 'Final' : 'Official';
+
+  return (
+    <Card
+      as="section"
+      variant="default"
+      padding="sm"
+      className={`mb-3 md:p-5 ${className}`.trim()}
+    >
+      <details className="group" defaultOpen={isLive}>
+        <summary className="flex cursor-pointer list-none items-start justify-between gap-3 [&::-webkit-details-marker]:hidden">
+          <div className="min-w-0 space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <ListMusic
+                className="h-4 w-4 shrink-0 text-brand-primary"
+                aria-hidden
+              />
+              <p className="text-[10px] font-black uppercase tracking-widest text-brand-primary">
+                Setlist
+              </p>
+              <span
+                className={`rounded-md border px-1.5 py-0.5 text-[9px] font-black uppercase tracking-wider ${
+                  isLive
+                    ? 'border-brand-primary/40 bg-brand-primary/15 text-brand-primary'
+                    : 'border-border-subtle bg-surface-inset text-content-secondary'
+                }`}
+              >
+                {statusLabel}
+              </span>
+            </div>
+            {showLabel ? (
+              <p className="truncate font-display text-base font-bold text-white sm:text-lg">
+                {showLabel}
+              </p>
+            ) : (
+              <p className="font-display text-base font-bold text-white sm:text-lg">
+                Official setlist
+              </p>
+            )}
+          </div>
+          <ChevronDown
+            className="mt-1 h-5 w-5 shrink-0 text-content-secondary transition-transform group-open:rotate-180"
+            aria-hidden
+          />
+        </summary>
+
+        <div className="mt-4 space-y-5 border-t border-border-subtle pt-4">
+          {grouped.hasSongs ? (
+            <div className="space-y-4">
+              <SetSongList label="Set 1" songs={grouped.set1} />
+              <SetSongList label="Set 2" songs={grouped.set2} />
+              <SetSongList label="Encore" songs={grouped.encore} />
+            </div>
+          ) : (
+            <p className="text-sm font-bold text-content-secondary">
+              Slot picks are in — full song order lands as the setlist builds.
+            </p>
+          )}
+
+          <div>
+            <p className="mb-2 text-[10px] font-black uppercase tracking-widest text-content-secondary">
+              Official pick slots
+            </p>
+            <OfficialPickSlotsGrid actualSetlist={actualSetlist} />
+          </div>
+        </div>
+      </details>
+    </Card>
+  );
+}

--- a/src/features/scoring/ui/StandingsShowOrPoolView.jsx
+++ b/src/features/scoring/ui/StandingsShowOrPoolView.jsx
@@ -4,6 +4,7 @@ import { Inbox, Loader2, Music } from 'lucide-react';
 import Card from '../../../shared/ui/Card';
 import PageTitle from '../../../shared/ui/PageTitle';
 import StandingsSelfRecapCard from './StandingsSelfRecapCard';
+import StandingsOfficialSetlistCard from './StandingsOfficialSetlistCard';
 import Leaderboard from './Leaderboard';
 import StandingsActiveShowCard from './StandingsActiveShowCard';
 import StandingsBannerWaitingSetlist from './StandingsBannerWaitingSetlist';
@@ -115,6 +116,13 @@ export default function StandingsShowOrPoolView({ screen }) {
           <div className="mt-4 md:mt-6">
             {!actualSetlist && picks.length > 0 ? (
               <StandingsBannerWaitingSetlist />
+            ) : null}
+            {actualSetlist ? (
+              <StandingsOfficialSetlistCard
+                actualSetlist={actualSetlist}
+                showLabel={showLabel}
+                showStatus={showStatus}
+              />
             ) : null}
             {selfStandingsRecap ? (
               <StandingsSelfRecapCard
@@ -229,6 +237,14 @@ export default function StandingsShowOrPoolView({ screen }) {
 
       {!actualSetlist && picks.length > 0 ? (
         <StandingsBannerWaitingSetlist />
+      ) : null}
+
+      {actualSetlist ? (
+        <StandingsOfficialSetlistCard
+          actualSetlist={actualSetlist}
+          showLabel={showLabel}
+          showStatus={showStatus}
+        />
       ) : null}
 
       {displayedPicks.length === 0 ? (

--- a/src/pages/landing/SplashPage.jsx
+++ b/src/pages/landing/SplashPage.jsx
@@ -10,7 +10,6 @@ import {
 import { ScoringRulesModalProvider } from '../../features/scoring';
 import { POOL_INVITE_STORAGE_KEY } from '../../shared/config/poolInvite';
 import { getLocalStorageItem } from '../../shared/lib/local-storage';
-import { showSuccessToast } from '../../shared/ui/toast';
 
 /** Dedupes Strict Mode double-invoke / rapid re-renders for the deferred-invite prompt. */
 let lastDeferredPoolInvitePromptAt = 0;
@@ -20,6 +19,10 @@ export default function Splash() {
   const closeModal = useCallback(() => setAuthModal(null), []);
   const openSignUpModal = useCallback(() => setAuthModal('signup'), []);
   const openSignInModal = useCallback(() => setAuthModal('signin'), []);
+  /** Invite is stored before splash mounts; seed once for modal join-context copy. */
+  const [poolInvitePending] = useState(
+    () => Boolean(getLocalStorageItem(POOL_INVITE_STORAGE_KEY)?.trim()),
+  );
 
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -60,14 +63,16 @@ export default function Splash() {
       return;
     }
 
-    const pending = getLocalStorageItem(POOL_INVITE_STORAGE_KEY)?.trim();
-    if (!pending) return;
+    // Returning / QA deep links keep Sign in; do not overwrite with Create account.
+    if (searchParams.get('login') === 'true') return;
+
+    if (!poolInvitePending) return;
     const now = Date.now();
     if (now - lastDeferredPoolInvitePromptAt < 600) return;
     lastDeferredPoolInvitePromptAt = now;
-    showSuccessToast('Sign in or create an account to join the pool!');
-    openSignInModal();
-  }, [openSignInModal]);
+    // Create account first so new Google joiners get the legal checkbox (#577 / #406).
+    openSignUpModal();
+  }, [openSignUpModal, poolInvitePending, searchParams]);
 
   return (
     <ScoringRulesModalProvider>
@@ -85,7 +90,13 @@ export default function Splash() {
         onOpenSignUpModal={openSignUpModal}
         onOpenSignInModal={openSignInModal}
       />
-      <SplashAuthModals authModal={authModal} closeModal={closeModal} />
+      <SplashAuthModals
+        authModal={authModal}
+        closeModal={closeModal}
+        onSwitchToSignIn={openSignInModal}
+        onSwitchToSignUp={openSignUpModal}
+        poolInvitePending={poolInvitePending}
+      />
     </ScoringRulesModalProvider>
   );
 }


### PR DESCRIPTION
## Summary

Early Sprint 8 promote (Trains 1–2 only). Remaining invite/comms/profile trains stay on `staging` until their batches are complete.

| Ver | Issue | Headline |
|-----|-------|----------|
| **1.20.21** | [#577](https://github.com/pat792/set-picks/issues/577) | Pool `/join/:code` → Create account + in-modal join banner |
| **1.20.22** | [#552](https://github.com/pat792/set-picks/issues/552) | Standings collapsible live/official setlist + pick-slots card |

Closes #577, Closes #552 (on merge to default branch).

**Not in this promote:** #578 invite epic (#579–#583), #572/#510/#512 comms, #513 profile hub, #573 process epic, #587 gap/LTP follow-up.

## Test plan
- [x] #585 / #586 `verify` green on staging merges
- [x] Manual: historical Standings setlist card looks correct
- [x] Manual: `/join/:code` Create account + banner (localhost)
- [ ] After Vercel prod: smoke Standings setlist on a past show + splash join path
- [ ] Post-merge (human): `npm run release:gate:full` → `npm run release:publish -- --confirm` for **v1.20.22**


Made with [Cursor](https://cursor.com)