### PR TITLE
fix(comms): dedupe tour rankings place copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.23.1] — 2026-07-16
+
+### Fixed
+- **`tour_rankings_daily` venue/location dedupe (#584)** — recap emails now use a non-location-led subject, name the show location once in the body, use “last night’s show” for the tour movement paragraph, and render same-venue next shows as “Back at …” instead of repeating the full next-up line. In-app preview copy mirrors the shared contract.
+
+---
+
 ## [1.23.0] — 2026-07-16
 
 ### Added

--- a/functions/commsTemplates.js
+++ b/functions/commsTemplates.js
@@ -336,7 +336,7 @@ const BUILDERS = {
 
   "tour-rankings-daily": (p) => {
     const handle = handleOf(p);
-    const venue = p.venue_name || p.venue_city || "the show";
+    const venue = venueLine(p) || "the show";
     const narrative =
       (typeof p.narrative_line === "string" && p.narrative_line.trim()) ||
       (typeof p.setlist_highlight === "string" && p.setlist_highlight.trim()) ||
@@ -387,9 +387,7 @@ const BUILDERS = {
         }${p.rank_change ? ` (${p.rank_change})` : ""}.`,
       },
       email: {
-        subject: p.venue_city
-          ? `Your ${p.venue_city} recap + tour update`
-          : "Your show recap + tour standings",
+        subject: "Your show recap + tour standings",
         text: emailText,
         signOff: assembled.signOff,
         ctaUrl: PICKS_CTA_URL,

--- a/functions/commsTemplates.test.js
+++ b/functions/commsTemplates.test.js
@@ -137,6 +137,32 @@ test("tour-rankings-daily email folds in show_recap's night-of content (#451)", 
   );
 });
 
+test("tour-rankings-daily email dedupes venue/location and same-venue next up (#584)", async () => {
+  const out = await renderCommsTemplate("tour-rankings-daily", {
+    handle: "RiverTranced",
+    show_date: "2026-07-19",
+    venue_name: "MSG",
+    venue_city: "New York, NY",
+    show_score: 70,
+    global_rank: 4,
+    global_total_pickers: 200,
+    tour_rank: 3,
+    total_tour_pickers: 50,
+    tour_points: 210,
+    rank_change: "up 2",
+    next_show_date: "2026-07-20",
+    next_show_venue: "MSG",
+  });
+
+  assert.equal(out.email.subject, "Your show recap + tour standings");
+  assert.match(out.email.text, /last night at 2026-07-19 — MSG, New York, NY went/);
+  assert.match(out.email.text, /After last night's show you climbed 2 spots\./);
+  assert.match(out.email.text, /Back at MSG 2026-07-20\./);
+  assert.equal((out.email.text.match(/New York, NY/g) || []).length, 1);
+  assert.doesNotMatch(out.email.text, /After New York, NY/);
+  assert.doesNotMatch(out.email.text, /Next up: 2026-07-20 — MSG/);
+});
+
 test("tour-countdown email uses picks CTA and avoids duplicate city in venue line", async () => {
   const out = await renderCommsTemplate("tour-countdown", {
     handle: "ArmenianMan",

--- a/functions/tourRankingsDailyCore.js
+++ b/functions/tourRankingsDailyCore.js
@@ -212,6 +212,51 @@ function tourTier(rankChange, tourRank) {
 }
 
 /**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function cleanText(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * @param {string} venue
+ * @param {string} city
+ * @returns {string}
+ */
+function appendCityIfNeeded(venue, city) {
+  if (!city) return venue;
+  if (!venue) return city;
+  if (venue.toLowerCase().includes(city.toLowerCase())) return venue;
+  return `${venue}, ${city}`;
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function normalizePlace(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+/**
+ * @param {string} nextVenue
+ * @param {string[]} currentLabels
+ * @returns {boolean}
+ */
+function isSamePlace(nextVenue, currentLabels) {
+  const next = normalizePlace(nextVenue);
+  if (!next) return false;
+  return currentLabels.some((label) => {
+    const current = normalizePlace(label);
+    return current && (current === next || current.includes(next) || next.includes(current));
+  });
+}
+
+/**
  * Build payload fields for one recipient of `tour_rankings_daily`.
  *
  * @param {{
@@ -286,17 +331,15 @@ function buildTourRankingsDailyParagraphs(p, opts = {}) {
   const handle =
     typeof p.handle === "string" && p.handle.trim() ? p.handle.trim() : "Picker";
   const omitHandle = opts.omitHandle === true;
-  const city =
-    (typeof p.venue_city === "string" && p.venue_city.trim()) ||
-    (typeof p.venue_name === "string" && p.venue_name.trim()) ||
-    "last night";
-  const place =
-    typeof p.venue_name === "string" && p.venue_name.trim()
-      ? p.venue_name.trim()
-      : city;
-  const date =
-    typeof p.show_date === "string" && p.show_date.trim() ? p.show_date.trim() : "";
+  const venue = cleanText(p.venue_name);
+  const city = cleanText(p.venue_city);
+  const place = appendCityIfNeeded(venue, city) || "last night";
+  const standaloneShowRef = place;
+  const combinedShowRef = "last night's show";
+  const paragraphShowRef = omitHandle ? combinedShowRef : standaloneShowRef;
+  const date = cleanText(p.show_date);
   const showLabel = date ? `${date} — ${place}` : place;
+  const paragraphShowLabel = omitHandle ? combinedShowRef : showLabel;
 
   const tourRank = p.tour_rank != null ? Number(p.tour_rank) : null;
   const total = p.total_tour_pickers != null ? Number(p.total_tour_pickers) : null;
@@ -322,7 +365,7 @@ function buildTourRankingsDailyParagraphs(p, opts = {}) {
     paras.push(`You're on the board!`);
     paras.push(
       omitHandle
-        ? `After ${showLabel} ${tourStanding}.`
+        ? `After ${paragraphShowLabel} ${tourStanding}.`
         : `${handle}, after ${showLabel} ${tourStanding}.`,
     );
     paras.push(
@@ -338,13 +381,13 @@ function buildTourRankingsDailyParagraphs(p, opts = {}) {
     const lateLead = omitHandle
       ? `Welcome aboard — ${
           showRank
-            ? `you finished ${showRank} last night at ${city}`
-            : `after ${city}`
+            ? `you finished ${showRank} last night`
+            : `after ${paragraphShowRef}`
         }, and ${tourStanding}.`
       : `${handle}, welcome aboard — ${
           showRank
-            ? `you finished ${showRank} last night at ${city}`
-            : `after ${city}`
+            ? `you finished ${showRank} last night at ${paragraphShowRef}`
+            : `after ${paragraphShowRef}`
         }, and ${tourStanding}.`;
     paras.push(lateLead);
     paras.push("There is still time to catch up — every show counts.");
@@ -366,14 +409,14 @@ function buildTourRankingsDailyParagraphs(p, opts = {}) {
     if (movement) {
       paras.push(
         omitHandle
-          ? `After ${city} you ${movement}.`
-          : `${handle}, after ${city} you ${movement}.`,
+          ? `After ${paragraphShowRef} you ${movement}.`
+          : `${handle}, after ${paragraphShowRef} you ${movement}.`,
       );
     } else {
       paras.push(
         omitHandle
-          ? `After ${city} ${tourStanding}.`
-          : `${handle}, after ${city} ${tourStanding}.`,
+          ? `After ${paragraphShowRef} ${tourStanding}.`
+          : `${handle}, after ${paragraphShowRef} ${tourStanding}.`,
       );
     }
 
@@ -402,16 +445,22 @@ function buildTourRankingsDailyParagraphs(p, opts = {}) {
   }
 
   if (p.next_show_date || p.next_show_venue) {
-    const nextVenue =
-      typeof p.next_show_venue === "string" ? p.next_show_venue.trim() : "";
-    const nextDate =
-      typeof p.next_show_date === "string" ? p.next_show_date.trim() : "";
+    const nextVenue = cleanText(p.next_show_venue);
+    const nextDate = cleanText(p.next_show_date);
+    const samePlace = isSamePlace(
+      nextVenue,
+      [venue, city, place].filter(Boolean),
+    );
     paras.push(
-      nextDate && nextVenue
-        ? `Next up: ${nextDate} — ${nextVenue}.`
-        : nextVenue
-          ? `Next up: ${nextVenue}.`
-          : `Next up: ${nextDate}.`,
+      samePlace && nextDate && nextVenue
+        ? `Back at ${nextVenue} ${nextDate}.`
+        : samePlace && nextVenue
+          ? `Back at ${nextVenue}.`
+          : nextDate && nextVenue
+            ? `Next up: ${nextDate} — ${nextVenue}.`
+            : nextVenue
+              ? `Next up: ${nextVenue}.`
+              : `Next up: ${nextDate}.`,
     );
   } else {
     paras.push("Keep your streak going on the next show.");

--- a/functions/tourRankingsDailyCore.test.js
+++ b/functions/tourRankingsDailyCore.test.js
@@ -240,3 +240,27 @@ test("copy: tied at display rank", () => {
   assert.match(paras.join(" "), /tied for #1/);
   assert.match(paras.join(" "), /leading the tour with 80 points/);
 });
+
+test("copy: combined email prose avoids repeating venue/city and uses same-venue next-up", () => {
+  const paras = buildTourRankingsDailyParagraphs(
+    {
+      handle: "RiverTranced",
+      show_date: "2026-07-19",
+      venue_name: "MSG",
+      venue_city: "New York, NY",
+      tour_rank: 3,
+      total_tour_pickers: 50,
+      tour_points: 210,
+      rank_change: "up 2",
+      next_show_date: "2026-07-20",
+      next_show_venue: "MSG",
+    },
+    { omitHandle: true },
+  );
+
+  const text = paras.join(" ");
+  assert.match(text, /After last night's show you climbed 2 spots\./);
+  assert.match(text, /Back at MSG 2026-07-20\./);
+  assert.doesNotMatch(text, /After New York, NY/);
+  assert.doesNotMatch(text, /2026-07-19 — MSG/);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setlistpickem",
-  "version": "1.18.1",
+  "version": "1.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setlistpickem",
-      "version": "1.18.1",
+      "version": "1.23.1",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "firebase": "10.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.23.0",
+  "version": "1.23.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/notifications/model/tourRankingsDailyCopy.js
+++ b/src/features/notifications/model/tourRankingsDailyCopy.js
@@ -4,25 +4,67 @@
  * Keep in sync with `functions/tourRankingsDailyCore.js` →
  * `buildTourRankingsDailyParagraphs` (functions cannot import this ESM module).
  *
+ * @param {unknown} value
+ * @returns {string}
+ */
+function cleanText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+/**
+ * @param {string} venue
+ * @param {string} city
+ * @returns {string}
+ */
+function appendCityIfNeeded(venue, city) {
+  if (!city) return venue;
+  if (!venue) return city;
+  if (venue.toLowerCase().includes(city.toLowerCase())) return venue;
+  return `${venue}, ${city}`;
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function normalizePlace(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+/**
+ * @param {string} nextVenue
+ * @param {string[]} currentLabels
+ * @returns {boolean}
+ */
+function isSamePlace(nextVenue, currentLabels) {
+  const next = normalizePlace(nextVenue);
+  if (!next) return false;
+  return currentLabels.some((label) => {
+    const current = normalizePlace(label);
+    return current && (current === next || current.includes(next) || next.includes(current));
+  });
+}
+
+/**
  * @param {Record<string, unknown>} p
  * @param {{ omitHandle?: boolean }} [opts]
  * @returns {string[]}
  */
 export function buildTourRankingsDailyParagraphs(p, opts = {}) {
-  const handle =
-    typeof p.handle === 'string' && p.handle.trim() ? p.handle.trim() : 'Picker';
+  const handle = cleanText(p.handle) || 'Picker';
   const omitHandle = opts.omitHandle === true;
-  const city =
-    (typeof p.venue_city === 'string' && p.venue_city.trim()) ||
-    (typeof p.venue_name === 'string' && p.venue_name.trim()) ||
-    'last night';
-  const place =
-    typeof p.venue_name === 'string' && p.venue_name.trim()
-      ? p.venue_name.trim()
-      : city;
-  const date =
-    typeof p.show_date === 'string' && p.show_date.trim() ? p.show_date.trim() : '';
+  const venue = cleanText(p.venue_name);
+  const city = cleanText(p.venue_city);
+  const place = appendCityIfNeeded(venue, city) || 'last night';
+  const standaloneShowRef = place;
+  const combinedShowRef = "last night's show";
+  const paragraphShowRef = omitHandle ? combinedShowRef : standaloneShowRef;
+  const date = cleanText(p.show_date);
   const showLabel = date ? `${date} — ${place}` : place;
+  const paragraphShowLabel = omitHandle ? combinedShowRef : showLabel;
 
   const tourRank = p.tour_rank != null ? Number(p.tour_rank) : null;
   const total = p.total_tour_pickers != null ? Number(p.total_tour_pickers) : null;
@@ -48,7 +90,7 @@ export function buildTourRankingsDailyParagraphs(p, opts = {}) {
     paras.push(`You're on the board!`);
     paras.push(
       omitHandle
-        ? `After ${showLabel} ${tourStanding}.`
+        ? `After ${paragraphShowLabel} ${tourStanding}.`
         : `${handle}, after ${showLabel} ${tourStanding}.`
     );
     paras.push(
@@ -64,13 +106,13 @@ export function buildTourRankingsDailyParagraphs(p, opts = {}) {
     const lateLead = omitHandle
       ? `Welcome aboard — ${
           showRank
-            ? `you finished ${showRank} last night at ${city}`
-            : `after ${city}`
+            ? `you finished ${showRank} last night`
+            : `after ${paragraphShowRef}`
         }, and ${tourStanding}.`
       : `${handle}, welcome aboard — ${
           showRank
-            ? `you finished ${showRank} last night at ${city}`
-            : `after ${city}`
+            ? `you finished ${showRank} last night at ${paragraphShowRef}`
+            : `after ${paragraphShowRef}`
         }, and ${tourStanding}.`;
     paras.push(lateLead);
     paras.push('There is still time to catch up — every show counts.');
@@ -92,14 +134,14 @@ export function buildTourRankingsDailyParagraphs(p, opts = {}) {
     if (movement) {
       paras.push(
         omitHandle
-          ? `After ${city} you ${movement}.`
-          : `${handle}, after ${city} you ${movement}.`
+          ? `After ${paragraphShowRef} you ${movement}.`
+          : `${handle}, after ${paragraphShowRef} you ${movement}.`
       );
     } else {
       paras.push(
         omitHandle
-          ? `After ${city} ${tourStanding}.`
-          : `${handle}, after ${city} ${tourStanding}.`
+          ? `After ${paragraphShowRef} ${tourStanding}.`
+          : `${handle}, after ${paragraphShowRef} ${tourStanding}.`
       );
     }
 
@@ -128,16 +170,19 @@ export function buildTourRankingsDailyParagraphs(p, opts = {}) {
   }
 
   if (p.next_show_date || p.next_show_venue) {
-    const nextVenue =
-      typeof p.next_show_venue === 'string' ? p.next_show_venue.trim() : '';
-    const nextDate =
-      typeof p.next_show_date === 'string' ? p.next_show_date.trim() : '';
+    const nextVenue = cleanText(p.next_show_venue);
+    const nextDate = cleanText(p.next_show_date);
+    const samePlace = isSamePlace(nextVenue, [venue, city, place].filter(Boolean));
     paras.push(
-      nextDate && nextVenue
-        ? `Next up: ${nextDate} — ${nextVenue}.`
-        : nextVenue
-          ? `Next up: ${nextVenue}.`
-          : `Next up: ${nextDate}.`
+      samePlace && nextDate && nextVenue
+        ? `Back at ${nextVenue} ${nextDate}.`
+        : samePlace && nextVenue
+          ? `Back at ${nextVenue}.`
+          : nextDate && nextVenue
+            ? `Next up: ${nextDate} — ${nextVenue}.`
+            : nextVenue
+              ? `Next up: ${nextVenue}.`
+              : `Next up: ${nextDate}.`
     );
   } else {
     paras.push('Keep your streak going on the next show.');

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.test.js
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.test.js
@@ -6,6 +6,7 @@ import {
   listCommsTemplateIds,
   triggerIdForTemplate,
 } from './commsTemplateRegistry.jsx';
+import { buildTourRankingsDailyParagraphs } from '../../model/tourRankingsDailyCopy';
 
 const EXPECTED_TEMPLATE_IDS = [
   'account-welcome',
@@ -123,6 +124,30 @@ describe('comms template registry', () => {
     expect(getCommsTemplateEntry('picks-confirmed').build({}).cta.href).toBe(
       '/dashboard/picks',
     );
+  });
+
+  it('tour rankings preview dedupes combined-copy place labels (#584)', () => {
+    const paragraphs = buildTourRankingsDailyParagraphs(
+      {
+        handle: 'RiverTranced',
+        show_date: '2026-07-19',
+        venue_name: 'MSG',
+        venue_city: 'New York, NY',
+        tour_rank: 3,
+        total_tour_pickers: 50,
+        tour_points: 210,
+        rank_change: 'up 2',
+        next_show_date: '2026-07-20',
+        next_show_venue: 'MSG',
+      },
+      { omitHandle: true }
+    );
+    const text = paragraphs.join(' ');
+
+    expect(text).toContain("After last night's show you climbed 2 spots.");
+    expect(text).toContain('Back at MSG 2026-07-20.');
+    expect(text).not.toContain('After New York, NY');
+    expect(text).not.toContain('Next up: 2026-07-20 — MSG');
   });
 
   it('maps templateId → catalog triggerId', () => {


### PR DESCRIPTION
Closes #584

## Summary
- Dedupe `tour_rankings_daily` place copy by making email subjects non-location-led and using the full venue/city label once in the night recap body.
- Updates shared tour-ranking paragraph copy so combined email prose says “last night's show” instead of repeating the city, while same-venue next shows render as “Back at …”.
- Mirrors the frontend in-app preview helper and bumps the app to `1.23.1` with a changelog entry.

## Test plan
- [x] `node --test functions/tourRankingsDailyCore.test.js functions/commsTemplates.test.js`
- [x] `npm test -- src/features/notifications/ui/commsTemplates/commsTemplateRegistry.test.js`
- [x] `npm run lint`
- [x] ReadLints reported no diagnostics for touched files.


Made with [Cursor](https://cursor.com)