### PR TITLE
feat(invite): Standings Invite CTA + chooser sheet (#581)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.21.2] — 2026-07-15
+
+### Added
+- **Standings invite chooser (#581)** — primary **Invite** CTA on dashboard Standings opens a sheet to share a site invite (`/invite/{handle}`) or pick a pool and share `/join/{code}?from={handle}`; empty-state copy wires to the same chooser.
+
+---
+
 ## [1.21.1] — 2026-07-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.21.1",
+  "version": "1.21.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/invite/index.js
+++ b/src/features/invite/index.js
@@ -20,3 +20,6 @@ export {
   shareOrCopyInviteUrl,
 } from './model/shareInvite';
 export { trackInviteShare } from './model/inviteAnalytics';
+export { useInviteChooser } from './model/useInviteChooser';
+export { default as InviteChooserSheet } from './ui/InviteChooserSheet';
+export { default as InviteChooserTrigger } from './ui/InviteChooserTrigger';

--- a/src/features/invite/model/useInviteChooser.js
+++ b/src/features/invite/model/useInviteChooser.js
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useAuth } from '../../auth';
+import {
+  buildPoolInviteUrl,
+  buildSiteInviteUrl,
+  normalizeInviteHandle,
+  shareInvite,
+} from './shareInvite';
+
+/**
+ * Standings / dashboard invite chooser — always surfaces site vs pool choice;
+ * never auto-shares a pool invite.
+ *
+ * @param {{
+ *   pools?: Array<{ id: string, name?: string, inviteCode?: string }>,
+ * }} [options]
+ */
+export function useInviteChooser({ pools = [] } = {}) {
+  const { userProfile } = useAuth();
+  const inviterHandle = normalizeInviteHandle(userProfile?.handle);
+
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState('choose');
+  const [selectedPoolId, setSelectedPoolId] = useState('');
+  const [sharing, setSharing] = useState(false);
+
+  const inviteablePools = useMemo(
+    () =>
+      (Array.isArray(pools) ? pools : []).filter((pool) =>
+        String(pool?.inviteCode ?? '').trim(),
+      ),
+    [pools],
+  );
+
+  const selectedPool = useMemo(
+    () => inviteablePools.find((pool) => pool.id === selectedPoolId) ?? null,
+    [inviteablePools, selectedPoolId],
+  );
+
+  const resetSheet = useCallback(() => {
+    setStep('choose');
+    setSelectedPoolId('');
+    setSharing(false);
+  }, []);
+
+  const openChooser = useCallback(() => {
+    resetSheet();
+    setOpen(true);
+  }, [resetSheet]);
+
+  const closeChooser = useCallback(() => {
+    setOpen(false);
+    resetSheet();
+  }, [resetSheet]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (selectedPoolId && !inviteablePools.some((pool) => pool.id === selectedPoolId)) {
+      setSelectedPoolId('');
+    }
+  }, [open, inviteablePools, selectedPoolId]);
+
+  const shareSiteInvite = useCallback(async () => {
+    if (!inviterHandle || sharing) return;
+    const url = buildSiteInviteUrl(inviterHandle);
+    if (!url) return;
+
+    setSharing(true);
+    try {
+      await shareInvite({
+        invite_kind: 'site',
+        url,
+        inviterHandle,
+      });
+      closeChooser();
+    } finally {
+      setSharing(false);
+    }
+  }, [inviterHandle, sharing, closeChooser]);
+
+  const sharePoolInvite = useCallback(async () => {
+    if (!selectedPool || sharing) return;
+    const inviteCode = String(selectedPool.inviteCode ?? '').trim();
+    if (!inviteCode) return;
+
+    const url = buildPoolInviteUrl(inviteCode, inviterHandle);
+    if (!url) return;
+
+    setSharing(true);
+    try {
+      await shareInvite({
+        invite_kind: 'pool',
+        url,
+        poolName: selectedPool.name,
+        inviterHandle,
+        pool_id: selectedPool.id,
+      });
+      closeChooser();
+    } finally {
+      setSharing(false);
+    }
+  }, [selectedPool, inviterHandle, sharing, closeChooser]);
+
+  const goToPoolStep = useCallback(() => {
+    setStep('pool');
+    setSelectedPoolId('');
+  }, []);
+
+  const backToChoose = useCallback(() => {
+    setStep('choose');
+    setSelectedPoolId('');
+  }, []);
+
+  return {
+    open,
+    step,
+    inviterHandle,
+    inviteablePools,
+    selectedPoolId,
+    setSelectedPoolId,
+    selectedPool,
+    sharing,
+    openChooser,
+    closeChooser,
+    shareSiteInvite,
+    sharePoolInvite,
+    goToPoolStep,
+    backToChoose,
+  };
+}

