### PR TITLE
feat(invite): shared invite kit (#579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.20.26] — 2026-07-15
+
+### Added
+- **Invite kit (#579)** — `features/invite` public API: site/pool URL + personalized copy builders, `shareInvite` + `invite_share` telemetry; pool share hook consumes the kit (`?from=` when handle provided).
+
+---
+
 ## [1.20.25] — 2026-07-15
 
 ### Changed

--- a/docs/API.md
+++ b/docs/API.md
@@ -271,7 +271,8 @@ These routes are part of the public surface. Renaming or removing them is a MAJO
 | `/` | None | Public splash / landing page |
 | `/how-it-works` | None | How to play marketing page |
 | `/how-scoring-works` | None | Scoring rules marketing page |
-| `/join/:code` | None | Pool invite deep link |
+| `/join/:code` | None | Pool invite deep link; optional `?from={handle}` for inviter personalization (kit #579; VIP landing #580) |
+| `/invite/:handle` | None | Site VIP invite deep link (**landing ships #580**; URL builders in invite kit #579) |
 | `/user/:userId` | None | Public player profile |
 | `/privacy` | None | Privacy policy |
 | `/terms` | None | Terms of service |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.25",
+  "version": "1.20.26",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/invite/index.js
+++ b/src/features/invite/index.js
@@ -1,0 +1,16 @@
+/**
+ * Personalized invite kit (#579) — public entry for site + pool invite URLs,
+ * copy, share helper, and telemetry. VIP landings (#580) and OG (#582) build on this.
+ */
+export {
+  buildPoolInviteShareTitle,
+  buildPoolInviteShareTitleFromInviter,
+  buildPoolInviteUrl,
+  buildSiteInviteShareTitle,
+  buildSiteInviteUrl,
+  createPoolInviteLink,
+  normalizeInviteHandle,
+  shareInvite,
+  shareOrCopyInviteUrl,
+} from './model/shareInvite';
+export { trackInviteShare } from './model/inviteAnalytics';

--- a/src/features/invite/model/inviteAnalytics.js
+++ b/src/features/invite/model/inviteAnalytics.js
@@ -1,0 +1,16 @@
+import { ga4Event } from '../../../shared/lib/ga4';
+
+/**
+ * @param {{
+ *   invite_kind: 'site' | 'pool',
+ *   via?: 'share' | 'copy',
+ *   pool_id?: string,
+ * }} params
+ */
+export function trackInviteShare({ invite_kind, via, pool_id }) {
+  ga4Event('invite_share', {
+    invite_kind: invite_kind === 'pool' ? 'pool' : 'site',
+    ...(via ? { via } : {}),
+    ...(pool_id ? { pool_id } : {}),
+  });
+}

--- a/src/features/invite/model/shareInvite.js
+++ b/src/features/invite/model/shareInvite.js
@@ -1,0 +1,72 @@
+import {
+  buildPoolInviteShareTitleFromInviter,
+  buildPoolInviteUrl,
+  buildSiteInviteShareTitle,
+  buildSiteInviteUrl,
+  normalizeInviteHandle,
+} from '../../../shared/lib/inviteKit';
+import { createPoolInviteLink } from '../../../shared/lib/createPoolInviteLink';
+import {
+  buildPoolInviteShareTitle,
+  shareOrCopyInviteUrl,
+} from '../../../shared/lib/shareOrCopyInviteUrl';
+import { trackInviteShare } from './inviteAnalytics';
+
+/**
+ * Share a site or pool invite and emit `invite_share` on success.
+ *
+ * @param {{
+ *   invite_kind: 'site' | 'pool',
+ *   url: string,
+ *   title?: string,
+ *   poolName?: string,
+ *   inviterHandle?: string,
+ *   pool_id?: string,
+ *   copyToastMessage?: string,
+ * }} args
+ */
+export async function shareInvite({
+  invite_kind,
+  url,
+  title,
+  poolName,
+  inviterHandle,
+  pool_id,
+  copyToastMessage = 'Invite link copied!',
+}) {
+  const kind = invite_kind === 'pool' ? 'pool' : 'site';
+  const resolvedTitle =
+    title ??
+    (kind === 'site'
+      ? buildSiteInviteShareTitle(inviterHandle)
+      : inviterHandle
+        ? buildPoolInviteShareTitleFromInviter(inviterHandle, poolName)
+        : buildPoolInviteShareTitle(poolName));
+
+  const result = await shareOrCopyInviteUrl(url, {
+    title: resolvedTitle,
+    poolName,
+    copyToastMessage,
+  });
+
+  if (result.ok) {
+    trackInviteShare({
+      invite_kind: kind,
+      via: result.via,
+      pool_id,
+    });
+  }
+
+  return result;
+}
+
+export {
+  buildPoolInviteShareTitle,
+  buildPoolInviteShareTitleFromInviter,
+  buildPoolInviteUrl,
+  buildSiteInviteShareTitle,
+  buildSiteInviteUrl,
+  createPoolInviteLink,
+  normalizeInviteHandle,
+  shareOrCopyInviteUrl,
+};

--- a/src/features/pools/model/usePoolInviteShare.js
+++ b/src/features/pools/model/usePoolInviteShare.js
@@ -1,17 +1,21 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { createPoolInviteLink } from '../../../shared/lib/createPoolInviteLink';
 import {
   buildPoolInviteShareTitle,
-  shareOrCopyInviteUrl,
-} from '../../../shared/lib/shareOrCopyInviteUrl';
+  buildPoolInviteShareTitleFromInviter,
+  buildPoolInviteUrl,
+  shareInvite,
+} from '../../invite';
 
 /**
  * Orchestrates pool invite link sharing (Web Share API or clipboard).
+ * Uses the shared invite kit (#579); optional inviter handle adds `?from=`.
  */
 export function usePoolInviteShare({
   inviteCode,
   poolName,
+  inviterHandle,
+  poolId,
   onSuccess,
   disabled = false,
 }) {
@@ -23,9 +27,13 @@ export function usePoolInviteShare({
 
   const handleShareClick = useCallback(async () => {
     if (disabled || !inviteCode) return;
-    const url = createPoolInviteLink(inviteCode);
-    const result = await shareOrCopyInviteUrl(url, {
+    const url = buildPoolInviteUrl(inviteCode, inviterHandle);
+    const result = await shareInvite({
+      invite_kind: 'pool',
+      url,
       poolName,
+      inviterHandle,
+      pool_id: poolId,
       copyToastMessage: 'Invite link copied!',
     });
 
@@ -37,7 +45,7 @@ export function usePoolInviteShare({
       setStatus('error');
       window.setTimeout(() => setStatus('idle'), 2000);
     }
-  }, [inviteCode, poolName, onSuccess, disabled]);
+  }, [inviteCode, poolName, inviterHandle, poolId, onSuccess, disabled]);
 
   const label =
     status === 'shared'
@@ -48,10 +56,14 @@ export function usePoolInviteShare({
           ? 'Try again'
           : 'Invite Friends!';
 
+  const title = inviterHandle
+    ? buildPoolInviteShareTitleFromInviter(inviterHandle, poolName)
+    : buildPoolInviteShareTitle(poolName);
+
   return {
     label,
     onShareClick: handleShareClick,
     disabled: disabled || !inviteCode,
-    title: buildPoolInviteShareTitle(poolName),
+    title,
   };
 }

--- a/src/features/pools/ui/PoolInviteShareButton.jsx
+++ b/src/features/pools/ui/PoolInviteShareButton.jsx
@@ -9,11 +9,20 @@ import { PoolInviteShareButtonView } from './PoolInviteShareButtonView';
 export default function PoolInviteShareButton({
   inviteCode,
   poolName,
+  inviterHandle,
+  poolId,
   onSuccess,
   disabled = false,
   className = '',
 }) {
-  const share = usePoolInviteShare({ inviteCode, poolName, onSuccess, disabled });
+  const share = usePoolInviteShare({
+    inviteCode,
+    poolName,
+    inviterHandle,
+    poolId,
+    onSuccess,
+    disabled,
+  });
 
   return (
     <PoolInviteShareButtonView

--- a/src/shared/lib/inviteKit.js
+++ b/src/shared/lib/inviteKit.js
@@ -1,0 +1,70 @@
+import { getPublicAppBaseUrl } from '../config/environment';
+
+/**
+ * Normalize a public handle for invite URLs / copy (trim; no `@`).
+ * @param {unknown} handle
+ * @returns {string}
+ */
+export function normalizeInviteHandle(handle) {
+  return String(handle ?? '')
+    .trim()
+    .replace(/^@+/, '');
+}
+
+/**
+ * Site VIP invite — never includes a pool code.
+ * @param {string} handle
+ * @returns {string}
+ */
+export function buildSiteInviteUrl(handle) {
+  const h = normalizeInviteHandle(handle);
+  const base = getPublicAppBaseUrl();
+  if (!base || !h) return '';
+  return `${base}/invite/${encodeURIComponent(h)}`;
+}
+
+/**
+ * Pool invite URL. Optional `from` personalizes landings / OG without changing the code.
+ * @param {string} inviteCode
+ * @param {string} [fromHandle]
+ * @returns {string}
+ */
+export function buildPoolInviteUrl(inviteCode, fromHandle) {
+  const code = String(inviteCode ?? '')
+    .trim()
+    .toUpperCase();
+  const base = getPublicAppBaseUrl();
+  if (!base || !code) return '';
+  const url = `${base}/join/${encodeURIComponent(code)}`;
+  const from = normalizeInviteHandle(fromHandle);
+  if (!from) return url;
+  return `${url}?from=${encodeURIComponent(from)}`;
+}
+
+/**
+ * @param {string} handle
+ * @returns {string}
+ */
+export function buildSiteInviteShareTitle(handle) {
+  const h = normalizeInviteHandle(handle);
+  if (!h) return "You're invited to Setlist Pick'em";
+  return `${h} invited you to Setlist Pick'em`;
+}
+
+/**
+ * Personalized pool invite headline (for share / OG).
+ * @param {string} handle
+ * @param {string | null | undefined} [poolName]
+ * @returns {string}
+ */
+export function buildPoolInviteShareTitleFromInviter(handle, poolName) {
+  const h = normalizeInviteHandle(handle);
+  const name = typeof poolName === 'string' ? poolName.trim() : '';
+  if (!h) {
+    return name
+      ? `You're invited to join a Setlist Pick'em pool: ${name}`
+      : "You're invited to join a Setlist Pick'em pool";
+  }
+  if (name) return `${h} invited you to join their pool: ${name}`;
+  return `${h} invited you to join their pool`;
+}

--- a/src/shared/lib/inviteKit.test.js
+++ b/src/shared/lib/inviteKit.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  buildPoolInviteShareTitleFromInviter,
+  buildPoolInviteUrl,
+  buildSiteInviteShareTitle,
+  buildSiteInviteUrl,
+  normalizeInviteHandle,
+} from './inviteKit';
+
+describe('inviteKit', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', { location: { origin: 'https://www.setlistpickem.com' } });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('normalizes handles', () => {
+    expect(normalizeInviteHandle('  @Trey  ')).toBe('Trey');
+    expect(normalizeInviteHandle('')).toBe('');
+  });
+
+  it('builds site invite URLs without pool codes', () => {
+    expect(buildSiteInviteUrl('Mikey')).toBe(
+      'https://www.setlistpickem.com/invite/Mikey',
+    );
+    expect(buildSiteInviteUrl('')).toBe('');
+  });
+
+  it('builds pool invite URLs with optional from=', () => {
+    expect(buildPoolInviteUrl('YEM42')).toBe(
+      'https://www.setlistpickem.com/join/YEM42',
+    );
+    expect(buildPoolInviteUrl('yem42', 'Mikey')).toBe(
+      'https://www.setlistpickem.com/join/YEM42?from=Mikey',
+    );
+  });
+
+  it('builds personalized share titles', () => {
+    expect(buildSiteInviteShareTitle('Mikey')).toBe(
+      "Mikey invited you to Setlist Pick'em",
+    );
+    expect(buildPoolInviteShareTitleFromInviter('Mikey', 'Denver Crew')).toBe(
+      'Mikey invited you to join their pool: Denver Crew',
+    );
+    expect(buildPoolInviteShareTitleFromInviter('Mikey')).toBe(
+      'Mikey invited you to join their pool',
+    );
+  });
+});


### PR DESCRIPTION
Closes #579

## Summary
- New `features/invite` public barrel: site/pool URL + personalized copy builders, `shareInvite`, `invite_share` telemetry
- Pure builders in `shared/lib/inviteKit.js` (email-portable contracts)
- `usePoolInviteShare` / `PoolInviteShareButton` consume the kit (`?from=` when `inviterHandle` provided)
- PATCH **1.20.26** (Train 3 foundation; `/invite/:handle` landing lands in #580 as MINOR)
- Documents intended `/invite/:handle` + `?from=` in `docs/API.md`

## Test plan
- [ ] `npm test` invite kit unit tests green
- [ ] Pool Invite Friends still shares / copies a join link
- [ ] With `inviterHandle`, URL includes `?from=` and title is personalized


Made with [Cursor](https://cursor.com)