### PR TITLE
feat(profile): curated avatar picker on Profile + public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.27.0] — 2026-07-16
+
+### Added
+- **Selectable profile avatars (#567)** — curated 12-mark set under `/avatars/*.svg`, persisted as `users.avatarId`. Picker on dashboard Profile; public `/user/:uid` shows the selected mark (default `ticket` when unset).
+
+---
+
 ## [1.26.0] — 2026-07-16
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.26.0  
+**Version:** 1.27.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 
@@ -18,7 +18,9 @@ All collections live in the default `(default)` Firestore database for project `
 |-------|------|-------|
 | `handle` | string | Display name |
 | `email` | string | Auth email — used for comms delivery |
-| `photoURL` | string? | Avatar URL |
+| `photoURL` | string? | Legacy optional URL field (unused by curated avatar picker) |
+| `avatarId` | string? | **v1.27.0+ (#567)** Curated avatar catalog id (e.g. `ticket`, `flame`). Missing/unknown → default `ticket` |
+| `favoriteSong` | string? | Display favorite; empty/`Unknown` treated as unset in UI |
 | `termsPrivacyAcceptedAt` | Timestamp? | Legal consent gate |
 | `createdAt` | Timestamp | Account creation |
 | `isAdmin` | boolean? | Admin custom claim mirror |

--- a/docs/RELEASE_TRAIN_SPRINT_9.md
+++ b/docs/RELEASE_TRAIN_SPRINT_9.md
@@ -149,6 +149,6 @@ Incomplete features must land dark, behind absent UX, flags, or forward-only fie
 | 2026-07-16 | Baseline | Fast-forward `staging` to `main` | `main` and `staging` aligned at `v1.23.0` |
 | 2026-07-16 | 0 | Manifest authored | Train defined; first PR targets `staging` |
 | 2026-07-16 | 0–1 | PRs #613–#616 merged | Manifest, #566 matrix, #584 place dedupe (1.23.1), #587 Phase A bustout badge (1.24.0); staging tip **1.24.0** |
-| 2026-07-16 | 2 | #617 + #618 merged | Foundation doc + avg points / show (1.24.1) |
-| 2026-07-16 | 2 | #619 merged | Catalog `debut` + avg vintage helpers (1.25.0) |
-| 2026-07-16 | 2 | #554 C + #553 in flight | `careerCorrectSlots` rollup + self top-picks strip + avg correct/vintage UI (1.26.0) |
+| 2026-07-16 | 2 | #617–#620 merged | Foundation + avg points (1.24.1) + debut/vintage helpers (1.25.0) + avg correct rollup / self top-picks / alignment fix (1.26.0); staging tip **1.26.0**; careerCorrectSlots backfilled |
+| 2026-07-16 | 3 | #567 in flight | Curated avatar picker + public profile mark (1.27.0) |
+| 2026-07-16 | 3 | Next | #568 badge awards/icons (matrix #566 locked) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setlistpickem",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setlistpickem",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "firebase": "10.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.26.0",
+  "version": "1.27.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/avatars/amp.svg
+++ b/public/avatars/amp.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#0B1220"/>
+  <rect x="14" y="16" width="36" height="32" rx="4" fill="#F97316"/>
+  <circle cx="32" cy="32" r="10" fill="#0B1220"/>
+  <circle cx="32" cy="32" r="5" fill="#FDBA74"/>
+  <rect x="20" y="20" width="8" height="3" rx="1.5" fill="#0B1220"/>
+</svg>

--- a/public/avatars/bolt.svg
+++ b/public/avatars/bolt.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#0B1220"/>
+  <path d="M34 12L20 34h10l-4 18 18-26H34l0-14z" fill="#FACC15"/>
+</svg>

--- a/public/avatars/cactus.svg
+++ b/public/avatars/cactus.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#0B1220"/>
+  <rect x="28" y="18" width="8" height="30" rx="4" fill="#22C55E"/>
+  <path d="M20 30h8v8a4 4 0 01-8 0v-8zM36 26h8v10a4 4 0 01-8 0V26z" fill="#16A34A"/>
+  <rect x="22" y="48" width="20" height="4" rx="2" fill="#854D0E"/>
+</svg>

--- a/public/avatars/compass.svg
+++ b/public/avatars/compass.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#0B1220"/>
+  <circle cx="32" cy="32" r="16" stroke="#2DD4BF" stroke-width="3"/>
+  <path d="M32 18l4 14-4 14-4-14 4-14z" fill="#5EEAD4"/>
+  <circle cx="32" cy="32" r="3" fill="#0B1220"/>
+</svg>

--- a/public/avatars/dice.svg
+++ b/public/avatars/dice.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#0B1220"/>
+  <rect x="16" y="16" width="32" height="32" rx="6" fill="#F43F5E"/>
+  <circle cx="24" cy="24" r="3" fill="#FFF1F2"/>
+  <circle cx="40" cy="24" r="3" fill="#FFF1F2"/>
+  <circle cx="32" cy="32" r="3" fill="#FFF1F2"/>
+  <circle cx="24" cy="40" r="3" fill="#FFF1F2"/>
+  <circle cx="40" cy="40" r="3" fill="#FFF1F2"/>
+</svg>

--- a/public/avatars/disc.svg
+++ b/public/avatars/disc.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#0B1220"/>
+  <circle cx="32" cy="32" r="18" fill="#38BDF8"/>
+  <circle cx="32" cy="32" r="12" stroke="#0B1220" stroke-width="2"/>
+  <circle cx="32" cy="32" r="4" fill="#0B1220"/>
+</svg>

--- a/public/avatars/flame.svg
+++ b/public/avatars/flame.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#0B1220"/>
+  <path d="M32 12c8 10 14 16 14 26a14 14 0 11-28 0c0-6 3-12 8-18 1 6 4 9 6 10V12z" fill="#FB7185"/>
+  <path d="M32 30c4 4 7 7 7 12a7 7 0 11-14 0c0-3 1.5-6 4-9 1 3 2 4 3 5v-8z" fill="#FDE68A"/>
+</svg>

--- a/public/avatars/lantern.svg
+++ b/public/avatars/lantern.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#0B1220"/>
+  <rect x="22" y="18" width="20" height="28" rx="6" fill="#F59E0B"/>
+  <rect x="26" y="22" width="12" height="20" rx="3" fill="#FEF3C7"/>
+  <path d="M28 14h8M32 14v4M24 46h16" stroke="#FBBF24" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/public/avatars/mic.svg
+++ b/public/avatars/mic.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#0B1220"/>
+  <rect x="26" y="12" width="12" height="22" rx="6" fill="#E11D48"/>
+  <path d="M20 30a12 12 0 0024 0" stroke="#E11D48" stroke-width="3" stroke-linecap="round"/>
+  <path d="M32 42v8M24 50h16" stroke="#94A3B8" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/public/avatars/star.svg
+++ b/public/avatars/star.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#0B1220"/>
+  <path d="M32 12l4.9 14.1H52l-11.5 8.4 4.4 14.1L32 40.2 19.1 48.6l4.4-14.1L12 26.1h15.1L32 12z" fill="#A78BFA"/>
+</svg>

--- a/public/avatars/ticket.svg
+++ b/public/avatars/ticket.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#0B1220"/>
+  <rect x="12" y="20" width="40" height="24" rx="4" fill="#14B8A6"/>
+  <circle cx="12" cy="32" r="5" fill="#0B1220"/>
+  <circle cx="52" cy="32" r="5" fill="#0B1220"/>
+  <path d="M28 26h16M28 32h12M28 38h14" stroke="#0B1220" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/public/avatars/wave.svg
+++ b/public/avatars/wave.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#0B1220"/>
+  <path d="M10 34c4-10 8-10 12 0s8 10 12 0 8-10 12 0 8 10 12 0" stroke="#22D3EE" stroke-width="4" stroke-linecap="round" fill="none"/>
+  <path d="M10 44c4-6 8-6 12 0s8 6 12 0 8-6 12 0 8 6 12 0" stroke="#67E8F9" stroke-width="3" stroke-linecap="round" opacity=".7" fill="none"/>
+</svg>

--- a/src/features/profile/api/profileApi.js
+++ b/src/features/profile/api/profileApi.js
@@ -25,14 +25,24 @@ export async function fetchUserProfileDocument(uid) {
 
 /**
  * Updates `users/{uid}` and syncs the new handle onto every pick doc for this user.
+ * `avatarId` is profile-only (not copied onto picks).
+ *
+ * @param {string} uid
+ * @param {{ handle: string, favoriteSong?: string, avatarId?: string }} fields
  */
-export async function updateUserProfileWithPickHandles(uid, { handle, favoriteSong }) {
+export async function updateUserProfileWithPickHandles(
+  uid,
+  { handle, favoriteSong, avatarId }
+) {
   const newHandle = handle.trim();
   const userPayload = {
     handle: newHandle,
     favoriteSong: (favoriteSong || '').trim() || 'Unknown',
     updatedAt: new Date().toISOString(),
   };
+  if (typeof avatarId === 'string' && avatarId.trim()) {
+    userPayload.avatarId = avatarId.trim();
+  }
 
   const picksQuery = query(
     collection(db, 'picks'),

--- a/src/features/profile/index.js
+++ b/src/features/profile/index.js
@@ -3,7 +3,15 @@ export { default as ProfileEditForm } from './ui/ProfileEditForm';
 export { default as ProfileSelfStatsPanel } from './ui/ProfileSelfStatsPanel';
 export { default as PublicProfileView } from './ui/PublicProfileView';
 export { default as TopPicksFrequencyStrip } from './ui/TopPicksFrequencyStrip';
+export { default as ProfileAvatar } from './ui/ProfileAvatar';
+export { default as AvatarPicker } from './ui/AvatarPicker';
 export { usePublicProfile } from './model/usePublicProfile';
 export { useUserProfile } from './model/useUserProfile';
 export { useUserSeasonStats } from './model/useUserSeasonStats';
 export { useProfilePickHeatmap } from './model/useProfilePickHeatmap';
+export {
+  DEFAULT_AVATAR_ID,
+  PROFILE_AVATARS,
+  normalizeAvatarId,
+  resolveAvatar,
+} from './model/avatarCatalog';

--- a/src/features/profile/model/avatarCatalog.js
+++ b/src/features/profile/model/avatarCatalog.js
@@ -1,0 +1,45 @@
+/**
+ * Curated profile avatar catalog (#567).
+ * Assets live under `/avatars/{id}.svg` (public/).
+ */
+
+/** @typedef {{ id: string, label: string, src: string }} ProfileAvatarOption */
+
+export const DEFAULT_AVATAR_ID = 'ticket';
+
+/** @type {readonly ProfileAvatarOption[]} */
+export const PROFILE_AVATARS = Object.freeze([
+  { id: 'ticket', label: 'Ticket stub', src: '/avatars/ticket.svg' },
+  { id: 'amp', label: 'Amp stack', src: '/avatars/amp.svg' },
+  { id: 'bolt', label: 'Lightning', src: '/avatars/bolt.svg' },
+  { id: 'disc', label: 'Vinyl disc', src: '/avatars/disc.svg' },
+  { id: 'mic', label: 'Mic stand', src: '/avatars/mic.svg' },
+  { id: 'star', label: 'Night star', src: '/avatars/star.svg' },
+  { id: 'wave', label: 'Sound wave', src: '/avatars/wave.svg' },
+  { id: 'cactus', label: 'Desert cactus', src: '/avatars/cactus.svg' },
+  { id: 'lantern', label: 'Glow lantern', src: '/avatars/lantern.svg' },
+  { id: 'dice', label: 'Lucky dice', src: '/avatars/dice.svg' },
+  { id: 'compass', label: 'Tour compass', src: '/avatars/compass.svg' },
+  { id: 'flame', label: 'Heater flame', src: '/avatars/flame.svg' },
+]);
+
+const AVATAR_BY_ID = new Map(PROFILE_AVATARS.map((a) => [a.id, a]));
+
+/**
+ * @param {unknown} avatarId
+ * @returns {string}
+ */
+export function normalizeAvatarId(avatarId) {
+  if (typeof avatarId !== 'string') return DEFAULT_AVATAR_ID;
+  const id = avatarId.trim();
+  return AVATAR_BY_ID.has(id) ? id : DEFAULT_AVATAR_ID;
+}
+
+/**
+ * @param {unknown} avatarId
+ * @returns {ProfileAvatarOption}
+ */
+export function resolveAvatar(avatarId) {
+  const id = normalizeAvatarId(avatarId);
+  return AVATAR_BY_ID.get(id) || PROFILE_AVATARS[0];
+}

--- a/src/features/profile/model/avatarCatalog.test.js
+++ b/src/features/profile/model/avatarCatalog.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_AVATAR_ID,
+  PROFILE_AVATARS,
+  normalizeAvatarId,
+  resolveAvatar,
+} from './avatarCatalog';
+
+describe('avatarCatalog', () => {
+  it('has unique ids and default in the catalog', () => {
+    const ids = PROFILE_AVATARS.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toContain(DEFAULT_AVATAR_ID);
+    expect(PROFILE_AVATARS.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('normalizes unknown / empty ids to default', () => {
+    expect(normalizeAvatarId(undefined)).toBe(DEFAULT_AVATAR_ID);
+    expect(normalizeAvatarId('')).toBe(DEFAULT_AVATAR_ID);
+    expect(normalizeAvatarId('not-a-real-avatar')).toBe(DEFAULT_AVATAR_ID);
+    expect(normalizeAvatarId('flame')).toBe('flame');
+  });
+
+  it('resolves src paths under /avatars', () => {
+    const avatar = resolveAvatar('disc');
+    expect(avatar.src).toBe('/avatars/disc.svg');
+    expect(avatar.label).toMatch(/vinyl/i);
+  });
+});

--- a/src/features/profile/model/useUserProfile.js
+++ b/src/features/profile/model/useUserProfile.js
@@ -7,6 +7,7 @@ import {
   updateUserProfileWithPickHandles,
 } from '../api/profileApi';
 import { showSuccessToast } from '../../../shared/ui/toast';
+import { DEFAULT_AVATAR_ID, normalizeAvatarId } from './avatarCatalog';
 
 /**
  * Loads the signed-in user's profile, holds edit form state, and persists updates.
@@ -18,6 +19,7 @@ export function useUserProfile(user) {
 
   const [handle, setHandle] = useState('');
   const [favoriteSong, setFavoriteSong] = useState('');
+  const [avatarId, setAvatarId] = useState(DEFAULT_AVATAR_ID);
   const [joinDate, setJoinDate] = useState('');
   const [isLoading, setIsLoading] = useState(!!uid);
   const [isSaving, setIsSaving] = useState(false);
@@ -28,6 +30,7 @@ export function useUserProfile(user) {
       setIsLoading(false);
       setHandle('');
       setFavoriteSong('');
+      setAvatarId(DEFAULT_AVATAR_ID);
       setJoinDate('');
       return;
     }
@@ -40,9 +43,11 @@ export function useUserProfile(user) {
       if (data) {
         setHandle(data.handle || '');
         setFavoriteSong(data.favoriteSong || '');
+        setAvatarId(normalizeAvatarId(data.avatarId));
       } else {
         setHandle('');
         setFavoriteSong('');
+        setAvatarId(DEFAULT_AVATAR_ID);
       }
     };
 
@@ -98,10 +103,13 @@ export function useUserProfile(user) {
       setMessage({ text: '', type: '' });
 
       try {
+        const nextAvatarId = normalizeAvatarId(avatarId);
         await updateUserProfileWithPickHandles(uid, {
           handle: trimmedHandle,
           favoriteSong,
+          avatarId: nextAvatarId,
         });
+        setAvatarId(nextAvatarId);
         setMessage({ text: 'Profile updated successfully! 🎸', type: 'success' });
         showSuccessToast('Profile updated! 🎸');
         return true;
@@ -114,18 +122,20 @@ export function useUserProfile(user) {
         setTimeout(() => setMessage({ text: '', type: '' }), 3000);
       }
     },
-    [uid, handle, favoriteSong],
+    [uid, handle, favoriteSong, avatarId],
   );
 
   return {
     handle,
     favoriteSong,
+    avatarId,
     joinDate,
     isLoading,
     isSaving,
     message,
     setHandle,
     setFavoriteSong,
+    setAvatarId,
     saveProfile,
   };
 }

--- a/src/features/profile/ui/AvatarPicker.jsx
+++ b/src/features/profile/ui/AvatarPicker.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { PROFILE_AVATARS } from '../model/avatarCatalog';
+import ProfileAvatar from './ProfileAvatar';
+
+/**
+ * Curated avatar picker grid (#567).
+ *
+ * @param {{
+ *   value: string,
+ *   onChange: (avatarId: string) => void,
+ *   disabled?: boolean,
+ * }} props
+ */
+export default function AvatarPicker({ value, onChange, disabled = false }) {
+  return (
+    <fieldset disabled={disabled} className="min-w-0">
+      <legend className="mb-2 ml-1 text-xs font-bold uppercase tracking-widest text-slate-400">
+        Avatar
+      </legend>
+      <div className="mb-3 flex items-center gap-3">
+        <ProfileAvatar avatarId={value} size="lg" />
+        <p className="text-[11px] font-medium leading-relaxed text-content-secondary">
+          Pick a mark for your Profile and public page. No uploads — curated
+          set only.
+        </p>
+      </div>
+      <div
+        className="grid grid-cols-4 gap-2 sm:grid-cols-6"
+        role="radiogroup"
+        aria-label="Choose avatar"
+      >
+        {PROFILE_AVATARS.map((avatar) => {
+          const selected = value === avatar.id;
+          return (
+            <button
+              key={avatar.id}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              aria-label={avatar.label}
+              disabled={disabled}
+              onClick={() => onChange(avatar.id)}
+              className={`rounded-2xl p-1 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary ${
+                selected
+                  ? 'bg-brand-primary/20 ring-2 ring-brand-primary'
+                  : 'hover:bg-surface-field'
+              }`}
+            >
+              <ProfileAvatar avatarId={avatar.id} size="sm" alt="" />
+            </button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}

--- a/src/features/profile/ui/ProfileAvatar.jsx
+++ b/src/features/profile/ui/ProfileAvatar.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { resolveAvatar } from '../model/avatarCatalog';
+
+/**
+ * Presentational profile avatar mark.
+ *
+ * @param {{
+ *   avatarId?: string | null,
+ *   size?: 'sm' | 'md' | 'lg',
+ *   className?: string,
+ *   alt?: string,
+ * }} props
+ */
+export default function ProfileAvatar({
+  avatarId,
+  size = 'md',
+  className = '',
+  alt,
+}) {
+  const avatar = resolveAvatar(avatarId);
+  const dim =
+    size === 'lg' ? 'h-20 w-20' : size === 'sm' ? 'h-10 w-10' : 'h-14 w-14';
+
+  return (
+    <img
+      src={avatar.src}
+      alt={alt ?? avatar.label}
+      width={size === 'lg' ? 80 : size === 'sm' ? 40 : 56}
+      height={size === 'lg' ? 80 : size === 'sm' ? 40 : 56}
+      className={`${dim} shrink-0 rounded-2xl border border-border-subtle bg-surface-field object-cover ${className}`.trim()}
+      decoding="async"
+    />
+  );
+}

--- a/src/features/profile/ui/ProfileEditForm.jsx
+++ b/src/features/profile/ui/ProfileEditForm.jsx
@@ -2,15 +2,18 @@ import React from 'react';
 
 import Button from '../../../shared/ui/Button';
 import Input from '../../../shared/ui/Input';
+import AvatarPicker from './AvatarPicker';
 
 /**
- * Editable profile fields (handle, favorite song) for the signed-in user.
+ * Editable profile fields (avatar, handle, favorite song) for the signed-in user.
  */
 export default function ProfileEditForm({
   handle,
   favoriteSong,
+  avatarId,
   onHandleChange,
   onFavoriteSongChange,
+  onAvatarChange,
   onSave,
   isSaving,
   isLoading = false,
@@ -21,6 +24,12 @@ export default function ProfileEditForm({
       onSubmit={onSave}
       className="space-y-6 rounded-3xl border border-border-subtle bg-surface-panel p-6 shadow-inset-glass"
     >
+      <AvatarPicker
+        value={avatarId}
+        onChange={onAvatarChange}
+        disabled={isLoading || isSaving}
+      />
+
       <div className="flex flex-col">
         <label className="text-xs font-bold text-slate-400 uppercase tracking-widest mb-2 ml-1">
           Display Name / Handle

--- a/src/features/profile/ui/PublicProfileView.jsx
+++ b/src/features/profile/ui/PublicProfileView.jsx
@@ -9,6 +9,7 @@ import {
   formatAvgCorrectPicksPerShow,
   formatAvgPointsPerShow,
 } from '../model/profileAverages';
+import ProfileAvatar from './ProfileAvatar';
 
 function formatPlayingSince(createdAt) {
   const value = formatMonthYear(createdAt);
@@ -66,15 +67,22 @@ export default function PublicProfileView({
       <div className="max-w-xl mx-auto px-4 py-10 pb-16">
         <BackButton className="mb-8" />
 
-        <header className="mb-2">
-          <h1 className="font-display text-3xl sm:text-4xl font-bold italic text-transparent bg-clip-text bg-gradient-to-r from-red-500 to-blue-500">
-            {handle}
-          </h1>
-          {playingSince && (
-            <p className="mt-2 text-xs font-bold uppercase tracking-widest text-brand-primary">
-              Playing since {playingSince}
-            </p>
-          )}
+        <header className="mb-2 flex items-start gap-4">
+          <ProfileAvatar
+            avatarId={profile.avatarId}
+            size="lg"
+            alt={`${handle}'s avatar`}
+          />
+          <div className="min-w-0">
+            <h1 className="font-display text-3xl sm:text-4xl font-bold italic text-transparent bg-clip-text bg-gradient-to-r from-red-500 to-blue-500">
+              {handle}
+            </h1>
+            {playingSince && (
+              <p className="mt-2 text-xs font-bold uppercase tracking-widest text-brand-primary">
+                Playing since {playingSince}
+              </p>
+            )}
+          </div>
         </header>
 
         <section className="mt-8 rounded-3xl border border-border-subtle bg-surface-panel p-6 shadow-inset-glass">

--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -22,12 +22,14 @@ export default function ProfilePage({ user: userProp }) {
   const {
     handle,
     favoriteSong,
+    avatarId,
     joinDate,
     isLoading,
     isSaving,
     message,
     setHandle,
     setFavoriteSong,
+    setAvatarId,
     saveProfile,
   } = useUserProfile(user);
 
@@ -60,8 +62,10 @@ export default function ProfilePage({ user: userProp }) {
       <ProfileEditForm
         handle={handle}
         favoriteSong={favoriteSong}
+        avatarId={avatarId}
         onHandleChange={setHandle}
         onFavoriteSongChange={setFavoriteSong}
+        onAvatarChange={setAvatarId}
         onSave={saveProfile}
         isSaving={isSaving}
         isLoading={isLoading}


### PR DESCRIPTION
Closes #567

## Summary
- Curated 12 SVG avatars under `/avatars/*.svg` with catalog + default `ticket`.
- Dashboard Profile picker persists `users.avatarId` (profile-only; not synced to picks).
- Public `/user/:uid` header shows selected mark; missing/unknown → default.
- SemVer **1.27.0** + `docs/API.md`.

## Test plan
- [ ] `npm test` / `npm run lint`
- [ ] Profile: pick an avatar, save, reload — selection sticks
- [ ] Public preview shows the same avatar
- [ ] User with no `avatarId` still gets the default ticket mark


Made with [Cursor](https://cursor.com)