### PR TITLE
fix(standings): mobile sticky pills nest under context bar (1.20.24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.24] — 2026-07-15
+
+### Fixed
+- **Standings mobile sticky nest** — Show/Tour/Pools stick flush under the Standings · Tour Date context bar (tighter top offset; Scoring rules overlays the pill row so it no longer adds a second tier).
+
+---
+
 ## [1.20.23] — 2026-07-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.23",
+  "version": "1.20.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/scoring/ui/StandingsStickyChrome.jsx
+++ b/src/features/scoring/ui/StandingsStickyChrome.jsx
@@ -6,6 +6,16 @@ import { dashboardPageTitleGradientClasses } from '../../../shared/config/dashbo
 import StandingsViewToggle from './StandingsViewToggle';
 
 /**
+ * Mobile sticky offset under fixed brand + context bars (Standings · Tour Date).
+ * Must match the *visual* bottom of that stack — not `main`’s looser `9rem`
+ * content padding — or pills leave a scroll gap under the H2 row.
+ *
+ * Brand ≈ py-2 + mark (~4.95rem); context ≈ py-3 + select (~3.25rem) ≈ 8.2rem.
+ */
+export const STANDINGS_STICKY_MOBILE_TOP =
+  'top-[calc(env(safe-area-inset-top,0px)+8.125rem)]';
+
+/**
  * Sticky Standings page chrome: desktop title + Show/Tour/Pools (and Scoring rules).
  * Sits in the dashboard `main` scrollport so winner/setlist/leaderboard scroll under it.
  * Mobile keeps “Standings” in the fixed context bar — title is desktop-only here.
@@ -30,13 +40,12 @@ export default function StandingsStickyChrome({
     <div
       className={[
         'sticky z-20',
-        // Mobile: sit below fixed brand + context bars (date lives in that stack).
-        'top-[calc(env(safe-area-inset-top,0px)+9rem)]',
+        // Flush under mobile Standings / Tour Date context bar.
+        STANDINGS_STICKY_MOBILE_TOP,
         // Desktop: under sticky Tour Date when Show/Pools; flush when Tour (no date).
-        // 5.75rem ≈ sticky date shell (pt/pb + Tour Date card) — keep in sync with layout.
         pinBelowDesktopDatePicker ? 'md:top-[5.75rem]' : 'md:top-0',
         '-mx-4 px-4 md:-mx-8 md:px-8',
-        'bg-brand-bg/90 pb-3 pt-1 backdrop-blur-md supports-[backdrop-filter]:bg-brand-bg/75',
+        'bg-brand-bg/90 py-2.5 backdrop-blur-md supports-[backdrop-filter]:bg-brand-bg/75',
         'border-b border-border-subtle/35',
       ].join(' ')}
     >
@@ -47,18 +56,24 @@ export default function StandingsStickyChrome({
       </h2>
 
       <div className="relative">
-        <div className="mb-2 flex items-center justify-end md:absolute md:right-0 md:top-1/2 md:z-10 md:mb-0 md:-translate-y-1/2">
+        {/* Always overlay so it never adds a second sticky tier above the pills. */}
+        <div className="absolute right-0 top-1/2 z-10 -translate-y-1/2">
           <button
             type="button"
             onClick={onOpenScoringRules}
-            className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold text-content-secondary transition-colors hover:bg-surface-panel hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
+            className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold text-content-secondary transition-colors hover:bg-surface-panel hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg sm:px-3 sm:text-xs"
           >
             <Scale className="h-3.5 w-3.5" aria-hidden />
-            Scoring rules
+            <span className="hidden min-[380px]:inline">Scoring rules</span>
+            <span className="min-[380px]:hidden">Rules</span>
           </button>
         </div>
 
-        <StandingsViewToggle view={view} onChange={onChange} className="mb-0" />
+        <StandingsViewToggle
+          view={view}
+          onChange={onChange}
+          className="mb-0 pr-[4.5rem] min-[380px]:pr-[7.25rem]"
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Mobile sticky Show/Tour/Pools now sit flush under the fixed Standings · Tour Date row (`8.125rem` clearance vs oversized `9rem`)
- Scoring rules overlays the pill row (no second sticky tier above the pills)
- PATCH **1.20.24**

## Test plan
- [ ] Mobile Safari / Chrome: scroll Standings — pills nest directly under Standings/Tour Date with no content gap
- [ ] Desktop sticky stack still: Tour Date → title → pills
- [ ] Tour view (no date): mobile pills still nest under Standings-only context bar


Made with [Cursor](https://cursor.com)