### PR TITLE
release: 1.22.3 — daily recap tense + invite share copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.22.3] — 2026-07-16
+
+### Fixed
+- **`tour_rankings_daily` night rank tense** — first paragraph uses past tense (`were ranked`) for prior-night global rank; tour paragraph stays present tense.
+- **Invite share nudge copy** — “Want to invite friends to join the community…” with Standings “invite friends” CTA guidance (service + marketing email blocks).
+- **Tour rankings canary preview** — passes `inviteBlockHtml` / header / CTA into the branded shell so previews match production share cards.
+
+---
+
 ## [1.22.2] — 2026-07-16
 
 ### Fixed

--- a/emails/src/components/InviteShareBlock.jsx
+++ b/emails/src/components/InviteShareBlock.jsx
@@ -28,7 +28,7 @@ const softLinkStyle = {
 };
 
 const INVITE_NUDGE_INTRO =
-  "Want to share with friends? Log in and tap Share on Standings — your invite link is ready there.";
+  'Want to invite friends to join the community? Log in and tap "invite friends" on the standings page to create a personal invite link.';
 
 const INVITE_NUDGE_FORWARD = "Or forward this email to a friend.";
 

--- a/functions/comms/inviteShareBlock.cjs
+++ b/functions/comms/inviteShareBlock.cjs
@@ -15,7 +15,7 @@ function escapeHtml(str) {
 const DEFAULT_INVITE_CTA = 'Open Standings to share →';
 
 const INVITE_NUDGE_INTRO =
-  "Want to share with friends? Log in and tap Share on Standings — your invite link is ready there.";
+  'Want to invite friends to join the community? Log in and tap "invite friends" on the standings page to create a personal invite link.';
 
 const INVITE_NUDGE_FORWARD = 'Or forward this email to a friend.';
 

--- a/functions/commsEmailWorker.js
+++ b/functions/commsEmailWorker.js
@@ -145,7 +145,7 @@ const MANAGE_PREFS_LINE_RE = /^manage which updates you get in notifications set
 const LEGACY_BRAND_SIGNOFF_RE = /^—\s*setlist pick'?em\.?$/i;
 /** Invite appendix lives in plain-text + HTML invite card — never the main body. */
 const INVITE_CREW_LINE_RE =
-  /^(invite your crew|share with friends|want to share with friends)\b/i;
+  /^(invite your crew|share with friends|want to share with friends|want to invite friends)\b/i;
 const INVITE_FORWARD_LINE_RE = /^or forward this email\b/i;
 const INVITE_SHARE_MSG_LINE_RE =
   /\binvites you to join\b|^you'?re invited to join setlist\b/i;

--- a/functions/commsEmailWorker.test.js
+++ b/functions/commsEmailWorker.test.js
@@ -403,14 +403,14 @@ test("buildBrandedEmailHtml strips invite appendix lines from HTML body", () => 
   const html = buildBrandedEmailHtml({
     siteUrl: "https://www.setlistpickem.com",
     bodyText:
-      "Recap paragraph.\n\nOpen the app: https://www.setlistpickem.com/dashboard/picks\n\nSee you on tour!\n\nWant to share with friends? Log in and tap Share on Standings — your invite link is ready there.\nOr forward this email to a friend.\n\nOpen Standings: https://www.setlistpickem.com/dashboard/standings?utm_source=email",
+      'Recap paragraph.\n\nOpen the app: https://www.setlistpickem.com/dashboard/picks\n\nSee you on tour!\n\nWant to invite friends to join the community? Log in and tap "invite friends" on the standings page to create a personal invite link.\nOr forward this email to a friend.\n\nOpen Standings: https://www.setlistpickem.com/dashboard/standings?utm_source=email',
     ctaUrl: "https://www.setlistpickem.com/dashboard/picks",
     settingsUrl: "https://www.setlistpickem.com/dashboard/profile/notifications",
     signOff: "See you on tour!",
     inviteBlockHtml: "<div>invite card</div>",
   });
   assert.match(html, /Recap paragraph\./);
-  assert.doesNotMatch(html, /Want to share with friends/);
+  assert.doesNotMatch(html, /Want to invite friends to join the community/);
   assert.doesNotMatch(html, /forward this email/);
   assert.doesNotMatch(html, /Open Standings:/);
   assert.doesNotMatch(html, /utm_source=email/);

--- a/functions/commsTemplates.js
+++ b/functions/commsTemplates.js
@@ -32,13 +32,17 @@ function handleOf(p) {
 
 /**
  * Readable night scorecard sentence (words around variables, not a comma list).
- * e.g. "You scored 70 points and are now ranked #4 of 200 globally, with 3 of 6 picks hitting."
+ * e.g. present: "You scored 70 points and are now ranked #4 of 200 globally, with 3 of 6 picks hitting."
+ * e.g. past (morning daily): "…and were ranked #4 of 200 globally…" — night rank is prior night.
  *
  * @param {Record<string, unknown>} p
- * @param {{ rankScope?: string }} [opts]
+ * @param {{ rankScope?: string, rankTense?: "present" | "past" }} [opts]
  * @returns {string} Full sentence including trailing period, or "" if nothing to say.
  */
-function buildShowScorecardSentence(p, { rankScope = "globally" } = {}) {
+function buildShowScorecardSentence(
+  p,
+  { rankScope = "globally", rankTense = "present" } = {}
+) {
   /** @type {string[]} */
   const lead = [];
   if (p.show_score != null) {
@@ -47,7 +51,13 @@ function buildShowScorecardSentence(p, { rankScope = "globally" } = {}) {
   if (p.global_rank != null) {
     const of =
       p.global_total_pickers != null ? ` of ${p.global_total_pickers}` : "";
-    lead.push(`are now ranked #${p.global_rank}${of} ${rankScope}`);
+    // Morning `tour_rankings_daily` looks back at last night → past tense.
+    // Night-of `show_recap` keeps present ("are now ranked").
+    lead.push(
+      rankTense === "past"
+        ? `were ranked #${p.global_rank}${of} ${rankScope}`
+        : `are now ranked #${p.global_rank}${of} ${rankScope}`
+    );
   }
 
   let sentence = "";
@@ -335,7 +345,10 @@ const BUILDERS = {
     const nightPara = [
       `${handle}, here's how last night at ${venue} went.`,
       narrative,
-      buildShowScorecardSentence(p, { rankScope: "globally" }),
+      buildShowScorecardSentence(p, {
+        rankScope: "globally",
+        rankTense: "past",
+      }),
     ]
       .filter(Boolean)
       .join(" ");

--- a/functions/commsTemplates.test.js
+++ b/functions/commsTemplates.test.js
@@ -101,14 +101,14 @@ test("tour-rankings-daily email folds in show_recap's night-of content (#451)", 
   assert.match(out.email.text, /climbed 2 spots/, "rank change rendered as climbed");
   assert.match(out.email.text, /2026-07-19/, "next show date");
   assert.match(out.push.body, /up 2/, "push keeps catalog rank_change token");
-  assert.match(out.email.text, /Want to share with friends/);
+  assert.match(out.email.text, /Want to invite friends to join the community/);
   assert.match(out.email.text, /forward this email to a friend/i);
   assert.match(out.email.text, /Open Standings:/);
   assert.match(out.email.text, /\/dashboard\/standings/);
   // Prose night + tour paragraphs (words around variables).
   assert.match(
     out.email.text,
-    /You scored 70 points and are now ranked #4 of 200 globally, with 3 of 6 picks hitting/,
+    /You scored 70 points and were ranked #4 of 200 globally, with 3 of 6 picks hitting/,
   );
   assert.match(out.email.text, /Still in the top 5 — ranked #3 of 50 with 210 points/);
   assert.equal(out.email.header?.eyebrow, "Tour standings");
@@ -122,7 +122,8 @@ test("tour-rankings-daily email folds in show_recap's night-of content (#451)", 
     "tour paragraph should not re-greet with handle",
   );
   assert.ok(out.email.inviteBlockHtml, "invite HTML block");
-  assert.match(out.email.inviteBlockHtml, /Want to share with friends/);
+  assert.match(out.email.inviteBlockHtml, /Want to invite friends to join the community/);
+  assert.match(out.email.inviteBlockHtml, /tap &quot;invite friends&quot;/);
   assert.match(out.email.inviteBlockHtml, /forward this email to a friend/i);
   assert.match(out.email.inviteBlockHtml, /Open Standings to share/);
   assert.match(out.email.inviteBlockHtml, /#2563eb/, "secondary standings link color");

--- a/functions/marketingCommsTemplates.test.js
+++ b/functions/marketingCommsTemplates.test.js
@@ -22,7 +22,7 @@ test("buildSummerTour2026LaunchChannels returns html, text, and subject", async 
 
   assert.match(out.email.subject, /bring your crew/i);
   assert.match(out.email.html, /Rivertranced/);
-  assert.match(out.email.html, /Want to share with friends/);
+  assert.match(out.email.html, /Want to invite friends to join the community/);
   assert.match(out.email.html, /forward this email to a friend/i);
   assert.match(out.email.html, /Open Standings to share/);
   assert.match(out.email.html, /\/dashboard\/standings/);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.22.2",
+  "version": "1.22.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/canary-tour-rankings-preview.mjs
+++ b/scripts/canary-tour-rankings-preview.mjs
@@ -253,13 +253,18 @@ for (const branch of BRANCHES) {
   const shell = buildProductionBrandedEmailShell({
     siteUrl,
     bodyText: rendered.email.text,
-    ctaUrl: buildEmailTrackedCtaUrl(rendered.email.ctaUrl || `${siteUrl}/dashboard/standings`, {
+    ctaUrl: buildEmailTrackedCtaUrl(rendered.email.ctaUrl || `${siteUrl}/dashboard/picks`, {
       triggerId: 'tour_rankings_daily',
       templateId: 'tour-rankings-daily',
-      cta: 'See standings',
+      cta: rendered.email.ctaLabel || 'Make picks for next show',
     }),
     settingsUrl,
+    ctaLabel: rendered.email.ctaLabel,
     signOff: rendered.email.signOff,
+    // Production worker passes this; without it the share appendix is stripped
+    // from HTML and the invite card never appears in the preview.
+    inviteBlockHtml: rendered.email.inviteBlockHtml,
+    header: rendered.email.header,
   });
 
   const subject = `[#544 ${branch.name}] ${rendered.email.subject}`;


### PR DESCRIPTION
## Summary
Promote **1.22.3** to `main` (cherry-picked from #607; excludes staging-only Standings sticky chrome):
- Past-tense night rank in `tour_rankings_daily`
- Updated invite share nudge copy
- Canary preview passes `inviteBlockHtml`

Closes the staging train item from #607.

## Test plan
- [x] #607 green on staging (`verify`, `functions`, Vercel)
- [ ] Main CI green
- [ ] Tag `v1.22.3` after merge; Functions deploy by operator


Made with [Cursor](https://cursor.com)