### PR TITLE
fix(picks): temp venue-local lock 7:55 PM

### DIFF
--- a/.cursor/skills/comms-triggers/SKILL.md
+++ b/.cursor/skills/comms-triggers/SKILL.md
@@ -17,7 +17,7 @@ You own the **trigger catalog** — what fires, for whom, when, through which ch
 2. `docs/comms-triggers/TRIGGER_CATALOG.md`
 3. `docs/comms-triggers/catalog.json`
 4. `src/features/comms/registry.js` — templateId linkage
-5. Game logic: `src/shared/utils/timeLogic.js`, `show_calendar`, picks lock (#303: 19:30 local)
+5. Game logic: `src/shared/utils/timeLogic.js`, `show_calendar`, picks lock (#303: 19:55 local)
 
 ## Trigger Spec checklist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.21.4] — 2026-07-15
+
+### Changed
+- **Picks lock time (temp)** — venue-local wall clock moves **7:30 PM → 7:55 PM** (app + Cloud Functions mirrors + reminder copy). Temporary until first-song / admin-configurable lock ships; reminder window is **T-3h through lock** (16:55–19:54 local).
+
+---
+
 ## [1.21.3] — 2026-07-15
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -230,7 +230,7 @@ Automated comms delivery triggered by Firestore writes, post-rollup hooks, live-
 | Live-scoring hook | `score_first_points`, `score_leader` | `recomputeLiveScoresForShow` |
 | `scheduledTourCountdownComms` | `tour_countdown` | Daily 9am PT cron (T-10/T-5/T-3/T-1) |
 | `scheduledTourRankingsDailyComms` | `tour_rankings_daily` | Daily 8am PT cron (morning-after show) |
-| `scheduledPicksLockReminder` | `picks_lock_reminder` | Every 15 min; venue-local show day **T-3h–lock** (16:30–19:29 when lock is 19:30); **not** gated by `COMMS_EVENT_ADAPTERS_ENABLED` (v1.19.0+) |
+| `scheduledPicksLockReminder` | `picks_lock_reminder` | Every 15 min; venue-local show day **T-3h–lock** (16:55–19:54 when lock is 19:55); **not** gated by `COMMS_EVENT_ADAPTERS_ENABLED` (v1.19.0+) |
 
 Trigger specs and channels: `docs/comms-triggers/catalog.json`. Admin canary/replay: `runCommsTrigger` (§2.2).
 

--- a/docs/comms-triggers/TRIGGER_CATALOG.md
+++ b/docs/comms-triggers/TRIGGER_CATALOG.md
@@ -41,7 +41,7 @@ Every template draws from this shared set. Each trigger declares the subset it u
 | `{{venue_name}}` | `show_calendar` snapshot | — |
 | `{{venue_city}}` | `show_calendar` snapshot | — |
 | `{{time_to_lock}}` | Computed at send time | — |
-| `{{lock_time_local}}` | Computed (19:30 venue-local) | `7:30 PM` |
+| `{{lock_time_local}}` | Computed (19:55 venue-local) | `7:55 PM` |
 | `{{tour_name}}` | Tour metadata | — |
 | `{{days_remaining}}` | Computed from tour start date | — |
 | `{{first_show_date}}` | Tour first show | — |
@@ -427,7 +427,7 @@ Up next: {{next_show_venue}} on {{next_show_date}}. Picks open now.
 |-------|-------|
 | **Status** | `shipped` |
 | **Automation** | `automated` |
-| **Schedule** | Every 15 min on show days, venue-local **T-3h through lock** (16:30–19:29 when lock is 19:30) |
+| **Schedule** | Every 15 min on show days, venue-local **T-3h through lock** (16:55–19:54 when lock is 19:55) |
 | **Channels** | `inApp`, `push`, `email` |
 | **Audience** | Users with a handle and **no picks** for tonight's show |
 | **Prefs key** | `reminders` (push + in-app only) |

--- a/docs/comms-triggers/catalog.json
+++ b/docs/comms-triggers/catalog.json
@@ -53,7 +53,7 @@
         { "name": "first_show_date", "source": "tour first show", "fallback": null },
         { "name": "first_show_venue", "source": "tour first show venue", "fallback": null },
         { "name": "first_show_city", "source": "tour first show city", "fallback": null },
-        { "name": "lock_time_local", "source": "computed (19:30 venue-local)", "fallback": "7:30 PM" },
+        { "name": "lock_time_local", "source": "computed (19:55 venue-local)", "fallback": "7:55 PM" },
         { "name": "picks_secured", "source": "picks where showDate=first_show + hasNonEmptyPicksObject", "fallback": false }
       ]
     },
