### PR TITLE
feat(standings): Phish.net setlist credit only (1.20.23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.23] — 2026-07-15
+
+### Added
+- **Standings setlist Phish.net credit** — in-card attribution + “see more show details” link to that show’s Phish.net setlist (API ToS attribution).
+
+---
+
 ## [1.20.22] — 2026-07-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.22",
+  "version": "1.20.23",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -8,6 +8,7 @@ export { default as StandingsSelfRecapCard } from './ui/StandingsSelfRecapCard';
 export { default as StandingsOfficialSetlistCard } from './ui/StandingsOfficialSetlistCard';
 export { computeStandingsSelfRecap } from './model/standingsSelfRecap';
 export { groupOfficialSetlistBySet } from './model/groupOfficialSetlistBySet';
+export { buildPhishNetSetlistUrl } from './model/buildPhishNetSetlistUrl';
 export { computeShowWinnerOfTheNight } from './model/useShowWinnerOfTheNight';
 export {
   GRADED_PICKS_SHARE_DOMAIN,

--- a/src/features/scoring/model/buildPhishNetSetlistUrl.js
+++ b/src/features/scoring/model/buildPhishNetSetlistUrl.js
@@ -1,0 +1,14 @@
+/**
+ * Public Phish.net setlist page for a show date (YYYY-MM-DD).
+ * `?d=` redirects to the slug URL; safe without venue slug on our side.
+ *
+ * @param {string} showDate
+ * @returns {string}
+ */
+export function buildPhishNetSetlistUrl(showDate) {
+  const d = String(showDate ?? '').trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(d)) {
+    return 'https://phish.net';
+  }
+  return `https://phish.net/setlists/?d=${encodeURIComponent(d)}`;
+}

--- a/src/features/scoring/model/buildPhishNetSetlistUrl.test.js
+++ b/src/features/scoring/model/buildPhishNetSetlistUrl.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildPhishNetSetlistUrl } from './buildPhishNetSetlistUrl';
+
+describe('buildPhishNetSetlistUrl', () => {
+  it('builds a dated setlists URL', () => {
+    expect(buildPhishNetSetlistUrl('2025-12-31')).toBe(
+      'https://phish.net/setlists/?d=2025-12-31',
+    );
+  });
+
+  it('falls back to phish.net home for invalid dates', () => {
+    expect(buildPhishNetSetlistUrl('')).toBe('https://phish.net');
+    expect(buildPhishNetSetlistUrl('not-a-date')).toBe('https://phish.net');
+    expect(buildPhishNetSetlistUrl(null)).toBe('https://phish.net');
+  });
+});

--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -238,6 +238,7 @@ export function useStandingsScreen(selectedDate, options = {}) {
     loading,
     showStatus,
     showLabel,
+    selectedDate,
     isShowToday,
     picks,
     actualSetlist,

--- a/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
+++ b/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { ChevronDown, ListMusic } from 'lucide-react';
+import { ChevronDown, ExternalLink, ListMusic } from 'lucide-react';
 
 import Card from '../../../shared/ui/Card';
+import { buildPhishNetSetlistUrl } from '../model/buildPhishNetSetlistUrl';
 import { groupOfficialSetlistBySet } from '../model/groupOfficialSetlistBySet';
 import OfficialPickSlotsGrid from './OfficialPickSlotsGrid';
 
@@ -35,12 +36,14 @@ function SetSongList({ label, songs }) {
  *
  * @param {object} props
  * @param {object} props.actualSetlist
+ * @param {string} [props.showDate] — YYYY-MM-DD for Phish.net setlist link
  * @param {string} [props.showLabel]
  * @param {string} [props.showStatus] — NEXT | LIVE | PAST | FUTURE
  * @param {string} [props.className]
  */
 export default function StandingsOfficialSetlistCard({
   actualSetlist,
+  showDate = '',
   showLabel = '',
   showStatus = '',
   className = '',
@@ -53,6 +56,7 @@ export default function StandingsOfficialSetlistCard({
 
   const isLive = showStatus === 'LIVE';
   const statusLabel = isLive ? 'Live' : showStatus === 'PAST' ? 'Final' : 'Official';
+  const phishNetHref = buildPhishNetSetlistUrl(showDate);
 
   return (
     <Card
@@ -117,6 +121,20 @@ export default function StandingsOfficialSetlistCard({
             </p>
             <OfficialPickSlotsGrid actualSetlist={actualSetlist} />
           </div>
+
+          <p className="text-xs font-semibold leading-relaxed text-content-secondary">
+            Setlist data courtesy of Phish.net.{' '}
+            <a
+              href={phishNetHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-teal-300 underline decoration-teal-500/50 underline-offset-2 hover:text-white hover:decoration-teal-300"
+            >
+              See more show details on Phish.net
+              <ExternalLink className="h-3 w-3 shrink-0" aria-hidden />
+              <span className="sr-only">(opens in a new tab)</span>
+            </a>
+          </p>
         </div>
       </details>
     </Card>

--- a/src/features/scoring/ui/StandingsShowOrPoolView.jsx
+++ b/src/features/scoring/ui/StandingsShowOrPoolView.jsx
@@ -30,6 +30,7 @@ export default function StandingsShowOrPoolView({ screen }) {
     loading,
     showStatus,
     showLabel,
+    selectedDate,
     isShowToday,
     picks,
     actualSetlist,
@@ -120,6 +121,7 @@ export default function StandingsShowOrPoolView({ screen }) {
             {actualSetlist ? (
               <StandingsOfficialSetlistCard
                 actualSetlist={actualSetlist}
+                showDate={selectedDate}
                 showLabel={showLabel}
                 showStatus={showStatus}
               />
@@ -242,6 +244,7 @@ export default function StandingsShowOrPoolView({ screen }) {
       {actualSetlist ? (
         <StandingsOfficialSetlistCard
           actualSetlist={actualSetlist}
+          showDate={selectedDate}
           showLabel={showLabel}
           showStatus={showStatus}
         />


### PR DESCRIPTION
## Summary
- Credit-only PATCH for prod: setlist card attribution + “See more show details on Phish.net”
- **No sticky chrome** (held on `staging` until mobile nest is fixed)
- Version **1.20.23** atop current `main` (1.20.22 setlist card)

## Test plan
- [ ] Prod Standings → expand setlist → Phish.net courtesy + link opens dated setlist
- [ ] No sticky header/pill changes vs current prod


Made with [Cursor](https://cursor.com)