### PR TITLE
feat(invite): VIP landings for /invite/:handle and /join/:code (#580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.21.0] — 2026-07-15
+
+### Added
+- **VIP invite landings (#580)** — `/invite/:handle` site VIP landing and `/join/:code?from=` pool landing with personalized copy when the inviter handle resolves; full-page auth CTAs (Create account primary, Sign in secondary). Site invites never write pool join storage; pool invites still store `phish_pool_pending_invite` and join after auth via `usePendingPoolJoin`.
+
+---
+
 ## [1.20.26] — 2026-07-15
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -271,8 +271,8 @@ These routes are part of the public surface. Renaming or removing them is a MAJO
 | `/` | None | Public splash / landing page |
 | `/how-it-works` | None | How to play marketing page |
 | `/how-scoring-works` | None | Scoring rules marketing page |
-| `/join/:code` | None | Pool invite deep link; optional `?from={handle}` for inviter personalization (kit #579; VIP landing #580) |
-| `/invite/:handle` | None | Site VIP invite deep link (**landing ships #580**; URL builders in invite kit #579) |
+| `/join/:code` | None | Pool invite deep link; optional `?from={handle}` for inviter personalization; VIP landing stores code and prompts auth (#580) |
+| `/invite/:handle` | None | Site VIP invite deep link; personalized landing when handle resolves; no pool join side effects (#580) |
 | `/user/:userId` | None | Public player profile |
 | `/privacy` | None | Privacy policy |
 | `/terms` | None | Terms of service |

--- a/docs/USER_ROUTING_AND_JOURNEYS.md
+++ b/docs/USER_ROUTING_AND_JOURNEYS.md
@@ -9,8 +9,9 @@ Defined in `src/app/App.jsx`.
 | Path | Access | Purpose |
 |------|--------|---------|
 | `/` | Public (splash); redirects if session exists | Marketing / SEO landing; auth modals |
+| `/invite/:handle` | Public | Site VIP invite landing; personalized when handle resolves; no pool storage |
 | `/join` | Public | Missing invite code → redirect home (`PoolInviteMissingCodePage`) |
-| `/join/:code` | Public | Stores invite code, redirects to `/`; auth funnel for join |
+| `/join/:code` | Public | Stores invite code; VIP landing with optional `?from=` personalization |
 | `/setup` | Signed-in only | Profile setup until Firestore user doc exists |
 | `/dashboard/*` | Signed-in + profile | App shell (`DashboardLayout`) |
 | `/user/:userId` | Public | Public player profile (no dashboard restore) |
@@ -40,6 +41,7 @@ Defined in `src/app/App.jsx`.
 Implemented in `src/shared/lib/dashboardLastPath.js` and used from:
 
 - `src/app/routes/HomeRoute.jsx` (signed-in visitor on `/`)
+- Invite landings via `useInviteLanding` (signed-in visitor on `/invite/:handle` or `/join/:code`)
 - `src/app/routes/SetupRoute.jsx` (profile already complete)
 - `src/features/auth/model/useProfileSetup.js` (after first profile save, full page load)
 
@@ -91,14 +93,20 @@ If nothing is stored, stored JSON is invalid, or the path is ineligible → **`/
 5. After successful save → `window.location.href = getDashboardEntryHref(...)` → usually **`/dashboard`**.
 6. `DashboardLayout` → default nested route **`/`** → **Picks**.
 
-### B. First-time user with invite (`/join/:code`)
+### B. First-time user with pool invite (`/join/:code`)
 
-1. `usePoolInviteInterceptor` (`src/features/pool-invite/model/usePoolInviteInterceptor.js`): valid code → saved under pool-invite storage key → **`navigate('/', { replace: true })`**.
-2. `SplashPage`: if invite code present in storage → open **Create account** modal with a persistent join banner (`src/pages/landing/SplashPage.jsx`). Returning invitees can switch to **Sign in** via the modal footer link (same banner, sign-in copy). (`/?login=true` still opens **Sign in**, and takes priority if both are present.)
-3. After auth → `HomeRoute` → `getDashboardEntryHref` → usually **`/dashboard`** (new device/browser).
+1. `usePoolInviteCodeStorage` (`src/features/pool-invite/model/usePoolInviteCodeStorage.js`): valid code → saved under pool-invite storage key → **VIP landing stays on `/join/:code`** (`InviteVipLanding` via `PoolInvitePage`). Optional `?from=` resolves inviter handle for personalized H1.
+2. User taps **Create account** or **Sign in** → splash auth modals with pool join banner (`poolInvitePending`). Create account honors legal checkbox (#577).
+3. After auth → `useInviteLanding` redirect → `getDashboardEntryHref` → usually **`/dashboard`** (new device/browser).
 4. `DashboardRoute` → **`/setup`** if no profile; after setup → **`/dashboard`** (then step 5).
 5. `usePendingPoolJoin` (`src/features/pool-invite/model/usePendingPoolJoin.js`) inside `DashboardLayout`: consumes invite code, joins pool → on **`joined`** or **`already-member`** → **`navigate('/dashboard/pools', { replace: true })`**. This **overrides** the URL from step 3–4 for those outcomes.
 6. Invalid/expired code: no navigation to Pools; user stays on the URL from `getDashboardEntryHref` (often Picks).
+
+### B2. First-time user with site invite (`/invite/:handle`)
+
+1. `InviteLandingPage` → `useInviteLanding` with `inviteKind: 'site'`. Resolves handle via `resolveInviterProfile`; generic VIP copy if missing/renamed. **Does not** write `phish_pool_pending_invite`.
+2. User taps **Create account** or **Sign in** → splash auth modals (no pool join banner).
+3. After auth → `getDashboardEntryHref` → **`/dashboard`** (or remembered tab) → setup if needed → normal dashboard flow. **No** `usePendingPoolJoin` side effects.
 
 ### C. Existing user, no invite (organic return)
 
@@ -107,7 +115,7 @@ If nothing is stored, stored JSON is invalid, or the path is ineligible → **`/
 
 ### D. Existing user with a new invite link
 
-1. Same as B.1–B.2 (code stored, splash prompts auth if needed).
+1. **Pool:** Same as B.1–B.2 (code stored on landing; signed-in visitors redirect immediately to dashboard with code already in storage).
 2. After sign-in, **`getDashboardEntryHref`** may briefly send the user to a **remembered** tab (e.g. Standings). Once `DashboardLayout` mounts, **`usePendingPoolJoin`** runs. On successful join / already-member → **`/dashboard/pools`** with **`replace: true`**.
 
 **Priority:** successful **invite join navigation** overrides the restored tab for those outcomes.
@@ -124,6 +132,7 @@ If nothing is stored, stored JSON is invalid, or the path is ineligible → **`/
 |-----------|----------|
 | Visit `/setup` with profile already present | `SetupRoute` → `getDashboardEntryHref` |
 | Visit `/join` without `:code` | `PoolInviteMissingCodePage` → `/` |
+| Visit `/invite/:handle` while signed in | `useInviteLanding` → `getDashboardEntryHref` (no pool storage) |
 | Visit `/user/:userId` | Public profile only; no `getDashboardEntryHref` |
 | Password reset completion | `/password-reset-complete` (public); flow continues per Firebase / app handling |
 
@@ -132,15 +141,16 @@ If nothing is stored, stored JSON is invalid, or the path is ineligible → **`/
 ```mermaid
 flowchart TD
   entry[Entry_URL]
-  splashOrDirect[Splash_or_direct_dashboard_URL]
+  inviteLanding{Invite_VIP_landing?}
   authGates[DashboardRoute_gates]
   restore[getDashboardEntryHref_or_URL_unchanged]
   layout[DashboardLayout_persist_path]
   pendingJoin{usePendingPoolJoin_invite_code?}
   poolsNav[Navigate_to_/dashboard/pools]
 
-  entry --> splashOrDirect
-  splashOrDirect --> authGates
+  entry --> inviteLanding
+  inviteLanding -->|site_/invite| authGates
+  inviteLanding -->|pool_/join| authGates
   authGates --> restore
   restore --> layout
   layout --> pendingJoin
@@ -157,7 +167,8 @@ flowchart TD
 | Dashboard / setup gates | `src/app/routes/DashboardRoute.jsx`, `src/app/routes/SetupRoute.jsx` |
 | Remember path read/write | `src/shared/lib/dashboardLastPath.js` |
 | Persist on navigation | `src/app/layout/DashboardLayout.jsx` |
-| Invite code capture | `src/features/pool-invite/model/usePoolInviteInterceptor.js` |
+| Invite code capture | `src/features/pool-invite/model/usePoolInviteCodeStorage.js` |
+| Site + pool VIP landing | `src/features/invite/ui/InviteVipLanding.jsx`, `src/features/invite/model/useInviteLanding.js` |
 | Post-auth join + Pools redirect | `src/features/pool-invite/model/usePendingPoolJoin.js` |
 | Profile completion redirect | `src/features/auth/model/useProfileSetup.js` |
-| Splash + invite join banner | `src/pages/landing/SplashPage.jsx` |
+| Splash + legacy pool modal prompt | `src/pages/landing/SplashPage.jsx` |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.20.26",
+  "version": "1.21.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -17,6 +17,7 @@ const PoolInviteMissingCodePage = lazy(() =>
   import('../pages/pool-invite/PoolInviteMissingCodePage')
 );
 const PoolInvitePage = lazy(() => import('../pages/pool-invite/PoolInvitePage'));
+const InviteLandingPage = lazy(() => import('../pages/invite/InviteLandingPage'));
 const HowItWorksPage = lazy(() => import('../pages/marketing/HowItWorksPage'));
 const HowScoringWorksPage = lazy(() => import('../pages/marketing/HowScoringWorksPage'));
 const PrivacyPolicyPage = lazy(() => import('../pages/legal/PrivacyPolicyPage'));
@@ -50,8 +51,11 @@ function App() {
         {/* Pool invite: no code — drop stale breadcrumb */}
         <Route path="/join" element={<PoolInviteMissingCodePage />} />
         <Route path="/join/" element={<PoolInviteMissingCodePage />} />
-        {/* Deep link — saves valid code and sends user through auth funnel */}
+        {/* Deep link — saves valid code and shows VIP landing (#580) */}
         <Route path="/join/:code" element={<PoolInvitePage />} />
+
+        {/* Site VIP invite — no pool join side effects */}
+        <Route path="/invite/:handle" element={<InviteLandingPage />} />
 
         {/* Dev-only: comms template preview gallery (no auth; prod redirects home) */}
         <Route path="/comms-preview" element={<CommsPreviewPage />} />

--- a/src/app/layout/model/shellTransitionKey.js
+++ b/src/app/layout/model/shellTransitionKey.js
@@ -13,6 +13,7 @@ export function shellTransitionKey(pathname) {
   const path = (pathname || '').replace(/\/+$/, '') || '/';
   if (path.startsWith('/dashboard')) return '/dashboard';
   if (path.startsWith('/join/')) return '/join/:code';
+  if (path.startsWith('/invite/')) return '/invite/:handle';
   if (path.startsWith('/user/')) return '/user/:userId';
   return path;
 }

--- a/src/app/layout/model/shellTransitionKey.test.js
+++ b/src/app/layout/model/shellTransitionKey.test.js
@@ -21,4 +21,9 @@ describe('shellTransitionKey', () => {
     expect(shellTransitionKey('/join/POOL1')).toBe('/join/:code');
     expect(shellTransitionKey('/join/abc/')).toBe('/join/:code');
   });
+
+  it('groups site invite deep links', () => {
+    expect(shellTransitionKey('/invite/Mikey')).toBe('/invite/:handle');
+    expect(shellTransitionKey('/invite/mikey/')).toBe('/invite/:handle');
+  });
 });

--- a/src/features/invite/api/resolveInviterProfile.js
+++ b/src/features/invite/api/resolveInviterProfile.js
@@ -1,0 +1,20 @@
+import { fetchPublicProfileByHandle } from '../../profile';
+import { normalizeInviteHandle } from '../../../shared/lib/inviteKit';
+
+/**
+ * Resolve a public inviter profile by handle for VIP landings.
+ * @param {unknown} handle
+ * @returns {Promise<{ uid: string, handle?: string } | null>}
+ */
+export async function resolveInviterProfile(handle) {
+  const normalized = normalizeInviteHandle(handle);
+  if (!normalized) return null;
+
+  try {
+    const profile = await fetchPublicProfileByHandle(normalized);
+    if (!profile) return null;
+    return profile;
+  } catch {
+    return null;
+  }
+}

--- a/src/features/invite/index.js
+++ b/src/features/invite/index.js
@@ -2,6 +2,12 @@
  * Personalized invite kit (#579) — public entry for site + pool invite URLs,
  * copy, share helper, and telemetry. VIP landings (#580) and OG (#582) build on this.
  */
+export { default as InviteVipLanding } from './ui/InviteVipLanding';
+export { useInviteLanding } from './model/useInviteLanding';
+export {
+  getInviteLandingHeadline,
+  getInviteLandingSubcopy,
+} from './model/inviteLandingCopy';
 export {
   buildPoolInviteShareTitle,
   buildPoolInviteShareTitleFromInviter,

--- a/src/features/invite/model/inviteLandingCopy.js
+++ b/src/features/invite/model/inviteLandingCopy.js
@@ -1,0 +1,25 @@
+import {
+  buildPoolInviteShareTitleFromInviter,
+  buildSiteInviteShareTitle,
+} from '../../../shared/lib/inviteKit';
+
+/**
+ * @param {{ inviteKind: 'site' | 'pool', resolvedHandle?: string | null }} params
+ */
+export function getInviteLandingHeadline({ inviteKind, resolvedHandle }) {
+  const handle = typeof resolvedHandle === 'string' ? resolvedHandle.trim() : '';
+  if (inviteKind === 'pool') {
+    return buildPoolInviteShareTitleFromInviter(handle);
+  }
+  return buildSiteInviteShareTitle(handle);
+}
+
+/**
+ * @param {{ inviteKind: 'site' | 'pool' }} params
+ */
+export function getInviteLandingSubcopy({ inviteKind }) {
+  if (inviteKind === 'pool') {
+    return 'Create a free account to join the pool and compete with your crew on tour.';
+  }
+  return 'Create a free account to predict setlists, track scores live, and compete with friends on Phish tour.';
+}

--- a/src/features/invite/model/inviteLandingCopy.test.js
+++ b/src/features/invite/model/inviteLandingCopy.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getInviteLandingHeadline,
+  getInviteLandingSubcopy,
+} from './inviteLandingCopy';
+
+describe('inviteLandingCopy', () => {
+  it('uses personalized site headline when handle resolves', () => {
+    expect(
+      getInviteLandingHeadline({ inviteKind: 'site', resolvedHandle: 'Mikey' }),
+    ).toBe("Mikey invited you to Setlist Pick'em");
+  });
+
+  it('falls back to generic site headline when handle is missing', () => {
+    expect(
+      getInviteLandingHeadline({ inviteKind: 'site', resolvedHandle: null }),
+    ).toBe("You're invited to Setlist Pick'em");
+  });
+
+  it('uses personalized pool headline when handle resolves', () => {
+    expect(
+      getInviteLandingHeadline({ inviteKind: 'pool', resolvedHandle: 'Mikey' }),
+    ).toBe('Mikey invited you to join their pool');
+  });
+
+  it('falls back to generic pool headline when handle is missing', () => {
+    expect(
+      getInviteLandingHeadline({ inviteKind: 'pool', resolvedHandle: null }),
+    ).toBe("You're invited to join a Setlist Pick'em pool");
+  });
+
+  it('returns kind-specific subcopy', () => {
+    expect(getInviteLandingSubcopy({ inviteKind: 'site' })).toMatch(/predict setlists/i);
+    expect(getInviteLandingSubcopy({ inviteKind: 'pool' })).toMatch(/join the pool/i);
+  });
+});

--- a/src/features/invite/model/useInviteLanding.js
+++ b/src/features/invite/model/useInviteLanding.js
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  isSplashGoogleModalInflight,
+  useAuth,
+} from '../../auth';
+import { normalizeInviteHandle } from '../../../shared/lib/inviteKit';
+import { getDashboardEntryHref } from '../../../shared/lib/dashboardLastPath';
+import { resolveInviterProfile } from '../api/resolveInviterProfile';
+import {
+  getInviteLandingHeadline,
+  getInviteLandingSubcopy,
+} from './inviteLandingCopy';
+
+/**
+ * @param {{ inviteKind: 'site' | 'pool', handle?: string | null }} options
+ */
+export function useInviteLanding({ inviteKind, handle: rawHandle }) {
+  const handle = normalizeInviteHandle(rawHandle);
+  const { user, isAdmin: isAdminUser } = useAuth();
+  const [authModal, setAuthModal] = useState(null);
+  const [inviter, setInviter] = useState(null);
+  const [resolveState, setResolveState] = useState(handle ? 'loading' : 'idle');
+
+  const closeModal = useCallback(() => setAuthModal(null), []);
+  const openSignUpModal = useCallback(() => setAuthModal('signup'), []);
+  const openSignInModal = useCallback(() => setAuthModal('signin'), []);
+
+  useEffect(() => {
+    if (!handle) {
+      setInviter(null);
+      setResolveState('idle');
+      return undefined;
+    }
+
+    let cancelled = false;
+    setResolveState('loading');
+
+    resolveInviterProfile(handle).then((profile) => {
+      if (cancelled) return;
+      setInviter(profile);
+      setResolveState('done');
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [handle]);
+
+  const resolvedHandle = inviter?.handle?.trim() || null;
+  const headline = useMemo(
+    () => getInviteLandingHeadline({ inviteKind, resolvedHandle }),
+    [inviteKind, resolvedHandle],
+  );
+  const subcopy = useMemo(
+    () => getInviteLandingSubcopy({ inviteKind }),
+    [inviteKind],
+  );
+
+  const poolInvitePending = inviteKind === 'pool';
+  const redirectTo =
+    user && !isSplashGoogleModalInflight()
+      ? getDashboardEntryHref({ isAdminUser })
+      : null;
+
+  return {
+    inviteKind,
+    handle,
+    resolveState,
+    headline,
+    subcopy,
+    poolInvitePending,
+    authModal,
+    closeModal,
+    openSignUpModal,
+    openSignInModal,
+    redirectTo,
+  };
+}

--- a/src/features/invite/ui/InviteVipLanding.jsx
+++ b/src/features/invite/ui/InviteVipLanding.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+import { useLocation } from 'react-router-dom';
+
+import { MarketingPageShell, SplashAuthModals } from '../../landing';
+import { SEO_CONFIG } from '../../../shared/config/seo';
+import Button from '../../../shared/ui/Button';
+
+/**
+ * Full-page VIP invite landing — distinct from splash modal overlay.
+ */
+export default function InviteVipLanding({
+  inviteKind,
+  resolveState,
+  headline,
+  subcopy,
+  poolInvitePending,
+  authModal,
+  closeModal,
+  openSignUpModal,
+  openSignInModal,
+}) {
+  const { pathname, search } = useLocation();
+  const pageTitle = `${headline} | Setlist Pick'Em`;
+  const canonicalUrl = `${SEO_CONFIG.siteUrl}${pathname}${search}`;
+
+  return (
+    <>
+      <Helmet>
+        <title>{pageTitle}</title>
+        <meta name="description" content={subcopy} />
+        <meta property="og:title" content={headline} />
+        <meta property="og:description" content={subcopy} />
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content={SEO_CONFIG.siteName} />
+        <meta property="og:image" content={SEO_CONFIG.ogImageUrl} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={headline} />
+        <meta name="twitter:description" content={subcopy} />
+        <meta name="twitter:image" content={SEO_CONFIG.ogImageUrl} />
+        <link rel="canonical" href={canonicalUrl} />
+      </Helmet>
+      <MarketingPageShell>
+        <section className="mx-auto flex min-h-[calc(100vh-5.35rem)] max-w-2xl flex-col items-center justify-center px-4 py-16 text-center sm:px-6 lg:px-8">
+          {resolveState === 'loading' ? (
+            <div
+              className="mb-6 h-8 w-8 animate-spin rounded-full border-2 border-brand-primary border-t-transparent"
+              aria-hidden
+            />
+          ) : null}
+          <p className="text-xs font-bold uppercase tracking-[0.2em] text-teal-400">
+            {inviteKind === 'pool' ? 'Pool invite' : "You're invited"}
+          </p>
+          <h1 className="mt-4 font-display text-3xl font-bold leading-tight text-white sm:text-4xl md:text-5xl">
+            {headline}
+          </h1>
+          <p className="mt-6 max-w-lg text-base leading-relaxed text-slate-300 sm:text-lg">
+            {subcopy}
+          </p>
+          <div className="mt-10 flex w-full max-w-md flex-col items-stretch gap-4">
+            <Button
+              variant="primary"
+              type="button"
+              onClick={openSignUpModal}
+              className="w-full py-3.5 text-base uppercase tracking-widest"
+            >
+              Create account
+            </Button>
+            <Button
+              variant="secondary"
+              type="button"
+              onClick={openSignInModal}
+              className="w-full py-3.5 text-base uppercase tracking-widest"
+            >
+              Sign in
+            </Button>
+          </div>
+        </section>
+      </MarketingPageShell>
+      <SplashAuthModals
+        authModal={authModal}
+        closeModal={closeModal}
+        onSwitchToSignIn={openSignInModal}
+        onSwitchToSignUp={openSignUpModal}
+        poolInvitePending={poolInvitePending}
+      />
+    </>
+  );
+}

--- a/src/features/pool-invite/index.js
+++ b/src/features/pool-invite/index.js
@@ -1,3 +1,7 @@
 export { default as PoolInviteRedirectWrapper } from './ui/PoolInviteRedirectWrapper';
 export { usePoolInviteInterceptor } from './model/usePoolInviteInterceptor';
+export {
+  storePoolInviteCodeFromParam,
+  usePoolInviteCodeStorage,
+} from './model/usePoolInviteCodeStorage';
 export { usePendingPoolJoin } from './model/usePendingPoolJoin';

--- a/src/features/pool-invite/model/usePoolInviteCodeStorage.js
+++ b/src/features/pool-invite/model/usePoolInviteCodeStorage.js
@@ -1,0 +1,32 @@
+import { useParams } from 'react-router-dom';
+
+import {
+  removeLocalStorageItem,
+  setLocalStorageItem,
+} from '../../../shared/lib/local-storage';
+import { isValidPoolInviteCodeFormat } from '../lib/inviteCodeFormat';
+import { POOL_INVITE_STORAGE_KEY } from '../config';
+
+function normalizeInviteCode(raw) {
+  if (raw == null || typeof raw !== 'string') return '';
+  return raw.trim().toUpperCase();
+}
+
+/** Persists a valid pool invite code from the route param (sync during render). */
+export function storePoolInviteCodeFromParam(rawCode) {
+  const code = normalizeInviteCode(rawCode);
+  if (!code || !isValidPoolInviteCodeFormat(code)) {
+    removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
+    return;
+  }
+  setLocalStorageItem(POOL_INVITE_STORAGE_KEY, code);
+}
+
+/**
+ * Stores `phish_pool_pending_invite` from `/join/:code` without leaving the route.
+ * Runs synchronously so signed-in redirects still capture the code.
+ */
+export function usePoolInviteCodeStorage() {
+  const { code: rawCode } = useParams();
+  storePoolInviteCodeFromParam(rawCode);
+}

--- a/src/features/pool-invite/model/usePoolInviteInterceptor.js
+++ b/src/features/pool-invite/model/usePoolInviteInterceptor.js
@@ -1,29 +1,18 @@
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import {
-  removeLocalStorageItem,
-  setLocalStorageItem,
-} from '../../../shared/lib/local-storage';
-import { isValidPoolInviteCodeFormat } from '../lib/inviteCodeFormat';
-import { POOL_INVITE_STORAGE_KEY } from '../config';
+import { storePoolInviteCodeFromParam } from './usePoolInviteCodeStorage';
 
-function normalizeInviteCode(raw) {
-  if (raw == null || typeof raw !== 'string') return '';
-  return raw.trim().toUpperCase();
-}
-
+/**
+ * @deprecated Prefer {@link usePoolInviteCodeStorage} on `/join/:code` VIP landings (#580).
+ * Legacy helper: stores code then redirects home (splash modal funnel).
+ */
 export function usePoolInviteInterceptor() {
   const { code: rawCode } = useParams();
   const navigate = useNavigate();
 
   useEffect(() => {
-    const code = normalizeInviteCode(rawCode);
-    if (!code || !isValidPoolInviteCodeFormat(code)) {
-      removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
-    } else {
-      setLocalStorageItem(POOL_INVITE_STORAGE_KEY, code);
-    }
+    storePoolInviteCodeFromParam(rawCode);
     navigate('/', { replace: true });
   }, [rawCode, navigate]);
 }

--- a/src/pages/invite/InviteLandingPage.jsx
+++ b/src/pages/invite/InviteLandingPage.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Navigate, useParams } from 'react-router-dom';
+
+import {
+  InviteVipLanding,
+  normalizeInviteHandle,
+  useInviteLanding,
+} from '../../features/invite';
+
+export default function InviteLandingPage() {
+  const { handle: rawHandle } = useParams();
+  const landing = useInviteLanding({
+    inviteKind: 'site',
+    handle: normalizeInviteHandle(rawHandle),
+  });
+
+  if (landing.redirectTo) {
+    return <Navigate to={landing.redirectTo} replace />;
+  }
+
+  return <InviteVipLanding {...landing} />;
+}

--- a/src/pages/pool-invite/PoolInvitePage.jsx
+++ b/src/pages/pool-invite/PoolInvitePage.jsx
@@ -1,7 +1,25 @@
 import React from 'react';
+import { Navigate, useSearchParams } from 'react-router-dom';
 
-import { PoolInviteRedirectWrapper } from '../../features/pool-invite';
+import {
+  InviteVipLanding,
+  normalizeInviteHandle,
+  useInviteLanding,
+} from '../../features/invite';
+import { usePoolInviteCodeStorage } from '../../features/pool-invite';
 
 export default function PoolInvitePage() {
-  return <PoolInviteRedirectWrapper />;
+  usePoolInviteCodeStorage();
+  const [searchParams] = useSearchParams();
+  const fromHandle = normalizeInviteHandle(searchParams.get('from'));
+  const landing = useInviteLanding({
+    inviteKind: 'pool',
+    handle: fromHandle,
+  });
+
+  if (landing.redirectTo) {
+    return <Navigate to={landing.redirectTo} replace />;
+  }
+
+  return <InviteVipLanding {...landing} />;
 }


### PR DESCRIPTION
Closes #580

## Summary
- Full-page VIP landings for site (`/invite/:handle`) and pool (`/join/:code?from=`) invites at **1.21.0**
- Site path never writes pool invite storage; pool path still stores code and joins via `usePendingPoolJoin`
- Create account primary / Sign in secondary; reuses splash auth modals
- Docs: `API.md` + `USER_ROUTING_AND_JOURNEYS.md`

## Test plan
- [ ] `/invite/:handle` with known handle → personalized H1; Create account opens signup
- [ ] `/invite/missing-handle` → generic VIP fallback; no `phish_pool_pending_invite` in localStorage
- [ ] `/join/:code?from=handle` → personalized pool landing; code stored; after auth → join → pools
- [ ] `/join/:code` without `from` → generic pool VIP; join still works
- [ ] Signed-in user hitting either route redirects to dashboard (pool code still stored on join path)
- [ ] `npm run lint` + `npm test` green


Made with [Cursor](https://cursor.com)