@@ -238,7 +238,7 @@
       "family": "show_calendar",
       "priority": "P0",
       "automation": "automated",
-      "schedule": "every 15min on show days, venue-local T-3h through lock (16:30–19:29 when lock is 19:30)",
+      "schedule": "every 15min on show days, venue-local T-3h through lock (16:55–19:54 when lock is 19:55)",
       "audience": "users_no_picks_tonight",
       "channels": ["inApp", "push", "email"],
       "prefKeys": ["reminders"],
@@ -254,7 +254,7 @@
         { "name": "venue_name", "source": "show_calendar", "fallback": null },
         { "name": "venue_city", "source": "show_calendar", "fallback": null },
         { "name": "time_to_lock", "source": "computed at send time", "fallback": null },
-        { "name": "lock_time_local", "source": "computed (19:30 venue-local)", "fallback": "7:30 PM" },
+        { "name": "lock_time_local", "source": "computed (19:55 venue-local)", "fallback": "7:55 PM" },
         { "name": "picks_secured", "source": "preview/edge only — production fanout skips users with picks", "fallback": false }
       ]
     },

--- a/functions/commsEventAdapters.js
+++ b/functions/commsEventAdapters.js
@@ -172,7 +172,7 @@ function findTourCountdownTargets(calendarShows, now, countdownDays = COUNTDOWN_
         first_show_venue: show.venue || "",
         first_show_city: show.city || "",
         timeZone: tz,
-        lock_time_local: "7:30 PM",
+        lock_time_local: "7:55 PM",
       });
     }
   }

