### PR TITLE
feat(standings): badge bustouts on setlist rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.24.0] — 2026-07-16
+
+### Added
+- **Standings setlist bustout badges (#587 Phase A)** — official setlist rows now badge songs present in `official_setlists.bustouts`, using the existing scoring snapshot with no new listeners or schema changes.
+
+---
+
 ## [1.23.1] — 2026-07-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setlistpickem",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setlistpickem",
-      "version": "1.23.1",
+      "version": "1.24.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "firebase": "10.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.23.1",
+  "version": "1.24.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/scoring/model/groupOfficialSetlistBySet.js
+++ b/src/features/scoring/model/groupOfficialSetlistBySet.js
@@ -85,3 +85,37 @@ export function groupOfficialSetlistBySet(actualSetlist) {
 
   return { set1, set2, encore, hasSongs, hasOfficialSlots };
 }
+
+/**
+ * @param {unknown} title
+ * @returns {string}
+ */
+function normalizeOfficialTitle(title) {
+  return String(title ?? '')
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Builds the per-show bustout title lookup used by Standings setlist rows.
+ * `official_setlists.bustouts` is already the scoring source of truth; this
+ * helper only normalizes display matching.
+ *
+ * @param {null | Record<string, unknown>} actualSetlist
+ * @returns {Set<string>}
+ */
+export function buildBustoutTitleSet(actualSetlist) {
+  if (!actualSetlist || typeof actualSetlist !== 'object') return new Set();
+  if (!Array.isArray(actualSetlist.bustouts)) return new Set();
+  return new Set(actualSetlist.bustouts.map(normalizeOfficialTitle).filter(Boolean));
+}
+
+/**
+ * @param {unknown} title
+ * @param {Set<string>} bustoutTitleSet
+ * @returns {boolean}
+ */
+export function isOfficialSetlistBustout(title, bustoutTitleSet) {
+  if (!(bustoutTitleSet instanceof Set) || bustoutTitleSet.size === 0) return false;
+  return bustoutTitleSet.has(normalizeOfficialTitle(title));
+}

--- a/src/features/scoring/model/groupOfficialSetlistBySet.test.js
+++ b/src/features/scoring/model/groupOfficialSetlistBySet.test.js
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { groupOfficialSetlistBySet } from './groupOfficialSetlistBySet';
+import {
+  buildBustoutTitleSet,
+  groupOfficialSetlistBySet,
+  isOfficialSetlistBustout,
+} from './groupOfficialSetlistBySet';
 
 describe('groupOfficialSetlistBySet', () => {
   it('returns empty groups for null/invalid', () => {
@@ -84,5 +88,16 @@ describe('groupOfficialSetlistBySet', () => {
     });
     expect(grouped.hasSongs).toBe(false);
     expect(grouped.hasOfficialSlots).toBe(true);
+  });
+
+  it('builds a normalized bustout title lookup for setlist rows', () => {
+    const bustouts = buildBustoutTitleSet({
+      bustouts: [" Colonel Forbin's Ascent ", "FLUFF'S TRAVELS", ''],
+    });
+
+    expect(isOfficialSetlistBustout("colonel forbin's ascent", bustouts)).toBe(true);
+    expect(isOfficialSetlistBustout("Fluff's Travels", bustouts)).toBe(true);
+    expect(isOfficialSetlistBustout('Tweezer', bustouts)).toBe(false);
+    expect(isOfficialSetlistBustout('Tweezer', buildBustoutTitleSet(null))).toBe(false);
   });
 });

--- a/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
+++ b/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
@@ -3,7 +3,11 @@ import { ChevronDown, ExternalLink, ListMusic } from 'lucide-react';
 
 import Card from '../../../shared/ui/Card';
 import { buildPhishNetSetlistUrl } from '../model/buildPhishNetSetlistUrl';
-import { groupOfficialSetlistBySet } from '../model/groupOfficialSetlistBySet';
+import {
+  buildBustoutTitleSet,
+  groupOfficialSetlistBySet,
+  isOfficialSetlistBustout,
+} from '../model/groupOfficialSetlistBySet';
 import OfficialPickSlotsGrid from './OfficialPickSlotsGrid';
 import {
   STANDINGS_BOX_BODY,
@@ -12,7 +16,7 @@ import {
   STANDINGS_CARD_SHELL,
 } from './standingsSurfaceClasses';
 
-function SetSongList({ label, songs }) {
+function SetSongList({ label, songs, bustoutTitleSet }) {
   if (!songs.length) return null;
   return (
     <div>
@@ -20,17 +24,28 @@ function SetSongList({ label, songs }) {
         {label}
       </p>
       <ol className="space-y-1">
-        {songs.map((title, idx) => (
-          <li
-            key={`${label}-${idx}-${title}`}
-            className={`flex gap-2 ${STANDINGS_BOX_BODY} text-slate-100`}
-          >
-            <span className="w-5 shrink-0 tabular-nums text-content-secondary">
-              {idx + 1}.
-            </span>
-            <span className="min-w-0">{title}</span>
-          </li>
-        ))}
+        {songs.map((title, idx) => {
+          const isBustout = isOfficialSetlistBustout(title, bustoutTitleSet);
+          return (
+            <li
+              key={`${label}-${idx}-${title}`}
+              className={`flex items-start gap-2 ${STANDINGS_BOX_BODY} text-slate-100`}
+            >
+              <span className="w-5 shrink-0 tabular-nums text-content-secondary">
+                {idx + 1}.
+              </span>
+              <span className="min-w-0 flex-1">{title}</span>
+              {isBustout ? (
+                <span
+                  className="shrink-0 rounded-full border border-orange-300/40 bg-orange-400/15 px-1.5 py-0.5 text-[9px] font-black uppercase tracking-wide text-orange-100"
+                  title="Bustout Boost eligibility"
+                >
+                  Bustout
+                </span>
+              ) : null}
+            </li>
+          );
+        })}
       </ol>
     </div>
   );
@@ -55,6 +70,7 @@ export default function StandingsOfficialSetlistCard({
   className = '',
 }) {
   const grouped = groupOfficialSetlistBySet(actualSetlist);
+  const bustoutTitleSet = buildBustoutTitleSet(actualSetlist);
 
   if (!actualSetlist || (!grouped.hasSongs && !grouped.hasOfficialSlots)) {
     return null;
@@ -107,9 +123,21 @@ export default function StandingsOfficialSetlistCard({
         <div className="mt-4 space-y-5 border-t border-border-subtle pt-4">
           {grouped.hasSongs ? (
             <div className="space-y-4">
-              <SetSongList label="Set 1" songs={grouped.set1} />
-              <SetSongList label="Set 2" songs={grouped.set2} />
-              <SetSongList label="Encore" songs={grouped.encore} />
+              <SetSongList
+                label="Set 1"
+                songs={grouped.set1}
+                bustoutTitleSet={bustoutTitleSet}
+              />
+              <SetSongList
+                label="Set 2"
+                songs={grouped.set2}
+                bustoutTitleSet={bustoutTitleSet}
+              />
+              <SetSongList
+                label="Encore"
+                songs={grouped.encore}
+                bustoutTitleSet={bustoutTitleSet}
+              />
             </div>
           ) : (
             <p className={STANDINGS_BOX_BODY}>


### PR DESCRIPTION
Refs #587

## Summary
- Adds a Standings official setlist row badge for songs present in `actualSetlist.bustouts`.
- Keeps Phase A UI-only: no new Firestore listeners, schema fields, or scoring changes.
- Adds normalized bustout title matching tests and bumps the app to `1.24.0` with a changelog entry.

## Test plan
- [x] `npm test -- src/features/scoring/model/groupOfficialSetlistBySet.test.js`
- [x] `npm run lint`
- [x] ReadLints reported no diagnostics for touched files.

## Notes
- This intentionally does not close #587; Phase B per-song gap / last-played schema work remains.


Made with [Cursor](https://cursor.com)