### PR TITLE
feat(profile): avg correct rollup + self top-picks strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.26.0] — 2026-07-16
+
+### Added
+- **Profile avg correct / show (#554 slice C)** — `rollupScoresForShow` materializes `users.careerCorrectSlots` (and per-tour `seasonStats.*.correctSlots`) with pick-level `correctSlotsCredited` for regrade-safe diffs. Public + self Profile show avg correct when the field is present; otherwise —.
+- **Self Profile top-picks strip (#553)** — frequency-forward ranked strip (top 10) on dashboard Profile, live-computed over the last 40 graded shows with correct / exact / wild / bustout secondary counts and `profile_pick_heatmap_computed` telemetry. Public heatmap deferred until a rollup path ships.
+- **Self Profile avg vintage** — mean catalog debut year over titles in the heatmap window (n of m dated).
+
+### Changed
+- Season-aggregates backfill / revert / premature-grade reset scripts now maintain `careerCorrectSlots` + `correctSlotsCredited`.
+
+---
+
 ## [1.25.0] — 2026-07-16
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.25.0  
+**Version:** 1.26.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 
@@ -23,7 +23,13 @@ All collections live in the default `(default)` Firestore database for project `
 | `createdAt` | Timestamp | Account creation |
 | `isAdmin` | boolean? | Admin custom claim mirror |
 | `notificationPrefs` | map | Channel opt-in flags (see §1.2) |
-| `seasonStats.{tourKey}` | map | Per-tour aggregated scoring |
+| `totalPoints` | number? | Career graded points (written by `rollupScoresForShow`) |
+| `showsPlayed` | number? | Career graded non-empty shows |
+| `wins` | number? | Career global night wins (ties share) |
+| `careerCorrectSlots` | number? | **v1.26.0+ (#554)** Sum of pick slots that scored > 0 across graded shows. Used for avg correct / show. Absent until rollup/backfill. |
+| `seasonStatsThroughShow` | string? | YYYY-MM-DD freshness watermark for materialized career/tour stats |
+| `seasonStatsSnapshotAt` | Timestamp? | Last rollup write time |
+| `seasonStats.{tourKey}` | map | Per-tour aggregated scoring (`totalPoints`, `shows`, `wins`, and **v1.26.0+** `correctSlots`) |
 
 ### 1.2 `users/{uid}` — `notificationPrefs` shape
 
@@ -70,6 +76,11 @@ All collections live in the default `(default)` Firestore database for project `
 ### 1.6 `picks/{pickId}` (subcollection: `pools/{poolId}/picks/{uid}`)
 
 Stores per-user, per-show slot picks and computed scores.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `correctSlotsCredited` | number? | **v1.26.0+ (#554)** Slots that scored > 0 on last finalize; used for regrade diffs into `users.careerCorrectSlots` |
+| `winCredited` | boolean? | Whether this pick currently counts as a global night win |
 
 ### 1.7 `fcm_notification_log/{dedupId}`
 

--- a/docs/PROFILE_STATS_READ_COST.md
+++ b/docs/PROFILE_STATS_READ_COST.md
@@ -75,3 +75,16 @@ Until then, the live-compute path stays the single source of truth so
 Profile `Wins` can't drift from the Standings (#218) and Tour standings
 (#219) surfaces — all three share
 `src/shared/utils/showAggregation.js::reduceShowWinners`.
+
+## Self Profile pick heatmap (#553 interim)
+
+`useProfilePickHeatmap` live-computes on dashboard Profile only:
+
+```
+reads ≈ 1 collection query (picks where userId == uid)
+       + min(|graded shows|, 40) official_setlists point reads
+```
+
+Telemetry event: `profile_pick_heatmap_computed` (same view/p95 thresholds
+as season stats). Public profile must not call this path until a
+`pickSongStats` (or equivalent) rollup lands.

--- a/docs/RELEASE_TRAIN_SPRINT_9.md
+++ b/docs/RELEASE_TRAIN_SPRINT_9.md
@@ -150,4 +150,5 @@ Incomplete features must land dark, behind absent UX, flags, or forward-only fie
 | 2026-07-16 | 0 | Manifest authored | Train defined; first PR targets `staging` |
 | 2026-07-16 | 0–1 | PRs #613–#616 merged | Manifest, #566 matrix, #584 place dedupe (1.23.1), #587 Phase A bustout badge (1.24.0); staging tip **1.24.0** |
 | 2026-07-16 | 2 | #617 + #618 merged | Foundation doc + avg points / show (1.24.1) |
-| 2026-07-16 | 2 | #554 slice B in flight | Catalog `debut` + avg vintage helpers (1.25.0); UI deferred until pick titles |
+| 2026-07-16 | 2 | #619 merged | Catalog `debut` + avg vintage helpers (1.25.0) |
+| 2026-07-16 | 2 | #554 C + #553 in flight | `careerCorrectSlots` rollup + self top-picks strip + avg correct/vintage UI (1.26.0) |

--- a/docs/profile/PROFILE_STATS_SPRINT9.md
+++ b/docs/profile/PROFILE_STATS_SPRINT9.md
@@ -1,7 +1,7 @@
 # Profile stats — Sprint 9 foundation (#553 / #554)
 
 **Train:** [Sprint 9 release train](../RELEASE_TRAIN_SPRINT_9.md) Wave 2  
-**Status:** Spec locked for implementation; UI ships in follow-up PRs.
+**Status:** Wave 2 implementation shipping (avg points + debut helpers + avg correct rollup + self top-picks strip).
 
 ---
 
@@ -104,9 +104,9 @@ Output: sorted by `pickedCount` desc, take top N.
 
 1. **This doc** (train kickoff) — merged (#617).
 2. **#554 slice A:** Surface avg points on Profile + public profile (derive from existing stats) — PATCH — merged (#618, 1.24.1).
-3. **#554 slice B:** Catalog `debut` field + avg vintage helpers — MINOR (1.25.0). UI when pick titles available (with slice C / #553).
-4. **#554 slice C:** Avg correct via rollup or bounded live compute — PATCH/MINOR per schema.
-5. **#553:** Top-picks strip UI behind self Profile first; public after rollup.
+3. **#554 slice B:** Catalog `debut` field + avg vintage helpers — MINOR (1.25.0) — merged (#619).
+4. **#554 slice C:** Avg correct via `users.careerCorrectSlots` rollup — MINOR (1.26.0).
+5. **#553:** Top-picks strip UI on self Profile (live, capped); public after rollup.
 
 ---
 

--- a/functions/revertRollupCore.js
+++ b/functions/revertRollupCore.js
@@ -9,6 +9,7 @@
 
 const {
   calculateTotalScore,
+  countCorrectSlots,
   persistableActualSetlistFromOfficialDoc,
 } = require("./scoringCore");
 const {
@@ -114,32 +115,43 @@ async function applyRevertRollupForShow({
   }
   const newGlobalMax = computeGlobalMaxScore(provisional, newScoresById);
 
-  /** @type {Map<string, { total: number, shows: number, wins: number, seasonTp: number, seasonShows: number, seasonWins: number }>} */
+  /** @type {Map<string, { total: number, shows: number, wins: number, correctSlots: number, seasonTp: number, seasonShows: number, seasonWins: number, seasonCorrect: number }>} */
   const userDeltas = new Map();
   for (const p of gradedRows) {
     const uid = String(p.userId || "");
     if (!uid) continue;
     const score = typeof p.score === "number" ? p.score : 0;
+    const userPicks = p.picks || {};
+    const newCorrectSlots = countCorrectSlots(userPicks, actualSetlist);
     const plan = computePerPickRollup({
-      pickData: { ...p, isGraded: false, winCredited: false },
+      pickData: { ...p, isGraded: false, winCredited: false, correctSlotsCredited: 0 },
       newScore: score,
       newGlobalMax,
+      newCorrectSlots,
     });
     const row = userDeltas.get(uid) || {
       total: 0,
       shows: 0,
       wins: 0,
+      correctSlots: 0,
       seasonTp: 0,
       seasonShows: 0,
       seasonWins: 0,
+      seasonCorrect: 0,
     };
     row.total += plan.scoreDiff;
     row.shows += plan.isFirstGrade ? 1 : 0;
     row.wins += plan.winsDelta;
+    if (plan.countsTowardSeason) {
+      row.correctSlots += plan.correctSlotsDiff;
+    }
     if (tourKey) {
       row.seasonTp += plan.scoreDiff;
       row.seasonShows += plan.isFirstGrade ? 1 : 0;
       row.seasonWins += plan.winsDelta;
+      if (plan.countsTowardSeason) {
+        row.seasonCorrect += plan.correctSlotsDiff;
+      }
     }
     userDeltas.set(uid, row);
   }
@@ -167,6 +179,9 @@ async function applyRevertRollupForShow({
           totalPoints: admin.firestore.FieldValue.increment(-d.total),
           showsPlayed: admin.firestore.FieldValue.increment(-d.shows),
           wins: admin.firestore.FieldValue.increment(-d.wins),
+          careerCorrectSlots: admin.firestore.FieldValue.increment(
+            -d.correctSlots
+          ),
         };
         if (tourKey) {
           upd[`seasonStats.${tourKey}.totalPoints`] =
@@ -175,6 +190,8 @@ async function applyRevertRollupForShow({
             admin.firestore.FieldValue.increment(-d.seasonShows);
           upd[`seasonStats.${tourKey}.wins`] =
             admin.firestore.FieldValue.increment(-d.seasonWins);
+          upd[`seasonStats.${tourKey}.correctSlots`] =
+            admin.firestore.FieldValue.increment(-d.seasonCorrect);
         }
         batch.set(ref, upd, { merge: true });
         n += 1;
@@ -188,6 +205,7 @@ async function applyRevertRollupForShow({
         batch.update(p.ref, {
           isGraded: false,
           winCredited: false,
+          correctSlotsCredited: admin.firestore.FieldValue.delete(),
           score: newScore,
           gradedAt: admin.firestore.FieldValue.delete(),
         });

--- a/functions/rollupCore.js
+++ b/functions/rollupCore.js
@@ -23,6 +23,7 @@
 
 const {
   calculateTotalScore,
+  countCorrectSlots,
   persistableActualSetlistFromOfficialDoc,
   setlistHasAnyPlayedSong,
 } = require("./scoringCore");
@@ -181,10 +182,13 @@ async function runRollupForShow({
       opCount = 0;
     }
     const newScore = newScoresById.get(pickDoc.id) || 0;
+    const userPicks = pickData.picks || {};
+    const newCorrectSlots = countCorrectSlots(userPicks, actualSetlist);
     const plan = computePerPickRollup({
       pickData,
       newScore,
       newGlobalMax,
+      newCorrectSlots,
     });
 
     if (pickData.userId && plan.isFirstGrade) {
@@ -215,6 +219,7 @@ async function runRollupForShow({
       score: newScore,
       isGraded: true,
       winCredited: plan.newIsWin,
+      correctSlotsCredited: plan.newCorrectSlots,
     };
     if (plan.isFirstGrade) {
       pickUpdate.gradedAt = admin.firestore.FieldValue.serverTimestamp();
@@ -227,6 +232,9 @@ async function runRollupForShow({
         plan.isFirstGrade ? 1 : 0
       ),
       wins: admin.firestore.FieldValue.increment(plan.winsDelta),
+      careerCorrectSlots: admin.firestore.FieldValue.increment(
+        plan.countsTowardSeason ? plan.correctSlotsDiff : 0
+      ),
       seasonStatsSnapshotAt: admin.firestore.FieldValue.serverTimestamp(),
       seasonStatsThroughShow: showDate,
     };
@@ -238,6 +246,9 @@ async function runRollupForShow({
             plan.isFirstGrade ? 1 : 0
           ),
           wins: admin.firestore.FieldValue.increment(plan.winsDelta),
+          correctSlots: admin.firestore.FieldValue.increment(
+            plan.countsTowardSeason ? plan.correctSlotsDiff : 0
+          ),
         },
       };
     }

--- a/functions/rollupSeasonAggregates.js
+++ b/functions/rollupSeasonAggregates.js
@@ -24,6 +24,7 @@
  *   isGraded?: boolean,
  *   score?: unknown,
  *   winCredited?: unknown,
+ *   correctSlotsCredited?: unknown,
  *   userId?: unknown,
  * }} PickLike
  */
@@ -138,10 +139,16 @@ function resolveTourKeyForDate(showDate, showDatesByTour) {
  * the previous rolled-up state, so re-finalizations never double-count
  * wins even when the global max changes.
  *
+ * `correctSlotsDiff` (#554) mirrors wins: first grade credits the full
+ * `newCorrectSlots` count; re-grade diffs against `pick.correctSlotsCredited`
+ * (missing → 0). Empty picks still get `newCorrectSlots = 0` and do not
+ * inflate `users.careerCorrectSlots` beyond the shows gate.
+ *
  * @param {{
  *   pickData: PickLike,
  *   newScore: number,
  *   newGlobalMax: number | null,
+ *   newCorrectSlots?: number,
  * }} input
  * @returns {{
  *   scoreDiff: number,
@@ -150,9 +157,16 @@ function resolveTourKeyForDate(showDate, showDatesByTour) {
  *   oldIsWin: boolean,
  *   winsDelta: number,
  *   countsTowardSeason: boolean,
+ *   newCorrectSlots: number,
+ *   correctSlotsDiff: number,
  * }}
  */
-function computePerPickRollup({ pickData, newScore, newGlobalMax }) {
+function computePerPickRollup({
+  pickData,
+  newScore,
+  newGlobalMax,
+  newCorrectSlots = 0,
+}) {
   const oldScore = typeof pickData?.score === "number" ? pickData.score : 0;
   const isFirstGrade = pickData?.isGraded !== true;
   const scoreDiff = isFirstGrade ? newScore : newScore - oldScore;
@@ -166,6 +180,19 @@ function computePerPickRollup({ pickData, newScore, newGlobalMax }) {
     newScore === newGlobalMax;
   const winsDelta = (newIsWin ? 1 : 0) - (oldIsWin ? 1 : 0);
 
+  const creditedCorrect =
+    typeof newCorrectSlots === "number" && Number.isFinite(newCorrectSlots)
+      ? Math.max(0, Math.trunc(newCorrectSlots))
+      : 0;
+  const oldCorrectSlots =
+    typeof pickData?.correctSlotsCredited === "number" &&
+    Number.isFinite(pickData.correctSlotsCredited)
+      ? Math.max(0, Math.trunc(pickData.correctSlotsCredited))
+      : 0;
+  const correctSlotsDiff = isFirstGrade
+    ? creditedCorrect
+    : creditedCorrect - oldCorrectSlots;
+
   return {
     scoreDiff,
     isFirstGrade,
@@ -173,6 +200,8 @@ function computePerPickRollup({ pickData, newScore, newGlobalMax }) {
     oldIsWin,
     winsDelta,
     countsTowardSeason,
+    newCorrectSlots: creditedCorrect,
+    correctSlotsDiff,
   };
 }
 

--- a/functions/rollupSeasonAggregates.test.js
+++ b/functions/rollupSeasonAggregates.test.js
@@ -230,3 +230,43 @@ test("computePerPickRollup: null globalMax (no eligible picks) credits nobody", 
   });
   assert.equal(plan.newIsWin, false);
 });
+
+test("computePerPickRollup: first-grade credits full newCorrectSlots", () => {
+  const plan = computePerPickRollup({
+    pickData: { picks: { s1o: "A" } },
+    newScore: 20,
+    newGlobalMax: 30,
+    newCorrectSlots: 3,
+  });
+  assert.equal(plan.newCorrectSlots, 3);
+  assert.equal(plan.correctSlotsDiff, 3);
+});
+
+test("computePerPickRollup: re-grade diffs correctSlotsCredited", () => {
+  const plan = computePerPickRollup({
+    pickData: {
+      picks: { s1o: "A" },
+      isGraded: true,
+      score: 20,
+      correctSlotsCredited: 2,
+    },
+    newScore: 25,
+    newGlobalMax: 30,
+    newCorrectSlots: 4,
+  });
+  assert.equal(plan.correctSlotsDiff, 2);
+});
+
+test("computePerPickRollup: missing correctSlotsCredited on re-grade treats old as 0", () => {
+  const plan = computePerPickRollup({
+    pickData: {
+      picks: { s1o: "A" },
+      isGraded: true,
+      score: 20,
+    },
+    newScore: 20,
+    newGlobalMax: 30,
+    newCorrectSlots: 2,
+  });
+  assert.equal(plan.correctSlotsDiff, 2);
+});

--- a/functions/scoringCore.js
+++ b/functions/scoringCore.js
@@ -124,6 +124,26 @@ function calculateTotalScore(userPicks, actualSetlist) {
   }, 0);
 }
 
+/**
+ * Count pick slots that scored > 0 (exact, in-setlist, wildcard, or bustout).
+ * Used for `users.careerCorrectSlots` (#554) — denominator is always
+ * `SCORE_FIELDS.length` per graded show, not filled-slot count.
+ *
+ * @param {Record<string, unknown> | null | undefined} userPicks
+ * @param {Record<string, unknown> | null | undefined} actualSetlist
+ * @returns {number}
+ */
+function countCorrectSlots(userPicks, actualSetlist) {
+  if (!actualSetlist || !userPicks) return 0;
+  let n = 0;
+  for (const fieldId of SCORE_FIELDS) {
+    if (calculateSlotScore(fieldId, userPicks[fieldId], actualSetlist) > 0) {
+      n += 1;
+    }
+  }
+  return n;
+}
+
 /** Mirrors `src/shared/utils/officialSetlistSanitize.js` (trim / drop empties). */
 function sanitizeOfficialSongList(arr) {
   if (!Array.isArray(arr)) return [];
@@ -231,6 +251,7 @@ module.exports = {
   setlistHasAnyPlayedSong,
   calculateSlotScore,
   calculateTotalScore,
+  countCorrectSlots,
   actualSetlistFromOfficialDoc,
   persistableActualSetlistFromOfficialDoc,
   playableSetlistFingerprint,

--- a/functions/scripts/backfillSeasonAggregates.js
+++ b/functions/scripts/backfillSeasonAggregates.js
@@ -52,6 +52,10 @@ const {
   resolveTourKeyForDate,
   hasNonEmptyPicksObject,
 } = require("../rollupSeasonAggregates");
+const {
+  countCorrectSlots,
+  persistableActualSetlistFromOfficialDoc,
+} = require("../scoringCore");
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
 const ENV_PATH = path.join(REPO_ROOT, ".env");
@@ -228,13 +232,14 @@ async function main() {
    *   totalPoints: number,
    *   shows: number,
    *   wins: number,
+   *   careerCorrectSlots: number,
    *   latestShow: string,
-   *   seasonStats: Record<string, { totalPoints: number, shows: number, wins: number }>,
+   *   seasonStats: Record<string, { totalPoints: number, shows: number, wins: number, correctSlots: number }>,
    * }>}
    */
   const perUser = new Map();
 
-  /** @type {{ ref: FirebaseFirestore.DocumentReference, winCredited: boolean }[]} */
+  /** @type {{ ref: FirebaseFirestore.DocumentReference, winCredited: boolean, correctSlotsCredited: number }[]} */
   const picksToStamp = [];
 
   let totalGradedPicks = 0;
@@ -250,6 +255,14 @@ async function main() {
     const gmax = computeGlobalMaxScore(rows);
     const tourKey = resolveTourKeyForDate(showDate, showDatesByTour);
 
+    const setlistSnap = await db
+      .collection("official_setlists")
+      .doc(showDate)
+      .get();
+    const actualSetlist = setlistSnap.exists
+      ? persistableActualSetlistFromOfficialDoc(setlistSnap.data() || {})
+      : null;
+
     for (const r of rows) {
       const uid = typeof r.userId === "string" ? r.userId : "";
       if (!uid) continue;
@@ -260,7 +273,11 @@ async function main() {
       if (!countsTowardSeason) {
         if (r.isGraded === true) skippedEmpty += 1;
         // Still stamp winCredited=false so re-finalize diffs cleanly.
-        picksToStamp.push({ ref: r.ref, winCredited: false });
+        picksToStamp.push({
+          ref: r.ref,
+          winCredited: false,
+          correctSlotsCredited: 0,
+        });
         continue;
       }
 
@@ -268,32 +285,43 @@ async function main() {
       const score = typeof r.score === "number" ? r.score : 0;
       const isWin =
         typeof gmax === "number" && gmax > 0 && score === gmax;
+      const correctSlots = actualSetlist
+        ? countCorrectSlots(r.picks || {}, actualSetlist)
+        : 0;
 
       const existing = perUser.get(uid) || {
         totalPoints: 0,
         shows: 0,
         wins: 0,
+        careerCorrectSlots: 0,
         latestShow: "",
         seasonStats: {},
       };
       existing.totalPoints += score;
       existing.shows += 1;
       if (isWin) existing.wins += 1;
+      existing.careerCorrectSlots += correctSlots;
       if (showDate > existing.latestShow) existing.latestShow = showDate;
       if (tourKey) {
         const tour = existing.seasonStats[tourKey] || {
           totalPoints: 0,
           shows: 0,
           wins: 0,
+          correctSlots: 0,
         };
         tour.totalPoints += score;
         tour.shows += 1;
         if (isWin) tour.wins += 1;
+        tour.correctSlots += correctSlots;
         existing.seasonStats[tourKey] = tour;
       }
       perUser.set(uid, existing);
 
-      picksToStamp.push({ ref: r.ref, winCredited: isWin });
+      picksToStamp.push({
+        ref: r.ref,
+        winCredited: isWin,
+        correctSlotsCredited: correctSlots,
+      });
     }
   }
 
@@ -316,7 +344,7 @@ async function main() {
     for (const [uid, row] of sample) {
       console.log(
         `  ${uid} → totalPoints=${row.totalPoints}, shows=${row.shows}, wins=${row.wins}, ` +
-          `latestShow=${row.latestShow}, tours=${Object.keys(row.seasonStats).length}`
+          `correctSlots=${row.careerCorrectSlots}, latestShow=${row.latestShow}, tours=${Object.keys(row.seasonStats).length}`
       );
     }
     console.log("");
@@ -349,6 +377,7 @@ async function main() {
         totalPoints: row.totalPoints,
         showsPlayed: row.shows,
         wins: row.wins,
+        careerCorrectSlots: row.careerCorrectSlots,
         seasonStats: row.seasonStats,
         seasonStatsSnapshotAt: admin.firestore.FieldValue.serverTimestamp(),
         seasonStatsThroughShow: row.latestShow,
@@ -360,7 +389,10 @@ async function main() {
 
   for (const p of picksToStamp) {
     await commitIfFull();
-    batch.update(p.ref, { winCredited: p.winCredited });
+    batch.update(p.ref, {
+      winCredited: p.winCredited,
+      correctSlotsCredited: p.correctSlotsCredited,
+    });
     opCount += 1;
   }
 

--- a/functions/scripts/resetPrematureGrade.js
+++ b/functions/scripts/resetPrematureGrade.js
@@ -23,6 +23,10 @@ const {
   computePerPickRollup,
   resolveTourKeyForDate,
 } = require("../rollupSeasonAggregates");
+const {
+  countCorrectSlots,
+  persistableActualSetlistFromOfficialDoc,
+} = require("../scoringCore");
 
 function parseArgs(argv) {
   const out = {};
@@ -112,6 +116,11 @@ async function main() {
     : null;
   const tourKey = resolveTourKeyForDate(showDate, showDatesByTour);
 
+  const setlistSnap = await db.collection("official_setlists").doc(showDate).get();
+  const actualSetlist = setlistSnap.exists
+    ? persistableActualSetlistFromOfficialDoc(setlistSnap.data() || {})
+    : null;
+
   const provisional = graded.map((p) => ({
     id: p.id,
     ...p,
@@ -124,33 +133,52 @@ async function main() {
   }
   const newGlobalMax = computeGlobalMaxScore(provisional, newScoresById);
 
-  /** @type {Map<string, { total: number, shows: number, wins: number, seasonTp: number, seasonShows: number, seasonWins: number }>} */
+  /** @type {Map<string, { total: number, shows: number, wins: number, correctSlots: number, seasonTp: number, seasonShows: number, seasonWins: number, seasonCorrect: number }>} */
   const userDeltas = new Map();
   for (const p of graded) {
     const uid = String(p.userId || "");
     if (!uid) continue;
     const score = typeof p.score === "number" ? p.score : 0;
+    const newCorrectSlots = actualSetlist
+      ? countCorrectSlots(p.picks || {}, actualSetlist)
+      : typeof p.correctSlotsCredited === "number"
+        ? p.correctSlotsCredited
+        : 0;
     const plan = computePerPickRollup({
       // Simulate pre-rollup pick shape so scoreDiff / winsDelta match the first-grade pass.
-      pickData: { ...p, isGraded: false, winCredited: false },
+      pickData: {
+        ...p,
+        isGraded: false,
+        winCredited: false,
+        correctSlotsCredited: 0,
+      },
       newScore: score,
       newGlobalMax,
+      newCorrectSlots,
     });
     const row = userDeltas.get(uid) || {
       total: 0,
       shows: 0,
       wins: 0,
+      correctSlots: 0,
       seasonTp: 0,
       seasonShows: 0,
       seasonWins: 0,
+      seasonCorrect: 0,
     };
     row.total += plan.scoreDiff;
     row.shows += plan.isFirstGrade ? 1 : 0;
     row.wins += plan.winsDelta;
+    if (plan.countsTowardSeason) {
+      row.correctSlots += plan.correctSlotsDiff;
+    }
     if (tourKey) {
       row.seasonTp += plan.scoreDiff;
       row.seasonShows += plan.isFirstGrade ? 1 : 0;
       row.seasonWins += plan.winsDelta;
+      if (plan.countsTowardSeason) {
+        row.seasonCorrect += plan.correctSlotsDiff;
+      }
     }
     userDeltas.set(uid, row);
   }
@@ -166,9 +194,9 @@ async function main() {
   console.log("\nPer-user rollup that would be reversed (--reconcile-users):");
   for (const [uid, d] of userDeltas) {
     console.log(
-      `  ${uid}: totalPoints -${d.total}, showsPlayed -${d.shows}, wins -${d.wins}` +
+      `  ${uid}: totalPoints -${d.total}, showsPlayed -${d.shows}, wins -${d.wins}, careerCorrectSlots -${d.correctSlots}` +
         (tourKey
-          ? ` | seasonStats.${tourKey}: tp -${d.seasonTp}, shows -${d.seasonShows}, wins -${d.seasonWins}`
+          ? ` | seasonStats.${tourKey}: tp -${d.seasonTp}, shows -${d.seasonShows}, wins -${d.seasonWins}, correct -${d.seasonCorrect}`
           : "")
     );
   }
@@ -193,6 +221,7 @@ async function main() {
       isGraded: false,
       score: 0,
       winCredited: false,
+      correctSlotsCredited: admin.firestore.FieldValue.delete(),
       gradedAt: admin.firestore.FieldValue.delete(),
     });
     ops += 1;
@@ -213,6 +242,7 @@ async function main() {
       totalPoints: admin.firestore.FieldValue.increment(-d.total),
       showsPlayed: admin.firestore.FieldValue.increment(-d.shows),
       wins: admin.firestore.FieldValue.increment(-d.wins),
+      careerCorrectSlots: admin.firestore.FieldValue.increment(-d.correctSlots),
     };
     if (tourKey) {
       // Dotted paths so other `seasonStats.*` tour keys are not clobbered on merge.
@@ -222,6 +252,8 @@ async function main() {
         admin.firestore.FieldValue.increment(-d.seasonShows);
       upd[`seasonStats.${tourKey}.wins`] =
         admin.firestore.FieldValue.increment(-d.seasonWins);
+      upd[`seasonStats.${tourKey}.correctSlots`] =
+        admin.firestore.FieldValue.increment(-d.seasonCorrect);
     }
     batch.set(ref, upd, { merge: true });
     ops += 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setlistpickem",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setlistpickem",
-      "version": "1.25.0",
+      "version": "1.26.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "firebase": "10.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.25.0",
+  "version": "1.26.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/profile/api/profilePickHeatmap.js
+++ b/src/features/profile/api/profilePickHeatmap.js
@@ -1,0 +1,141 @@
+import { collection, doc, getDoc, getDocs, query, where } from 'firebase/firestore';
+
+import { db } from '../../../shared/lib/firebase';
+import { whenFirebaseReady } from '../../../shared/lib/firebaseAppCheck';
+import { pickCountsTowardSeason } from '../../../shared/utils/showAggregation';
+import { normalizeOfficialSetlistDocData } from '../../scoring';
+import {
+  aggregatePickSongStats,
+  PROFILE_TOP_PICKS_N,
+} from '../model/aggregatePickSongStats';
+
+/**
+ * Interim live-compute budget for self Profile heatmap (#553).
+ * Caps graded shows (newest first) so profile views stay bounded.
+ */
+export const PROFILE_PICK_HEATMAP_MAX_SHOWS = 40;
+
+/**
+ * @typedef {Object} ProfilePickHeatmapResult
+ * @property {import('../model/aggregatePickSongStats').PickSongStatRow[]} rows
+ * @property {string[]} songTitles
+ * @property {number} showsAggregated
+ * @property {number} showsAvailable
+ * @property {number} setlistReads
+ * @property {'live'} source
+ */
+
+/**
+ * @typedef {Object} ProfilePickHeatmapTelemetry
+ * @property {number} shows_checked
+ * @property {number} shows_played
+ * @property {number} collection_queries
+ * @property {number} setlist_reads
+ * @property {'live'} source
+ */
+
+/**
+ * Live-compute top pick frequency for a user (self Profile interim path).
+ *
+ * Read budget: 1 `picks where userId == uid` query + up to
+ * `PROFILE_PICK_HEATMAP_MAX_SHOWS` `official_setlists/{date}` point reads.
+ *
+ * @param {string | undefined} uid
+ * @param {{
+ *   maxShows?: number,
+ *   topN?: number,
+ *   onTelemetry?: (t: ProfilePickHeatmapTelemetry) => void,
+ * }} [options]
+ * @returns {Promise<ProfilePickHeatmapResult>}
+ */
+export async function computeProfilePickHeatmap(uid, options = {}) {
+  const maxShows =
+    typeof options.maxShows === 'number' && options.maxShows > 0
+      ? Math.trunc(options.maxShows)
+      : PROFILE_PICK_HEATMAP_MAX_SHOWS;
+  const topN =
+    typeof options.topN === 'number' && options.topN > 0
+      ? Math.trunc(options.topN)
+      : PROFILE_TOP_PICKS_N;
+
+  /** @type {ProfilePickHeatmapTelemetry} */
+  const telemetry = {
+    shows_checked: 0,
+    shows_played: 0,
+    collection_queries: 0,
+    setlist_reads: 0,
+    source: 'live',
+  };
+  const emit = () => {
+    if (typeof options.onTelemetry === 'function') {
+      try {
+        options.onTelemetry(telemetry);
+      } catch (err) {
+        console.warn('computeProfilePickHeatmap telemetry failed:', err);
+      }
+    }
+  };
+
+  const id = typeof uid === 'string' ? uid.trim() : '';
+  if (!id) {
+    emit();
+    return {
+      rows: [],
+      songTitles: [],
+      showsAggregated: 0,
+      showsAvailable: 0,
+      setlistReads: 0,
+      source: 'live',
+    };
+  }
+
+  await whenFirebaseReady();
+
+  const picksSnap = await getDocs(
+    query(collection(db, 'picks'), where('userId', '==', id))
+  );
+  telemetry.collection_queries = 1;
+  telemetry.shows_checked = picksSnap.size;
+
+  const graded = [];
+  for (const pickDoc of picksSnap.docs) {
+    const data = pickDoc.data() || {};
+    if (!pickCountsTowardSeason(data)) continue;
+    graded.push({
+      showDate: typeof data.showDate === 'string' ? data.showDate : '',
+      picks: data.picks && typeof data.picks === 'object' ? data.picks : {},
+    });
+  }
+  graded.sort((a, b) => (a.showDate < b.showDate ? 1 : a.showDate > b.showDate ? -1 : 0));
+  const capped = graded.slice(0, maxShows);
+  telemetry.shows_played = capped.length;
+
+  /** @type {Map<string, Record<string, unknown>>} */
+  const setlistsByDate = new Map();
+  const dates = [
+    ...new Set(capped.map((p) => p.showDate).filter(Boolean)),
+  ];
+  const chunkSize = 12;
+  for (let i = 0; i < dates.length; i += chunkSize) {
+    const slice = dates.slice(i, i + chunkSize);
+    const snaps = await Promise.all(
+      slice.map((date) => getDoc(doc(db, 'official_setlists', date)))
+    );
+    telemetry.setlist_reads += slice.length;
+    for (let j = 0; j < slice.length; j += 1) {
+      const snap = snaps[j];
+      if (!snap.exists()) continue;
+      const normalized = normalizeOfficialSetlistDocData(snap.data() || {});
+      if (normalized) setlistsByDate.set(slice[j], normalized);
+    }
+  }
+
+  const aggregated = aggregatePickSongStats(capped, setlistsByDate, { topN });
+  emit();
+  return {
+    ...aggregated,
+    showsAvailable: graded.length,
+    setlistReads: telemetry.setlist_reads,
+    source: 'live',
+  };
+}

--- a/src/features/profile/api/profileSeasonStats.js
+++ b/src/features/profile/api/profileSeasonStats.js
@@ -10,6 +10,9 @@ import { fetchGlobalMaxScoreForShow } from '../../scoring';
  * @property {number} shows         Number of finalized shows the user played.
  * @property {number} wins          Shows this user won overall (global max
  *                                  among every graded pick for that show).
+ * @property {number | undefined} careerCorrectSlots
+ *   Sum of slots that scored > 0 across graded shows (#554). Absent until
+ *   rollup/backfill writes the field — UI should treat missing as unknown.
  */
 
 /**
@@ -211,5 +214,12 @@ export function readMaterializedSeasonStats(userData, latestFinalizedShow) {
       ? userData.seasonStatsThroughShow
       : '';
   if (!through || through < latestFinalizedShow) return null;
-  return { totalPoints, shows, wins };
+  const out = { totalPoints, shows, wins };
+  if (
+    typeof userData.careerCorrectSlots === 'number' &&
+    Number.isFinite(userData.careerCorrectSlots)
+  ) {
+    out.careerCorrectSlots = userData.careerCorrectSlots;
+  }
+  return out;
 }

--- a/src/features/profile/api/profileSeasonStats.test.js
+++ b/src/features/profile/api/profileSeasonStats.test.js
@@ -22,6 +22,20 @@ describe('readMaterializedSeasonStats', () => {
     });
   });
 
+  it('includes careerCorrectSlots when present on the user doc', () => {
+    expect(
+      readMaterializedSeasonStats(
+        { ...FRESH, careerCorrectSlots: 18 },
+        '2026-04-23'
+      )
+    ).toEqual({
+      totalPoints: 42,
+      shows: 5,
+      wins: 2,
+      careerCorrectSlots: 18,
+    });
+  });
+
   it('returns the materialized triple when the snapshot is ahead of the latest finalized show', () => {
     expect(
       readMaterializedSeasonStats(

--- a/src/features/profile/index.js
+++ b/src/features/profile/index.js
@@ -1,6 +1,9 @@
 export { fetchPublicProfileByHandle } from './api/publicProfileApi';
 export { default as ProfileEditForm } from './ui/ProfileEditForm';
+export { default as ProfileSelfStatsPanel } from './ui/ProfileSelfStatsPanel';
 export { default as PublicProfileView } from './ui/PublicProfileView';
+export { default as TopPicksFrequencyStrip } from './ui/TopPicksFrequencyStrip';
 export { usePublicProfile } from './model/usePublicProfile';
 export { useUserProfile } from './model/useUserProfile';
 export { useUserSeasonStats } from './model/useUserSeasonStats';
+export { useProfilePickHeatmap } from './model/useProfilePickHeatmap';

--- a/src/features/profile/model/aggregatePickSongStats.js
+++ b/src/features/profile/model/aggregatePickSongStats.js
@@ -1,0 +1,105 @@
+import { FORM_FIELDS } from '../../../shared/data/gameConfig';
+import { getSlotScoreBreakdown } from '../../../shared/utils/scoring';
+
+/** Default top-N for the Profile frequency strip (#553). */
+export const PROFILE_TOP_PICKS_N = 10;
+
+/**
+ * @typedef {{
+ *   title: string,
+ *   pickedCount: number,
+ *   correctCount: number,
+ *   exactSlotHits: number,
+ *   wildcardHits: number,
+ *   bustoutBoosts: number,
+ * }} PickSongStatRow
+ */
+
+/**
+ * Aggregate graded pick docs into per-song frequency stats.
+ *
+ * @param {Array<{
+ *   picks?: Record<string, unknown>,
+ *   showDate?: string,
+ * }>} gradedPicks
+ * @param {Map<string, Record<string, unknown>> | Record<string, Record<string, unknown>> | null | undefined} setlistsByDate
+ * @param {{ topN?: number }} [options]
+ * @returns {{
+ *   rows: PickSongStatRow[],
+ *   songTitles: string[],
+ *   showsAggregated: number,
+ * }}
+ */
+export function aggregatePickSongStats(gradedPicks, setlistsByDate, options = {}) {
+  const topN =
+    typeof options.topN === 'number' && options.topN > 0
+      ? Math.trunc(options.topN)
+      : PROFILE_TOP_PICKS_N;
+
+  const lookup =
+    setlistsByDate instanceof Map
+      ? (d) => setlistsByDate.get(d)
+      : setlistsByDate && typeof setlistsByDate === 'object'
+        ? (d) => setlistsByDate[d]
+        : () => undefined;
+
+  /** @type {Map<string, PickSongStatRow>} */
+  const byKey = new Map();
+
+  const list = Array.isArray(gradedPicks) ? gradedPicks : [];
+  for (const pick of list) {
+    const slots = pick?.picks && typeof pick.picks === 'object' ? pick.picks : {};
+    const showDate = typeof pick?.showDate === 'string' ? pick.showDate : '';
+    const actual = showDate ? lookup(showDate) : undefined;
+
+    for (const field of FORM_FIELDS) {
+      const raw = slots[field.id];
+      if (typeof raw !== 'string') continue;
+      const title = raw.trim();
+      if (!title) continue;
+      const key = title.toLowerCase();
+      let row = byKey.get(key);
+      if (!row) {
+        row = {
+          title,
+          pickedCount: 0,
+          correctCount: 0,
+          exactSlotHits: 0,
+          wildcardHits: 0,
+          bustoutBoosts: 0,
+        };
+        byKey.set(key, row);
+      }
+      row.pickedCount += 1;
+
+      if (!actual) continue;
+      const breakdown = getSlotScoreBreakdown(field.id, title, actual);
+      if (breakdown.points > 0) {
+        row.correctCount += 1;
+      }
+      if (
+        breakdown.kind === 'exact_slot' ||
+        breakdown.kind === 'encore_exact'
+      ) {
+        row.exactSlotHits += 1;
+      }
+      if (breakdown.kind === 'wildcard_hit') {
+        row.wildcardHits += 1;
+      }
+      if (breakdown.bustoutBoost) {
+        row.bustoutBoosts += 1;
+      }
+    }
+  }
+
+  const rows = [...byKey.values()].sort((a, b) => {
+    if (b.pickedCount !== a.pickedCount) return b.pickedCount - a.pickedCount;
+    return a.title.localeCompare(b.title);
+  });
+
+  return {
+    rows: rows.slice(0, topN),
+    songTitles: rows.map((r) => r.title),
+    showsAggregated: list.length,
+  };
+}

--- a/src/features/profile/model/aggregatePickSongStats.test.js
+++ b/src/features/profile/model/aggregatePickSongStats.test.js
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { aggregatePickSongStats } from './aggregatePickSongStats';
+
+describe('aggregatePickSongStats', () => {
+  const setlist = {
+    s1o: 'Tweezer',
+    s1c: 'Golgi Apparatus',
+    s2o: 'Ghost',
+    s2c: 'You Enjoy Myself',
+    enc: 'Tweezer Reprise',
+    wild: '',
+    officialSetlist: ['Tweezer', 'Ghost', 'You Enjoy Myself', 'Tweezer Reprise'],
+    bustouts: ['Ghost'],
+  };
+
+  it('ranks by pick frequency and counts hit kinds', () => {
+    const { rows, songTitles, showsAggregated } = aggregatePickSongStats(
+      [
+        {
+          showDate: '2026-07-01',
+          picks: {
+            s1o: 'Tweezer',
+            s1c: 'Wilson',
+            s2o: 'Ghost',
+            s2c: 'YEM',
+            enc: 'Tweezer Reprise',
+            wild: 'Ghost',
+          },
+        },
+        {
+          showDate: '2026-07-02',
+          picks: {
+            s1o: 'Tweezer',
+            s1c: 'Wilson',
+            s2o: 'Free',
+            s2c: 'YEM',
+            enc: 'Character Zero',
+            wild: 'Tweezer',
+          },
+        },
+      ],
+      { '2026-07-01': setlist, '2026-07-02': setlist },
+      { topN: 5 }
+    );
+
+    expect(showsAggregated).toBe(2);
+    expect(rows[0].title).toBe('Tweezer');
+    expect(rows[0].pickedCount).toBe(3);
+    expect(rows[0].correctCount).toBeGreaterThan(0);
+    expect(songTitles).toContain('Tweezer');
+    expect(rows.length).toBeLessThanOrEqual(5);
+  });
+
+  it('still counts frequency when setlist is missing', () => {
+    const { rows } = aggregatePickSongStats(
+      [
+        {
+          showDate: '2026-07-01',
+          picks: { s1o: 'Tweezer', wild: 'Ghost' },
+        },
+      ],
+      new Map(),
+      { topN: 10 }
+    );
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: 'Tweezer',
+          pickedCount: 1,
+          correctCount: 0,
+        }),
+        expect.objectContaining({
+          title: 'Ghost',
+          pickedCount: 1,
+          correctCount: 0,
+        }),
+      ])
+    );
+    expect(rows).toHaveLength(2);
+  });
+});

--- a/src/features/profile/model/profileAverages.js
+++ b/src/features/profile/model/profileAverages.js
@@ -1,9 +1,14 @@
 /**
  * Profile averages derived from existing season / career stats (#554).
  * Avg points needs no extra Firestore reads — only totalPoints / shows.
+ * Avg correct uses `careerCorrectSlots` when materialised at finalize.
  * Avg vintage joins pick titles to catalog `debut` in memory (0 extra reads
  * once titles + catalog are already loaded).
  */
+
+import { FORM_FIELDS } from '../../../shared/data/gameConfig';
+
+export const PROFILE_SLOTS_PER_SHOW = FORM_FIELDS.length;
 
 /**
  * @param {{ totalPoints?: unknown, shows?: unknown } | null | undefined} stats
@@ -32,6 +37,46 @@ export function formatAvgPointsPerShow(avg) {
   if (typeof avg !== 'number' || !Number.isFinite(avg)) return '—';
   const rounded = Math.round(avg * 10) / 10;
   return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}
+
+/**
+ * Mean correct slots per graded show.
+ * `careerCorrectSlots / (shows * PROFILE_SLOTS_PER_SHOW)` when both are known.
+ * Missing `careerCorrectSlots` → null (forward-only until rollup/backfill).
+ *
+ * @param {{
+ *   careerCorrectSlots?: unknown,
+ *   shows?: unknown,
+ * } | null | undefined} stats
+ * @returns {number | null}
+ */
+export function computeAvgCorrectPicksPerShow(stats) {
+  const correct =
+    typeof stats?.careerCorrectSlots === 'number' &&
+    Number.isFinite(stats.careerCorrectSlots)
+      ? stats.careerCorrectSlots
+      : null;
+  const shows =
+    typeof stats?.shows === 'number' && Number.isFinite(stats.shows)
+      ? stats.shows
+      : null;
+  if (correct == null || shows == null || shows <= 0) return null;
+  return correct / (shows * PROFILE_SLOTS_PER_SHOW);
+}
+
+/**
+ * @param {number | null | undefined} avg
+ * @returns {string}
+ */
+export function formatAvgCorrectPicksPerShow(avg) {
+  if (typeof avg !== 'number' || !Number.isFinite(avg)) return '—';
+  const rounded = Math.round(avg * 100) / 100;
+  if (Number.isInteger(rounded)) return String(rounded);
+  const one = Math.round(avg * 10) / 10;
+  if (Math.abs(one - rounded) < 1e-9) {
+    return Number.isInteger(one) ? String(one) : one.toFixed(1);
+  }
+  return rounded.toFixed(2);
 }
 
 /**

--- a/src/features/profile/model/profileAverages.test.js
+++ b/src/features/profile/model/profileAverages.test.js
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildDebutYearBySongName,
+  computeAvgCorrectPicksPerShow,
   computeAvgPointsPerShow,
   computeAvgSongVintage,
   debutYearFromCatalogDebut,
+  formatAvgCorrectPicksPerShow,
   formatAvgPointsPerShow,
   formatAvgSongVintage,
 } from './profileAverages';
@@ -70,5 +72,18 @@ describe('profileAverages', () => {
       uniqueCount: 1,
     });
     expect(formatAvgSongVintage(null)).toBe('—');
+  });
+
+  it('computes avg correct slots per show from careerCorrectSlots', () => {
+    // 18 correct across 3 shows × 6 slots → 18/18 = 1
+    expect(
+      computeAvgCorrectPicksPerShow({ careerCorrectSlots: 18, shows: 3 })
+    ).toBe(1);
+    expect(
+      computeAvgCorrectPicksPerShow({ careerCorrectSlots: 9, shows: 3 })
+    ).toBe(0.5);
+    expect(computeAvgCorrectPicksPerShow({ shows: 3 })).toBeNull();
+    expect(formatAvgCorrectPicksPerShow(0.5)).toBe('0.5');
+    expect(formatAvgCorrectPicksPerShow(null)).toBe('—');
   });
 });

--- a/src/features/profile/model/profilePickHeatmapTelemetry.js
+++ b/src/features/profile/model/profilePickHeatmapTelemetry.js
@@ -1,0 +1,45 @@
+import { ga4Event, ga4IsReady } from '../../../shared/lib/ga4';
+import { PROFILE_STATS_TELEMETRY_THRESHOLDS } from './profileStatsTelemetry';
+
+const EVENT_NAME = 'profile_pick_heatmap_computed';
+
+/** Same materialize thresholds as season-stats (#220 / #553). */
+export const PROFILE_PICK_HEATMAP_TELEMETRY_THRESHOLDS =
+  PROFILE_STATS_TELEMETRY_THRESHOLDS;
+
+/**
+ * @param {{
+ *   shows_checked: number,
+ *   shows_played: number,
+ *   collection_queries: number,
+ *   setlist_reads?: number,
+ *   elapsed_ms: number,
+ *   self_view: boolean,
+ *   cache_hit?: boolean,
+ *   source?: 'live',
+ * }} payload
+ */
+export function emitProfilePickHeatmapTelemetry(payload) {
+  const params = {
+    shows_checked: Number(payload.shows_checked) || 0,
+    shows_played: Number(payload.shows_played) || 0,
+    collection_queries: Number(payload.collection_queries) || 0,
+    setlist_reads: Number(payload.setlist_reads) || 0,
+    elapsed_ms: Math.max(0, Math.round(Number(payload.elapsed_ms) || 0)),
+    self_view: Boolean(payload.self_view),
+    cache_hit: Boolean(payload.cache_hit),
+    source: 'live',
+  };
+
+  try {
+    if (ga4IsReady()) {
+      ga4Event(EVENT_NAME, params);
+    }
+  } catch (err) {
+    console.warn('emitProfilePickHeatmapTelemetry: GA4 emit failed:', err);
+  }
+
+  if (import.meta.env.DEV) {
+    console.info(`[telemetry] ${EVENT_NAME}`, params);
+  }
+}

--- a/src/features/profile/model/useProfilePickHeatmap.js
+++ b/src/features/profile/model/useProfilePickHeatmap.js
@@ -1,0 +1,100 @@
+import { useEffect, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { computeProfilePickHeatmap } from '../api/profilePickHeatmap';
+import { emitProfilePickHeatmapTelemetry } from './profilePickHeatmapTelemetry';
+
+/**
+ * Self-Profile top-picks heatmap (#553). Live-compute only — do not enable
+ * for public profiles until a rollup lands.
+ *
+ * @param {string | undefined} uid
+ * @param {{ enabled?: boolean }} [options]
+ */
+export function useProfilePickHeatmap(uid, options = {}) {
+  const trimmedUid = typeof uid === 'string' ? uid.trim() : '';
+  const enabled = options.enabled !== false && trimmedUid.length > 0;
+
+  const lastComputeTelemetryRef = useRef(
+    /**
+     * @type {{
+     *   shows_checked: number,
+     *   shows_played: number,
+     *   collection_queries: number,
+     *   setlist_reads: number,
+     *   elapsed_ms: number,
+     * } | null}
+     */ (null)
+  );
+
+  const query = useQuery({
+    queryKey: ['profile-pick-heatmap', trimmedUid],
+    enabled,
+    staleTime: 5 * 60 * 1000,
+    queryFn: async () => {
+      const startedAt =
+        typeof performance !== 'undefined' && typeof performance.now === 'function'
+          ? performance.now()
+          : Date.now();
+      /** @type {import('../api/profilePickHeatmap').ProfilePickHeatmapTelemetry | null} */
+      let captured = null;
+      try {
+        return await computeProfilePickHeatmap(trimmedUid, {
+          onTelemetry: (t) => {
+            captured = { ...t };
+          },
+        });
+      } finally {
+        const endedAt =
+          typeof performance !== 'undefined' && typeof performance.now === 'function'
+            ? performance.now()
+            : Date.now();
+        if (captured) {
+          lastComputeTelemetryRef.current = {
+            shows_checked: captured.shows_checked,
+            shows_played: captured.shows_played,
+            collection_queries: captured.collection_queries,
+            setlist_reads: captured.setlist_reads,
+            elapsed_ms: endedAt - startedAt,
+          };
+        }
+      }
+    },
+  });
+
+  const emittedForFetchKeyRef = useRef(/** @type {string | null} */ (null));
+  useEffect(() => {
+    if (!enabled || !query.isSuccess) return;
+    const fetchKey = `${trimmedUid}:${query.isFetchedAfterMount ? 'fresh' : 'cached'}`;
+    if (emittedForFetchKeyRef.current === fetchKey) return;
+    emittedForFetchKeyRef.current = fetchKey;
+
+    const cacheHit = !query.isFetchedAfterMount;
+    const computeTelemetry =
+      !cacheHit && lastComputeTelemetryRef.current
+        ? lastComputeTelemetryRef.current
+        : {
+            shows_checked: 0,
+            shows_played: 0,
+            collection_queries: 0,
+            setlist_reads: 0,
+            elapsed_ms: 0,
+          };
+
+    emitProfilePickHeatmapTelemetry({
+      ...computeTelemetry,
+      self_view: true,
+      cache_hit: cacheHit,
+      source: 'live',
+    });
+  }, [enabled, query.isSuccess, query.isFetchedAfterMount, trimmedUid]);
+
+  return {
+    rows: query.data?.rows ?? [],
+    songTitles: query.data?.songTitles ?? [],
+    showsAggregated: query.data?.showsAggregated ?? 0,
+    showsAvailable: query.data?.showsAvailable ?? 0,
+    loading: query.isPending || query.isFetching,
+    error: query.error,
+  };
+}

--- a/src/features/profile/ui/ProfileSelfStatsPanel.jsx
+++ b/src/features/profile/ui/ProfileSelfStatsPanel.jsx
@@ -65,23 +65,17 @@ export default function ProfileSelfStatsPanel({ uid }) {
         <h2 className="mb-4 text-xs font-black uppercase tracking-widest text-content-secondary">
           Your stats
         </h2>
-        <div className="grid grid-cols-2 gap-x-3 gap-y-1.5 text-center sm:grid-cols-4">
-          {columns.map(({ key, label }) => (
-            <p
-              key={`${key}-label`}
-              className="self-end px-0.5 text-[10px] font-black uppercase leading-snug tracking-wider text-content-secondary"
-            >
-              {label}
-            </p>
-          ))}
-          {columns.map(({ key, value }) => (
-            <div
-              key={`${key}-value`}
-              className="flex min-h-[3.25rem] items-center justify-center rounded-2xl border border-border-subtle bg-surface-field px-2 py-3"
-            >
-              <span className="text-2xl font-black tabular-nums leading-none tracking-tight text-brand-primary">
-                {statsLoading && key !== 'vintage' ? '…' : value}
-              </span>
+        <div className="grid grid-cols-2 gap-3 text-center sm:grid-cols-4">
+          {columns.map(({ key, label, value }) => (
+            <div key={key} className="flex flex-col gap-1.5">
+              <p className="flex flex-1 items-end justify-center px-0.5 text-[10px] font-black uppercase leading-snug tracking-wider text-content-secondary">
+                {label}
+              </p>
+              <div className="flex min-h-[3.25rem] items-center justify-center rounded-2xl border border-border-subtle bg-surface-field px-2 py-3">
+                <span className="text-2xl font-black tabular-nums leading-none tracking-tight text-brand-primary">
+                  {statsLoading && key !== 'vintage' ? '…' : value}
+                </span>
+              </div>
             </div>
           ))}
         </div>

--- a/src/features/profile/ui/ProfileSelfStatsPanel.jsx
+++ b/src/features/profile/ui/ProfileSelfStatsPanel.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+
+import { useSongCatalog } from '../../song-catalog';
+import {
+  buildDebutYearBySongName,
+  computeAvgCorrectPicksPerShow,
+  computeAvgPointsPerShow,
+  computeAvgSongVintage,
+  formatAvgCorrectPicksPerShow,
+  formatAvgPointsPerShow,
+  formatAvgSongVintage,
+} from '../model/profileAverages';
+import { useProfilePickHeatmap } from '../model/useProfilePickHeatmap';
+import { useUserSeasonStats } from '../model/useUserSeasonStats';
+import TopPicksFrequencyStrip from './TopPicksFrequencyStrip';
+
+/**
+ * Self-Profile stats: season averages + top-picks frequency strip (#553 / #554).
+ * Heatmap is self-only (live-compute); public profile stays on the lighter strip.
+ *
+ * @param {{ uid?: string }} props
+ */
+export default function ProfileSelfStatsPanel({ uid }) {
+  const { stats, loading: statsLoading } = useUserSeasonStats(uid);
+  const heatmap = useProfilePickHeatmap(uid, { enabled: Boolean(uid) });
+  const { songs } = useSongCatalog();
+
+  const debutMap = buildDebutYearBySongName(songs);
+  const vintage = computeAvgSongVintage(heatmap.songTitles, debutMap);
+
+  const avgPoints = formatAvgPointsPerShow(computeAvgPointsPerShow(stats));
+  const avgCorrect = formatAvgCorrectPicksPerShow(
+    computeAvgCorrectPicksPerShow(stats)
+  );
+  const avgVintage = formatAvgSongVintage(vintage.avgYear);
+
+  const columns = [
+    {
+      key: 'avgPts',
+      label: 'Avg pts / show',
+      value: avgPoints,
+    },
+    {
+      key: 'avgCorrect',
+      label: 'Avg correct / show',
+      value: avgCorrect,
+    },
+    {
+      key: 'vintage',
+      label: 'Avg vintage',
+      value: avgVintage,
+    },
+    {
+      key: 'shows',
+      label: 'Shows',
+      value: typeof stats?.shows === 'number' ? stats.shows : 0,
+    },
+  ];
+
+  if (!uid) return null;
+
+  return (
+    <div className="mb-8">
+      <section className="rounded-3xl border border-border-subtle bg-surface-panel p-6 shadow-inset-glass">
+        <h2 className="mb-4 text-xs font-black uppercase tracking-widest text-content-secondary">
+          Your stats
+        </h2>
+        <div className="grid grid-cols-2 gap-x-3 gap-y-1.5 text-center sm:grid-cols-4">
+          {columns.map(({ key, label }) => (
+            <p
+              key={`${key}-label`}
+              className="self-end px-0.5 text-[10px] font-black uppercase leading-snug tracking-wider text-content-secondary"
+            >
+              {label}
+            </p>
+          ))}
+          {columns.map(({ key, value }) => (
+            <div
+              key={`${key}-value`}
+              className="flex min-h-[3.25rem] items-center justify-center rounded-2xl border border-border-subtle bg-surface-field px-2 py-3"
+            >
+              <span className="text-2xl font-black tabular-nums leading-none tracking-tight text-brand-primary">
+                {statsLoading && key !== 'vintage' ? '…' : value}
+              </span>
+            </div>
+          ))}
+        </div>
+        <p className="mt-3 text-[11px] font-medium leading-relaxed text-content-secondary">
+          Career averages across graded nights. Avg correct needs the
+          finalize rollup field (shows — until backfilled). Vintage is the
+          mean debut year of songs in your recent top-picks window
+          {vintage.datedCount > 0
+            ? ` (${vintage.datedCount} of ${vintage.uniqueCount} dated)`
+            : ''}
+          .
+        </p>
+      </section>
+
+      <TopPicksFrequencyStrip
+        rows={heatmap.rows}
+        loading={heatmap.loading}
+        showsAggregated={heatmap.showsAggregated}
+        showsAvailable={heatmap.showsAvailable}
+      />
+    </div>
+  );
+}

--- a/src/features/profile/ui/PublicProfileView.jsx
+++ b/src/features/profile/ui/PublicProfileView.jsx
@@ -112,30 +112,24 @@ export default function PublicProfileView({
           <h2 className="mb-4 text-xs font-black uppercase tracking-widest text-content-secondary">
             Stats
           </h2>
-          <div className="grid grid-cols-2 gap-x-3 gap-y-1.5 text-center sm:grid-cols-3">
-            {statColumns.map(({ key, label }) => (
-              <p
-                key={`${key}-label`}
-                className="self-end px-0.5 text-[10px] font-black uppercase leading-snug tracking-wider text-content-secondary"
-              >
-                {label}
-              </p>
-            ))}
+          <div className="grid grid-cols-2 gap-3 text-center sm:grid-cols-3">
             {statColumns.map(({ key, label, value }) => (
-              <div
-                key={`${key}-value`}
-                className="flex min-h-[3.25rem] items-center justify-center rounded-2xl border border-border-subtle bg-surface-field px-2 py-3"
-              >
-                {statsLoading ? (
-                  <Loader2
-                    className="h-5 w-5 shrink-0 animate-spin text-brand-primary"
-                    aria-label={`Loading ${label}`}
-                  />
-                ) : (
-                  <span className="text-2xl font-black tabular-nums leading-none tracking-tight text-brand-primary">
-                    {value}
-                  </span>
-                )}
+              <div key={key} className="flex flex-col gap-1.5">
+                <p className="flex flex-1 items-end justify-center px-0.5 text-[10px] font-black uppercase leading-snug tracking-wider text-content-secondary">
+                  {label}
+                </p>
+                <div className="flex min-h-[3.25rem] items-center justify-center rounded-2xl border border-border-subtle bg-surface-field px-2 py-3">
+                  {statsLoading ? (
+                    <Loader2
+                      className="h-5 w-5 shrink-0 animate-spin text-brand-primary"
+                      aria-label={`Loading ${label}`}
+                    />
+                  ) : (
+                    <span className="text-2xl font-black tabular-nums leading-none tracking-tight text-brand-primary">
+                      {value}
+                    </span>
+                  )}
+                </div>
               </div>
             ))}
           </div>

--- a/src/features/profile/ui/PublicProfileView.jsx
+++ b/src/features/profile/ui/PublicProfileView.jsx
@@ -4,7 +4,9 @@ import { Loader2 } from 'lucide-react';
 import { formatMonthYear } from '../../../shared';
 import BackButton from '../../../shared/ui/BackButton';
 import {
+  computeAvgCorrectPicksPerShow,
   computeAvgPointsPerShow,
+  formatAvgCorrectPicksPerShow,
   formatAvgPointsPerShow,
 } from '../model/profileAverages';
 
@@ -43,10 +45,18 @@ export default function PublicProfileView({
   const avgPointsDisplay = formatAvgPointsPerShow(
     computeAvgPointsPerShow(stats)
   );
+  const avgCorrectDisplay = formatAvgCorrectPicksPerShow(
+    computeAvgCorrectPicksPerShow(stats)
+  );
 
   const statColumns = [
     { key: 'points', label: 'Total points', value: totalPoints },
-    { key: 'avg', label: 'Avg / show', value: avgPointsDisplay },
+    { key: 'avg', label: 'Avg pts / show', value: avgPointsDisplay },
+    {
+      key: 'avgCorrect',
+      label: 'Avg correct / show',
+      value: avgCorrectDisplay,
+    },
     { key: 'wins', label: 'Wins', value: wins },
     { key: 'shows', label: 'Shows', value: shows },
   ];
@@ -81,7 +91,9 @@ export default function PublicProfileView({
             Active pools
           </h2>
           {userPools.length === 0 ? (
-            <p className="text-sm font-bold text-content-secondary">Not in any pools</p>
+            <p className="text-sm font-bold text-content-secondary">
+              Not in any pools
+            </p>
           ) : (
             <div className="flex flex-wrap gap-2">
               {userPools.map((pool) => (
@@ -100,7 +112,7 @@ export default function PublicProfileView({
           <h2 className="mb-4 text-xs font-black uppercase tracking-widest text-content-secondary">
             Stats
           </h2>
-          <div className="grid grid-cols-2 gap-x-3 gap-y-1.5 text-center sm:grid-cols-4">
+          <div className="grid grid-cols-2 gap-x-3 gap-y-1.5 text-center sm:grid-cols-3">
             {statColumns.map(({ key, label }) => (
               <p
                 key={`${key}-label`}
@@ -128,9 +140,11 @@ export default function PublicProfileView({
             ))}
           </div>
           <p className="mt-3 text-[11px] font-medium leading-relaxed text-content-secondary">
-            Running totals across every graded night. Avg / show is total
-            points divided by shows played. Wins count nights with the overall
-            top score, not just in a single pool.
+            Running totals across every graded night. Avg pts / show is total
+            points divided by shows played. Avg correct / show is correct
+            slots per show (6 slots) when the career rollup is present;
+            otherwise —. Wins count nights with the overall top score, not
+            just in a single pool.
           </p>
         </section>
       </div>

--- a/src/features/profile/ui/TopPicksFrequencyStrip.jsx
+++ b/src/features/profile/ui/TopPicksFrequencyStrip.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { Loader2 } from 'lucide-react';
+
+/**
+ * Ranked top-picks intensity strip (#553). Frequency-forward; secondary
+ * hit counts when available from setlist join.
+ *
+ * @param {{
+ *   rows?: Array<{
+ *     title: string,
+ *     pickedCount: number,
+ *     correctCount: number,
+ *     exactSlotHits: number,
+ *     wildcardHits: number,
+ *     bustoutBoosts: number,
+ *   }>,
+ *   loading?: boolean,
+ *   showsAggregated?: number,
+ *   showsAvailable?: number,
+ * }} props
+ */
+export default function TopPicksFrequencyStrip({
+  rows = [],
+  loading = false,
+  showsAggregated = 0,
+  showsAvailable = 0,
+}) {
+  const maxPicked = rows.reduce(
+    (m, r) => Math.max(m, typeof r.pickedCount === 'number' ? r.pickedCount : 0),
+    0
+  );
+
+  return (
+    <section className="mt-6 rounded-3xl border border-border-subtle bg-surface-panel p-6 shadow-inset-glass">
+      <h2 className="mb-1 text-xs font-black uppercase tracking-widest text-content-secondary">
+        Top picks
+      </h2>
+      <p className="mb-4 text-[11px] font-medium leading-relaxed text-content-secondary">
+        Songs you lock in most often
+        {showsAggregated > 0
+          ? ` · last ${showsAggregated} graded show${showsAggregated === 1 ? '' : 's'}`
+          : ''}
+        {showsAvailable > showsAggregated
+          ? ` (of ${showsAvailable})`
+          : ''}
+        .
+      </p>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-8">
+          <Loader2
+            className="h-6 w-6 animate-spin text-brand-primary"
+            aria-label="Loading top picks"
+          />
+        </div>
+      ) : rows.length === 0 ? (
+        <p className="text-sm font-bold text-content-secondary">
+          No graded picks yet — play a show to build your strip.
+        </p>
+      ) : (
+        <ul className="space-y-2.5">
+          {rows.map((row) => {
+            const intensity =
+              maxPicked > 0 ? Math.max(0.12, row.pickedCount / maxPicked) : 0.12;
+            return (
+              <li key={row.title.toLowerCase()}>
+                <div className="flex items-baseline justify-between gap-3">
+                  <span className="truncate text-sm font-bold text-white">
+                    {row.title}
+                  </span>
+                  <span className="shrink-0 text-xs font-black tabular-nums text-brand-primary">
+                    ×{row.pickedCount}
+                  </span>
+                </div>
+                <div
+                  className="mt-1 h-1.5 overflow-hidden rounded-full bg-surface-field"
+                  aria-hidden
+                >
+                  <div
+                    className="h-full rounded-full bg-gradient-to-r from-red-500/80 to-blue-500/80"
+                    style={{ width: `${Math.round(intensity * 100)}%` }}
+                  />
+                </div>
+                <p className="mt-1 text-[10px] font-medium uppercase tracking-wide text-content-secondary">
+                  Correct {row.correctCount}
+                  <span className="mx-1.5 text-border-subtle">·</span>
+                  Exact {row.exactSlotHits}
+                  <span className="mx-1.5 text-border-subtle">·</span>
+                  Wild {row.wildcardHits}
+                  <span className="mx-1.5 text-border-subtle">·</span>
+                  Bustout {row.bustoutBoosts}
+                </p>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -2,6 +2,7 @@ export {
   fetchGlobalMaxScoreForShow,
   fetchGlobalShowWinners,
 } from './api/globalShowAggregation';
+export { normalizeOfficialSetlistDocData } from './api/standingsApi';
 export { default as Leaderboard } from './ui/Leaderboard';
 export { default as GradedPicksShareBar } from './ui/GradedPicksShareBar';
 export { default as StandingsSelfRecapCard } from './ui/StandingsSelfRecapCard';

--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -3,7 +3,11 @@ import { Link, useOutletContext } from 'react-router-dom';
 import { ExternalLink } from 'lucide-react';
 
 import { InstallAppCard } from '../../features/install';
-import { ProfileEditForm, useUserProfile } from '../../features/profile';
+import {
+  ProfileEditForm,
+  ProfileSelfStatsPanel,
+  useUserProfile,
+} from '../../features/profile';
 import { dashboardPageTitleGradientClasses } from '../../shared/config/dashboardHeadingTypography';
 import DashboardActionRow from '../../shared/ui/DashboardActionRow';
 import DashboardRowPill from '../../shared/ui/DashboardRowPill';
@@ -50,6 +54,8 @@ export default function ProfilePage({ user: userProp }) {
           </p>
         )}
       </div>
+
+      <ProfileSelfStatsPanel uid={user?.uid} />
 
       <ProfileEditForm
         handle={handle}


### PR DESCRIPTION
Closes #554
Closes #553

## Summary
- **#554 slice C:** `rollupScoresForShow` writes `users.careerCorrectSlots` (+ tour `correctSlots`) with pick `correctSlotsCredited` for regrade-safe diffs; revert/backfill/reset scripts updated. Public + self Profile show avg correct when the field exists (otherwise —).
- **#553:** Self Profile top-picks frequency strip (top 10, last 40 graded shows) with correct/exact/wild/bustout secondary counts and `profile_pick_heatmap_computed` telemetry. Public heatmap deferred.
- Self Profile also surfaces avg vintage from catalog `debut` over titles in the heatmap window.
- SemVer **1.26.0** + `docs/API.md` schema notes.

## Test plan
- [ ] `npm test` / `npm run lint`
- [ ] `cd functions && node --test rollupSeasonAggregates.test.js scoringCore.test.js`
- [ ] Signed-in: `/dashboard` Profile shows Your stats + Top picks (loading → rows or empty state)
- [ ] Public `/user/:uid` shows Avg correct / show as — until rollup/backfill, then a number after next finalize
- [ ] (Ops, optional) dry-run `node functions/scripts/backfillSeasonAggregates.js` then `--apply` to backfill careerCorrectSlots


Made with [Cursor](https://cursor.com)