--- a/functions/commsTemplates.js
+++ b/functions/commsTemplates.js
@@ -143,14 +143,14 @@ const BUILDERS = {
       [
         `${handleOf(p)}, the run kicks off ${when}.`,
         firstShow ? `First show: ${firstShow}.` : "",
-        `Picks lock at ${p.lock_time_local || "7:30 PM"} local on show night.`,
+        `Picks lock at ${p.lock_time_local || "7:55 PM"} local on show night.`,
       ],
       { ctaUrl: PICKS_CTA_URL }
     );
     return {
       push: {
         title: `${p.tour_name || "The tour"} starts ${when}`,
-        body: `Get your picks ready — locks at ${p.lock_time_local || "7:30 PM"} local.`,
+        body: `Get your picks ready — locks at ${p.lock_time_local || "7:55 PM"} local.`,
       },
       email: {
         subject: `${p.tour_name || "The tour"} starts ${when}`,
@@ -301,7 +301,7 @@ const BUILDERS = {
 
   "picks-lock-reminder": (p) => {
     const venue = venueLine(p);
-    const lockLabel = p.lock_time_local || "7:30 PM";
+    const lockLabel = p.lock_time_local || "7:55 PM";
     const timePhrase = p.time_to_lock ? ` in ${p.time_to_lock}` : "";
     const ctaUrl = picksCtaUrl(p);
     const assembled = assembleServiceEmail(

--- a/functions/commsTemplates.test.js
+++ b/functions/commsTemplates.test.js
@@ -113,7 +113,7 @@ test("tour-countdown email uses picks CTA and avoids duplicate city in venue lin
     first_show_date: "2026-07-07",
     first_show_venue: "Kohl Center, Madison, WI",
     first_show_city: "Madison, WI",
-    lock_time_local: "7:30 PM",
+    lock_time_local: "7:55 PM",
   });
   assert.equal(out.email.ctaLabel, "Make Your Picks");
   assert.equal(out.email.ctaUrl, "https://www.setlistpickem.com/dashboard/picks");

--- a/functions/picksLockReminder.js
+++ b/functions/picksLockReminder.js
@@ -10,10 +10,10 @@ const { hasNonEmptyPicksObject } = require("./rollupSeasonAggregates");
 const { createCommsAdapterRuntime } = require("./commsAdapterRuntime");
 const { resolveDedupKey } = require("./commsCatalog");
 
-/** Mirrors `src/shared/utils/timeLogic.js` (7:30pm local). */
+/** Mirrors `src/shared/utils/timeLogic.js` (7:55pm local). */
 const SHOW_PICKS_LOCK_HOUR = 19;
-const SHOW_PICKS_LOCK_MINUTE = 30;
-const LOCK_TIME_LOCAL_LABEL = "7:30 PM";
+const SHOW_PICKS_LOCK_MINUTE = 55;
+const LOCK_TIME_LOCAL_LABEL = "7:55 PM";
 
 const DEFAULT_SHOW_TIME_ZONE = "America/Los_Angeles";
 /** Reminder window opens this many minutes before venue-local lock. */

--- a/functions/picksLockReminder.test.js
+++ b/functions/picksLockReminder.test.js
@@ -16,7 +16,7 @@ test("reminderLogDocId", () => {
 
 test("findReminderTonightShow returns null before T-3h window", () => {
   const shows = [{ date: "2099-06-15", timeZone: "America/Los_Angeles" }];
-  // 4:00pm PDT — still before 4:30pm (lock 7:30 − 3h).
+  // 4:00pm PDT — still before 4:55pm (lock 7:55 − 3h).
   const now = new Date("2099-06-15T23:00:00.000Z");
   assert.equal(findReminderTonightShow(shows, now), null);
 });
@@ -30,7 +30,7 @@ test("findReminderTonightShow returns show in T-3h–lock window with venue meta
       city: "New York, NY",
     },
   ];
-  // 5:30pm PDT — inside 4:30–7:30 window.
+  // 5:30pm PDT — inside 4:55–7:55 window.
   const now = new Date("2099-06-16T00:30:00.000Z");
   const out = findReminderTonightShow(shows, now);
   assert.ok(out);
@@ -48,8 +48,8 @@ test("isPastPicksLock is true after local lock", () => {
 });
 
 test("formatTimeToLock returns 3 hours at window open", () => {
-  // 4:30pm PDT on show day → exactly 3 hours until 7:30pm lock.
-  const now = new Date("2099-06-15T23:30:00.000Z");
+  // 4:55pm PDT on show day → exactly 3 hours until 7:55pm lock.
+  const now = new Date("2099-06-15T23:55:00.000Z");
   assert.equal(formatTimeToLock("2099-06-15", "America/Los_Angeles", now), "3 hours");
 });
 

--- a/functions/showFinalizationGate.js
+++ b/functions/showFinalizationGate.js
@@ -10,7 +10,7 @@
 const DEFAULT_SHOW_TIME_ZONE = "America/Los_Angeles";
 
 const SHOW_PICKS_LOCK_HOUR_LOCAL = 19;
-const SHOW_PICKS_LOCK_MINUTE_LOCAL = 30;
+const SHOW_PICKS_LOCK_MINUTE_LOCAL = 55;
 
 function resolveShowTimeZone(show, fallback = DEFAULT_SHOW_TIME_ZONE) {
   const explicit =

--- a/functions/showFinalizationGate.test.js
+++ b/functions/showFinalizationGate.test.js
@@ -33,7 +33,7 @@ test("evaluateManualFinalizeTimingGate: allows PAST without force", () => {
 });
 
 test("evaluateManualFinalizeTimingGate: blocks LIVE without force", () => {
-  // 8:10pm Eastern on the show date — after 7:30pm picks lock.
+  // 8:10pm Eastern on the show date — after 7:55pm picks lock.
   const now = new Date("2026-04-30T20:10:00-04:00");
   const st = getShowStatus("2026-04-30", CAL, now);
   assert.equal(st, "LIVE");

--- a/functions/tourCountdownRecoveryDelivery.js
+++ b/functions/tourCountdownRecoveryDelivery.js
@@ -15,7 +15,7 @@ const { hasNonEmptyPicksObject } = require("./rollupSeasonAggregates");
 
 const TRIGGER_ID = "tour_countdown";
 const DEFAULT_SHOW_TIME_ZONE = "America/Los_Angeles";
-const DEFAULT_LOCK_TIME_LOCAL = "7:30 PM";
+const DEFAULT_LOCK_TIME_LOCAL = "7:55 PM";
 
 /**
  * @param {unknown} data

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.21.3",
+  "version": "1.21.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/canary-comms-preview.mjs
+++ b/scripts/canary-comms-preview.mjs
@@ -105,7 +105,7 @@ const TRIGGERS_TO_PREVIEW = [
     payload: {
       tour_name: "Fall Tour '26",
       days_remaining: 3,
-      lock_time_local: '7:30 PM',
+      lock_time_local: '7:55 PM',
       first_show_date: 'Fri, Sep 11',
       first_show_venue: 'Madison Square Garden',
       first_show_city: 'New York, NY',
@@ -116,7 +116,7 @@ const TRIGGERS_TO_PREVIEW = [
     triggerId: 'picks_lock_reminder',
     payload: {
       venue_name: 'Madison Square Garden',
-      lock_time_local: '7:30 PM',
+      lock_time_local: '7:55 PM',
     },
     vars: { showYmd: '2026-09-11' },
   },

--- a/scripts/qa-daily-cap-test.mjs
+++ b/scripts/qa-daily-cap-test.mjs
@@ -89,14 +89,14 @@ const FIRST = {
   payload: {
     tour_name: "Fall Tour '26",
     days_remaining: 2,
-    lock_time_local: '7:30 PM',
+    lock_time_local: '7:55 PM',
     first_show_venue: 'Madison Square Garden',
   },
   vars: { tourId: 'daily-cap-qa', days_remaining: 2 },
 };
 const SECOND = {
   triggerId: 'picks_lock_reminder',
-  payload: { venue_name: 'Madison Square Garden', lock_time_local: '7:30 PM' },
+  payload: { venue_name: 'Madison Square Garden', lock_time_local: '7:55 PM' },
   vars: { showYmd: '2026-09-12' },
 };
 

--- a/scripts/send-local-email-preview.mjs
+++ b/scripts/send-local-email-preview.mjs
@@ -141,7 +141,7 @@ if (tourCountdown) {
     first_show_date: '2026-07-07',
     first_show_venue: 'Kohl Center, Madison, WI',
     first_show_city: 'Madison, WI',
-    lock_time_local: '7:30 PM',
+    lock_time_local: '7:55 PM',
   });
   const shell = buildProductionBrandedEmailShell({
     siteUrl,
@@ -172,7 +172,7 @@ if (picksLockReminder) {
     venue_name: 'Kohl Center',
     venue_city: 'Madison, WI',
     time_to_lock: '3 hours',
-    lock_time_local: '7:30 PM',
+    lock_time_local: '7:55 PM',
   });
   const shell = buildProductionBrandedEmailShell({
     siteUrl,

--- a/src/features/admin/ui/AdminForm.jsx
+++ b/src/features/admin/ui/AdminForm.jsx
@@ -180,7 +180,7 @@ export default function AdminForm({ user, selectedDate }) {
             <AdminActionToggle
               id="admin-picks-lock"
               title="Picks lock"
-              description="One-click override when the show starts before 7:30 PM local or Phish.net is slow."
+              description="One-click override when the show starts before 7:55 PM local or Phish.net is slow."
               open={picksLockOpen}
               onOpenChange={setPicksLockOpen}
             >

--- a/src/features/admin/ui/AdminPicksLockControls.jsx
+++ b/src/features/admin/ui/AdminPicksLockControls.jsx
@@ -15,7 +15,7 @@ export default function AdminPicksLockControls({
   const canLock = showStatus === 'NEXT' && !picksAlreadyLocked && !disabled;
 
   let helperText =
-    'Picks lock at 7:30 PM venue-local, when set 1 starts on Phish.net, or when you lock them here.';
+    'Picks lock at 7:55 PM venue-local, when set 1 starts on Phish.net, or when you lock them here.';
   if (showStatus && showStatus !== 'NEXT') {
     helperText = 'Lock picks now is only available while this show is NEXT (before wall-clock lock).';
   } else if (adminLockActive) {

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
@@ -170,7 +170,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           venueLine(p, { dateKey: 'first_show_date', venueKey: 'first_show_venue', cityKey: 'first_show_city' })
             ? `First show: ${venueLine(p, { dateKey: 'first_show_date', venueKey: 'first_show_venue', cityKey: 'first_show_city' })}.`
             : 'Get your picks ready before the first downbeat.',
-          `Picks lock at ${p.lock_time_local || '7:30 PM'} local on show night — don't get shut out.`,
+          `Picks lock at ${p.lock_time_local || '7:55 PM'} local on show night — don't get shut out.`,
         ],
         cta: tourCountdownInAppCta(p),
       };
@@ -185,7 +185,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           first_show_date: 'Jul 18',
           first_show_venue: 'MSG',
           first_show_city: 'New York, NY',
-          lock_time_local: '7:30 PM',
+          lock_time_local: '7:55 PM',
         },
       },
       {
@@ -197,7 +197,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           first_show_date: 'Jul 18',
           first_show_venue: 'MSG',
           first_show_city: 'New York, NY',
-          lock_time_local: '7:30 PM',
+          lock_time_local: '7:55 PM',
         },
       },
       {
@@ -209,7 +209,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           first_show_date: 'Jul 7',
           first_show_venue: 'Kohl Center',
           first_show_city: 'Madison, WI',
-          lock_time_local: '7:30 PM',
+          lock_time_local: '7:55 PM',
         },
       },
       {
@@ -232,7 +232,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           first_show_date: 'Jul 7',
           first_show_venue: 'Kohl Center',
           first_show_city: 'Madison, WI',
-          lock_time_local: '7:30 PM',
+          lock_time_local: '7:55 PM',
           picks_secured: true,
         },
       },
@@ -591,7 +591,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
       eyebrow: 'Picks lock soon',
       title: 'Lock in your picks',
       paragraphs: [
-        `${handleOf(p)}, ${venueLine(p) || "tonight's show"} locks at ${p.lock_time_local || '7:30 PM'} local${
+        `${handleOf(p)}, ${venueLine(p) || "tonight's show"} locks at ${p.lock_time_local || '7:55 PM'} local${
           p.time_to_lock ? ` — about ${p.time_to_lock} away` : ''
         }.`,
         isPicksSecured(p)
@@ -611,7 +611,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           venue_name: 'MSG',
           venue_city: 'New York, NY',
           time_to_lock: '3 hours',
-          lock_time_local: '7:30 PM',
+          lock_time_local: '7:55 PM',
         },
       },
       {
@@ -622,7 +622,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           venue_name: 'MSG',
           venue_city: 'New York, NY',
           time_to_lock: '3 hours',
-          lock_time_local: '7:30 PM',
+          lock_time_local: '7:55 PM',
           picks_secured: true,
         },
       },

--- a/src/features/picks/model/useSetlistLockToast.js
+++ b/src/features/picks/model/useSetlistLockToast.js
@@ -8,7 +8,7 @@ import { showSuccessToast } from '../../../shared/ui/toast';
  *
  * Handles the common case where the user has the dashboard open around show
  * time: without a page reload, the status changes live and the toast fires
- * when 7:30 pm local arrives.  A hard reload after lock (initial status
+ * when 7:55 pm local arrives.  A hard reload after lock (initial status
  * already 'LIVE') does not re-fire the toast.
  *
  * @param {string|null} showStatus - Result of getShowStatus() for the active

--- a/src/shared/utils/timeLogic.js
+++ b/src/shared/utils/timeLogic.js
@@ -7,11 +7,11 @@ export const SHOW_SCHEDULE_TIMEZONE = DEFAULT_SHOW_TIME_ZONE;
 
 /**
  * Picks lock at this local time on the show's calendar date in the show's local timezone.
- * 7:30pm local wall clock — earlier than set 1 for most shows so War Room has
- * headroom for manual lock if Phish.net / auto paths lag.
+ * Temporary: 7:55pm venue-local (was 7:30). Revert / replace with first-song /
+ * admin-configurable lock when that lands.
  */
 export const SHOW_PICKS_LOCK_HOUR_LOCAL = 19;
-export const SHOW_PICKS_LOCK_MINUTE_LOCAL = 30;
+export const SHOW_PICKS_LOCK_MINUTE_LOCAL = 55;
 // Back-compat aliases for existing imports.
 export const SHOW_PICKS_LOCK_HOUR_PT = SHOW_PICKS_LOCK_HOUR_LOCAL;
 export const SHOW_PICKS_LOCK_MINUTE_PT = SHOW_PICKS_LOCK_MINUTE_LOCAL;

--- a/src/shared/utils/timeLogic.test.js
+++ b/src/shared/utils/timeLogic.test.js
@@ -34,13 +34,13 @@ describe('venue-local lock + status (#278)', () => {
   });
 
   it('evaluates lock time in the show timezone instead of fixed PT', () => {
-    // Chicago CDT = UTC-5 in July: 00:20Z = 7:20pm, 00:31Z = 7:31pm local.
+    // Chicago CDT = UTC-5 in July: 00:20Z = 7:20pm, 00:56Z = 7:56pm local.
     const at1920Chicago = new Date('2026-07-11T00:20:00.000Z');
-    const at1931Chicago = new Date('2026-07-11T00:31:00.000Z');
+    const at1956Chicago = new Date('2026-07-11T00:56:00.000Z');
 
     expect(isPastPicksLock('2026-07-10', 'America/Chicago', at1920Chicago)).toBe(false);
-    expect(isPastPicksLock('2026-07-10', 'America/Chicago', at1931Chicago)).toBe(true);
-    expect(isPastPicksLock('2026-07-10', 'America/Los_Angeles', at1931Chicago)).toBe(false);
+    expect(isPastPicksLock('2026-07-10', 'America/Chicago', at1956Chicago)).toBe(true);
+    expect(isPastPicksLock('2026-07-10', 'America/Los_Angeles', at1956Chicago)).toBe(false);
   });
 
   it('chooses next show using each show local today', () => {
@@ -56,9 +56,9 @@ describe('venue-local lock + status (#278)', () => {
     expect(getNextShow(shows)).toEqual(shows[1]);
   });
 
-  it('marks a show LIVE at 7:30 in the venue timezone on show date', () => {
+  it('marks a show LIVE at 7:55 in the venue timezone on show date', () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-07-11T00:31:00.000Z'));
+    vi.setSystemTime(new Date('2026-07-11T00:56:00.000Z'));
 
     const shows = [
       { date: '2026-07-10', venue: 'Kohl Center, Madison, WI', timeZone: 'America/Chicago' },
@@ -69,7 +69,7 @@ describe('venue-local lock + status (#278)', () => {
 
   it('keeps fallback venue parsing for old docs without explicit timeZone', () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-07-11T00:31:00.000Z'));
+    vi.setSystemTime(new Date('2026-07-11T00:56:00.000Z'));
 
     const shows = [{ date: '2026-07-10', venue: 'Kohl Center, Madison, WI' }];
 


### PR DESCRIPTION
## Summary
- Temporary global picks lock: **7:30 → 7:55 PM venue-local** (client `timeLogic` + Functions mirrors + reminder label/copy) until first-song / admin-configurable lock lands.
- Reminder window shifts with lock: **T-3h through lock** (16:55–19:54 local). SemVer **1.21.4** PATCH.

## Deploy for tonight (do both)
1. **Web (Vercel)** — merge this PR → promote/ship production so players’ clients use `isPastPicksLock` at 19:55. Without a prod SPA deploy, the app still locks at 7:30.
2. **Functions** — after merge (or from this branch while checking out the commit):
   ```bash
   npm run deploy:functions:phishnet
   ```
   That includes `scheduledPicksLockReminder` (copy + reminder window). `showFinalizationGate` is bundled into rollup/phishnet consumers in the same deploy path — deploy before War Room / auto-finalize tonight if you care about the server gate matching 7:55.

## Test plan
- [ ] `npm test -- --run src/shared/utils/timeLogic.test.js`
- [ ] `cd functions && node --test picksLockReminder.test.js showFinalizationGate.test.js`
- [ ] After prod web deploy: on tonight’s show as NEXT, confirm picks stay editable past 7:30 venue-local and lock at 7:55
- [ ] War Room helper text shows 7:55
- [ ] Reminder job (if still firing) uses `7:55 PM` in payload


Made with [Cursor](https://cursor.com)