--- a/src/features/invite/ui/InviteChooserSheet.jsx
+++ b/src/features/invite/ui/InviteChooserSheet.jsx
@@ -1,0 +1,197 @@
+import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { ChevronLeft, Share2, Users, X } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import Button from '../../../shared/ui/Button';
+import FilterPill from '../../../shared/ui/FilterPill';
+
+/**
+ * Bottom sheet for site vs pool invite choice (#581). Mirrors dashboard modal
+ * patterns (`ScoringRulesModal`, `ConfirmationModal`).
+ */
+export default function InviteChooserSheet({
+  open,
+  onClose,
+  step,
+  inviterHandle,
+  inviteablePools,
+  selectedPoolId,
+  onSelectPoolId,
+  selectedPool,
+  sharing,
+  onShareSiteInvite,
+  onSharePoolInvite,
+  onGoToPoolStep,
+  onBackToChoose,
+}) {
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') onCloseRef.current();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.body.style.overflow = prev;
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  const hasHandle = Boolean(inviterHandle);
+  const isChooseStep = step === 'choose';
+  const isPoolStep = step === 'pool';
+  const hasPools = inviteablePools.length > 0;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[100] flex items-end justify-center p-0 sm:items-center sm:p-4"
+      role="presentation"
+    >
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        aria-label="Close invite options"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="invite-chooser-heading"
+        className="relative z-10 flex max-h-[min(90vh,calc(100dvh-env(safe-area-inset-bottom,0px)))] w-full max-w-lg flex-col overflow-hidden rounded-t-2xl border border-border-subtle bg-surface-panel-strong shadow-inset-glass ring-1 ring-white/10 sm:max-h-[90vh] sm:rounded-2xl"
+      >
+        <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border-muted bg-surface-panel-strong px-3 pb-2 pt-[max(0.5rem,env(safe-area-inset-top))]">
+          {isPoolStep ? (
+            <button
+              type="button"
+              onClick={onBackToChoose}
+              className="inline-flex items-center gap-1 rounded-lg px-2 py-2 text-xs font-semibold text-content-secondary transition-colors hover:bg-surface-panel hover:text-white"
+            >
+              <ChevronLeft className="h-4 w-4" aria-hidden />
+              Back
+            </button>
+          ) : (
+            <span className="w-16" aria-hidden />
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex items-center justify-center rounded-lg p-2 text-slate-300 transition-colors hover:bg-surface-panel hover:text-white"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" aria-hidden />
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 pb-[max(1rem,env(safe-area-inset-bottom))] pt-4 sm:px-6 sm:pb-6">
+          <h2
+            id="invite-chooser-heading"
+            className="font-display text-lg font-bold text-white sm:text-xl"
+          >
+            {isChooseStep ? 'Invite friends' : 'Choose a pool'}
+          </h2>
+          <p className="mt-2 text-sm font-medium leading-relaxed text-content-secondary">
+            {isChooseStep
+              ? 'Share Setlist Pick\u2019em or invite friends into one of your pools.'
+              : 'Pick which pool to share — your friends will join with your invite link.'}
+          </p>
+
+          {isChooseStep ? (
+            <div className="mt-6 flex flex-col gap-3">
+              <button
+                type="button"
+                onClick={onShareSiteInvite}
+                disabled={!hasHandle || sharing}
+                className="flex w-full items-start gap-3 rounded-2xl border border-border-subtle bg-surface-panel/80 p-4 text-left transition-colors hover:border-brand-primary/40 hover:bg-surface-panel disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <span className="mt-0.5 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand-primary/15 text-brand-primary">
+                  <Share2 className="h-5 w-5" aria-hidden />
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-base font-bold text-white">
+                    Invite to Setlist Pick&apos;em
+                  </span>
+                  <span className="mt-1 block text-sm font-medium text-content-secondary">
+                    {hasHandle
+                      ? `Share your personal link — no pool code.`
+                      : 'Set your handle on Profile before sharing a site invite.'}
+                  </span>
+                </span>
+              </button>
+
+              <button
+                type="button"
+                onClick={onGoToPoolStep}
+                disabled={sharing}
+                className="flex w-full items-start gap-3 rounded-2xl border border-border-subtle bg-surface-panel/80 p-4 text-left transition-colors hover:border-brand-primary/40 hover:bg-surface-panel disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <span className="mt-0.5 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand-primary/15 text-brand-primary">
+                  <Users className="h-5 w-5" aria-hidden />
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-base font-bold text-white">
+                    Invite to a pool
+                  </span>
+                  <span className="mt-1 block text-sm font-medium text-content-secondary">
+                    Choose one of your pools, then share its join link
+                    {hasHandle ? ` with @${inviterHandle}.` : '.'}
+                  </span>
+                </span>
+              </button>
+            </div>
+          ) : null}
+
+          {isPoolStep ? (
+            <div className="mt-6">
+              {!hasPools ? (
+                <div className="rounded-2xl border border-border-subtle bg-surface-panel/60 p-4 text-center">
+                  <p className="mb-3 text-sm font-bold text-content-secondary">
+                    You aren&apos;t in any pools yet.
+                  </p>
+                  <Link
+                    to="/dashboard/pools"
+                    onClick={onClose}
+                    className="inline-flex items-center gap-1.5 rounded-full border border-brand-primary/40 bg-brand-primary/10 px-4 py-1.5 text-sm font-semibold text-brand-primary transition-colors hover:bg-brand-primary/15"
+                  >
+                    Join or create a pool
+                  </Link>
+                </div>
+              ) : (
+                <>
+                  <div className="flex flex-wrap gap-1.5">
+                    {inviteablePools.map((pool) => (
+                      <FilterPill
+                        key={pool.id}
+                        selected={selectedPoolId === pool.id}
+                        onClick={() => onSelectPoolId(pool.id)}
+                      >
+                        {pool.name || 'Pool'}
+                      </FilterPill>
+                    ))}
+                  </div>
+                  <Button
+                    type="button"
+                    variant="primary"
+                    size="sm"
+                    className="mt-5 w-full"
+                    onClick={onSharePoolInvite}
+                    disabled={!selectedPool || sharing}
+                  >
+                    {sharing ? 'Sharing…' : 'Share pool invite'}
+                  </Button>
+                </>
+              )}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/features/invite/ui/InviteChooserTrigger.jsx
+++ b/src/features/invite/ui/InviteChooserTrigger.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { UserPlus } from 'lucide-react';
+
+/**
+ * Primary standings Invite control — opens the chooser sheet (never auto-shares).
+ */
+export default function InviteChooserTrigger({ onClick, className = '' }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={[
+        'inline-flex items-center gap-1.5 rounded-full border border-brand-primary/45 bg-brand-primary/15 px-2.5 py-1 text-[11px] font-bold text-brand-primary transition-colors hover:bg-brand-primary/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg sm:px-3 sm:text-xs',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <UserPlus className="h-3.5 w-3.5" aria-hidden />
+      <span>Invite</span>
+    </button>
+  );
+}

--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../../auth';
+import { useInviteChooser } from '../../invite';
 import { userHasSubmittedPickEntry } from '../../picks';
 import { useUserPools } from '../../pools';
 import { useShowCalendar } from '../../show-calendar';
@@ -59,6 +60,7 @@ export function useStandingsScreen(selectedDate, options = {}) {
   const { user } = useAuth();
   const { showDates, showDatesByTour } = useShowCalendar();
   const { pools: userPools } = useUserPools(user?.uid);
+  const inviteChooser = useInviteChooser({ pools: userPools });
 
   const { view, poolId, setView, setPoolId } = useStandingsView({
     userPools,
@@ -260,5 +262,7 @@ export function useStandingsScreen(selectedDate, options = {}) {
     onSelectShowDate: onSelectShowDate ?? null,
 
     redactOpponentPicksPreLock,
+
+    inviteChooser,
   };
 }

--- a/src/features/scoring/ui/StandingsShowOrPoolView.jsx
+++ b/src/features/scoring/ui/StandingsShowOrPoolView.jsx
@@ -50,6 +50,7 @@ export default function StandingsShowOrPoolView({ screen }) {
     lastShowViewResults,
     onSelectShowDate,
     redactOpponentPicksPreLock,
+    inviteChooser,
   } = screen;
 
   const isPoolsView = view === 'pools';
@@ -283,9 +284,21 @@ export default function StandingsShowOrPoolView({ screen }) {
                 No picks yet
               </PageTitle>
               <p className="max-w-sm font-bold text-content-secondary">
-                {isPoolsView
-                  ? 'Nobody in this pool has locked in yet. Invite friends from Pools.'
-                  : 'Be the first to lock in picks for this show — head to the Picks tab.'}
+                {isPoolsView ? (
+                  <>
+                    Nobody in this pool has locked in yet.{' '}
+                    <button
+                      type="button"
+                      onClick={inviteChooser?.openChooser}
+                      className="font-bold text-brand-primary underline decoration-brand-primary/50 underline-offset-2 transition-colors hover:text-brand-primary-strong"
+                    >
+                      Invite friends
+                    </button>{' '}
+                    to join the fun.
+                  </>
+                ) : (
+                  'Be the first to lock in picks for this show — head to the Picks tab.'
+                )}
               </p>
             </>
           )}

--- a/src/features/scoring/ui/StandingsStickyChrome.jsx
+++ b/src/features/scoring/ui/StandingsStickyChrome.jsx
@@ -3,6 +3,7 @@ import { Scale } from 'lucide-react';
 
 import { NAV_LABEL_STANDINGS } from '../../../shared/config/dashboardVocabulary';
 import { dashboardPageTitleGradientClasses } from '../../../shared/config/dashboardHeadingTypography';
+import { InviteChooserTrigger } from '../../invite';
 import StandingsViewToggle from './StandingsViewToggle';
 
 /**
@@ -27,6 +28,7 @@ export const STANDINGS_STICKY_MOBILE_TOP =
  *   view: 'show' | 'tour' | 'pools',
  *   onChange: (next: 'show' | 'tour' | 'pools') => void,
  *   onOpenScoringRules: () => void,
+ *   onOpenInvite?: () => void,
  *   pinBelowDesktopDatePicker?: boolean,
  * }} props
  */
@@ -34,6 +36,7 @@ export default function StandingsStickyChrome({
   view,
   onChange,
   onOpenScoringRules,
+  onOpenInvite,
   pinBelowDesktopDatePicker = false,
 }) {
   return (
@@ -56,6 +59,11 @@ export default function StandingsStickyChrome({
       </h2>
 
       <div className="relative">
+        {onOpenInvite ? (
+          <div className="absolute left-0 top-1/2 z-10 -translate-y-1/2">
+            <InviteChooserTrigger onClick={onOpenInvite} />
+          </div>
+        ) : null}
         {/* Always overlay so it never adds a second sticky tier above the pills. */}
         <div className="absolute right-0 top-1/2 z-10 -translate-y-1/2">
           <button
@@ -72,7 +80,10 @@ export default function StandingsStickyChrome({
         <StandingsViewToggle
           view={view}
           onChange={onChange}
-          className="mb-0 pr-[4.5rem] min-[380px]:pr-[7.25rem]"
+          className={[
+            'mb-0',
+            onOpenInvite ? 'pl-[4.75rem] pr-[4.5rem] min-[380px]:pr-[7.25rem]' : 'pr-[4.5rem] min-[380px]:pr-[7.25rem]',
+          ].join(' ')}
         />
       </div>
     </div>

--- a/src/pages/standings/StandingsPage.jsx
+++ b/src/pages/standings/StandingsPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { InviteChooserSheet } from '../../features/invite';
 import {
   StandingsShowOrPoolView,
   StandingsStickyChrome,
@@ -9,6 +10,7 @@ import {
 
 export default function StandingsPage({ selectedDate, onSelectShowDate }) {
   const screen = useStandingsScreen(selectedDate, { onSelectShowDate });
+  const invite = screen.inviteChooser;
 
   return (
     <div className="w-full">
@@ -16,7 +18,24 @@ export default function StandingsPage({ selectedDate, onSelectShowDate }) {
         view={screen.view}
         onChange={screen.setView}
         onOpenScoringRules={screen.openScoringRules}
+        onOpenInvite={invite.openChooser}
         pinBelowDesktopDatePicker={screen.view !== 'tour'}
+      />
+
+      <InviteChooserSheet
+        open={invite.open}
+        onClose={invite.closeChooser}
+        step={invite.step}
+        inviterHandle={invite.inviterHandle}
+        inviteablePools={invite.inviteablePools}
+        selectedPoolId={invite.selectedPoolId}
+        onSelectPoolId={invite.setSelectedPoolId}
+        selectedPool={invite.selectedPool}
+        sharing={invite.sharing}
+        onShareSiteInvite={invite.shareSiteInvite}
+        onSharePoolInvite={invite.sharePoolInvite}
+        onGoToPoolStep={invite.goToPoolStep}
+        onBackToChoose={invite.backToChoose}
       />
 
       <div className="mt-5">


### PR DESCRIPTION
Closes #581

**Merge after** #596 (`1.21.1` OG) so SemVer stays monotonic.

## Summary
- Primary **Invite** CTA on dashboard Standings (sticky chrome) opens an explicit site-vs-pool chooser — never silent-defaults to a pool
- Site share: `/invite/{handle}` via invite kit + `invite_share` telemetry
- Pool share: pick a membership → `/join/{code}?from={handle}`
- Empty-state “Invite friends” wires to the same sheet
- SemVer **1.21.2** PATCH

## Test plan
- [ ] Standings → Invite → chooser always shows both options
- [ ] Site share URL has no join code; telemetry `invite_kind: site`
- [ ] Pool path requires selecting a pool; URL includes `?from=` handle; `invite_kind: pool`
- [ ] Empty pool “No picks yet” Invite friends opens same sheet
- [ ] No handle → site option disabled with Profile hint
- [ ] `npm run lint` + `npm test` green