### PR TITLE
feat(profile): show avg points per show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.24.1] — 2026-07-16
+
+### Added
+- **Profile avg points / show (#554 slice A)** — public profile stats strip derives average points per graded show from existing career totals (no extra Firestore reads).
+
+---
+
 ## [1.24.0] — 2026-07-16
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setlistpickem",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setlistpickem",
-      "version": "1.24.0",
+      "version": "1.24.1",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "firebase": "10.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.24.0",
+  "version": "1.24.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/profile/model/profileAverages.js
+++ b/src/features/profile/model/profileAverages.js
@@ -1,0 +1,33 @@
+/**
+ * Profile averages derived from existing season / career stats (#554).
+ * Avg points needs no extra Firestore reads — only totalPoints / shows.
+ */
+
+/**
+ * @param {{ totalPoints?: unknown, shows?: unknown } | null | undefined} stats
+ * @returns {number | null} Mean points per graded show, or null when undefined
+ */
+export function computeAvgPointsPerShow(stats) {
+  const totalPoints =
+    typeof stats?.totalPoints === 'number' && Number.isFinite(stats.totalPoints)
+      ? stats.totalPoints
+      : null;
+  const shows =
+    typeof stats?.shows === 'number' && Number.isFinite(stats.shows)
+      ? stats.shows
+      : null;
+  if (totalPoints == null || shows == null || shows <= 0) return null;
+  return totalPoints / shows;
+}
+
+/**
+ * Display helper — one decimal when needed, otherwise integer string.
+ *
+ * @param {number | null | undefined} avg
+ * @returns {string}
+ */
+export function formatAvgPointsPerShow(avg) {
+  if (typeof avg !== 'number' || !Number.isFinite(avg)) return '—';
+  const rounded = Math.round(avg * 10) / 10;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}

--- a/src/features/profile/model/profileAverages.test.js
+++ b/src/features/profile/model/profileAverages.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeAvgPointsPerShow,
+  formatAvgPointsPerShow,
+} from './profileAverages';
+
+describe('profileAverages', () => {
+  it('computes avg points per show from career totals', () => {
+    expect(computeAvgPointsPerShow({ totalPoints: 210, shows: 5 })).toBe(42);
+    expect(computeAvgPointsPerShow({ totalPoints: 100, shows: 3 })).toBeCloseTo(
+      100 / 3
+    );
+  });
+
+  it('returns null when shows are missing or zero', () => {
+    expect(computeAvgPointsPerShow({ totalPoints: 10, shows: 0 })).toBeNull();
+    expect(computeAvgPointsPerShow({ totalPoints: 10 })).toBeNull();
+    expect(computeAvgPointsPerShow(null)).toBeNull();
+  });
+
+  it('formats display with at most one decimal', () => {
+    expect(formatAvgPointsPerShow(42)).toBe('42');
+    expect(formatAvgPointsPerShow(100 / 3)).toBe('33.3');
+    expect(formatAvgPointsPerShow(null)).toBe('—');
+  });
+});

--- a/src/features/profile/ui/PublicProfileView.jsx
+++ b/src/features/profile/ui/PublicProfileView.jsx
@@ -3,6 +3,10 @@ import { Loader2 } from 'lucide-react';
 
 import { formatMonthYear } from '../../../shared';
 import BackButton from '../../../shared/ui/BackButton';
+import {
+  computeAvgPointsPerShow,
+  formatAvgPointsPerShow,
+} from '../model/profileAverages';
 
 function formatPlayingSince(createdAt) {
   const value = formatMonthYear(createdAt);
@@ -36,9 +40,13 @@ export default function PublicProfileView({
     typeof stats?.totalPoints === 'number' ? stats.totalPoints : 0;
   const wins = typeof stats?.wins === 'number' ? stats.wins : 0;
   const shows = typeof stats?.shows === 'number' ? stats.shows : 0;
+  const avgPointsDisplay = formatAvgPointsPerShow(
+    computeAvgPointsPerShow(stats)
+  );
 
   const statColumns = [
     { key: 'points', label: 'Total points', value: totalPoints },
+    { key: 'avg', label: 'Avg / show', value: avgPointsDisplay },
     { key: 'wins', label: 'Wins', value: wins },
     { key: 'shows', label: 'Shows', value: shows },
   ];
@@ -92,7 +100,7 @@ export default function PublicProfileView({
           <h2 className="mb-4 text-xs font-black uppercase tracking-widest text-content-secondary">
             Stats
           </h2>
-          <div className="grid grid-cols-3 gap-x-3 gap-y-1.5 text-center">
+          <div className="grid grid-cols-2 gap-x-3 gap-y-1.5 text-center sm:grid-cols-4">
             {statColumns.map(({ key, label }) => (
               <p
                 key={`${key}-label`}
@@ -120,8 +128,9 @@ export default function PublicProfileView({
             ))}
           </div>
           <p className="mt-3 text-[11px] font-medium leading-relaxed text-content-secondary">
-            Running totals across every graded night. Wins count shows where
-            this player had the top score overall, not just in a single pool.
+            Running totals across every graded night. Avg / show is total
+            points divided by shows played. Wins count nights with the overall
+            top score, not just in a single pool.
           </p>
         </section>
       </div>


### PR DESCRIPTION
Refs #554

## Summary
- Adds `computeAvgPointsPerShow` / `formatAvgPointsPerShow` derived from existing career `totalPoints` and `shows` (zero extra Firestore reads).
- Surfaces **Avg / show** on the public profile stats strip (2×2 mobile / 4-col desktop).
- Bumps to **1.24.1** with changelog. Avg correct + vintage remain for later #554 slices per `docs/profile/PROFILE_STATS_SPRINT9.md` (#617).

## Test plan
- [x] `npm test -- src/features/profile/model/profileAverages.test.js`
- [x] `npm run lint`
- [ ] On PR preview: open a public `/user/:uid` with graded shows and confirm Avg / show ≈ total ÷ shows


Made with [Cursor](https://cursor.com)