### PR TITLE
fix(standings): official slots Encore 2 + wrap titles (1.20.25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.25] — 2026-07-15
+
+### Changed
+- **Official pick slots** — sixth cell is **Encore 2** (from `encoreSongs[1]`) instead of blank Wildcard; song titles wrap so long names fit.
+
+---
+
 ## [1.20.23] — 2026-07-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.23",
+  "version": "1.20.25",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/scoring/ui/OfficialPickSlotsGrid.jsx
+++ b/src/features/scoring/ui/OfficialPickSlotsGrid.jsx
@@ -1,42 +1,57 @@
 import React from 'react';
 
-import { FORM_FIELDS } from '../../../shared/data/gameConfig';
-
-/** Official pick-slot board — wildcard stays blank by design (#552). */
+/**
+ * Fan-facing official slot board for Standings (#552).
+ * Same six-box layout as pick fields, but the sixth slot is **Encore 2**
+ * (not Wildcard) — most shows have 1–2 encore songs; all encore titles stay
+ * in `encoreSongs` / the setlist list.
+ *
+ * @param {{ actualSetlist: Record<string, unknown> | null | undefined }} props
+ */
 export default function OfficialPickSlotsGrid({ actualSetlist }) {
+  const encoreSongs = Array.isArray(actualSetlist?.encoreSongs)
+    ? actualSetlist.encoreSongs
+        .map((t) => String(t ?? '').trim())
+        .filter(Boolean)
+    : [];
+
+  const encPrimary =
+    encoreSongs[0] || String(actualSetlist?.enc ?? '').trim() || '';
+  const encSecondary = encoreSongs[1] || '';
+
+  const slots = [
+    { id: 's1o', label: 'Set 1 Opener', value: String(actualSetlist?.s1o ?? '').trim() },
+    { id: 's1c', label: 'Set 1 Closer', value: String(actualSetlist?.s1c ?? '').trim() },
+    { id: 's2o', label: 'Set 2 Opener', value: String(actualSetlist?.s2o ?? '').trim() },
+    { id: 's2c', label: 'Set 2 Closer', value: String(actualSetlist?.s2c ?? '').trim() },
+    { id: 'enc', label: 'Encore', value: encPrimary },
+    { id: 'enc2', label: 'Encore 2', value: encSecondary },
+  ];
+
   return (
     <div
       className="grid grid-cols-2 gap-2 sm:gap-3"
       role="list"
       aria-label="Official pick slots"
     >
-      {FORM_FIELDS.map((field) => {
-        const isWild = field.id === 'wild';
-        const raw = isWild ? '' : String(actualSetlist?.[field.id] ?? '').trim();
-        const value = isWild ? null : raw || null;
-
+      {slots.map((field) => {
+        const value = field.value || null;
         return (
           <div
             key={field.id}
             role="listitem"
-            className="flex flex-col gap-1 rounded-xl border border-border-muted bg-surface-inset p-3"
+            className="flex min-w-0 flex-col gap-1 rounded-xl border border-border-muted bg-surface-inset p-3"
           >
             <span className="text-[8px] font-bold uppercase tracking-wider text-content-secondary">
               {field.label}
             </span>
-            {isWild ? (
-              <span className="text-xs font-bold text-content-secondary/80">
-                — <span className="font-semibold">personal pick</span>
-              </span>
-            ) : (
-              <span
-                className={`text-xs font-bold truncate ${
-                  value ? 'text-white' : 'text-content-secondary'
-                }`}
-              >
-                {value || '—'}
-              </span>
-            )}
+            <span
+              className={`text-xs font-bold leading-snug break-words ${
+                value ? 'text-white' : 'text-content-secondary'
+              }`}
+            >
+              {value || '—'}
+            </span>
           </div>
         );
       })}

--- a/src/features/scoring/ui/OfficialPickSlotsGrid.test.js
+++ b/src/features/scoring/ui/OfficialPickSlotsGrid.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import OfficialPickSlotsGrid from './OfficialPickSlotsGrid.jsx';
+
+describe('OfficialPickSlotsGrid', () => {
+  it('shows Encore 2 from encoreSongs[1] instead of wildcard', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OfficialPickSlotsGrid, {
+        actualSetlist: {
+          s1o: 'Martian Monster',
+          enc: 'First Tube',
+          encoreSongs: ['First Tube', 'Tweezer Reprise'],
+        },
+      }),
+    );
+    expect(html).toContain('Encore 2');
+    expect(html).toContain('Tweezer Reprise');
+    expect(html).not.toContain('Wildcard');
+    expect(html).not.toContain('personal pick');
+  });
+
+  it('wraps long titles (no truncate class)', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OfficialPickSlotsGrid, {
+        actualSetlist: {
+          s1o: 'McGrupp and the Watchful Hosemasters',
+        },
+      }),
+    );
+    expect(html).toContain('break-words');
+    expect(html).not.toContain('truncate');
+  });
+
+  it('falls back to enc slot when encoreSongs missing', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OfficialPickSlotsGrid, {
+        actualSetlist: { enc: 'Character Zero' },
+      }),
+    );
+    expect(html).toContain('Character Zero');
+    expect(html).toContain('Encore 2');
+  });
+});


### PR DESCRIPTION
## Summary
- Official pick board sixth cell: **Encore 2** (`encoreSongs[1]`) instead of blank Wildcard (game wild pick unchanged)
- Encore 1 still uses `encoreSongs[0]` / `enc`
- Slot titles use `break-words` so boxes expand for long names
- PATCH **1.20.25** (skips staging’s 1.20.24 sticky version)

## Test plan
- [ ] Standings setlist → official board shows Encore + Encore 2 when the show has two encore songs
- [ ] Long titles wrap inside cells (no ellipsis truncate)
- [ ] Single-encore shows: Encore filled, Encore 2 shows —


Made with [Cursor](https://cursor.com)