### PR TITLE
feat(catalog): publish song debut for avg vintage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.25.0] — 2026-07-16
+
+### Added
+- **Song catalog `debut` field (#554 slice B)** — `song-catalog.json` rows now include Phish.net `debut` (string, empty when unknown). Profile avg-vintage helpers join pick titles to catalog debut years in memory; UI surfaces when pick titles are available (slice C / heatmap).
+
+---
+
 ## [1.24.1] — 2026-07-16
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.22.0  
+**Version:** 1.25.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 
@@ -230,6 +230,8 @@ When `alreadyLocked` is `true`, the doc already carried `lockReason: admin_overr
 ### 2.3 `getPhishnetSetlist`, `scheduledPhishnetShowCalendar`, `refreshPhishnetShowCalendar`, `refreshLiveScoresForShow`, `scheduledPhishnetSongCatalog`, `refreshPhishnetSongCatalog`, `scheduledPhishnetLiveSetlistPoll`, `setLiveSetlistAutomationState`, `pollLiveSetlistNow`, `sendPushCanary`
 
 Phish.net integration and live scoring functions. Deployed via `npm run deploy:functions:phishnet`. Internal admin use — request/response shapes documented in `docs/PHISHNET_CALLABLE_RUNBOOK.md`.
+
+**Storage object `song-catalog.json` (v1.25.0+, #554):** published by `scheduledPhishnetSongCatalog` / `refreshPhishnetSongCatalog`. Each song object includes `{ name, total, gap, last, debut }` where `debut` is a string (typically `YYYY-MM-DD`) or `""` when unknown. See `docs/SONG_CATALOG.md`. Adding `debut` is a **MINOR** catalog-field addition (clients may ignore unknown fields).
 
 ### 2.4 Comms event adapters (v1.7.0+)
 

--- a/docs/RELEASE_TRAIN_SPRINT_9.md
+++ b/docs/RELEASE_TRAIN_SPRINT_9.md
@@ -149,4 +149,5 @@ Incomplete features must land dark, behind absent UX, flags, or forward-only fie
 | 2026-07-16 | Baseline | Fast-forward `staging` to `main` | `main` and `staging` aligned at `v1.23.0` |
 | 2026-07-16 | 0 | Manifest authored | Train defined; first PR targets `staging` |
 | 2026-07-16 | 0–1 | PRs #613–#616 merged | Manifest, #566 matrix, #584 place dedupe (1.23.1), #587 Phase A bustout badge (1.24.0); staging tip **1.24.0** |
-| 2026-07-16 | 2 | Kickoff | Profile stats foundation next: #554 averages + vintage source, then #553 heatmap |
+| 2026-07-16 | 2 | #617 + #618 merged | Foundation doc + avg points / show (1.24.1) |
+| 2026-07-16 | 2 | #554 slice B in flight | Catalog `debut` + avg vintage helpers (1.25.0); UI deferred until pick titles |

--- a/docs/SONG_CATALOG.md
+++ b/docs/SONG_CATALOG.md
@@ -7,7 +7,7 @@
 1. **Source of truth (live):** Phish.net API v5 `GET /v5/songs.json` (server-side only, `PHISHNET_API_KEY`).
 2. **Publish:** Cloud Functions write **`song-catalog.json`** to the **default Firebase Storage bucket** (`makePublic()` is best-effort; not required for the default client path).
 3. **Client URL:** By default the app uses **`getDownloadURL()`** (Firebase Storage SDK) for `song-catalog.json`. That respects **`storage.rules`** (`allow read: if true`) and avoids opening the whole bucket on **GCS IAM**. A raw browser URL like `https://storage.googleapis.com/<bucket>/song-catalog.json` **does not** use Firebase rules and returns **`AccessDenied`** for anonymous users unless you add **`allUsers` → Storage Object Viewer** on the bucket (usually avoid on buckets that hold private uploads). Override with **`VITE_SONG_CATALOG_URL`** only if you host the JSON elsewhere (CDN) with anonymous GET + CORS.
-4. **Fetch + cache:** `useSongCatalog` **`fetch()`**s the resolved URL. **localStorage** (`set-picks.songCatalogCache.v1`): if data was saved **within the last 3 days**, the hook **skips** both `getDownloadURL` and `fetch`. On failure, an **older cache** is used if present; otherwise **`src/shared/data/phishSongs.js`**.
+4. **Fetch + cache:** `useSongCatalog` **`fetch()`**s the resolved URL. **localStorage** (`set-picks.songCatalogCache.v2`): if data was saved **within the last 6 hours**, the hook **skips** both `getDownloadURL` and `fetch`. On failure, an **older cache** is used if present; otherwise **`src/shared/data/phishSongs.js`**.
 5. **Scoring does not read this catalog (post-#214).** `recomputeLiveScoresForShow` and `calculateSlotScore` in `functions/index.js` — and their client counterparts in `src/shared/utils/scoring.js` — read bustout membership from `actualSetlist.bustouts`. `functions/songCatalogSource.js` (5-minute TTL loader) is still present in-tree but is no longer threaded into grading; it can be removed in a follow-up once no code path imports it. The bundled catalogs (`src/shared/data/phishSongs.js`, `functions/phishSongs.js`) remain only as Storage-fallback seeds for `useSongCatalog` / the storage loader.
 
 ## Operations
@@ -43,9 +43,19 @@ Edit **`scripts/song-catalog-storage-cors.json`** if your web origin is not alre
 
 ```json
 {
-  "songs": [{ "name": "…", "total": "…", "gap": "…", "last": "…" }],
+  "songs": [{ "name": "…", "total": "…", "gap": "…", "last": "…", "debut": "…" }],
   "songCount": 975,
   "source": "phish.net/v5/songs",
   "updatedAt": "2026-04-09T12:00:00.000Z"
 }
 ```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | string | Song title (Phish.net `song`) |
+| `total` | string | Times played (`times_played`), or `—` |
+| `gap` | string | Shows since last play (`gap`), or `—` |
+| `last` | string | Last played date (`last_played`), or `—` |
+| `debut` | string | First performance date/year (`debut`), typically `YYYY-MM-DD`; **empty string** when unknown (v1.25.0+, #554). Do **not** treat `gap` / `last` as vintage. |
+
+Bundled fallbacks (`src/shared/data/phishSongs.js`, `functions/phishSongs.js`) may omit `debut` — treat missing as unknown when computing avg song vintage.

--- a/docs/profile/PROFILE_STATS_SPRINT9.md
+++ b/docs/profile/PROFILE_STATS_SPRINT9.md
@@ -102,9 +102,9 @@ Output: sorted by `pickedCount` desc, take top N.
 
 ## Implementation order (Wave 2)
 
-1. **This doc** (train kickoff).
-2. **#554 slice A:** Surface avg points on Profile + public profile (derive from existing stats) — PATCH.
-3. **#554 slice B:** Catalog `debut` field + avg vintage when pick titles available — MINOR.
+1. **This doc** (train kickoff) — merged (#617).
+2. **#554 slice A:** Surface avg points on Profile + public profile (derive from existing stats) — PATCH — merged (#618, 1.24.1).
+3. **#554 slice B:** Catalog `debut` field + avg vintage helpers — MINOR (1.25.0). UI when pick titles available (with slice C / #553).
 4. **#554 slice C:** Avg correct via rollup or bounded live compute — PATCH/MINOR per schema.
 5. **#553:** Top-picks strip UI behind self Profile first; public after rollup.
 

--- a/functions/phishnetSongCatalog.js
+++ b/functions/phishnetSongCatalog.js
@@ -29,8 +29,22 @@ function isPhishNetPayloadOk(data) {
 }
 
 /**
+ * Phish.net `debut` → catalog string (YYYY-MM-DD, year, or empty).
+ * @param {unknown} raw
+ * @returns {string}
+ */
+function normalizeDebutField(raw) {
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    const y = Math.trunc(raw);
+    return y >= 1900 && y <= 2100 ? String(y) : "";
+  }
+  if (typeof raw === "string" && raw.trim()) return raw.trim();
+  return "";
+}
+
+/**
  * @param {unknown} row
- * @returns {{ name: string, total: string, gap: string, last: string } | null}
+ * @returns {{ name: string, total: string, gap: string, last: string, debut: string } | null}
  */
 function normalizePhishnetSongRow(row) {
   if (!row || typeof row !== "object") return null;
@@ -56,12 +70,14 @@ function normalizePhishnetSongRow(row) {
   const last =
     typeof lastRaw === "string" && lastRaw.trim() ? lastRaw.trim() : "—";
 
-  return { name, total, gap, last };
+  const debut = normalizeDebutField(rec.debut);
+
+  return { name, total, gap, last, debut };
 }
 
 /**
  * @param {string} apiKey
- * @returns {Promise<{ name: string, total: string, gap: string, last: string }[]>}
+ * @returns {Promise<{ name: string, total: string, gap: string, last: string, debut: string }[]>}
  */
 async function fetchPhishnetSongsNormalized(apiKey) {
   const key = String(apiKey ?? "").trim();
@@ -186,6 +202,7 @@ async function syncPhishnetSongCatalogToStorage(apiKey, opts = {}) {
 module.exports = {
   syncPhishnetSongCatalogToStorage,
   normalizePhishnetSongRow,
+  normalizeDebutField,
   isPhishNetPayloadOk,
   CATALOG_STORAGE_PATH,
   publicGcsUrlForCatalog,

--- a/functions/phishnetSongCatalog.test.js
+++ b/functions/phishnetSongCatalog.test.js
@@ -16,13 +16,25 @@ test("normalizePhishnetSongRow maps v5 row", () => {
     times_played: 414,
     gap: 5,
     last_played: "2025-12-31",
+    debut: "1990-09-28",
   };
   assert.deepEqual(normalizePhishnetSongRow(row), {
     name: "Tweezer",
     total: "414",
     gap: "5",
     last: "2025-12-31",
+    debut: "1990-09-28",
   });
+});
+
+test("normalizePhishnetSongRow maps missing debut to empty string", () => {
+  const out = normalizePhishnetSongRow({
+    song: "Wilson",
+    times_played: 100,
+    gap: 1,
+    last_played: "2026-01-01",
+  });
+  assert.equal(out.debut, "");
 });
 
 test("normalizePhishnetSongRow returns null for empty song", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setlistpickem",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setlistpickem",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "firebase": "10.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.24.1",
+  "version": "1.25.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/profile/model/profileAverages.js
+++ b/src/features/profile/model/profileAverages.js
@@ -1,6 +1,8 @@
 /**
  * Profile averages derived from existing season / career stats (#554).
  * Avg points needs no extra Firestore reads — only totalPoints / shows.
+ * Avg vintage joins pick titles to catalog `debut` in memory (0 extra reads
+ * once titles + catalog are already loaded).
  */
 
 /**
@@ -30,4 +32,92 @@ export function formatAvgPointsPerShow(avg) {
   if (typeof avg !== 'number' || !Number.isFinite(avg)) return '—';
   const rounded = Math.round(avg * 10) / 10;
   return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}
+
+/**
+ * Parse catalog / Phish.net debut into a calendar year.
+ * Accepts `YYYY-MM-DD`, bare `YYYY`, or leading-year strings.
+ *
+ * @param {unknown} debut
+ * @returns {number | null}
+ */
+export function debutYearFromCatalogDebut(debut) {
+  if (typeof debut === 'number' && Number.isFinite(debut)) {
+    const y = Math.trunc(debut);
+    return y >= 1900 && y <= 2100 ? y : null;
+  }
+  if (typeof debut !== 'string' || !debut.trim()) return null;
+  const m = debut.trim().match(/^(\d{4})/);
+  if (!m) return null;
+  const y = Number(m[1]);
+  if (!Number.isFinite(y) || y < 1900 || y > 2100) return null;
+  return y;
+}
+
+/**
+ * @param {{ name?: unknown, debut?: unknown }[] | null | undefined} songs
+ * @returns {Map<string, number>} lowercased name → debut year
+ */
+export function buildDebutYearBySongName(songs) {
+  const map = new Map();
+  if (!Array.isArray(songs)) return map;
+  for (const song of songs) {
+    const name =
+      typeof song?.name === 'string' ? song.name.trim().toLowerCase() : '';
+    if (!name || map.has(name)) continue;
+    const year = debutYearFromCatalogDebut(song?.debut);
+    if (year != null) map.set(name, year);
+  }
+  return map;
+}
+
+/**
+ * Mean debut year across **unique** song titles (case-insensitive).
+ * Titles with unknown/missing debut are excluded from the mean.
+ *
+ * @param {Iterable<string> | null | undefined} songTitles
+ * @param {Map<string, number> | Record<string, number> | null | undefined} debutYearByName
+ * @returns {{ avgYear: number | null, datedCount: number, uniqueCount: number }}
+ */
+export function computeAvgSongVintage(songTitles, debutYearByName) {
+  const unique = new Set();
+  if (songTitles) {
+    for (const title of songTitles) {
+      if (typeof title !== 'string') continue;
+      const key = title.trim().toLowerCase();
+      if (key) unique.add(key);
+    }
+  }
+
+  const lookup =
+    debutYearByName instanceof Map
+      ? (k) => debutYearByName.get(k)
+      : debutYearByName && typeof debutYearByName === 'object'
+        ? (k) => debutYearByName[k]
+        : () => undefined;
+
+  let sum = 0;
+  let datedCount = 0;
+  for (const key of unique) {
+    const year = lookup(key);
+    if (typeof year === 'number' && Number.isFinite(year)) {
+      sum += year;
+      datedCount += 1;
+    }
+  }
+
+  return {
+    avgYear: datedCount > 0 ? sum / datedCount : null,
+    datedCount,
+    uniqueCount: unique.size,
+  };
+}
+
+/**
+ * @param {number | null | undefined} avgYear
+ * @returns {string}
+ */
+export function formatAvgSongVintage(avgYear) {
+  if (typeof avgYear !== 'number' || !Number.isFinite(avgYear)) return '—';
+  return String(Math.round(avgYear));
 }

--- a/src/features/profile/model/profileAverages.test.js
+++ b/src/features/profile/model/profileAverages.test.js
@@ -1,27 +1,74 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildDebutYearBySongName,
   computeAvgPointsPerShow,
+  computeAvgSongVintage,
+  debutYearFromCatalogDebut,
   formatAvgPointsPerShow,
+  formatAvgSongVintage,
 } from './profileAverages';
 
 describe('profileAverages', () => {
-  it('computes avg points per show from career totals', () => {
+  it('computes mean points per show', () => {
     expect(computeAvgPointsPerShow({ totalPoints: 210, shows: 5 })).toBe(42);
     expect(computeAvgPointsPerShow({ totalPoints: 100, shows: 3 })).toBeCloseTo(
-      100 / 3
+      33.333,
+      2,
     );
   });
 
-  it('returns null when shows are missing or zero', () => {
+  it('returns null when shows is missing or zero', () => {
     expect(computeAvgPointsPerShow({ totalPoints: 10, shows: 0 })).toBeNull();
     expect(computeAvgPointsPerShow({ totalPoints: 10 })).toBeNull();
-    expect(computeAvgPointsPerShow(null)).toBeNull();
   });
 
-  it('formats display with at most one decimal', () => {
+  it('formats avg points for display', () => {
     expect(formatAvgPointsPerShow(42)).toBe('42');
-    expect(formatAvgPointsPerShow(100 / 3)).toBe('33.3');
+    expect(formatAvgPointsPerShow(33.333)).toBe('33.3');
     expect(formatAvgPointsPerShow(null)).toBe('—');
+  });
+
+  it('parses debut years from catalog strings', () => {
+    expect(debutYearFromCatalogDebut('1990-09-28')).toBe(1990);
+    expect(debutYearFromCatalogDebut('1983')).toBe(1983);
+    expect(debutYearFromCatalogDebut('')).toBeNull();
+    expect(debutYearFromCatalogDebut('—')).toBeNull();
+    expect(debutYearFromCatalogDebut(1997)).toBe(1997);
+  });
+
+  it('builds a case-insensitive debut year map', () => {
+    const map = buildDebutYearBySongName([
+      { name: 'Tweezer', debut: '1990-09-28' },
+      { name: 'Wilson', debut: '' },
+      { name: 'Ghost', debut: '1997-06-13' },
+    ]);
+    expect(map.get('tweezer')).toBe(1990);
+    expect(map.has('wilson')).toBe(false);
+    expect(map.get('ghost')).toBe(1997);
+  });
+
+  it('averages vintage over unique dated titles only', () => {
+    const debuts = buildDebutYearBySongName([
+      { name: 'Tweezer', debut: '1990-09-28' },
+      { name: 'Ghost', debut: '1997-06-13' },
+    ]);
+    const result = computeAvgSongVintage(
+      ['Tweezer', 'tweezer', 'Ghost', 'Unknown Song'],
+      debuts,
+    );
+    expect(result.uniqueCount).toBe(3);
+    expect(result.datedCount).toBe(2);
+    expect(result.avgYear).toBeCloseTo((1990 + 1997) / 2, 5);
+    expect(formatAvgSongVintage(result.avgYear)).toBe('1994');
+  });
+
+  it('returns null avg when no titles are dated', () => {
+    expect(computeAvgSongVintage(['Foo'], new Map())).toEqual({
+      avgYear: null,
+      datedCount: 0,
+      uniqueCount: 1,
+    });
+    expect(formatAvgSongVintage(null)).toBe('—');
   });
 });

--- a/src/features/song-catalog/model/selectCatalogSongs.js
+++ b/src/features/song-catalog/model/selectCatalogSongs.js
@@ -3,7 +3,7 @@ import { PHISH_SONGS } from '../../../shared/data/phishSongs.js';
 /**
  * @param {unknown} remoteSongs
  * @param {{ name: string }[]} [fallbackSongs]
- * @returns {{ songs: { name: string, total?: string, gap?: string, last?: string }[], source: 'cdn' | 'fallback' }}
+ * @returns {{ songs: { name: string, total?: string, gap?: string, last?: string, debut?: string }[], source: 'cdn' | 'fallback' }}
  */
 export function selectCatalogSongs(remoteSongs, fallbackSongs = PHISH_SONGS) {
   if (Array.isArray(remoteSongs) && remoteSongs.length > 0) {

--- a/src/features/song-catalog/model/songCatalogConstants.js
+++ b/src/features/song-catalog/model/songCatalogConstants.js
@@ -1,5 +1,5 @@
 /** localStorage key for cached Phish.net-derived catalog JSON. */
-export const SONG_CATALOG_CACHE_KEY = 'set-picks.songCatalogCache.v1';
+export const SONG_CATALOG_CACHE_KEY = 'set-picks.songCatalogCache.v2';
 
 /**
  * Skip network if cache was written within this window (6 hours).

--- a/src/features/song-catalog/model/useSongCatalog.js
+++ b/src/features/song-catalog/model/useSongCatalog.js
@@ -8,18 +8,18 @@ import {
 import { resolveSongCatalogFetchUrl } from './songCatalogUrl.js';
 
 /**
- * @typedef {{ fetchedAt: number, songs: { name: string, total?: string, gap?: string, last?: string }[], updatedAt?: string }} CatalogCacheV1
+ * @typedef {{ fetchedAt: number, songs: { name: string, total?: string, gap?: string, last?: string, debut?: string }[], updatedAt?: string }} CatalogCacheV1
  */
 
 /**
  * @param {unknown} body
- * @returns {{ name: string, total?: string, gap?: string, last?: string }[] | null}
+ * @returns {{ name: string, total?: string, gap?: string, last?: string, debut?: string }[] | null}
  */
 function songsFromResponseBody(body) {
   if (!body || typeof body !== 'object') return null;
   const songs = /** @type {Record<string, unknown>} */ (body).songs;
   if (!Array.isArray(songs) || songs.length === 0) return null;
-  return /** @type {{ name: string, total?: string, gap?: string, last?: string }[]} */ (
+  return /** @type {{ name: string, total?: string, gap?: string, last?: string, debut?: string }[]} */ (
     songs
   );
 }
@@ -64,7 +64,7 @@ function writeCatalogCache(entry) {
  * Falls back to bundled `PHISH_SONGS` when unavailable.
  *
  * @returns {{
- *   songs: { name: string, total?: string, gap?: string, last?: string }[],
+ *   songs: { name: string, total?: string, gap?: string, last?: string, debut?: string }[],
  *   source: 'cdn' | 'fallback',
  *   loadError: Error | null,
  *   isLoading: boolean,


### PR DESCRIPTION
Part of #554

## Summary
- Publish Phish.net `debut` on each `song-catalog.json` row (empty string when unknown) — MINOR catalog field.
- Add `computeAvgSongVintage` / debut-year helpers for when pick titles are available (UI deferred until slice C / #553 titles path).
- Document payload in `docs/SONG_CATALOG.md` + `docs/API.md`; bump to **1.25.0**; invalidate client catalog cache key → `v2`.

## Test plan
- [ ] `cd functions && node --test phishnetSongCatalog.test.js`
- [ ] `npm test` / `npm run lint`
- [ ] After functions deploy: Admin → Refresh song catalog; confirm a row includes `debut`
- [ ] Confirm autocomplete still works (cache miss → fresh catalog)
- [ ] Confirm public profile still shows Avg / show (unchanged UI this PR)


Made with [Cursor](https://cursor.com)