### PR TITLE
feat(comms): email invite share block for site and pool (#583)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.21.3] — 2026-07-15
+
+### Added
+- **Email invite share block (#583)** — Reusable site + pool invite block in React Email (`InviteShareBlock`) and service comms HTML shell; personalized headline + tracked VIP URLs (`/invite/{handle}`, `/join/{code}?from={handle}`) with `utm_source=email`, `utm_campaign`, `utm_content`. Wired into `tour_rankings_daily` lifecycle email and Summer Tour 2026 marketing template (aligned with invite kit copy).
+
+---
+
 ## [1.21.2] — 2026-07-15
 
 ### Added

--- a/docs/comms-triggers/CTA_ROUTE_AUDIT.md
+++ b/docs/comms-triggers/CTA_ROUTE_AUDIT.md
@@ -27,7 +27,8 @@ Label rule: **never promise a surface the href does not deliver.** Inbox cards s
 | `tour-countdown` | `/dashboard/picks` | |
 | `picks-confirmed` | `/dashboard` default | Prefer picks in a follow-up if still shipping |
 | `show-recap` | `/dashboard/standings#self-recap` | Rare (email folded into morning send #451) |
-| `tour-rankings_daily` | `/dashboard/picks` | Catalog: “Make picks for next show” |
+| `tour-rankings_daily` | `/dashboard/picks` | Catalog: “Make picks for next show”; includes invite share block when `invite_url` present (#583) |
+| `summer-tour-2026-launch` | invite `shareUrl` / `invite_url` | Pool `/join/{code}?from={handle}` or site `/invite/{handle}` + UTMs (#583) |
 | `picks-lock-reminder` | `/dashboard/picks` | |
 
 ## Push deep links

--- a/docs/comms-triggers/TRIGGER_CATALOG.md
+++ b/docs/comms-triggers/TRIGGER_CATALOG.md
@@ -81,6 +81,11 @@ Every template draws from this shared set. Each trigger declares the subset it u
 | `{{next_show_date}}` | Next scheduled show | — |
 | `{{next_show_venue}}` | Next show venue | — |
 | `{{pool_tour_rank}}` | Pool-specific tour rank | — |
+| `{{invite_kind}}` | `site` or `pool` — which VIP landing the invite URL targets | `site` |
+| `{{invite_url}}` | Tracked invite link (`/invite/{handle}` or `/join/{code}?from={handle}` + UTMs) | — |
+| `{{invite_headline}}` | Personalized invite line (mirrors invite kit copy) | — |
+| `{{inviter_handle}}` | Handle embedded in invite URL / headline | `{{handle}}` |
+| `{{invite_code}}` | Pool invite code when `invite_kind=pool` | — |
 
 ---
 
@@ -411,7 +416,8 @@ Up next: {{next_show_venue}} on {{next_show_date}}. Picks open now.
 4. **Your tour position** — rank, points, shows played, rank change vs yesterday.
 5. **Pool standing** — `{{pool_tour_rank}}` in `{{pool_name}}` (if applicable).
 6. **Next show** — {{next_show_venue}}, {{next_show_date}}. Picks are open.
-7. **CTA:** `Make picks for next show`
+7. **Invite friends** — personalized invite headline + link (`{{invite_headline}}`, `{{invite_url}}`; pool variant when user has a pool).
+8. **CTA:** `Make picks for next show`
 
 ---
 

--- a/docs/comms-triggers/catalog.json
+++ b/docs/comms-triggers/catalog.json
@@ -222,7 +222,12 @@
         { "name": "shows_played", "source": "count of graded shows this tour", "fallback": null },
         { "name": "pool_tour_rank", "source": "pool tour leaderboard (not populated in v1)", "fallback": null },
         { "name": "next_show_date", "source": "show_calendar", "fallback": null },
-        { "name": "next_show_venue", "source": "show_calendar", "fallback": null }
+        { "name": "next_show_venue", "source": "show_calendar", "fallback": null },
+        { "name": "invite_kind", "source": "computed: pool when user has invite_code else site", "fallback": "site" },
+        { "name": "invite_url", "source": "computed from invite kit + email UTMs", "fallback": null },
+        { "name": "invite_headline", "source": "computed from invite kit copy", "fallback": null },
+        { "name": "inviter_handle", "source": "users/{uid}.handle", "fallback": null },
+        { "name": "invite_code", "source": "pools/{poolId}.inviteCode (first user pool)", "fallback": null }
       ]
     },
     {
@@ -302,8 +307,13 @@
         { "name": "greeting_name", "source": "users/{uid}.handle", "fallback": "friend" },
         { "name": "audience_segment", "source": "marketingAudience resolver", "fallback": "sphere_alum" },
         { "name": "opener_label", "source": "tour calendar", "fallback": "Tuesday, July 7" },
-        { "name": "share_url", "source": "pool invite /join/:code or homepage", "fallback": null },
+        { "name": "share_url", "source": "invite kit URL with email UTMs", "fallback": null },
+        { "name": "invite_kind", "source": "computed: pool when invite_code else site", "fallback": "site" },
+        { "name": "invite_url", "source": "alias of share_url", "fallback": null },
+        { "name": "invite_headline", "source": "computed from invite kit copy", "fallback": null },
+        { "name": "inviter_handle", "source": "users/{uid}.handle", "fallback": null },
         { "name": "invite_code", "source": "users.pools[0] → pools.inviteCode", "fallback": null },
+        { "name": "pool_name", "source": "users.pools[0] → pools.name", "fallback": null },
         { "name": "campaignId", "source": "vars.campaignId", "fallback": "summer_tour_2026" }
       ]
     }

--- a/emails/scripts/preview.mjs
+++ b/emails/scripts/preview.mjs
@@ -24,13 +24,25 @@ mkdirSync(outDir, { recursive: true });
 
 const variants = [
   {
-    file: "summer-tour-2026-launch-sphere-alum.html",
-    label: "Sphere alum (default cohort)",
+    file: "summer-tour-2026-launch-sphere-alum-pool.html",
+    label: "Sphere alum — pool invite",
     props: {
       greetingName: "Pat",
+      inviterHandle: "Pat",
       audienceSegment: "sphere_alum",
       openerLabel: "Tuesday, July 7",
       inviteCode: "DEMO1",
+      poolName: "Denver Crew",
+    },
+  },
+  {
+    file: "summer-tour-2026-launch-site-invite.html",
+    label: "Site VIP invite (no pool)",
+    props: {
+      greetingName: "Pat",
+      inviterHandle: "Pat",
+      audienceSegment: "sphere_alum",
+      openerLabel: "Tuesday, July 7",
     },
   },
   {
@@ -38,6 +50,7 @@ const variants = [
     label: "Post-Sphere signup",
     props: {
       greetingName: "Pat",
+      inviterHandle: "Pat",
       audienceSegment: "post_sphere_signup",
       openerLabel: "Tuesday, July 7",
     },

--- a/emails/src/components/InviteShareBlock.jsx
+++ b/emails/src/components/InviteShareBlock.jsx
@@ -1,0 +1,84 @@
+import { Link, Text } from "@react-email/components";
+import {
+  buildPoolInviteShareTitleFromInviter,
+  buildSiteInviteShareTitle,
+  normalizeInviteHandle,
+} from "../lib/inviteKit.js";
+
+const headlineStyle = {
+  margin: "24px 0 8px",
+  fontSize: "15px",
+  fontWeight: 700,
+  color: "#1a1a2e",
+};
+
+const linkStyle = {
+  display: "inline-block",
+  marginTop: "8px",
+  marginBottom: "8px",
+  padding: "12px 24px",
+  backgroundColor: "#7c3aed",
+  color: "#ffffff",
+  textDecoration: "none",
+  borderRadius: "8px",
+  fontWeight: 700,
+  fontSize: "14px",
+};
+
+const urlStyle = {
+  display: "block",
+  margin: "0 0 16px",
+  fontSize: "13px",
+  lineHeight: 1.5,
+  color: "#64748b",
+  wordBreak: "break-all",
+};
+
+/**
+ * Shareable invite block — site or pool variant (#583).
+ *
+ * @param {{
+ *   inviterHandle?: string,
+ *   inviteUrl?: string,
+ *   inviteKind?: 'site' | 'pool',
+ *   poolName?: string,
+ *   inviteHeadline?: string,
+ *   ctaLabel?: string,
+ * }} props
+ */
+export function InviteShareBlock({
+  inviterHandle,
+  inviteUrl,
+  inviteKind = "site",
+  poolName,
+  inviteHeadline,
+  ctaLabel,
+}) {
+  const url = typeof inviteUrl === "string" ? inviteUrl.trim() : "";
+  if (!url) return null;
+
+  const handle = normalizeInviteHandle(inviterHandle);
+  const kind = inviteKind === "pool" ? "pool" : "site";
+  const headline =
+    typeof inviteHeadline === "string" && inviteHeadline.trim()
+      ? inviteHeadline.trim()
+      : kind === "pool"
+        ? buildPoolInviteShareTitleFromInviter(handle, poolName)
+        : buildSiteInviteShareTitle(handle);
+  const buttonLabel =
+    typeof ctaLabel === "string" && ctaLabel.trim()
+      ? ctaLabel.trim()
+      : handle
+        ? `Share with your friends, ${handle} →`
+        : "Share with your friends →";
+
+  return (
+    <>
+      <Text style={headlineStyle}>{headline}</Text>
+      <Link href={url} style={linkStyle}>
+        {buttonLabel}
+      </Link>
+      <Text style={urlStyle}>{url}</Text>
+    </>
+  );
+}

--- a/emails/src/lib/inviteKit.js
+++ b/emails/src/lib/inviteKit.js
@@ -1,0 +1,135 @@
+/**
+ * Invite URL + copy helpers for the emails workspace (#583).
+ * Mirrors `src/shared/lib/inviteKit.js` — do not import Vite src from here.
+ */
+
+const DEFAULT_SITE_URL = "https://www.setlistpickem.com";
+
+/**
+ * @param {unknown} handle
+ * @returns {string}
+ */
+export function normalizeInviteHandle(handle) {
+  return String(handle ?? "")
+    .trim()
+    .replace(/^@+/, "");
+}
+
+/**
+ * @param {string} handle
+ * @param {string} [baseUrl]
+ * @returns {string}
+ */
+export function buildSiteInviteUrl(handle, baseUrl = DEFAULT_SITE_URL) {
+  const h = normalizeInviteHandle(handle);
+  const base = String(baseUrl ?? DEFAULT_SITE_URL).replace(/\/+$/, "");
+  if (!base || !h) return "";
+  return `${base}/invite/${encodeURIComponent(h)}`;
+}
+
+/**
+ * @param {string} inviteCode
+ * @param {string} [fromHandle]
+ * @param {string} [baseUrl]
+ * @returns {string}
+ */
+export function buildPoolInviteUrl(inviteCode, fromHandle, baseUrl = DEFAULT_SITE_URL) {
+  const code = String(inviteCode ?? "")
+    .trim()
+    .toUpperCase();
+  const base = String(baseUrl ?? DEFAULT_SITE_URL).replace(/\/+$/, "");
+  if (!base || !code) return "";
+  const url = `${base}/join/${encodeURIComponent(code)}`;
+  const from = normalizeInviteHandle(fromHandle);
+  if (!from) return url;
+  return `${url}?from=${encodeURIComponent(from)}`;
+}
+
+/**
+ * @param {string} handle
+ * @returns {string}
+ */
+export function buildSiteInviteShareTitle(handle) {
+  const h = normalizeInviteHandle(handle);
+  if (!h) return "You're invited to Setlist Pick'em";
+  return `${h} invited you to Setlist Pick'em`;
+}
+
+/**
+ * @param {string} handle
+ * @param {string | null | undefined} [poolName]
+ * @returns {string}
+ */
+export function buildPoolInviteShareTitleFromInviter(handle, poolName) {
+  const h = normalizeInviteHandle(handle);
+  const name = typeof poolName === "string" ? poolName.trim() : "";
+  if (!h) {
+    return name
+      ? `You're invited to join a Setlist Pick'em pool: ${name}`
+      : "You're invited to join a Setlist Pick'em pool";
+  }
+  if (name) return `${h} invited you to join their pool: ${name}`;
+  return `${h} invited you to join their pool`;
+}
+
+/**
+ * Append standard email UTMs to an invite URL.
+ *
+ * @param {string} url
+ * @param {{ campaign: string, content?: string }} opts
+ * @returns {string}
+ */
+export function appendInviteEmailUtms(url, { campaign, content = "invite_share" }) {
+  const trimmed = String(url ?? "").trim();
+  if (!trimmed) return "";
+  const params = new URLSearchParams({
+    utm_source: "email",
+    utm_campaign: String(campaign ?? "").trim(),
+    utm_content: String(content ?? "invite_share").trim(),
+  });
+  const joiner = trimmed.includes("?") ? "&" : "?";
+  return `${trimmed}${joiner}${params.toString()}`;
+}
+
+/**
+ * Resolve invite kind + tracked URL for email templates.
+ *
+ * @param {{
+ *   baseUrl?: string,
+ *   inviterHandle?: string,
+ *   inviteCode?: string | null,
+ *   poolName?: string | null,
+ *   campaign: string,
+ *   utmContent?: string,
+ * }} opts
+ * @returns {{ invite_kind: 'site' | 'pool', invite_url: string, invite_headline: string } | null}
+ */
+export function resolveEmailInviteShare({
+  baseUrl = DEFAULT_SITE_URL,
+  inviterHandle,
+  inviteCode,
+  poolName,
+  campaign,
+  utmContent,
+}) {
+  const handle = normalizeInviteHandle(inviterHandle);
+  const code =
+    typeof inviteCode === "string" && inviteCode.trim()
+      ? inviteCode.trim().toUpperCase()
+      : "";
+  const kind = code ? "pool" : "site";
+  const rawUrl =
+    kind === "pool"
+      ? buildPoolInviteUrl(code, handle, baseUrl)
+      : buildSiteInviteUrl(handle, baseUrl);
+  if (!rawUrl) return null;
+  const invite_url = appendInviteEmailUtms(rawUrl, {
+    campaign,
+    content: utmContent,
+  });
+  const invite_headline =
+    kind === "pool"
+      ? buildPoolInviteShareTitleFromInviter(handle, poolName)
+      : buildSiteInviteShareTitle(handle);
+  return { invite_kind: kind, invite_url, invite_headline };
+}

--- a/emails/src/templates/SummerTour2026Launch.jsx
+++ b/emails/src/templates/SummerTour2026Launch.jsx
@@ -1,6 +1,8 @@
 import { Link, Text } from "@react-email/components";
 import { FeatureBlock } from "../components/FeatureBlock.jsx";
+import { InviteShareBlock } from "../components/InviteShareBlock.jsx";
 import { MarketingLayout } from "../components/MarketingLayout.jsx";
+import { resolveEmailInviteShare } from "../lib/inviteKit.js";
 
 const greetingStyle = {
   margin: "0 0 16px",
@@ -30,19 +32,6 @@ const signoffStyle = {
   color: "#1a1a2e",
 };
 
-const ctaButtonStyle = {
-  display: "inline-block",
-  marginTop: "8px",
-  marginBottom: "8px",
-  padding: "12px 24px",
-  backgroundColor: "#7c3aed",
-  color: "#ffffff",
-  textDecoration: "none",
-  borderRadius: "8px",
-  fontWeight: 700,
-  fontSize: "14px",
-};
-
 const inlineLinkStyle = {
   display: "block",
   margin: "-8px 0 16px",
@@ -51,46 +40,66 @@ const inlineLinkStyle = {
   textDecoration: "underline",
 };
 
-const utmQuery =
-  "utm_source=email&utm_campaign=summer_tour_2026_launch&utm_content=share_friends";
-
-/**
- * Pool invite links use `/join/:code` so iMessage/Slack get pool-specific OG previews
- * (see `createPoolInviteLink` + `api/invite/[code].js`). Falls back to homepage OG.
- */
-function resolveShareUrl(base, shareUrl, inviteCode) {
-  if (shareUrl) return shareUrl;
-  const normalized = inviteCode?.trim().toUpperCase();
-  if (normalized) {
-    return `${base}/join/${encodeURIComponent(normalized)}?${utmQuery}`;
-  }
-  return `${base}/?${utmQuery}`;
-}
-
 /**
  * Marketing email #1 — Summer Tour 2026 pre-opener launch (#468).
  *
  * @param {{
  *   greetingName?: string,
+ *   inviterHandle?: string,
  *   audienceSegment?: 'sphere_alum' | 'post_sphere_signup' | 'sphere_alum_and_new',
  *   openerLabel?: string,
  *   siteUrl?: string,
  *   settingsUrl?: string,
  *   shareUrl?: string,
+ *   inviteUrl?: string,
+ *   inviteKind?: 'site' | 'pool',
+ *   inviteHeadline?: string,
  *   inviteCode?: string,
+ *   poolName?: string,
  * }} props
  */
 export function SummerTour2026Launch({
   greetingName = "friend",
+  inviterHandle,
   audienceSegment = "sphere_alum",
   openerLabel = "Tuesday, July 7",
   siteUrl = "https://www.setlistpickem.com",
   settingsUrl,
   shareUrl,
+  inviteUrl,
+  inviteKind,
+  inviteHeadline,
   inviteCode,
+  poolName,
 }) {
   const base = siteUrl.replace(/\/+$/, "");
-  const inviteUrl = resolveShareUrl(base, shareUrl, inviteCode);
+  const handle =
+    typeof inviterHandle === "string" && inviterHandle.trim()
+      ? inviterHandle.trim()
+      : greetingName !== "friend"
+        ? greetingName
+        : "";
+  const resolvedShare =
+    typeof shareUrl === "string" && shareUrl.trim()
+      ? {
+          invite_kind: inviteKind === "pool" ? "pool" : "site",
+          invite_url: shareUrl.trim(),
+          invite_headline: inviteHeadline || "",
+        }
+      : typeof inviteUrl === "string" && inviteUrl.trim()
+        ? {
+            invite_kind: inviteKind === "pool" ? "pool" : "site",
+            invite_url: inviteUrl.trim(),
+            invite_headline: inviteHeadline || "",
+          }
+        : resolveEmailInviteShare({
+            baseUrl: base,
+            inviterHandle: handle,
+            inviteCode,
+            poolName,
+            campaign: "summer_tour_2026_launch",
+            utmContent: "share_friends",
+          });
   const installHowToUrl = `${base}/dashboard/profile?utm_source=email&utm_campaign=summer_tour_2026_launch&utm_content=install_howto`;
 
   const introParagraphs =
@@ -155,9 +164,18 @@ export function SummerTour2026Launch({
         — Pat
       </Text>
 
-      <Link href={inviteUrl} style={ctaButtonStyle}>
-        Share with your friends, {greetingName} →
-      </Link>
+      <InviteShareBlock
+        inviterHandle={handle || greetingName}
+        inviteUrl={resolvedShare?.invite_url}
+        inviteKind={resolvedShare?.invite_kind}
+        poolName={poolName}
+        inviteHeadline={resolvedShare?.invite_headline}
+        ctaLabel={
+          greetingName !== "friend"
+            ? `Share with your friends, ${greetingName} →`
+            : undefined
+        }
+      />
     </MarketingLayout>
   );
 }

--- a/functions/comms/inviteContext.cjs
+++ b/functions/comms/inviteContext.cjs
@@ -1,0 +1,99 @@
+'use strict';
+
+const { resolveEmailInviteShare } = require('./inviteKit.cjs');
+
+/**
+ * First pool invite code + name for a user (same pool order as marketing batch).
+ *
+ * @param {import('firebase-admin').firestore.Firestore} db
+ * @param {Record<string, unknown> | null | undefined} userData
+ * @returns {Promise<{ inviteCode: string | null, poolName: string | null }>}
+ */
+async function inviteContextForUser(db, userData) {
+  const poolIds = Array.isArray(userData?.pools) ? userData.pools : [];
+  if (poolIds.length === 0) return { inviteCode: null, poolName: null };
+  const poolSnap = await db.collection('pools').doc(String(poolIds[0])).get();
+  if (!poolSnap.exists) return { inviteCode: null, poolName: null };
+  const data = poolSnap.data() || {};
+  const code =
+    typeof data.inviteCode === 'string' && data.inviteCode.trim()
+      ? data.inviteCode.trim().toUpperCase()
+      : null;
+  const poolName =
+    typeof data.name === 'string' && data.name.trim() ? data.name.trim() : null;
+  return { inviteCode: code, poolName };
+}
+
+/**
+ * Build invite payload fields for email templates from user + pool context.
+ *
+ * @param {{
+ *   baseUrl?: string,
+ *   inviterHandle?: string,
+ *   inviteCode?: string | null,
+ *   poolName?: string | null,
+ *   campaign: string,
+ *   utmContent?: string,
+ * }} opts
+ * @returns {Record<string, string> | null}
+ */
+function buildInviteEmailFields(opts) {
+  const share = resolveEmailInviteShare(opts);
+  if (!share) return null;
+  return {
+    invite_kind: share.invite_kind,
+    invite_url: share.invite_url,
+    invite_headline: share.invite_headline,
+    ...(opts.inviteCode ? { invite_code: String(opts.inviteCode).trim().toUpperCase() } : {}),
+    ...(opts.poolName ? { pool_name: String(opts.poolName).trim() } : {}),
+    ...(opts.inviterHandle ? { inviter_handle: String(opts.inviterHandle).trim() } : {}),
+  };
+}
+
+/**
+ * Resolve invite share from a template payload (pre-enriched or inline vars).
+ *
+ * @param {Record<string, unknown>} payload
+ * @param {{ campaign: string, baseUrl?: string, utmContent?: string }} opts
+ * @returns {{ invite_kind: 'site' | 'pool', invite_url: string, invite_headline: string } | null}
+ */
+function resolveInviteShareFromPayload(payload, { campaign, baseUrl, utmContent }) {
+  if (typeof payload?.invite_url === 'string' && payload.invite_url.trim()) {
+    return {
+      invite_kind: payload.invite_kind === 'pool' ? 'pool' : 'site',
+      invite_url: payload.invite_url.trim(),
+      invite_headline:
+        typeof payload.invite_headline === 'string' && payload.invite_headline.trim()
+          ? payload.invite_headline.trim()
+          : '',
+    };
+  }
+  const handle =
+    typeof payload?.inviter_handle === 'string' && payload.inviter_handle.trim()
+      ? payload.inviter_handle.trim()
+      : typeof payload?.handle === 'string'
+        ? payload.handle.trim()
+        : '';
+  const inviteCode =
+    typeof payload?.invite_code === 'string' && payload.invite_code.trim()
+      ? payload.invite_code.trim()
+      : null;
+  const poolName =
+    typeof payload?.pool_name === 'string' && payload.pool_name.trim()
+      ? payload.pool_name.trim()
+      : null;
+  return resolveEmailInviteShare({
+    baseUrl,
+    inviterHandle: handle,
+    inviteCode,
+    poolName,
+    campaign,
+    utmContent,
+  });
+}
+
+module.exports = {
+  inviteContextForUser,
+  buildInviteEmailFields,
+  resolveInviteShareFromPayload,
+};

--- a/functions/comms/inviteKit.cjs
+++ b/functions/comms/inviteKit.cjs
@@ -1,0 +1,144 @@
+'use strict';
+
+/**
+ * Invite URL + copy helpers for Cloud Functions (#583).
+ * Mirrors `emails/src/lib/inviteKit.js` and `src/shared/lib/inviteKit.js`.
+ */
+
+const DEFAULT_SITE_URL = 'https://www.setlistpickem.com';
+
+/**
+ * @param {unknown} handle
+ * @returns {string}
+ */
+function normalizeInviteHandle(handle) {
+  return String(handle ?? '')
+    .trim()
+    .replace(/^@+/, '');
+}
+
+/**
+ * @param {string} handle
+ * @param {string} [baseUrl]
+ * @returns {string}
+ */
+function buildSiteInviteUrl(handle, baseUrl = DEFAULT_SITE_URL) {
+  const h = normalizeInviteHandle(handle);
+  const base = String(baseUrl ?? DEFAULT_SITE_URL).replace(/\/+$/, '');
+  if (!base || !h) return '';
+  return `${base}/invite/${encodeURIComponent(h)}`;
+}
+
+/**
+ * @param {string} inviteCode
+ * @param {string} [fromHandle]
+ * @param {string} [baseUrl]
+ * @returns {string}
+ */
+function buildPoolInviteUrl(inviteCode, fromHandle, baseUrl = DEFAULT_SITE_URL) {
+  const code = String(inviteCode ?? '')
+    .trim()
+    .toUpperCase();
+  const base = String(baseUrl ?? DEFAULT_SITE_URL).replace(/\/+$/, '');
+  if (!base || !code) return '';
+  const url = `${base}/join/${encodeURIComponent(code)}`;
+  const from = normalizeInviteHandle(fromHandle);
+  if (!from) return url;
+  return `${url}?from=${encodeURIComponent(from)}`;
+}
+
+/**
+ * @param {string} handle
+ * @returns {string}
+ */
+function buildSiteInviteShareTitle(handle) {
+  const h = normalizeInviteHandle(handle);
+  if (!h) return "You're invited to Setlist Pick'em";
+  return `${h} invited you to Setlist Pick'em`;
+}
+
+/**
+ * @param {string} handle
+ * @param {string | null | undefined} [poolName]
+ * @returns {string}
+ */
+function buildPoolInviteShareTitleFromInviter(handle, poolName) {
+  const h = normalizeInviteHandle(handle);
+  const name = typeof poolName === 'string' ? poolName.trim() : '';
+  if (!h) {
+    return name
+      ? `You're invited to join a Setlist Pick'em pool: ${name}`
+      : "You're invited to join a Setlist Pick'em pool";
+  }
+  if (name) return `${h} invited you to join their pool: ${name}`;
+  return `${h} invited you to join their pool`;
+}
+
+/**
+ * @param {string} url
+ * @param {{ campaign: string, content?: string }} opts
+ * @returns {string}
+ */
+function appendInviteEmailUtms(url, { campaign, content = 'invite_share' }) {
+  const trimmed = String(url ?? '').trim();
+  if (!trimmed) return '';
+  const params = new URLSearchParams({
+    utm_source: 'email',
+    utm_campaign: String(campaign ?? '').trim(),
+    utm_content: String(content ?? 'invite_share').trim(),
+  });
+  const joiner = trimmed.includes('?') ? '&' : '?';
+  return `${trimmed}${joiner}${params.toString()}`;
+}
+
+/**
+ * @param {{
+ *   baseUrl?: string,
+ *   inviterHandle?: string,
+ *   inviteCode?: string | null,
+ *   poolName?: string | null,
+ *   campaign: string,
+ *   utmContent?: string,
+ * }} opts
+ * @returns {{ invite_kind: 'site' | 'pool', invite_url: string, invite_headline: string } | null}
+ */
+function resolveEmailInviteShare({
+  baseUrl = DEFAULT_SITE_URL,
+  inviterHandle,
+  inviteCode,
+  poolName,
+  campaign,
+  utmContent,
+}) {
+  const handle = normalizeInviteHandle(inviterHandle);
+  const code =
+    typeof inviteCode === 'string' && inviteCode.trim()
+      ? inviteCode.trim().toUpperCase()
+      : '';
+  const kind = code ? 'pool' : 'site';
+  const rawUrl =
+    kind === 'pool'
+      ? buildPoolInviteUrl(code, handle, baseUrl)
+      : buildSiteInviteUrl(handle, baseUrl);
+  if (!rawUrl) return null;
+  const invite_url = appendInviteEmailUtms(rawUrl, {
+    campaign,
+    content: utmContent,
+  });
+  const invite_headline =
+    kind === 'pool'
+      ? buildPoolInviteShareTitleFromInviter(handle, poolName)
+      : buildSiteInviteShareTitle(handle);
+  return { invite_kind: kind, invite_url, invite_headline };
+}
+
+module.exports = {
+  DEFAULT_SITE_URL,
+  normalizeInviteHandle,
+  buildSiteInviteUrl,
+  buildPoolInviteUrl,
+  buildSiteInviteShareTitle,
+  buildPoolInviteShareTitleFromInviter,
+  appendInviteEmailUtms,
+  resolveEmailInviteShare,
+};

--- a/functions/comms/inviteKit.test.js
+++ b/functions/comms/inviteKit.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildSiteInviteUrl,
+  buildPoolInviteUrl,
+  resolveEmailInviteShare,
+} = require('./inviteKit.cjs');
+
+test('buildSiteInviteUrl matches SPA invite kit shape', () => {
+  assert.equal(
+    buildSiteInviteUrl('Mikey'),
+    'https://www.setlistpickem.com/invite/Mikey'
+  );
+});
+
+test('buildPoolInviteUrl includes from handle before UTMs', () => {
+  assert.equal(
+    buildPoolInviteUrl('YEM42', 'Mikey'),
+    'https://www.setlistpickem.com/join/YEM42?from=Mikey'
+  );
+});
+
+test('resolveEmailInviteShare prefers pool invite when code present', () => {
+  const out = resolveEmailInviteShare({
+    inviterHandle: 'RiverTranced',
+    inviteCode: 'ABC12',
+    poolName: 'Denver Crew',
+    campaign: 'tour_rankings_daily',
+  });
+  assert.equal(out?.invite_kind, 'pool');
+  assert.match(out?.invite_url, /\/join\/ABC12\?from=RiverTranced/);
+  assert.match(out?.invite_url, /utm_source=email/);
+  assert.match(out?.invite_url, /utm_campaign=tour_rankings_daily/);
+  assert.match(out?.invite_url, /utm_content=invite_share/);
+  assert.match(out?.invite_headline, /RiverTranced invited you to join their pool: Denver Crew/);
+});
+
+test('resolveEmailInviteShare falls back to site invite without pool code', () => {
+  const out = resolveEmailInviteShare({
+    inviterHandle: 'RiverTranced',
+    campaign: 'tour_rankings_daily',
+  });
+  assert.equal(out?.invite_kind, 'site');
+  assert.match(out?.invite_url, /\/invite\/RiverTranced/);
+});

--- a/functions/comms/inviteShareBlock.cjs
+++ b/functions/comms/inviteShareBlock.cjs
@@ -1,0 +1,55 @@
+'use strict';
+
+const { EMAIL_BRAND_PRIMARY, EMAIL_BRAND_BG_DEEP } = require('./emailBranding.cjs');
+
+/**
+ * @param {string} str
+ * @returns {string}
+ */
+function escapeHtml(str) {
+  return String(str ?? '').replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c])
+  );
+}
+
+/**
+ * @param {{ invite_headline: string, invite_url: string, ctaLabel?: string }} share
+ * @returns {string[]}
+ */
+function buildInviteSharePlainTextLines(share) {
+  if (!share?.invite_url) return [];
+  const headline = String(share.invite_headline || '').trim();
+  const url = String(share.invite_url || '').trim();
+  const lines = [];
+  if (headline) lines.push(headline);
+  lines.push(`Invite link: ${url}`);
+  return lines;
+}
+
+/**
+ * Branded HTML invite block for the service email shell (#583).
+ *
+ * @param {{ invite_headline: string, invite_url: string, ctaLabel?: string }} share
+ * @returns {string}
+ */
+function buildInviteShareHtmlBlock(share) {
+  if (!share?.invite_url) return '';
+  const headline = escapeHtml(share.invite_headline || '');
+  const url = escapeHtml(share.invite_url);
+  const buttonLabel = escapeHtml(
+    typeof share.ctaLabel === 'string' && share.ctaLabel.trim()
+      ? share.ctaLabel.trim()
+      : 'Share your invite →'
+  );
+  return `<div style="margin:24px 0 20px 0;padding:16px;border:1px solid #e2e8f0;border-radius:12px;background-color:#f8fafc;">
+  <p style="margin:0 0 12px 0;font-size:15px;line-height:1.5;font-weight:700;color:#1a1a2e;">${headline}</p>
+  <a href="${url}" style="display:inline-block;margin:0 0 8px 0;padding:12px 24px;background-color:${EMAIL_BRAND_PRIMARY};color:${EMAIL_BRAND_BG_DEEP};text-decoration:none;border-radius:12px;font-weight:700;font-size:15px;">${buttonLabel}</a>
+  <p style="margin:0;font-size:13px;line-height:1.5;color:#64748b;word-break:break-all;">${url}</p>
+</div>`;
+}
+
+module.exports = {
+  buildInviteSharePlainTextLines,
+  buildInviteShareHtmlBlock,
+  escapeHtml,
+};

--- a/functions/commsEmailWorker.js
+++ b/functions/commsEmailWorker.js
@@ -211,10 +211,11 @@ function rewritePlainTextCtaUrl(text, rawCtaUrl, trackedCtaUrl) {
  *   ctaLabel?: string,
  *   signOff?: string,
  *   wordmarkSrc?: string,
+ *   inviteBlockHtml?: string,
  * }} opts
  * @returns {string}
  */
-function buildBrandedEmailHtml({ siteUrl, bodyText, ctaUrl, settingsUrl, ctaLabel, signOff, wordmarkSrc }) {
+function buildBrandedEmailHtml({ siteUrl, bodyText, ctaUrl, settingsUrl, ctaLabel, signOff, wordmarkSrc, inviteBlockHtml }) {
   const buttonLabel = typeof ctaLabel === "string" && ctaLabel.trim() ? ctaLabel.trim() : "Open Setlist Pick'em";
   const signOffLine = typeof signOff === "string" ? signOff.trim() : "";
   const base = (siteUrl || DEFAULT_SITE_URL).replace(/\/+$/, "");
@@ -236,6 +237,8 @@ function buildBrandedEmailHtml({ siteUrl, bodyText, ctaUrl, settingsUrl, ctaLabe
   const signOffHtml = signOffLine
     ? `<p style="margin:0 0 20px 0;font-size:15px;line-height:1.5;color:#64748b;font-style:italic;">${escapeHtml(signOffLine)}</p>`
     : "";
+  const inviteHtml =
+    typeof inviteBlockHtml === "string" && inviteBlockHtml.trim() ? inviteBlockHtml.trim() : "";
   const wordmarkBlockStyle = [
     `width:${EMAIL_SHELL_WORDMARK_WIDTH_PX}px`,
     "max-width:100%",
@@ -273,6 +276,7 @@ function buildBrandedEmailHtml({ siteUrl, bodyText, ctaUrl, settingsUrl, ctaLabe
             <tr>
               <td style="padding:8px 24px 8px 24px;font-family:-apple-system,Helvetica,Arial,sans-serif;">
                 ${paragraphs}
+                ${inviteHtml}
                 ${signOffHtml}
                 <a href="${escapeHtml(ctaUrl)}" style="display:inline-block;margin-top:8px;padding:14px 28px;background-color:${EMAIL_BRAND_PRIMARY};color:${EMAIL_BRAND_BG_DEEP};text-decoration:none;border-radius:12px;font-weight:700;font-size:16px;">${escapeHtml(buttonLabel)}</a>
               </td>
@@ -415,6 +419,7 @@ function createCommsEmailWorker({
           settingsUrl,
           ctaLabel,
           signOff: rendered.email.signOff,
+          inviteBlockHtml: rendered.email.inviteBlockHtml,
         });
     const html = usesPreRenderedHtml ? rendered.email.html : shell.html;
     const idempotencyKey = forceResend

--- a/functions/commsEventAdapters.js
+++ b/functions/commsEventAdapters.js
@@ -27,6 +27,12 @@ const {
   nextTourShowDate,
   buildTourRankingsDailyPayloadFields,
 } = require("./tourRankingsDailyCore");
+const {
+  inviteContextForUser,
+  buildInviteEmailFields,
+} = require("./comms/inviteContext.cjs");
+
+const SITE_URL = "https://www.setlistpickem.com";
 
 const DEFAULT_SHOW_TIME_ZONE = "America/Los_Angeles";
 const COUNTDOWN_DAYS = [10, 5, 3, 1];
@@ -724,6 +730,20 @@ async function runScheduledTourRankingsDaily({
         nextShowDate: nextDate,
         nextShowVenue: nextMeta?.venue || "",
       });
+      // eslint-disable-next-line no-await-in-loop
+      const { inviteCode, poolName } = await inviteContextForUser(db, userData);
+      const inviterHandle =
+        pickHandle ||
+        (typeof userData.handle === "string" ? userData.handle.trim() : "");
+      const inviteFields =
+        buildInviteEmailFields({
+          baseUrl: SITE_URL,
+          inviterHandle,
+          inviteCode,
+          poolName,
+          campaign: "tour_rankings_daily",
+        }) || {};
+      Object.assign(payload, inviteFields);
       recipients.push({
         uid,
         userData,

--- a/functions/commsTemplates.js
+++ b/functions/commsTemplates.js
@@ -14,6 +14,11 @@
 "use strict";
 
 const { buildTourRankingsDailyParagraphs } = require("./tourRankingsDailyCore");
+const {
+  buildInviteShareHtmlBlock,
+  buildInviteSharePlainTextLines,
+} = require("./comms/inviteShareBlock.cjs");
+const { resolveInviteShareFromPayload } = require("./comms/inviteContext.cjs");
 
 const SITE_URL = "https://www.setlistpickem.com";
 const APP_CTA_URL = `${SITE_URL}/dashboard`;
@@ -253,9 +258,17 @@ const BUILDERS = {
     ].filter(Boolean);
 
     const tourParas = buildTourRankingsDailyParagraphs(p);
-    const assembled = assembleServiceEmail([...nightOf, "", ...tourParas].filter(Boolean), {
-      ctaUrl: PICKS_CTA_URL,
+    const inviteShare = resolveInviteShareFromPayload(p, {
+      campaign: "tour_rankings_daily",
+      baseUrl: SITE_URL,
     });
+    const inviteLines = inviteShare ? buildInviteSharePlainTextLines(inviteShare) : [];
+    const assembled = assembleServiceEmail(
+      [...nightOf, "", ...tourParas, ...(inviteLines.length ? ["", ...inviteLines] : [])].filter(Boolean),
+      {
+        ctaUrl: PICKS_CTA_URL,
+      }
+    );
 
     const pushRank =
       p.tour_rank != null
@@ -279,6 +292,9 @@ const BUILDERS = {
         signOff: assembled.signOff,
         ctaUrl: PICKS_CTA_URL,
         ctaLabel: "Make picks for next show",
+        ...(inviteShare
+          ? { inviteBlockHtml: buildInviteShareHtmlBlock(inviteShare) }
+          : {}),
       },
     };
   },

--- a/functions/commsTemplates.test.js
+++ b/functions/commsTemplates.test.js
@@ -85,6 +85,10 @@ test("tour-rankings-daily email folds in show_recap's night-of content (#451)", 
     rank_change: "up 2",
     next_show_date: "2026-07-19",
     next_show_venue: "Sphere",
+    invite_kind: "pool",
+    invite_url:
+      "https://www.setlistpickem.com/join/ABC12?from=RiverTranced&utm_source=email&utm_campaign=tour_rankings_daily&utm_content=invite_share",
+    invite_headline: "RiverTranced invited you to join their pool: Denver Crew",
   });
   // Night-of recap content is present even though show_recap no longer emails.
   assert.match(out.email.text, /70/, "show score");
@@ -95,6 +99,10 @@ test("tour-rankings-daily email folds in show_recap's night-of content (#451)", 
   assert.match(out.email.text, /climbed 2/, "rank change rendered as climbed");
   assert.match(out.email.text, /2026-07-19/, "next show date");
   assert.match(out.push.body, /up 2/, "push keeps catalog rank_change token");
+  assert.match(out.email.text, /RiverTranced invited you to join their pool/);
+  assert.match(out.email.text, /\/join\/ABC12\?from=RiverTranced/);
+  assert.ok(out.email.inviteBlockHtml, "invite HTML block");
+  assert.match(out.email.inviteBlockHtml, /Share your invite/);
 });
 
 test("tour-countdown email uses picks CTA and avoids duplicate city in venue line", async () => {

--- a/functions/marketingBatchDelivery.js
+++ b/functions/marketingBatchDelivery.js
@@ -11,39 +11,14 @@ const { deliverCommsTrigger, buildDefaultWorkers } = require("./commsDelivery");
 const { createCommsEmailWorker, buildResendClient } = require("./commsEmailWorker");
 const { resolveSummerTour2026LaunchAudience } = require("./marketingAudience");
 const { buildSummerTour2026LaunchChannels } = require("./marketingCommsTemplates");
+const {
+  inviteContextForUser,
+  buildInviteEmailFields,
+} = require("./comms/inviteContext.cjs");
 
 const TRIGGER_ID = "marketing_summer_tour_2026_launch";
 const CAMPAIGN_ID = "summer_tour_2026";
 const SITE_URL = "https://www.setlistpickem.com";
-const BASE_UTM = "utm_source=email&utm_campaign=summer_tour_2026_launch";
-
-/**
- * @param {string} base
- * @param {string | null | undefined} inviteCode
- * @returns {string}
- */
-function buildInviteShareUrl(base, inviteCode) {
-  const normalized =
-    typeof inviteCode === "string" ? inviteCode.trim().toUpperCase() : "";
-  if (normalized) {
-    return `${base}/join/${encodeURIComponent(normalized)}?${BASE_UTM}&utm_content=share_friends`;
-  }
-  return `${base}/?${BASE_UTM}&utm_content=share_friends`;
-}
-
-/**
- * @param {import("firebase-admin").firestore.Firestore} db
- * @param {Record<string, unknown> | null | undefined} userData
- * @returns {Promise<string | null>}
- */
-async function inviteCodeForUser(db, userData) {
-  const poolIds = Array.isArray(userData?.pools) ? userData.pools : [];
-  if (poolIds.length === 0) return null;
-  const poolSnap = await db.collection("pools").doc(String(poolIds[0])).get();
-  if (!poolSnap.exists) return null;
-  const code = poolSnap.data()?.inviteCode;
-  return typeof code === "string" && code.trim() ? code.trim().toUpperCase() : null;
-}
 
 /**
  * @param {Record<string, unknown> | undefined} userData
@@ -55,21 +30,43 @@ function handleFromUser(userData) {
 }
 
 /**
+ * @param {Record<string, unknown> | null | undefined} userData
+ * @returns {string}
+ */
+function inviteHandleFromUser(userData) {
+  return userData && typeof userData.handle === "string" ? userData.handle.trim() : "";
+}
+
+/**
  * @param {string} segment
- * @param {string} handle
+ * @param {string} greetingName
+ * @param {string} inviterHandle
  * @param {string | null} inviteCode
+ * @param {string | null} poolName
  * @returns {Record<string, string>}
  */
-function buildEmailPayload(segment, handle, inviteCode) {
+function buildEmailPayload(segment, greetingName, inviterHandle, inviteCode, poolName) {
   const base = SITE_URL.replace(/\/+$/, "");
+  const inviteFields =
+    buildInviteEmailFields({
+      baseUrl: base,
+      inviterHandle,
+      inviteCode,
+      poolName,
+      campaign: "summer_tour_2026_launch",
+      utmContent: "share_friends",
+    }) || {};
   return {
-    greetingName: handle,
+    greetingName,
+    inviterHandle,
     audienceSegment: segment,
     openerLabel: "Tuesday, July 7",
     siteUrl: base,
     settingsUrl: `${base}/dashboard/profile/notifications`,
-    shareUrl: buildInviteShareUrl(base, inviteCode),
+    shareUrl: inviteFields.invite_url || "",
     ...(inviteCode ? { inviteCode } : {}),
+    ...(poolName ? { poolName } : {}),
+    ...inviteFields,
   };
 }
 
@@ -134,16 +131,18 @@ async function deliverMarketingSummerTour2026Launch({
       typeof userData.email === "string" && userData.email.includes("@")
         ? userData.email.trim()
         : null;
-    const handle = handleFromUser(userData);
+    const greetingName = handleFromUser(userData);
+    const inviterHandle = inviteHandleFromUser(userData);
     // eslint-disable-next-line no-await-in-loop
-    const inviteCode = await inviteCodeForUser(db, userData);
+    const { inviteCode, poolName } = await inviteContextForUser(db, userData);
 
     preview.push({
       uid: member.uid,
       segment: member.segment,
-      handle,
+      handle: greetingName,
       email,
       inviteCode,
+      poolName,
     });
 
     if (!email) continue;
@@ -151,7 +150,13 @@ async function deliverMarketingSummerTour2026Launch({
     recipients.push({
       uid: member.uid,
       userData,
-      payload: buildEmailPayload(member.segment, handle, inviteCode),
+      payload: buildEmailPayload(
+        member.segment,
+        greetingName,
+        inviterHandle,
+        inviteCode,
+        poolName
+      ),
       vars: {
         uid: member.uid,
         campaignId: CAMPAIGN_ID,

--- a/functions/marketingCommsTemplates.test.js
+++ b/functions/marketingCommsTemplates.test.js
@@ -8,19 +8,23 @@ const { buildSummerTour2026LaunchChannels } = require("./marketingCommsTemplates
 test("buildSummerTour2026LaunchChannels returns html, text, and subject", async () => {
   const out = await buildSummerTour2026LaunchChannels({
     greetingName: "Rivertranced",
+    inviterHandle: "Rivertranced",
     audienceSegment: "sphere_alum",
     openerLabel: "Tuesday, July 7",
     siteUrl: "https://www.setlistpickem.com",
     settingsUrl: "https://www.setlistpickem.com/dashboard/profile/notifications",
-    shareUrl: "https://www.setlistpickem.com/join/ABC12?utm_content=share_friends",
+    shareUrl:
+      "https://www.setlistpickem.com/join/ABC12?from=Rivertranced&utm_source=email&utm_campaign=summer_tour_2026_launch&utm_content=share_friends",
     inviteCode: "ABC12",
+    inviteKind: "pool",
+    inviteHeadline: "Rivertranced invited you to join their pool",
   });
 
   assert.match(out.email.subject, /bring your crew/i);
   assert.match(out.email.html, /Rivertranced/);
   assert.match(out.email.html, /Share with your friends/);
-  assert.match(out.email.html, /Rivertranced/);
-  assert.match(out.email.html, /\/join\/ABC12/);
+  assert.match(out.email.html, /Rivertranced invited you to join their pool/);
+  assert.match(out.email.html, /\/join\/ABC12\?from=Rivertranced/);
   assert.match(out.email.text, /Rivertranced/);
   assert.match(out.email.text, /Pat/);
   assert.ok(out.email.html.includes("<!DOCTYPE html") || out.email.html.includes("<html"));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.21.2",
+  "version": "1.21.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #583

Train 4 after Invite Train 3 (staging at **1.21.2**). SemVer **1.21.3**.

## Summary
- Reusable site + pool invite share block for React Email + lifecycle HTML shell
- Personalized headline + VIP URLs matching invite kit (`/invite/{handle}`, `/join/{code}?from={handle}`) with email UTMs
- Wired into `tour_rankings_daily` and Summer Tour 2026 marketing template
- Trigger catalog / CTA docs updated

## Test plan
- [ ] `npm run emails:build` + `cd functions && npm test` (or at least `inviteKit.test.js`)
- [ ] `npm run emails:preview` — site + pool variants show invite line + correct links
- [ ] Tour rankings canary preview includes invite block when handle present
- [ ] Pool path includes `?from=` handle; site path has no join code
- [ ] Held on staging (no promote)


Made with [Cursor](https://cursor.com)