### PR TITLE
feat(invite): OG handlers for /invite/:handle and pool ?from= (#582)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.21.1] — 2026-07-15
+
+### Added
+- **Invite OG handlers (#582)** — `api/invite.js` serves personalized Open Graph tags for `/invite/:handle` (site VIP) and `/join/:code?from=` (pool inviter); crawlers resolve handle/pool via Firebase Admin; browsers get SPA shell with static OG injection (no Firestore). Rewrites in `vercel.json`.
+
+---
+
 ## [1.21.0] — 2026-07-15
 
 ### Added

--- a/api/invite.js
+++ b/api/invite.js
@@ -1,31 +1,30 @@
 /**
- * Vercel Serverless Function — dynamic OG tags for /join/:code invite links.
+ * Vercel Serverless Function — dynamic OG tags for invite landings.
  *
- * Flat `api/invite.js` + `?code=` query (vercel.json rewrite) — nested
+ * Flat `api/invite.js` + query params (vercel.json rewrites) — nested
  * `api/invite/[code].js` never registered on Vercel deploy (same class of bug
  * as api/email-click; see f883d02).
  *
- * Social crawlers (Facebook, Instagram, Twitter, Slack, …) don't execute
- * JavaScript, so they can't read OG tags injected by React. This function
- * intercepts every /join/:code request and:
+ * Rewrites:
+ *   • `/join/:code`   → `/api/invite?code=:code` (+ unmatched query, e.g. `from`)
+ *   • `/invite/:handle` → `/api/invite?handle=:handle`
  *
- *   • For **social crawlers**: serves a minimal HTML page with pool-specific
- *     OG meta tags fetched from Firestore via the Firebase Admin SDK.
+ * Social crawlers don't execute JavaScript, so they can't read OG tags injected
+ * by React. This function intercepts invite requests and:
+ *
+ *   • For **social crawlers**: serves a minimal HTML page with personalized OG
+ *     meta tags (pool name / inviter handle via Firebase Admin when needed).
  *
  *   • For **regular browsers**: serves the built SPA shell (dist/index.html)
- *     so React Router can handle the /join/:code route without a redirect
- *     loop. Vite's built output is bundled into the function at deploy time
- *     via vercel.json `includeFiles`.
+ *     with cheap static OG injection — no Firestore round trip.
  *
- * Fallback: if Firestore is unreachable or the invite code is unknown the
- * function falls back to the app's default OG tags — the invite link still
- * works, it just shows generic copy.
+ * Fallback: if Firestore is unreachable or lookups fail, generic default OG
+ * tags are used — invite links still work in the SPA.
  *
  * Required Vercel env var:
- *   FIREBASE_SERVICE_ACCOUNT — JSON string of the Firebase service account
- *                              (enables Admin SDK without GCP ADC).
+ *   FIREBASE_SERVICE_ACCOUNT — JSON string of the Firebase service account.
  *
- * Issue #128.
+ * Issues #128, #582.
  */
 
 import { readFileSync } from 'fs';
@@ -34,24 +33,15 @@ import { fileURLToPath } from 'url';
 import { initializeApp, getApps, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 
-// ---------------------------------------------------------------------------
-// Constants (mirror src/shared/config/seo.js — must not import from src/)
-// ---------------------------------------------------------------------------
-
-const SITE_URL = 'https://www.setlistpickem.com';
-const SITE_NAME = "Setlist Pick 'Em";
-const DEFAULT_OG_IMAGE =
-  'https://www.setlistpickem.com/branding/og-card-1200x630.jpg?v=20260711';
-const DEFAULT_OG_IMAGE_ALT = "Setlist Pick 'Em — live setlist prediction game";
-const DEFAULT_TITLE = "Setlist Pick'em | The Ultimate Live Music Prediction Game";
-const DEFAULT_DESCRIPTION =
-  "Setlist Pick 'Em is a free live setlist prediction game for Phish fans. Pick openers, closers, encore, and a wildcard before each show; scores update in real time as songs are played. Compete in a global pool or create private pools with friends.";
-
-// Social-crawler user-agent detection (case-insensitive substring match).
-// Instagram link previews use Meta's `facebookexternalhit` scraper — do NOT
-// match bare `Instagram` (the in-app browser UA contains that token).
-const CRAWLER_RE =
-  /facebookexternalhit|Facebot|Twitterbot|WhatsApp|Slackbot|LinkedInBot|TelegramBot|Discordbot|redditbot|Applebot|Googlebot|bingbot|ia_archiver/i;
+import {
+  buildCrawlerHtml,
+  buildInvitePageUrl,
+  CRAWLER_RE,
+  DEFAULT_OG_IMAGE,
+  injectOgIntoSpa,
+  normalizeInviteHandle,
+  resolveInviteOgContent,
+} from './inviteOgHelpers.mjs';
 
 // ---------------------------------------------------------------------------
 // Firebase Admin — lazy singleton
@@ -63,13 +53,11 @@ function initAdmin() {
   if (sa) {
     initializeApp({ credential: cert(JSON.parse(sa)) });
   } else {
-    // Application Default Credentials fallback (works in GCP environments).
     initializeApp();
   }
 }
 
 /**
- * Looks up a pool document by invite code.
  * @param {string} code — already upper-cased
  * @returns {Promise<{ name: string } | null>}
  */
@@ -85,72 +73,23 @@ async function fetchPoolByCode(code) {
   return snap.docs[0].data();
 }
 
-// ---------------------------------------------------------------------------
-// HTML helpers
-// ---------------------------------------------------------------------------
-
-function escapeHtml(str) {
-  return String(str ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
-
-function buildOgMetaTags({ title, description, url, image, imageAlt = DEFAULT_OG_IMAGE_ALT }) {
-  return [
-    `  <title>${escapeHtml(title)}</title>`,
-    `  <meta property="og:site_name" content="${escapeHtml(SITE_NAME)}" />`,
-    `  <meta property="og:title" content="${escapeHtml(title)}" />`,
-    `  <meta property="og:description" content="${escapeHtml(description)}" />`,
-    `  <meta property="og:image" content="${escapeHtml(image)}" />`,
-    `  <meta property="og:image:secure_url" content="${escapeHtml(image)}" />`,
-    `  <meta property="og:image:type" content="image/jpeg" />`,
-    `  <meta property="og:image:width" content="1200" />`,
-    `  <meta property="og:image:height" content="630" />`,
-    `  <meta property="og:image:alt" content="${escapeHtml(imageAlt)}" />`,
-    `  <meta property="og:url" content="${escapeHtml(url)}" />`,
-    `  <meta property="og:type" content="website" />`,
-    `  <meta name="twitter:card" content="summary_large_image" />`,
-    `  <meta name="twitter:title" content="${escapeHtml(title)}" />`,
-    `  <meta name="twitter:description" content="${escapeHtml(description)}" />`,
-    `  <meta name="twitter:image" content="${escapeHtml(image)}" />`,
-  ].join('\n');
-}
-
 /**
- * Builds a minimal OG-tagged HTML shell for social crawlers.
- * Browsers never see this; they get the full SPA shell instead.
+ * Mirrors client `fetchPublicProfileByHandle` (users collection, exact handle).
+ * @param {string} handle — normalized
+ * @returns {Promise<{ handle?: string } | null>}
  */
-function buildCrawlerHtml(og) {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-${buildOgMetaTags(og)}
-</head>
-<body></body>
-</html>`;
-}
-
-/**
- * Injects dynamic OG meta tags into the built SPA shell (dist/index.html).
- * Tags are inserted immediately after <meta charset> so they appear before the
- * static defaults — Facebook and most parsers use the first occurrence.
- *
- * @param {string} spaHtml — contents of dist/index.html
- * @param {{ title: string, description: string, url: string, image: string }} og
- * @returns {string}
- */
-function injectOgIntoSpa(spaHtml, og) {
-  const dynamicTags = buildOgMetaTags(og);
-
-  // Insert dynamic tags right after <meta charset> (before any static defaults).
-  return spaHtml.replace(
-    /(<meta\s+charset[^>]*\/?>)/i,
-    `$1\n${dynamicTags}`,
-  );
+async function fetchPublicProfileByHandle(handle) {
+  const h = normalizeInviteHandle(handle);
+  if (!h) return null;
+  initAdmin();
+  const db = getFirestore();
+  const snap = await db
+    .collection('users')
+    .where('handle', '==', h)
+    .limit(1)
+    .get();
+  if (snap.empty) return null;
+  return snap.docs[0].data();
 }
 
 // ---------------------------------------------------------------------------
@@ -164,10 +103,8 @@ let _spaTemplate = undefined;
 function loadSpaTemplate() {
   if (_spaTemplate !== undefined) return _spaTemplate;
 
-  // Vercel bundles includeFiles relative to the project root into the function
-  // working directory. Try the most likely paths.
   const candidates = [
-    join(process.cwd(), 'dist', 'index.html'), // /var/task/dist/index.html
+    join(process.cwd(), 'dist', 'index.html'),
     join(__dirname, '..', 'dist', 'index.html'),
   ];
 
@@ -180,7 +117,7 @@ function loadSpaTemplate() {
     }
   }
 
-  _spaTemplate = null; // negative-cache: dist not present (dev / build skipped)
+  _spaTemplate = null;
   return null;
 }
 
@@ -190,60 +127,58 @@ function loadSpaTemplate() {
 
 export default async function handler(req, res) {
   const code = String(req.query.code ?? '').trim().toUpperCase();
-  const inviteUrl = `${SITE_URL}/join/${code}`;
+  const handle = normalizeInviteHandle(req.query.handle ?? '');
+  const from = normalizeInviteHandle(req.query.from ?? '');
+  const isSiteInvite = Boolean(handle) && !code;
+
   const ua = req.headers['user-agent'] ?? '';
   const isCrawler = CRAWLER_RE.test(ua);
 
-  // 1. Regular browsers: serve the SPA shell immediately — no Firestore round
-  //    trip. Marketing-email /join/:code clicks were paying a cold-start Admin
-  //    lookup on every load even though only crawlers consume OG meta tags.
+  let poolName = null;
+  /** @type {boolean | undefined} */
+  let siteProfileFound;
+
+  if (isCrawler) {
+    try {
+      if (isSiteInvite) {
+        const profile = await fetchPublicProfileByHandle(handle);
+        siteProfileFound = Boolean(profile);
+      } else if (code) {
+        const pool = await fetchPoolByCode(code);
+        poolName = pool?.name ? String(pool.name).trim() : null;
+      }
+    } catch (err) {
+      console.error('[og-invite] Firestore lookup failed:', err?.message ?? err);
+      if (isSiteInvite) siteProfileFound = false;
+    }
+  }
+
+  const { title, description } = resolveInviteOgContent({
+    code,
+    handle: isSiteInvite ? handle : '',
+    from,
+    poolName,
+    siteProfileFound,
+  });
+
+  const pageUrl = buildInvitePageUrl({
+    code,
+    handle: isSiteInvite ? handle : '',
+    from,
+  });
+
+  const og = { title, description, url: pageUrl, image: DEFAULT_OG_IMAGE };
+
   if (!isCrawler) {
     const spaHtml = loadSpaTemplate();
     if (spaHtml) {
-      let title = DEFAULT_TITLE;
-      let description = DEFAULT_DESCRIPTION;
-      if (code) {
-        title = "Join my Setlist Pick 'Em pool!";
-        description =
-          "You've been invited to a private Setlist Pick 'Em pool. Pick your setlist and compete to win.";
-      }
-      const og = { title, description, url: inviteUrl, image: DEFAULT_OG_IMAGE };
       const html = injectOgIntoSpa(spaHtml, og);
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
       res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate');
       return res.status(200).send(html);
     }
-    // dist/index.html not available (local dev without a prior build).
-    // Fall through to crawler path — acceptable in dev.
   }
 
-  // 2. Crawlers (or dev fallback): resolve pool-specific OG copy from Firestore.
-  // Keep "Join my … pool" wording aligned with client share/clipboard copy
-  // (`buildPoolInviteShareTitle` in shareOrCopyInviteUrl.js).
-  let title = DEFAULT_TITLE;
-  let description = DEFAULT_DESCRIPTION;
-
-  if (code) {
-    title = "Join my Setlist Pick 'Em pool!";
-    description =
-      "You've been invited to a private Setlist Pick 'Em pool. Pick your setlist and compete to win.";
-    try {
-      const pool = await fetchPoolByCode(code);
-      if (pool?.name) {
-        const poolName = String(pool.name).trim();
-        if (poolName) {
-          title = `Join my Setlist Pick 'Em pool: ${poolName}`;
-          description = `Join my Setlist Pick 'Em pool — ${poolName}. Pick openers, closers, and more before each show.`;
-        }
-      }
-    } catch (err) {
-      console.error('[og-invite] Firestore lookup failed:', err?.message ?? err);
-    }
-  }
-
-  const og = { title, description, url: inviteUrl, image: DEFAULT_OG_IMAGE };
-
-  // 3. Lightweight OG-tagged shell for crawlers (or dev without dist/).
   const html = buildCrawlerHtml(og);
   res.setHeader('Content-Type', 'text/html; charset=utf-8');
   res.setHeader('Cache-Control', 'public, max-age=300, stale-while-revalidate=60');

--- a/api/inviteOgHelpers.mjs
+++ b/api/inviteOgHelpers.mjs
@@ -1,0 +1,228 @@
+/**
+ * Pure helpers for invite OG (api/invite.js). Mirrors src/shared/config/seo.js and
+ * src/shared/lib/inviteKit.js — must not import from src/.
+ */
+
+export const SITE_URL = 'https://www.setlistpickem.com';
+export const SITE_NAME = "Setlist Pick 'Em";
+export const OG_IMAGE_VERSION = '20260711';
+export const DEFAULT_OG_IMAGE = `${SITE_URL}/branding/og-card-1200x630.jpg?v=${OG_IMAGE_VERSION}`;
+export const DEFAULT_OG_IMAGE_ALT = "Setlist Pick 'Em — live setlist prediction game";
+export const DEFAULT_TITLE = "Setlist Pick'em | The Ultimate Live Music Prediction Game";
+export const DEFAULT_DESCRIPTION =
+  "Setlist Pick 'Em is a free live setlist prediction game for Phish fans. Pick openers, closers, encore, and a wildcard before each show; scores update in real time as songs are played. Compete in a global pool or create private pools with friends.";
+
+/** Social-crawler user-agent detection (case-insensitive substring match). */
+export const CRAWLER_RE =
+  /facebookexternalhit|Facebot|Twitterbot|WhatsApp|Slackbot|LinkedInBot|TelegramBot|Discordbot|redditbot|Applebot|Googlebot|bingbot|ia_archiver/i;
+
+export const SITE_INVITE_DESCRIPTION =
+  'Create a free account to predict setlists, track scores live, and compete with friends on Phish tour.';
+
+export const POOL_INVITE_FROM_DESCRIPTION =
+  'Create a free account to join the pool and compete with your crew on tour.';
+
+export const POOL_INVITE_GENERIC_DESCRIPTION =
+  "You've been invited to a private Setlist Pick 'Em pool. Pick your setlist and compete to win.";
+
+const DEFAULT_POOL_SHARE_TITLE = "Join my Setlist Pick 'Em pool!";
+
+/**
+ * @param {unknown} handle
+ * @returns {string}
+ */
+export function normalizeInviteHandle(handle) {
+  return String(handle ?? '')
+    .trim()
+    .replace(/^@+/, '');
+}
+
+/**
+ * @param {string} handle
+ * @returns {string}
+ */
+export function buildSiteInviteShareTitle(handle) {
+  const h = normalizeInviteHandle(handle);
+  if (!h) return "You're invited to Setlist Pick'em";
+  return `${h} invited you to Setlist Pick'em`;
+}
+
+/**
+ * @param {string} handle
+ * @param {string | null | undefined} [poolName]
+ * @returns {string}
+ */
+export function buildPoolInviteShareTitleFromInviter(handle, poolName) {
+  const h = normalizeInviteHandle(handle);
+  const name = typeof poolName === 'string' ? poolName.trim() : '';
+  if (!h) {
+    return name
+      ? `You're invited to join a Setlist Pick'em pool: ${name}`
+      : "You're invited to join a Setlist Pick'em pool";
+  }
+  if (name) return `${h} invited you to join their pool: ${name}`;
+  return `${h} invited you to join their pool`;
+}
+
+/**
+ * @param {string | null | undefined} [poolName]
+ * @returns {string}
+ */
+export function buildPoolInviteShareTitle(poolName) {
+  const name = typeof poolName === 'string' ? poolName.trim() : '';
+  if (name) return `Join my Setlist Pick 'Em pool: ${name}`;
+  return DEFAULT_POOL_SHARE_TITLE;
+}
+
+/**
+ * @param {string | null | undefined} [poolName]
+ * @returns {string}
+ */
+export function buildPoolInviteDescription(poolName) {
+  const name = typeof poolName === 'string' ? poolName.trim() : '';
+  if (name) {
+    return `Join my Setlist Pick 'Em pool — ${name}. Pick openers, closers, and more before each show.`;
+  }
+  return POOL_INVITE_GENERIC_DESCRIPTION;
+}
+
+/**
+ * @param {{ code?: string, handle?: string, from?: string }} params
+ * @returns {string}
+ */
+export function buildInvitePageUrl({ code = '', handle = '', from = '' } = {}) {
+  const normalizedHandle = normalizeInviteHandle(handle);
+  const normalizedCode = String(code ?? '').trim().toUpperCase();
+  const normalizedFrom = normalizeInviteHandle(from);
+
+  if (normalizedHandle && !normalizedCode) {
+    return `${SITE_URL}/invite/${encodeURIComponent(normalizedHandle)}`;
+  }
+
+  if (!normalizedCode) return SITE_URL;
+
+  let url = `${SITE_URL}/join/${encodeURIComponent(normalizedCode)}`;
+  if (normalizedFrom) {
+    url += `?from=${encodeURIComponent(normalizedFrom)}`;
+  }
+  return url;
+}
+
+/**
+ * Resolve OG title + description for invite landings.
+ *
+ * @param {{
+ *   code?: string,
+ *   handle?: string,
+ *   from?: string,
+ *   poolName?: string | null,
+ *   siteProfileFound?: boolean,
+ * }} params
+ * @returns {{ title: string, description: string }}
+ */
+export function resolveInviteOgContent({
+  code = '',
+  handle = '',
+  from = '',
+  poolName = null,
+  siteProfileFound,
+} = {}) {
+  const normalizedHandle = normalizeInviteHandle(handle);
+  const normalizedFrom = normalizeInviteHandle(from);
+  const normalizedCode = String(code ?? '').trim().toUpperCase();
+  const trimmedPoolName = typeof poolName === 'string' ? poolName.trim() : '';
+
+  if (normalizedHandle && !normalizedCode) {
+    if (siteProfileFound === false) {
+      return { title: DEFAULT_TITLE, description: DEFAULT_DESCRIPTION };
+    }
+    return {
+      title: buildSiteInviteShareTitle(normalizedHandle),
+      description: SITE_INVITE_DESCRIPTION,
+    };
+  }
+
+  if (normalizedCode) {
+    if (normalizedFrom) {
+      return {
+        title: buildPoolInviteShareTitleFromInviter(normalizedFrom, trimmedPoolName || undefined),
+        description: POOL_INVITE_FROM_DESCRIPTION,
+      };
+    }
+
+    return {
+      title: buildPoolInviteShareTitle(trimmedPoolName || undefined),
+      description: buildPoolInviteDescription(trimmedPoolName || undefined),
+    };
+  }
+
+  return { title: DEFAULT_TITLE, description: DEFAULT_DESCRIPTION };
+}
+
+export function escapeHtml(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * @param {{ title: string, description: string, url: string, image: string, imageAlt?: string }} og
+ * @returns {string}
+ */
+export function buildOgMetaTags({
+  title,
+  description,
+  url,
+  image,
+  imageAlt = DEFAULT_OG_IMAGE_ALT,
+}) {
+  return [
+    `  <title>${escapeHtml(title)}</title>`,
+    `  <meta property="og:site_name" content="${escapeHtml(SITE_NAME)}" />`,
+    `  <meta property="og:title" content="${escapeHtml(title)}" />`,
+    `  <meta property="og:description" content="${escapeHtml(description)}" />`,
+    `  <meta property="og:image" content="${escapeHtml(image)}" />`,
+    `  <meta property="og:image:secure_url" content="${escapeHtml(image)}" />`,
+    `  <meta property="og:image:type" content="image/jpeg" />`,
+    `  <meta property="og:image:width" content="1200" />`,
+    `  <meta property="og:image:height" content="630" />`,
+    `  <meta property="og:image:alt" content="${escapeHtml(imageAlt)}" />`,
+    `  <meta property="og:url" content="${escapeHtml(url)}" />`,
+    `  <meta property="og:type" content="website" />`,
+    `  <meta name="twitter:card" content="summary_large_image" />`,
+    `  <meta name="twitter:title" content="${escapeHtml(title)}" />`,
+    `  <meta name="twitter:description" content="${escapeHtml(description)}" />`,
+    `  <meta name="twitter:image" content="${escapeHtml(image)}" />`,
+  ].join('\n');
+}
+
+/**
+ * @param {{ title: string, description: string, url: string, image: string }} og
+ * @returns {string}
+ */
+export function buildCrawlerHtml(og) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+${buildOgMetaTags(og)}
+</head>
+<body></body>
+</html>`;
+}
+
+/**
+ * @param {string} spaHtml
+ * @param {{ title: string, description: string, url: string, image: string }} og
+ * @returns {string}
+ */
+export function injectOgIntoSpa(spaHtml, og) {
+  const dynamicTags = buildOgMetaTags(og);
+  return spaHtml.replace(
+    /(<meta\s+charset[^>]*\/?>)/i,
+    `$1\n${dynamicTags}`,
+  );
+}

--- a/api/inviteOgHelpers.test.js
+++ b/api/inviteOgHelpers.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildInvitePageUrl,
+  buildPoolInviteShareTitle,
+  buildPoolInviteShareTitleFromInviter,
+  buildSiteInviteShareTitle,
+  CRAWLER_RE,
+  DEFAULT_DESCRIPTION,
+  DEFAULT_TITLE,
+  POOL_INVITE_FROM_DESCRIPTION,
+  POOL_INVITE_GENERIC_DESCRIPTION,
+  resolveInviteOgContent,
+  SITE_INVITE_DESCRIPTION,
+} from './inviteOgHelpers.mjs';
+
+describe('inviteOgHelpers', () => {
+  it('detects social crawlers without matching Instagram in-app browser', () => {
+    expect(CRAWLER_RE.test('facebookexternalhit/1.1')).toBe(true);
+    expect(CRAWLER_RE.test('Twitterbot/1.0')).toBe(true);
+    expect(CRAWLER_RE.test('Instagram 219.0.0.12.117 Android')).toBe(false);
+  });
+
+  it('builds invite page URLs', () => {
+    expect(buildInvitePageUrl({ handle: 'Mikey' })).toBe(
+      'https://www.setlistpickem.com/invite/Mikey',
+    );
+    expect(buildInvitePageUrl({ code: 'yem42' })).toBe(
+      'https://www.setlistpickem.com/join/YEM42',
+    );
+    expect(buildInvitePageUrl({ code: 'YEM42', from: 'Mikey' })).toBe(
+      'https://www.setlistpickem.com/join/YEM42?from=Mikey',
+    );
+  });
+
+  it('resolves site invite OG for browsers (static handle)', () => {
+    expect(
+      resolveInviteOgContent({ handle: 'Mikey' }),
+    ).toEqual({
+      title: buildSiteInviteShareTitle('Mikey'),
+      description: SITE_INVITE_DESCRIPTION,
+    });
+  });
+
+  it('falls back to generic site OG when crawler profile lookup fails', () => {
+    expect(
+      resolveInviteOgContent({ handle: 'unknown', siteProfileFound: false }),
+    ).toEqual({
+      title: DEFAULT_TITLE,
+      description: DEFAULT_DESCRIPTION,
+    });
+  });
+
+  it('resolves pool invite OG with from= and optional pool name', () => {
+    expect(
+      resolveInviteOgContent({ code: 'YEM42', from: 'Mikey', poolName: 'Denver Crew' }),
+    ).toEqual({
+      title: buildPoolInviteShareTitleFromInviter('Mikey', 'Denver Crew'),
+      description: POOL_INVITE_FROM_DESCRIPTION,
+    });
+
+    expect(
+      resolveInviteOgContent({ code: 'YEM42', from: 'Mikey' }),
+    ).toEqual({
+      title: buildPoolInviteShareTitleFromInviter('Mikey'),
+      description: POOL_INVITE_FROM_DESCRIPTION,
+    });
+  });
+
+  it('resolves pool invite OG without from= using legacy pool copy', () => {
+    expect(
+      resolveInviteOgContent({ code: 'YEM42', poolName: 'Denver Crew' }),
+    ).toEqual({
+      title: buildPoolInviteShareTitle('Denver Crew'),
+      description:
+        "Join my Setlist Pick 'Em pool — Denver Crew. Pick openers, closers, and more before each show.",
+    });
+
+    expect(resolveInviteOgContent({ code: 'YEM42' })).toEqual({
+      title: buildPoolInviteShareTitle(),
+      description: POOL_INVITE_GENERIC_DESCRIPTION,
+    });
+  });
+});

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.20.0  
+**Version:** 1.21.1  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 
@@ -271,8 +271,8 @@ These routes are part of the public surface. Renaming or removing them is a MAJO
 | `/` | None | Public splash / landing page |
 | `/how-it-works` | None | How to play marketing page |
 | `/how-scoring-works` | None | Scoring rules marketing page |
-| `/join/:code` | None | Pool invite deep link; optional `?from={handle}` for inviter personalization; VIP landing stores code and prompts auth (#580) |
-| `/invite/:handle` | None | Site VIP invite deep link; personalized landing when handle resolves; no pool join side effects (#580) |
+| `/join/:code` | None | Pool invite deep link; optional `?from={handle}` for inviter personalization; VIP landing stores code and prompts auth (#580); personalized OG (#582) |
+| `/invite/:handle` | None | Site VIP invite deep link; personalized landing when handle resolves; no pool join side effects (#580); personalized OG (#582) |
 | `/user/:userId` | None | Public player profile |
 | `/privacy` | None | Privacy policy |
 | `/terms` | None | Terms of service |
@@ -305,6 +305,21 @@ Applied via `vercel.json` to all routes. Policy details: `docs/SECURITY_HEADERS.
 | `Content-Security-Policy-Report-Only` | Report-only | Flip to `Content-Security-Policy` after soak (promote-day) |
 
 Adding or tightening enforced CSP is MINOR; removing a security header is MAJOR.
+
+### 3.3 Invite landing Open Graph (`api/invite.js`)
+
+Social crawlers (Meta, X, Slack, …) do not execute JavaScript. Invite URLs are rewritten to `api/invite.js`, which returns pool- or inviter-specific OG tags for crawlers and the SPA shell for regular browsers.
+
+| Public path | Rewrite (`vercel.json`) | Query params | Crawler behavior | Browser behavior |
+|-------------|-------------------------|--------------|------------------|------------------|
+| `/join/:code` | `/api/invite?code=:code` | Unmatched query preserved (e.g. `?from={handle}`) | Resolves pool name via Admin SDK; `from` personalizes title via invite-kit copy | SPA shell + static OG (no Firestore) |
+| `/invite/:handle` | `/api/invite?handle=:handle` | — | Resolves `users.handle` via Admin SDK; generic OG if missing | SPA shell + static OG from URL handle |
+
+Copy mirrors `src/shared/lib/inviteKit.js` (`buildSiteInviteShareTitle`, `buildPoolInviteShareTitleFromInviter`) and legacy pool OG (`Join my Setlist Pick 'Em pool: {name}`) when `from` is absent. Constants mirror `src/shared/config/seo.js` in `api/inviteOgHelpers.mjs` (no `src/` imports in serverless).
+
+**Vercel env:** `FIREBASE_SERVICE_ACCOUNT` (JSON) enables Firestore Admin lookups for crawlers.
+
+**Tests:** `api/inviteOgHelpers.test.js` (pure helpers; no Vercel runtime).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.21.0",
+  "version": "1.21.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/vercel.json
+++ b/vercel.json
@@ -29,6 +29,10 @@
       "destination": "/favicon/favicon.ico"
     },
     {
+      "source": "/invite/:handle",
+      "destination": "/api/invite?handle=:handle"
+    },
+    {
       "source": "/join/:code",
       "destination": "/api/invite?code=:code"
     },

--- a/vite.config.js
+++ b/vite.config.js
@@ -54,7 +54,7 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'node',
-    include: ['src/**/*.test.js'],
+    include: ['src/**/*.test.js', 'api/**/*.test.js'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Closes #582

Depends on #594 (#580 VIP landings) — branch includes that commit until #594 merges; rebase if needed.

## Summary
- Crawler-friendly OG for `/invite/:handle` and `/join/:code?from=` at **1.21.1**
- Extends `api/invite.js`; pure helpers in `api/inviteOgHelpers.mjs` (+ unit tests)
- Browser UA still gets SPA shell (no Firestore tax); crawlers resolve handle/pool via Admin
- `vercel.json` rewrite for `/invite/:handle`; `?from=` preserved on join rewrite
- Docs: `API.md` § Invite landing Open Graph

## Test plan
- [ ] After deploy: crawler UA on `/invite/:handle` → personalized `og:title` / `og:description`
- [ ] Browser UA on `/invite/:handle` → SPA VIP landing (from #580)
- [ ] `/join/:code?from=handle` crawler → inviter + pool name copy when resolvable
- [ ] Unknown handle/code → generic OG fallback
- [ ] `npm test -- api/inviteOgHelpers.test.js` green


Made with [Cursor](https://cursor.com)