### PR TITLE
feat(standings): tour stats explorer + Stats tab (#555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 ## [1.30.0] — 2026-07-17
 
 ### Added
-- **Tour stats explorer (#555)** — private dashboard route `/dashboard/tour-stats` aggregates the current tour’s `official_setlists` on demand (unique songs, top frequency, bustouts, high-gap highlights) plus a self pick overlay (correct slots / bustout hits / top-song overlap). Linked from Standings → Tour. No public SEO route or rollup schema in v1. SemVer MINOR for the new dashboard surface.
+- **Tour stats explorer (#555)** — private dashboard route `/dashboard/tour-stats` aggregates a selectable tour’s `official_setlists` on demand (unique songs, top frequency, bustouts, high-gap highlights) plus a self pick overlay (correct slots / bustout hits / top-song overlap). Peer Standings chrome tab (**Show \| Tour \| Stats \| Pools**); shares the Tour view’s chrome tour scope picker (`?tour=`). No public SEO route or rollup schema in v1. SemVer MINOR for the new dashboard surface.
+
+### Changed
+- **Standings IA (#555 UX)** — Stats is a fourth Standings view tab (not a buried Tour-only link and not a fifth primary bottom-nav item). Mobile context title on `/dashboard/tour-stats` stays **Standings**; sticky chrome matches Show/Tour/Pools.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.30.0] — 2026-07-17
+
+### Added
+- **Tour stats explorer (#555)** — private dashboard route `/dashboard/tour-stats` aggregates the current tour’s `official_setlists` on demand (unique songs, top frequency, bustouts, high-gap highlights) plus a self pick overlay (correct slots / bustout hits / top-song overlap). Linked from Standings → Tour. No public SEO route or rollup schema in v1. SemVer MINOR for the new dashboard surface.
+
+---
+
 ## [1.29.0] — 2026-07-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ### Changed
 - **Standings IA (#555 UX)** — Stats is a fourth Standings view tab (not a buried Tour-only link and not a fifth primary bottom-nav item). Mobile context title on `/dashboard/tour-stats` stays **Standings**; sticky chrome matches Show/Tour/Pools.
+- **Tour stats copy/layout (#555)** — summary reads “x of n tour dates”; grids use setlist-style column headers; summary tiles are Unique songs / Songs played / Unique ratio / Bustouts with Info tooltips (no footnote strip); Bustouts card keeps the scoring-rules “What is a bustout?” link; High gaps / Most played use Info tooltips.
+
+### Fixed
+- **Tour stats data hygiene (#555)** — the Bustouts and High-gaps cards now only count songs actually played that night, so stale `official_setlists` snapshot entries (the writer unions `bustouts`/`songGaps` across polls and never drops removed rows) no longer leak in as never-played “bustouts” or mislabeled high gaps. A played song whose frozen pre-show gap clears the bustout threshold is now shown as a bustout even if the frozen `bustouts` array missed it, keeping the two cards consistent. “Most played” ties now break by lifetime plays (song catalog) instead of alphabetically.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -320,7 +320,7 @@ These routes are part of the public surface. Renaming or removing them is a MAJO
 | `/setup` | Auth | Profile setup (new users) |
 | `/dashboard/*` | Auth | Full game dashboard |
 
-Dashboard sub-routes are documented in `docs/DASHBOARD_IA.md`. Notable secondary route: **`/dashboard/tour-stats`** (**v1.30.0 / #555**) — private tour stats explorer (unique songs, frequency, bustouts, self pick overlay). Standings nav stays active.
+Dashboard sub-routes are documented in `docs/DASHBOARD_IA.md`. Notable secondary route: **`/dashboard/tour-stats`** (**v1.30.0 / #555**) — private tour stats explorer (unique songs, frequency, bustouts, self pick overlay). Peer Standings chrome tab (**Stats** alongside Show / Tour / Pools); shares tour scope (`?tour=`) with Tour view. Standings nav stays active.
 
 ### 3.1 Email CTA click-through host (`click.setlistpickem.com`)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.29.0  
+**Version:** 1.30.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 
@@ -320,7 +320,7 @@ These routes are part of the public surface. Renaming or removing them is a MAJO
 | `/setup` | Auth | Profile setup (new users) |
 | `/dashboard/*` | Auth | Full game dashboard |
 
-Dashboard sub-routes are documented in `docs/DASHBOARD_IA.md`.
+Dashboard sub-routes are documented in `docs/DASHBOARD_IA.md`. Notable secondary route: **`/dashboard/tour-stats`** (**v1.30.0 / #555**) — private tour stats explorer (unique songs, frequency, bustouts, self pick overlay). Standings nav stays active.
 
 ### 3.1 Email CTA click-through host (`click.setlistpickem.com`)
 

--- a/docs/DASHBOARD_IA.md
+++ b/docs/DASHBOARD_IA.md
@@ -13,6 +13,12 @@ Single reference for **support**, **product**, and **engineering** when adding r
 
 **Admin** (fifth item, single admin user): `/dashboard/admin` — War Room.
 
+### Standings child: Tour stats (#555)
+
+| Route | Path | Notes |
+|-------|------|-------|
+| **Tour stats** | `/dashboard/tour-stats` | Private explorer: unique songs, frequency, bustouts, self pick overlay. Standings tab stays active (Pools/Profile child pattern). No global date picker. Linked from Standings → Tour view. |
+
 ### Profile cluster (#418)
 
 | Sub-nav | Path | Responsibility |

--- a/docs/DASHBOARD_IA.md
+++ b/docs/DASHBOARD_IA.md
@@ -17,7 +17,7 @@ Single reference for **support**, **product**, and **engineering** when adding r
 
 | Route | Path | Notes |
 |-------|------|-------|
-| **Tour stats** | `/dashboard/tour-stats` | Private explorer: unique songs, frequency, bustouts, self pick overlay. Standings tab stays active (Pools/Profile child pattern). No global date picker. Linked from Standings → Tour view. |
+| **Stats** (Standings peer tab) | `/dashboard/tour-stats` | Private explorer: unique songs, frequency, bustouts, self pick overlay. Discovered via Standings chrome **Show \| Tour \| Stats \| Pools** (not a 5th primary nav tab). Standings tab stays active. Shares the chrome **tour scope** picker with Tour view (`?tour=`). No global date picker. |
 
 ### Profile cluster (#418)
 
@@ -62,7 +62,7 @@ Rationale: **Entity-first** detail view without a second full-width display titl
 | **Messages** | Profile-cluster inbox + prefs (`NAV_LABEL_MESSAGES`); path `/dashboard/profile/notifications`. |
 | **Account** | Profile-cluster account surface (`NAV_LABEL_ACCOUNT`); path `/dashboard/profile/account`. |
 | **Admin** | Tab label for `/dashboard/admin` (`NAV_LABEL_ADMIN`); context + desktop H1 stay **War Room** (meta string in `dashboardPageMeta.js`). |
-| **Standings** | Tab, context bar for `/dashboard/standings` (`NAV_LABEL_STANDINGS`). Desktop **Standings** title + Show/Tour/Pools pills live in sticky in-page chrome (not the layout H2) so banners and the leaderboard scroll underneath. View is URL-synced via `?view=show\|tour\|pools` and the Pools view takes an optional `?pool=<id>` sub-selector. `?view=tour` hides the global date picker (tour standings are cumulative). |
+| **Standings** | Tab, context bar for `/dashboard/standings` and `/dashboard/tour-stats` (`NAV_LABEL_STANDINGS`). Desktop **Standings** title + Show/Tour/Stats/Pools pills live in sticky in-page chrome (not the layout H2) so banners and the leaderboard scroll underneath. View is URL-synced via `?view=show\|tour\|pools` on standings; **Stats** navigates to `/dashboard/tour-stats`. Pools view takes an optional `?pool=<id>` sub-selector. `?view=tour` and `/dashboard/tour-stats` hide the global date picker and show the shared tour scope picker (`?tour=`). |
 | **Show standings** | Ordered points for **one show date** only (Standings screen); use this phrase in glossary, help, and cross-links where the “one night” nuance matters. |
 | **All-time standings** | Cumulative points / wins / shows across **every** finalized show (all tours). Canonical name on pool details (`POOL_ALL_TIME_STANDINGS_HEADING`) and optional global companion on Standings. Replaces legacy **Season totals**. See #148. |
 | **Tour standings** | Cumulative points / wins / shows scoped to the **current tour** via `show_calendar.showDatesByTour` (`TOUR_STANDINGS_HEADING`). Global on Standings (#219), pool-scoped on pool details (#148). |

--- a/docs/RELEASE_TRAIN_SPRINT_9.md
+++ b/docs/RELEASE_TRAIN_SPRINT_9.md
@@ -153,3 +153,5 @@ Incomplete features must land dark, behind absent UX, flags, or forward-only fie
 | 2026-07-16 | 3 | #621 merged | Curated avatar picker + public mark (**1.27.0**) |
 | 2026-07-16 | 3 | #622 merged | Milestone badges v1 + standings pins / unset-avatar chip (**1.28.1**) |
 | 2026-07-16 | 4 | #587 Phase B in flight (#623) | Frozen per-song `official_setlists.songGaps` + Standings gap grid → **1.29.0**. #555 next: dashboard-first, on-demand tour-setlist aggregation |
+| 2026-07-17 | 3–4 | #622 + #623 merged | Badges/avatars (**1.28.1**) + setlist gaps (**1.29.0**); staging tip **1.29.0** |
+| 2026-07-17 | 4 | #555 in flight | Dashboard Tour stats explorer → **1.30.0** |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setlistpickem",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setlistpickem",
-      "version": "1.29.0",
+      "version": "1.30.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "firebase": "10.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.29.0",
+  "version": "1.30.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/verify-dashboard-meta.mjs
+++ b/scripts/verify-dashboard-meta.mjs
@@ -16,6 +16,7 @@ import {
   NAV_LABEL_POOLS,
   NAV_LABEL_PROFILE,
   NAV_LABEL_STANDINGS,
+  NAV_LABEL_TOUR_STATS,
   POOL_DETAILS_LAYOUT_EYEBROW,
 } from '../src/shared/config/dashboardVocabulary.js';
 
@@ -75,6 +76,16 @@ const CASES = [
       contextTitle: NAV_LABEL_STANDINGS,
       showDatePicker: false,
       layoutDesktopHeading: null,
+      layoutDetailEyebrow: null,
+    },
+  },
+  {
+    // #555: Tour stats explorer — secondary under Standings; no date picker.
+    path: '/dashboard/tour-stats',
+    expect: {
+      contextTitle: NAV_LABEL_TOUR_STATS,
+      showDatePicker: false,
+      layoutDesktopHeading: NAV_LABEL_TOUR_STATS,
       layoutDetailEyebrow: null,
     },
   },

--- a/scripts/verify-dashboard-meta.mjs
+++ b/scripts/verify-dashboard-meta.mjs
@@ -16,7 +16,6 @@ import {
   NAV_LABEL_POOLS,
   NAV_LABEL_PROFILE,
   NAV_LABEL_STANDINGS,
-  NAV_LABEL_TOUR_STATS,
   POOL_DETAILS_LAYOUT_EYEBROW,
 } from '../src/shared/config/dashboardVocabulary.js';
 
@@ -80,12 +79,12 @@ const CASES = [
     },
   },
   {
-    // #555: Tour stats explorer — secondary under Standings; no date picker.
+    // #555: Tour stats — peer Standings view; tour scope picker, no date picker.
     path: '/dashboard/tour-stats',
     expect: {
-      contextTitle: NAV_LABEL_TOUR_STATS,
+      contextTitle: NAV_LABEL_STANDINGS,
       showDatePicker: false,
-      layoutDesktopHeading: NAV_LABEL_TOUR_STATS,
+      layoutDesktopHeading: null,
       layoutDetailEyebrow: null,
     },
   },

--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -66,6 +66,7 @@ const AdminPage = lazy(dashboardLazyRouteImport.admin);
 const AccountPage = lazy(dashboardLazyRouteImport.account);
 const PoolHubPage = lazy(dashboardLazyRouteImport.poolHub);
 const NotificationsPage = lazy(dashboardLazyRouteImport.notifications);
+const TourStatsPage = lazy(dashboardLazyRouteImport.tourStats);
 
 function LazyDashboardRoute({ children }) {
   return <Suspense fallback={<RouteSuspenseFallback />}>{children}</Suspense>;
@@ -146,7 +147,9 @@ export default function DashboardLayout() {
   const isWarRoomRoute = meta.desktopHeadingTone === 'warRoom';
   const isStandingsRoute =
     location.pathname === '/dashboard/standings' ||
-    location.pathname === '/dashboard/standings/';
+    location.pathname === '/dashboard/standings/' ||
+    location.pathname === '/dashboard/tour-stats' ||
+    location.pathname === '/dashboard/tour-stats/';
   const isPicksRoute =
     location.pathname === '/dashboard' ||
     location.pathname === '/dashboard/' ||
@@ -200,11 +203,19 @@ export default function DashboardLayout() {
               item.path === '/dashboard/pools' &&
               (location.pathname === '/dashboard/pools' ||
                 location.pathname.startsWith('/dashboard/pool/'));
+            const isStandingsSection =
+              item.path === '/dashboard/standings' &&
+              (location.pathname === '/dashboard/standings' ||
+                location.pathname === '/dashboard/standings/' ||
+                location.pathname === '/dashboard/tour-stats' ||
+                location.pathname === '/dashboard/tour-stats/');
             const isActive =
               isProfileSection ||
               isPoolsSection ||
+              isStandingsSection ||
               (!isProfileSection &&
                 !isPoolsSection &&
+                !isStandingsSection &&
                 (location.pathname === item.path ||
                   (item.path === '/dashboard' && location.pathname === '/dashboard/')));
             return (
@@ -336,6 +347,14 @@ export default function DashboardLayout() {
               }
             />
             <Route
+              path="tour-stats"
+              element={
+                <LazyDashboardRoute>
+                  <TourStatsPage selectedDate={selectedDate} />
+                </LazyDashboardRoute>
+              }
+            />
+            <Route
               path="admin"
               element={
                 <LazyDashboardRoute>
@@ -405,11 +424,19 @@ export default function DashboardLayout() {
               item.path === '/dashboard/pools' &&
               (location.pathname === '/dashboard/pools' ||
                 location.pathname.startsWith('/dashboard/pool/'));
+            const isStandingsSection =
+              item.path === '/dashboard/standings' &&
+              (location.pathname === '/dashboard/standings' ||
+                location.pathname === '/dashboard/standings/' ||
+                location.pathname === '/dashboard/tour-stats' ||
+                location.pathname === '/dashboard/tour-stats/');
             const isActive =
               isProfileSection ||
               isPoolsSection ||
+              isStandingsSection ||
               (!isProfileSection &&
                 !isPoolsSection &&
+                !isStandingsSection &&
                 (location.pathname === item.path ||
                   (item.path === '/dashboard' && location.pathname === '/dashboard/')));
             return (

--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -350,7 +350,7 @@ export default function DashboardLayout() {
               path="tour-stats"
               element={
                 <LazyDashboardRoute>
-                  <TourStatsPage selectedDate={selectedDate} />
+                  <TourStatsPage />
                 </LazyDashboardRoute>
               }
             />

--- a/src/app/layout/model/dashboardPageMeta.js
+++ b/src/app/layout/model/dashboardPageMeta.js
@@ -15,7 +15,6 @@ import {
   NAV_LABEL_POOLS,
   NAV_LABEL_PROFILE,
   NAV_LABEL_STANDINGS,
-  NAV_LABEL_TOUR_STATS,
   POOL_DETAILS_LAYOUT_EYEBROW,
 } from '../../../shared/config/dashboardVocabulary.js';
 import {
@@ -48,8 +47,8 @@ function readViewQuery(search) {
  * @param {string} pathname
  * @param {string | URLSearchParams | null | undefined} [search]  `location.search`.
  *   Used by `/dashboard/standings` to hide the global date picker when
- *   `?view=tour` is active (#255) — tour standings are cumulative, so
- *   a date selector has no meaning there.
+ *   `?view=tour` is active (#255), and by `/dashboard/tour-stats` (#555) —
+ *   both are tour-scoped and share the chrome tour picker.
  */
 export function getDashboardPageMeta(pathname, search) {
   const normalized = normalizeDashboardPathname(pathname);
@@ -77,12 +76,12 @@ export function getDashboardPageMeta(pathname, search) {
   const isPoolHub = normalized.startsWith('/dashboard/pool/');
   const isStandings = normalized === '/dashboard/standings';
   const isTourStats = normalized === '/dashboard/tour-stats';
+  // Tour standings + Tour stats share the chrome tour scope picker (#295 / #555).
   const isStandingsTourView =
-    isStandings && readViewQuery(search) === 'tour';
+    (isStandings && readViewQuery(search) === 'tour') || isTourStats;
 
   const contextTitle = (() => {
-    if (isStandings) return NAV_LABEL_STANDINGS;
-    if (isTourStats) return NAV_LABEL_TOUR_STATS;
+    if (isStandings || isTourStats) return NAV_LABEL_STANDINGS;
     if (normalized === '/dashboard/pools') return NAV_LABEL_POOLS;
     if (isPoolHub) return NAV_LABEL_POOL_DETAILS;
     if (isProfileIdentity) return NAV_LABEL_PROFILE;
@@ -93,12 +92,14 @@ export function getDashboardPageMeta(pathname, search) {
   })();
 
   const showDatePicker =
-    !isProfileCluster && !isPoolHub && !isStandingsTourView && !isTourStats;
+    !isProfileCluster && !isPoolHub && !isStandingsTourView;
 
-  // Profile cluster + pool details own in-page headings; Standings owns a sticky
-  // title + Show/Tour/Pools chrome (#552 follow-up) so layout does not duplicate H1.
+  // Profile cluster + pool details own in-page headings; Standings (+ Stats peer)
+  // owns sticky title + Show/Tour/Stats/Pools chrome so layout does not duplicate H1.
   const layoutDesktopHeading =
-    !isProfileCluster && !isPoolHub && !isStandings ? contextTitle : null;
+    !isProfileCluster && !isPoolHub && !isStandings && !isTourStats
+      ? contextTitle
+      : null;
 
   const layoutDetailEyebrow = isPoolHub ? POOL_DETAILS_LAYOUT_EYEBROW : null;
 

--- a/src/app/layout/model/dashboardPageMeta.js
+++ b/src/app/layout/model/dashboardPageMeta.js
@@ -15,6 +15,7 @@ import {
   NAV_LABEL_POOLS,
   NAV_LABEL_PROFILE,
   NAV_LABEL_STANDINGS,
+  NAV_LABEL_TOUR_STATS,
   POOL_DETAILS_LAYOUT_EYEBROW,
 } from '../../../shared/config/dashboardVocabulary.js';
 import {
@@ -75,11 +76,13 @@ export function getDashboardPageMeta(pathname, search) {
   const isAdmin = normalized === '/dashboard/admin';
   const isPoolHub = normalized.startsWith('/dashboard/pool/');
   const isStandings = normalized === '/dashboard/standings';
+  const isTourStats = normalized === '/dashboard/tour-stats';
   const isStandingsTourView =
     isStandings && readViewQuery(search) === 'tour';
 
   const contextTitle = (() => {
     if (isStandings) return NAV_LABEL_STANDINGS;
+    if (isTourStats) return NAV_LABEL_TOUR_STATS;
     if (normalized === '/dashboard/pools') return NAV_LABEL_POOLS;
     if (isPoolHub) return NAV_LABEL_POOL_DETAILS;
     if (isProfileIdentity) return NAV_LABEL_PROFILE;
@@ -89,7 +92,8 @@ export function getDashboardPageMeta(pathname, search) {
     return NAV_LABEL_PICKS;
   })();
 
-  const showDatePicker = !isProfileCluster && !isPoolHub && !isStandingsTourView;
+  const showDatePicker =
+    !isProfileCluster && !isPoolHub && !isStandingsTourView && !isTourStats;
 
   // Profile cluster + pool details own in-page headings; Standings owns a sticky
   // title + Show/Tour/Pools chrome (#552 follow-up) so layout does not duplicate H1.

--- a/src/app/layout/model/dashboardRouteModules.js
+++ b/src/app/layout/model/dashboardRouteModules.js
@@ -14,11 +14,13 @@ export const dashboardLazyRouteImport = {
   account: () => import('../../../pages/profile/AccountPage'),
   poolHub: () => import('../../../pages/pools/PoolHubPage'),
   notifications: () => import('../../../pages/notifications/NotificationsPage'),
+  tourStats: () => import('../../../pages/tour-stats/TourStatsPage'),
 };
 
 /** Nav path → lazy route keys to warm before navigation. */
 export const DASHBOARD_NAV_PRELOAD_BY_PATH = Object.freeze({
   '/dashboard/admin': ['admin'],
+  '/dashboard/standings': ['tourStats'],
 });
 
 const started = new Set();
@@ -48,6 +50,7 @@ export function dashboardLazyRouteKeysForPathname(pathname) {
   const path = pathname.replace(/\/+$/, '') || '/dashboard';
   if (path.startsWith('/dashboard/pool/')) return ['poolHub'];
   if (path === '/dashboard/admin') return ['admin'];
+  if (path === '/dashboard/tour-stats') return ['tourStats'];
   if (isProfileClusterPath(path)) {
     const keys = [];
     if (path.includes('/notifications')) keys.push('notifications');

--- a/src/app/layout/model/dashboardRouteModules.test.js
+++ b/src/app/layout/model/dashboardRouteModules.test.js
@@ -9,7 +9,7 @@ import {
 describe('dashboardRouteModules', () => {
   it('defines lazy import factories only for secondary dashboard routes', () => {
     expect(Object.keys(dashboardLazyRouteImport).sort()).toEqual(
-      ['account', 'admin', 'notifications', 'poolHub'].sort()
+      ['account', 'admin', 'notifications', 'poolHub', 'tourStats'].sort()
     );
   });
 
@@ -17,9 +17,14 @@ describe('dashboardRouteModules', () => {
     expect(DASHBOARD_NAV_PRELOAD_BY_PATH['/dashboard/admin']).toEqual(['admin']);
   });
 
+  it('preloads tour stats from standings nav', () => {
+    expect(DASHBOARD_NAV_PRELOAD_BY_PATH['/dashboard/standings']).toEqual(['tourStats']);
+  });
+
   it('derives active lazy route keys from pathname', () => {
     expect(dashboardLazyRouteKeysForPathname('/dashboard/pools')).toEqual([]);
     expect(dashboardLazyRouteKeysForPathname('/dashboard/pool/abc123')).toEqual(['poolHub']);
     expect(dashboardLazyRouteKeysForPathname('/dashboard/profile/account')).toEqual(['account']);
+    expect(dashboardLazyRouteKeysForPathname('/dashboard/tour-stats')).toEqual(['tourStats']);
   });
 });

--- a/src/features/scoring/index.js
+++ b/src/features/scoring/index.js
@@ -25,9 +25,12 @@ export { useStandingsLeaderboardView } from './model/useStandingsLeaderboardView
 export { useStandingsScreen } from './model/useStandingsScreen';
 export {
   DEFAULT_STANDINGS_VIEW,
+  STANDINGS_PATH_VIEWS,
   STANDINGS_VIEWS,
   useStandingsView,
 } from './model/useStandingsView';
+export { buildStandingsViewPath } from './model/standingsViewPath';
+export { useStandingsViewChange } from './model/useStandingsViewChange';
 export { default as ScoringRulesContent } from './ui/ScoringRulesContent';
 export { default as ScoringRulesModal } from './ui/ScoringRulesModal';
 export {

--- a/src/features/scoring/model/standingsViewPath.js
+++ b/src/features/scoring/model/standingsViewPath.js
@@ -1,0 +1,46 @@
+/**
+ * Path helpers for Standings IA views (#255 / #555).
+ *
+ * Stats lives on `/dashboard/tour-stats` (dedicated route); Show / Tour / Pools
+ * stay on `/dashboard/standings` with `?view=`. Tour scope (`?tour=`) is shared.
+ */
+
+/** @typedef {'show' | 'tour' | 'pools' | 'stats'} StandingsViewId */
+
+/**
+ * @param {StandingsViewId} view
+ * @param {{
+ *   tourKey?: string | null,
+ *   poolId?: string | null,
+ * }} [opts]
+ * @returns {string}
+ */
+export function buildStandingsViewPath(view, opts = {}) {
+  const tourKey =
+    typeof opts.tourKey === 'string' && opts.tourKey.trim()
+      ? opts.tourKey.trim()
+      : '';
+  const poolId =
+    typeof opts.poolId === 'string' && opts.poolId.trim()
+      ? opts.poolId.trim()
+      : '';
+
+  if (view === 'stats') {
+    const params = new URLSearchParams();
+    if (tourKey) params.set('tour', tourKey);
+    const q = params.toString();
+    return q ? `/dashboard/tour-stats?${q}` : '/dashboard/tour-stats';
+  }
+
+  const params = new URLSearchParams();
+  if (view === 'tour') {
+    params.set('view', 'tour');
+    if (tourKey) params.set('tour', tourKey);
+  } else if (view === 'pools') {
+    params.set('view', 'pools');
+    if (poolId) params.set('pool', poolId);
+  }
+  // `show` omits `?view=` (canonical default).
+  const q = params.toString();
+  return q ? `/dashboard/standings?${q}` : '/dashboard/standings';
+}

--- a/src/features/scoring/model/standingsViewPath.test.js
+++ b/src/features/scoring/model/standingsViewPath.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildStandingsViewPath } from './standingsViewPath';
+
+describe('buildStandingsViewPath', () => {
+  it('builds the canonical Show path with no query', () => {
+    expect(buildStandingsViewPath('show')).toBe('/dashboard/standings');
+  });
+
+  it('builds Tour with optional tour key', () => {
+    expect(buildStandingsViewPath('tour')).toBe('/dashboard/standings?view=tour');
+    expect(buildStandingsViewPath('tour', { tourKey: 'Summer 2026' })).toBe(
+      '/dashboard/standings?view=tour&tour=Summer+2026',
+    );
+  });
+
+  it('builds Pools with optional pool id', () => {
+    expect(buildStandingsViewPath('pools')).toBe('/dashboard/standings?view=pools');
+    expect(buildStandingsViewPath('pools', { poolId: 'abc' })).toBe(
+      '/dashboard/standings?view=pools&pool=abc',
+    );
+  });
+
+  it('builds Stats on the dedicated tour-stats route', () => {
+    expect(buildStandingsViewPath('stats')).toBe('/dashboard/tour-stats');
+    expect(buildStandingsViewPath('stats', { tourKey: 'Spring 2026' })).toBe(
+      '/dashboard/tour-stats?tour=Spring+2026',
+    );
+  });
+
+  it('ignores blank tour / pool keys', () => {
+    expect(buildStandingsViewPath('stats', { tourKey: '  ' })).toBe(
+      '/dashboard/tour-stats',
+    );
+    expect(buildStandingsViewPath('pools', { poolId: '' })).toBe(
+      '/dashboard/standings?view=pools',
+    );
+  });
+});

--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -31,6 +31,7 @@ import { computeStandingsSelfRecap } from './standingsSelfRecap';
 import { useStandingsLeaderboardView } from './useStandingsLeaderboardView';
 import { useStandingsTourSelection } from './useStandingsTourSelection';
 import { useStandingsView } from './useStandingsView';
+import { useStandingsViewChange } from './useStandingsViewChange';
 import { useTourStandings } from './useTourStandings';
 import { useScoringRulesModal } from '../ui/ScoringRulesModalProvider';
 
@@ -66,10 +67,16 @@ export function useStandingsScreen(selectedDate, options = {}) {
   const { pools: userPools } = useUserPools(user?.uid);
   const inviteChooser = useInviteChooser({ pools: userPools });
 
-  const { view, poolId, setView, setPoolId } = useStandingsView({
+  const {
+    view,
+    poolId,
+    setView: setPathView,
+    setPoolId,
+  } = useStandingsView({
     userPools,
     navTargetPoolId: targetPoolId || undefined,
   });
+  const setView = useStandingsViewChange({ view, setPathView });
 
   const activeFilter = view === 'pools' && poolId ? poolId : 'global';
 

--- a/src/features/scoring/model/useStandingsView.js
+++ b/src/features/scoring/model/useStandingsView.js
@@ -4,18 +4,26 @@ import { useSearchParams } from 'react-router-dom';
 import { ga4Event } from '../../../shared/lib/ga4';
 
 /**
- * Canonical standings view ids (#255). Keep aligned with
- * `dashboardPageMeta.js` (which hides the date picker when `view=tour`)
- * and `scripts/verify-dashboard-meta.mjs`.
+ * Views owned by `/dashboard/standings?view=` (#255). Keep aligned with
+ * `dashboardPageMeta.js` and `scripts/verify-dashboard-meta.mjs`.
  */
-export const STANDINGS_VIEWS = Object.freeze(['show', 'tour', 'pools']);
+export const STANDINGS_PATH_VIEWS = Object.freeze(['show', 'tour', 'pools']);
+
+/**
+ * Full Standings IA toggle (#555 adds Stats). Stats lives on
+ * `/dashboard/tour-stats` — see {@link buildStandingsViewPath}.
+ */
+export const STANDINGS_VIEWS = Object.freeze([
+  ...STANDINGS_PATH_VIEWS,
+  'stats',
+]);
 
 /** Default view when the URL has no `?view` query. */
 export const DEFAULT_STANDINGS_VIEW = 'show';
 const RECENT_STANDINGS_POOL_KEY = 'standings.recentPoolId';
 
-function isKnownView(v) {
-  return typeof v === 'string' && STANDINGS_VIEWS.includes(v);
+function isKnownPathView(v) {
+  return typeof v === 'string' && STANDINGS_PATH_VIEWS.includes(v);
 }
 
 /**
@@ -24,7 +32,7 @@ function isKnownView(v) {
  * renders something sensible rather than an empty tab panel.
  */
 export function normalizeView(raw) {
-  return isKnownView(raw) ? raw : DEFAULT_STANDINGS_VIEW;
+  return isKnownPathView(raw) ? raw : DEFAULT_STANDINGS_VIEW;
 }
 
 /**

--- a/src/features/scoring/model/useStandingsView.test.js
+++ b/src/features/scoring/model/useStandingsView.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DEFAULT_STANDINGS_VIEW,
+  STANDINGS_PATH_VIEWS,
   STANDINGS_VIEWS,
   deriveDefaultPoolId,
   deriveStandingsView,
@@ -9,10 +10,15 @@ import {
 } from './useStandingsView';
 
 describe('normalizeView', () => {
-  it('returns known views verbatim', () => {
-    for (const v of STANDINGS_VIEWS) {
+  it('returns known path views verbatim', () => {
+    for (const v of STANDINGS_PATH_VIEWS) {
       expect(normalizeView(v)).toBe(v);
     }
+  });
+
+  it('does not treat Stats as a standings-path view', () => {
+    expect(STANDINGS_VIEWS).toContain('stats');
+    expect(normalizeView('stats')).toBe(DEFAULT_STANDINGS_VIEW);
   });
 
   it.each([

--- a/src/features/scoring/model/useStandingsViewChange.js
+++ b/src/features/scoring/model/useStandingsViewChange.js
@@ -1,0 +1,62 @@
+import { useCallback } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+import { ga4Event } from '../../../shared/lib/ga4';
+import { buildStandingsViewPath } from './standingsViewPath';
+import { DEFAULT_STANDINGS_VIEW, STANDINGS_VIEWS } from './useStandingsView';
+
+/**
+ * Cross-route Standings IA toggle (#555).
+ *
+ * Show / Tour / Pools stay on `/dashboard/standings` (delegating to the
+ * in-page `setPathView` when already there — that path owns GA4). Stats
+ * navigates to `/dashboard/tour-stats`. Preserves `?tour=` across Tour ↔ Stats.
+ *
+ * @param {{
+ *   view: 'show' | 'tour' | 'pools' | 'stats',
+ *   setPathView?: (next: 'show' | 'tour' | 'pools') => void,
+ * }} options
+ */
+export function useStandingsViewChange({ view, setPathView }) {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  return useCallback(
+    (nextView) => {
+      const normalized =
+        typeof nextView === 'string' && STANDINGS_VIEWS.includes(nextView)
+          ? nextView
+          : DEFAULT_STANDINGS_VIEW;
+      if (normalized === view) return;
+
+      const tourKey = searchParams.get('tour') || '';
+      const poolId = searchParams.get('pool') || '';
+
+      if (normalized === 'stats' || view === 'stats') {
+        ga4Event('standings_view_change', { from: view, to: normalized });
+        navigate(
+          buildStandingsViewPath(normalized, {
+            tourKey:
+              normalized === 'tour' || normalized === 'stats' ? tourKey : '',
+            poolId: normalized === 'pools' ? poolId : '',
+          }),
+        );
+        return;
+      }
+
+      if (typeof setPathView === 'function') {
+        setPathView(normalized);
+        return;
+      }
+
+      ga4Event('standings_view_change', { from: view, to: normalized });
+      navigate(
+        buildStandingsViewPath(normalized, {
+          tourKey: normalized === 'tour' ? tourKey : '',
+          poolId: normalized === 'pools' ? poolId : '',
+        }),
+      );
+    },
+    [navigate, searchParams, setPathView, view],
+  );
+}

--- a/src/features/scoring/ui/StandingsMobileFixedChrome.jsx
+++ b/src/features/scoring/ui/StandingsMobileFixedChrome.jsx
@@ -9,13 +9,13 @@ import StandingsViewToggle from './StandingsViewToggle';
 
 /**
  * Mobile-only Standings views chrome (#609) — fixed under the context bar.
- * Show/Tour/Pools fills the tools band (Profile-style full-width segmented
+ * Show/Tour/Stats/Pools fills the tools band (Profile-style full-width segmented
  * control). Scoring rules Scale portals into the context-bar trailing slot
- * so the H2 row stays seamless across Show / Tour / Pools.
+ * so the H2 row stays seamless across Standings views.
  *
  * @param {{
- *   view: 'show' | 'tour' | 'pools',
- *   onChange: (next: 'show' | 'tour' | 'pools') => void,
+ *   view: 'show' | 'tour' | 'pools' | 'stats',
+ *   onChange: (next: 'show' | 'tour' | 'pools' | 'stats') => void,
  *   onOpenScoringRules: () => void,
  * }} props
  */

--- a/src/features/scoring/ui/StandingsStickyChrome.jsx
+++ b/src/features/scoring/ui/StandingsStickyChrome.jsx
@@ -6,7 +6,7 @@ import { dashboardPageTitleGradientClasses } from '../../../shared/config/dashbo
 import StandingsViewToggle from './StandingsViewToggle';
 
 /**
- * Desktop Standings page chrome: title + Show/Tour/Pools + Scoring rules.
+ * Desktop Standings page chrome: title + Show/Tour/Stats/Pools + Scoring rules.
  * Sticky in the dashboard `main` scrollport under the Tour Date / Tour scope row.
  * Invite lives in-flow as {@link StandingsInvitePromo} (mirrors mobile).
  *
@@ -17,8 +17,8 @@ import StandingsViewToggle from './StandingsViewToggle';
  * `DashboardLayout` (`md:top-[5.75rem]`).
  *
  * @param {{
- *   view: 'show' | 'tour' | 'pools',
- *   onChange: (next: 'show' | 'tour' | 'pools') => void,
+ *   view: 'show' | 'tour' | 'pools' | 'stats',
+ *   onChange: (next: 'show' | 'tour' | 'pools' | 'stats') => void,
  *   onOpenScoringRules: () => void,
  *   pinBelowDesktopDatePicker?: boolean,
  * }} props

--- a/src/features/scoring/ui/StandingsTourView.jsx
+++ b/src/features/scoring/ui/StandingsTourView.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 
 import Card from '../../../shared/ui/Card';
 import PageTitle from '../../../shared/ui/PageTitle';
@@ -15,6 +14,7 @@ import {
  *
  * Tour selection lives in the dashboard chrome (Tour Date slot) via
  * {@link StandingsTourScopeSelect} (#609), not inline here.
+ * Stats discovery is the peer Standings tab (Show / Tour / Stats / Pools).
  *
  * Pure presentational — all state comes from `useStandingsScreen`.
  */
@@ -48,22 +48,12 @@ export default function StandingsTourView({
     );
   }
   return (
-    <div className="space-y-3">
-      <div className="flex justify-end">
-        <Link
-          to="/dashboard/tour-stats"
-          className="text-xs font-bold uppercase tracking-wider text-teal-300 underline decoration-teal-500/40 underline-offset-2 hover:text-white hover:decoration-teal-300"
-        >
-          Tour stats
-        </Link>
-      </div>
-      <TourStandingsSection
-        tourName={tourName}
-        leaders={leaders}
-        loading={loading}
-        error={error}
-        selfUserId={selfUserId}
-      />
-    </div>
+    <TourStandingsSection
+      tourName={tourName}
+      leaders={leaders}
+      loading={loading}
+      error={error}
+      selfUserId={selfUserId}
+    />
   );
 }

--- a/src/features/scoring/ui/StandingsTourView.jsx
+++ b/src/features/scoring/ui/StandingsTourView.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import Card from '../../../shared/ui/Card';
 import PageTitle from '../../../shared/ui/PageTitle';
@@ -47,12 +48,22 @@ export default function StandingsTourView({
     );
   }
   return (
-    <TourStandingsSection
-      tourName={tourName}
-      leaders={leaders}
-      loading={loading}
-      error={error}
-      selfUserId={selfUserId}
-    />
+    <div className="space-y-3">
+      <div className="flex justify-end">
+        <Link
+          to="/dashboard/tour-stats"
+          className="text-xs font-bold uppercase tracking-wider text-teal-300 underline decoration-teal-500/40 underline-offset-2 hover:text-white hover:decoration-teal-300"
+        >
+          Tour stats
+        </Link>
+      </div>
+      <TourStandingsSection
+        tourName={tourName}
+        leaders={leaders}
+        loading={loading}
+        error={error}
+        selfUserId={selfUserId}
+      />
+    </div>
   );
 }

--- a/src/features/scoring/ui/StandingsViewToggle.jsx
+++ b/src/features/scoring/ui/StandingsViewToggle.jsx
@@ -1,16 +1,17 @@
 import React from 'react';
-import { CalendarDays, ListOrdered, Users } from 'lucide-react';
+import { BarChart3, CalendarDays, ListOrdered, Users } from 'lucide-react';
 
 import ChromeSegmentedControl from '../../../shared/ui/ChromeSegmentedControl';
 
 const OPTIONS = [
   { id: 'show', label: 'Show', icon: ListOrdered },
   { id: 'tour', label: 'Tour', icon: CalendarDays },
+  { id: 'stats', label: 'Stats', icon: BarChart3 },
   { id: 'pools', label: 'Pools', icon: Users },
 ];
 
 const baseClass =
-  'shrink-0 inline-flex items-center gap-1.5 rounded-full border px-4 py-1.5 text-sm font-semibold tracking-tight transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg';
+  'shrink-0 inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-semibold tracking-tight transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg';
 
 /**
  * Active state mirrors `Button variant="primary"` (teal fill, dark text,
@@ -27,20 +28,18 @@ const unselectedClass =
   'border-border-venue/70 bg-surface-panel text-slate-300 hover:border-border-venue-strong hover:bg-surface-panel-strong hover:text-white';
 
 /**
- * Primary IA toggle for `/dashboard/standings` (#255) — three-way pick
- * between show-scoped standings, tour-scoped cumulative standings, and
- * pool-scoped show standings.
+ * Primary IA toggle for Standings (#255 / #555) — Show / Tour / Stats / Pools.
  *
  * Responsive contract (#609): mobile fixed chrome uses boxed
- * `ChromeSegmentedControl` (icons + equal thirds); `md+` renders as an
+ * `ChromeSegmentedControl` (icons + equal quarters); `md+` renders as an
  * auto-width inline pill group with primary CTA active state.
  *
- * State + URL sync lives in {@link useStandingsView}; this is the
- * presentational half.
+ * State + navigation lives in {@link useStandingsView} /
+ * {@link useStandingsViewChange}; this is the presentational half.
  *
  * @param {{
- *   view: 'show' | 'tour' | 'pools',
- *   onChange: (next: 'show' | 'tour' | 'pools') => void,
+ *   view: 'show' | 'tour' | 'pools' | 'stats',
+ *   onChange: (next: 'show' | 'tour' | 'pools' | 'stats') => void,
  *   className?: string,
  * }} props
  */
@@ -59,7 +58,7 @@ export default function StandingsViewToggle({ view, onChange, className = '' }) 
         role="tablist"
         aria-label="Standings view"
         className={[
-          'mb-5 hidden w-auto items-center justify-center gap-2 md:flex',
+          'mb-5 hidden w-auto flex-wrap items-center justify-center gap-2 md:flex',
           className,
         ]
           .filter(Boolean)
@@ -77,7 +76,7 @@ export default function StandingsViewToggle({ view, onChange, className = '' }) 
               className={[
                 baseClass,
                 selected ? selectedClass : unselectedClass,
-                'min-w-[5.5rem] justify-center',
+                'min-w-[4.75rem] justify-center',
               ].join(' ')}
             >
               <Icon className="h-4 w-4 shrink-0" aria-hidden />

--- a/src/features/tour-stats/api/computeTourStatsSelfOverlay.js
+++ b/src/features/tour-stats/api/computeTourStatsSelfOverlay.js
@@ -1,0 +1,132 @@
+import { doc, getDoc } from 'firebase/firestore';
+
+import { FORM_FIELDS } from '../../../shared/data/gameConfig';
+import { db } from '../../../shared/lib/firebase';
+import { whenFirebaseReady } from '../../../shared/lib/firebaseAppCheck';
+import { calculateSlotScore } from '../../../shared/utils/scoring';
+
+import { TOUR_SETLIST_READ_CHUNK } from './fetchTourOfficialSetlists';
+
+/**
+ * @param {string} showDate
+ * @param {string} uid
+ * @returns {string}
+ */
+function pickDocId(showDate, uid) {
+  return `${showDate}_${uid}`;
+}
+
+/**
+ * Minimal private overlay: how the signed-in user's tour picks stack up (#555).
+ *
+ * Read budget: up to N `picks/{showDate}_{uid}` point reads (chunked).
+ *
+ * @param {string} uid
+ * @param {Array<{ showDate: string, setlist: Record<string, unknown> | null }>} setlistDocs
+ * @param {{
+ *   topSongTitles?: string[],
+ *   chunkSize?: number,
+ * }} [options]
+ * @returns {Promise<{
+ *   showsPicked: number,
+ *   slotsFilled: number,
+ *   slotsCorrect: number,
+ *   bustoutHits: number,
+ *   topSongOverlap: number,
+ *   pickReads: number,
+ * }>}
+ */
+export async function computeTourStatsSelfOverlay(uid, setlistDocs, options = {}) {
+  const id = typeof uid === 'string' ? uid.trim() : '';
+  const docs = Array.isArray(setlistDocs) ? setlistDocs : [];
+  const topKeys = new Set(
+    (Array.isArray(options.topSongTitles) ? options.topSongTitles : [])
+      .map((t) => String(t ?? '').trim().toLowerCase())
+      .filter(Boolean),
+  );
+  const chunkSize =
+    typeof options.chunkSize === 'number' && options.chunkSize > 0
+      ? Math.trunc(options.chunkSize)
+      : TOUR_SETLIST_READ_CHUNK;
+
+  if (!id || docs.length === 0) {
+    return {
+      showsPicked: 0,
+      slotsFilled: 0,
+      slotsCorrect: 0,
+      bustoutHits: 0,
+      topSongOverlap: 0,
+      pickReads: 0,
+    };
+  }
+
+  await whenFirebaseReady();
+
+  const dates = docs.map((d) => d.showDate).filter(Boolean);
+  /** @type {Map<string, Record<string, unknown>>} */
+  const picksByDate = new Map();
+  let pickReads = 0;
+
+  for (let i = 0; i < dates.length; i += chunkSize) {
+    const chunk = dates.slice(i, i + chunkSize);
+    const snaps = await Promise.all(
+      chunk.map((showDate) => getDoc(doc(db, 'picks', pickDocId(showDate, id)))),
+    );
+    pickReads += chunk.length;
+    for (let j = 0; j < chunk.length; j += 1) {
+      const snap = snaps[j];
+      if (!snap.exists()) continue;
+      const data = snap.data() || {};
+      const picks = data.picks && typeof data.picks === 'object' ? data.picks : null;
+      if (picks) picksByDate.set(chunk[j], picks);
+    }
+  }
+
+  let showsPicked = 0;
+  let slotsFilled = 0;
+  let slotsCorrect = 0;
+  let bustoutHits = 0;
+  const pickedTop = new Set();
+
+  for (const entry of docs) {
+    const picks = picksByDate.get(entry.showDate);
+    if (!picks) continue;
+    const filled = FORM_FIELDS.some((f) => {
+      const v = picks[f.id];
+      return typeof v === 'string' && v.trim().length > 0;
+    });
+    if (!filled) continue;
+    showsPicked += 1;
+
+    const setlist = entry.setlist;
+    const bustoutSet = new Set(
+      Array.isArray(setlist?.bustouts)
+        ? setlist.bustouts.map((t) => String(t ?? '').trim().toLowerCase()).filter(Boolean)
+        : [],
+    );
+
+    for (const field of FORM_FIELDS) {
+      const raw = picks[field.id];
+      const title = typeof raw === 'string' ? raw.trim() : '';
+      if (!title) continue;
+      slotsFilled += 1;
+      const key = title.toLowerCase();
+      if (topKeys.has(key)) pickedTop.add(key);
+
+      if (setlist) {
+        const score = calculateSlotScore(field.id, title, setlist);
+        if (score > 0) slotsCorrect += 1;
+        if (bustoutSet.has(key) && score > 0) bustoutHits += 1;
+      }
+    }
+  }
+
+  return {
+    showsPicked,
+    slotsFilled,
+    slotsCorrect,
+    bustoutHits,
+    topSongOverlap: pickedTop.size,
+    pickReads,
+  };
+}

--- a/src/features/tour-stats/api/fetchTourOfficialSetlists.js
+++ b/src/features/tour-stats/api/fetchTourOfficialSetlists.js
@@ -1,0 +1,58 @@
+import { doc, getDoc } from 'firebase/firestore';
+
+import { db } from '../../../shared/lib/firebase';
+import { whenFirebaseReady } from '../../../shared/lib/firebaseAppCheck';
+import { normalizeOfficialSetlistDocData } from '../../scoring';
+
+/** Concurrent point-read chunk size (mirrors profile heatmap / tour standings). */
+export const TOUR_SETLIST_READ_CHUNK = 8;
+
+/**
+ * @param {string[]} showDates
+ * @param {{ chunkSize?: number }} [options]
+ * @returns {Promise<{
+ *   docs: Array<{ showDate: string, setlist: ReturnType<typeof normalizeOfficialSetlistDocData> }>,
+ *   setlistReads: number,
+ *   missingDates: string[],
+ * }>}
+ */
+export async function fetchTourOfficialSetlists(showDates, options = {}) {
+  const dates = Array.isArray(showDates)
+    ? [...new Set(showDates.map((d) => String(d ?? '').trim()).filter(Boolean))].sort()
+    : [];
+  const chunkSize =
+    typeof options.chunkSize === 'number' && options.chunkSize > 0
+      ? Math.trunc(options.chunkSize)
+      : TOUR_SETLIST_READ_CHUNK;
+
+  await whenFirebaseReady();
+
+  /** @type {Array<{ showDate: string, setlist: ReturnType<typeof normalizeOfficialSetlistDocData> }>} */
+  const docs = [];
+  /** @type {string[]} */
+  const missingDates = [];
+  let setlistReads = 0;
+
+  for (let i = 0; i < dates.length; i += chunkSize) {
+    const chunk = dates.slice(i, i + chunkSize);
+    const snaps = await Promise.all(
+      chunk.map((showDate) => getDoc(doc(db, 'official_setlists', showDate))),
+    );
+    setlistReads += chunk.length;
+    for (let j = 0; j < chunk.length; j += 1) {
+      const showDate = chunk[j];
+      const snap = snaps[j];
+      if (!snap.exists()) {
+        missingDates.push(showDate);
+        docs.push({ showDate, setlist: null });
+        continue;
+      }
+      docs.push({
+        showDate,
+        setlist: normalizeOfficialSetlistDocData(snap.data()),
+      });
+    }
+  }
+
+  return { docs, setlistReads, missingDates };
+}

--- a/src/features/tour-stats/index.js
+++ b/src/features/tour-stats/index.js
@@ -1,0 +1,2 @@
+export { useTourStatsScreen } from './model/useTourStatsScreen';
+export { default as TourStatsView } from './ui/TourStatsView';

--- a/src/features/tour-stats/model/aggregateTourSetlistStats.js
+++ b/src/features/tour-stats/model/aggregateTourSetlistStats.js
@@ -1,0 +1,185 @@
+/**
+ * Pure tour-level aggregation over normalized `official_setlists` docs (#555).
+ * Display / explorer only — not used for scoring.
+ */
+
+/**
+ * @param {unknown} title
+ * @returns {string}
+ */
+function normalizeTitle(title) {
+  return String(title ?? '')
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * @typedef {{
+ *   title: string,
+ *   timesPlayed: number,
+ *   showDates: string[],
+ * }} TourSongFrequencyRow
+ *
+ * @typedef {{
+ *   title: string,
+ *   showDate: string,
+ *   gap: number | null,
+ * }} TourBustoutRow
+ *
+ * @typedef {{
+ *   title: string,
+ *   showDate: string,
+ *   gap: number,
+ * }} TourGapHighlightRow
+ *
+ * @typedef {{
+ *   tourShowCount: number,
+ *   showsWithSetlist: number,
+ *   uniqueSongs: number,
+ *   totalSongPlays: number,
+ *   topSongs: TourSongFrequencyRow[],
+ *   bustouts: TourBustoutRow[],
+ *   gapHighlights: TourGapHighlightRow[],
+ * }} TourSetlistStats
+ */
+
+export const TOUR_STATS_TOP_N = 15;
+/** Surface high-gap non-bustout songs in the explorer (≥ this gap). */
+export const TOUR_STATS_GAP_HIGHLIGHT_MIN = 20;
+
+/**
+ * @param {Array<{
+ *   showDate: string,
+ *   setlist: null | Record<string, unknown>,
+ * }>} docs
+ * @param {{
+ *   tourShowCount?: number,
+ *   topN?: number,
+ *   gapHighlightMin?: number,
+ * }} [options]
+ * @returns {TourSetlistStats}
+ */
+export function aggregateTourSetlistStats(docs, options = {}) {
+  const topN =
+    typeof options.topN === 'number' && options.topN > 0
+      ? Math.trunc(options.topN)
+      : TOUR_STATS_TOP_N;
+  const gapHighlightMin =
+    typeof options.gapHighlightMin === 'number' && options.gapHighlightMin >= 0
+      ? Math.trunc(options.gapHighlightMin)
+      : TOUR_STATS_GAP_HIGHLIGHT_MIN;
+  const tourShowCount =
+    typeof options.tourShowCount === 'number' && options.tourShowCount >= 0
+      ? Math.trunc(options.tourShowCount)
+      : Array.isArray(docs)
+        ? docs.length
+        : 0;
+
+  /** @type {Map<string, { title: string, timesPlayed: number, showDates: string[] }>} */
+  const bySong = new Map();
+  /** @type {TourBustoutRow[]} */
+  const bustouts = [];
+  /** @type {TourGapHighlightRow[]} */
+  const gapHighlights = [];
+  let showsWithSetlist = 0;
+  let totalSongPlays = 0;
+
+  const list = Array.isArray(docs) ? docs : [];
+  for (const entry of list) {
+    if (!entry || typeof entry !== 'object') continue;
+    const showDate = typeof entry.showDate === 'string' ? entry.showDate.trim() : '';
+    const setlist = entry.setlist;
+    if (!setlist || typeof setlist !== 'object') continue;
+
+    const titles = Array.isArray(setlist.officialSetlist)
+      ? setlist.officialSetlist.map((t) => String(t ?? '').trim()).filter(Boolean)
+      : [];
+    if (titles.length === 0) continue;
+    showsWithSetlist += 1;
+
+    const seenThisShow = new Set();
+    for (const title of titles) {
+      const key = normalizeTitle(title);
+      if (!key || seenThisShow.has(key)) continue;
+      seenThisShow.add(key);
+      totalSongPlays += 1;
+      const existing = bySong.get(key);
+      if (existing) {
+        existing.timesPlayed += 1;
+        if (showDate) existing.showDates.push(showDate);
+      } else {
+        bySong.set(key, {
+          title,
+          timesPlayed: 1,
+          showDates: showDate ? [showDate] : [],
+        });
+      }
+    }
+
+    const bustoutList = Array.isArray(setlist.bustouts) ? setlist.bustouts : [];
+    const bustoutKeys = new Set();
+    for (const raw of bustoutList) {
+      const title = String(raw ?? '').trim();
+      const key = normalizeTitle(title);
+      if (!title || !key || bustoutKeys.has(key)) continue;
+      bustoutKeys.add(key);
+      const gaps = setlist.songGaps;
+      const gapRaw =
+        gaps && typeof gaps === 'object' && !Array.isArray(gaps) ? gaps[key] : null;
+      const gap =
+        typeof gapRaw === 'number' && Number.isFinite(gapRaw)
+          ? Math.trunc(gapRaw)
+          : null;
+      bustouts.push({ title, showDate, gap });
+    }
+
+    const gaps = setlist.songGaps;
+    if (gaps && typeof gaps === 'object' && !Array.isArray(gaps)) {
+      for (const [key, gapRaw] of Object.entries(gaps)) {
+        const gap =
+          typeof gapRaw === 'number' && Number.isFinite(gapRaw)
+            ? Math.trunc(gapRaw)
+            : null;
+        if (gap == null || gap < gapHighlightMin) continue;
+        if (bustoutKeys.has(key)) continue;
+        const match = bySong.get(key);
+        const title = match?.title || key;
+        gapHighlights.push({ title, showDate, gap });
+      }
+    }
+  }
+
+  const topSongs = [...bySong.values()]
+    .sort((a, b) => {
+      if (b.timesPlayed !== a.timesPlayed) return b.timesPlayed - a.timesPlayed;
+      return a.title.localeCompare(b.title);
+    })
+    .slice(0, topN)
+    .map((row) => ({
+      title: row.title,
+      timesPlayed: row.timesPlayed,
+      showDates: [...row.showDates],
+    }));
+
+  bustouts.sort((a, b) => {
+    const ga = a.gap ?? -1;
+    const gb = b.gap ?? -1;
+    if (gb !== ga) return gb - ga;
+    return a.title.localeCompare(b.title);
+  });
+
+  gapHighlights.sort((a, b) => {
+    if (b.gap !== a.gap) return b.gap - a.gap;
+    return a.title.localeCompare(b.title);
+  });
+
+  return {
+    tourShowCount,
+    showsWithSetlist,
+    uniqueSongs: bySong.size,
+    totalSongPlays,
+    topSongs,
+    bustouts,
+    gapHighlights: gapHighlights.slice(0, topN),
+  };
+}

--- a/src/features/tour-stats/model/aggregateTourSetlistStats.js
+++ b/src/features/tour-stats/model/aggregateTourSetlistStats.js
@@ -3,6 +3,8 @@
  * Display / explorer only — not used for scoring.
  */
 
+import { SCORING_RULES } from '../../../shared/utils/scoring';
+
 /**
  * @param {unknown} title
  * @returns {string}
@@ -11,6 +13,27 @@ function normalizeTitle(title) {
   return String(title ?? '')
     .trim()
     .toLowerCase();
+}
+
+/**
+ * @param {unknown} raw
+ * @returns {number | null}
+ */
+function toGap(raw) {
+  const n = typeof raw === 'number' ? raw : Number(raw);
+  return Number.isFinite(n) ? Math.trunc(n) : null;
+}
+
+/**
+ * @param {undefined | null | Map<string, number> | Record<string, number>} lifetime
+ * @param {string} key
+ * @returns {number}
+ */
+function lifetimePlaysFor(lifetime, key) {
+  if (!lifetime) return 0;
+  if (lifetime instanceof Map) return Number(lifetime.get(key)) || 0;
+  if (typeof lifetime === 'object') return Number(lifetime[key]) || 0;
+  return 0;
 }
 
 /**
@@ -44,8 +67,8 @@ function normalizeTitle(title) {
  */
 
 export const TOUR_STATS_TOP_N = 15;
-/** Surface high-gap non-bustout songs in the explorer (≥ this gap). */
-export const TOUR_STATS_GAP_HIGHLIGHT_MIN = 20;
+/** Surface high-gap non-bustout songs in the explorer (≥ this gap, below bustout). */
+export const TOUR_STATS_GAP_HIGHLIGHT_MIN = 10;
 
 /**
  * @param {Array<{
@@ -56,6 +79,8 @@ export const TOUR_STATS_GAP_HIGHLIGHT_MIN = 20;
  *   tourShowCount?: number,
  *   topN?: number,
  *   gapHighlightMin?: number,
+ *   bustoutMinGap?: number,
+ *   lifetimePlaysByKey?: Map<string, number> | Record<string, number> | null,
  * }} [options]
  * @returns {TourSetlistStats}
  */
@@ -68,6 +93,11 @@ export function aggregateTourSetlistStats(docs, options = {}) {
     typeof options.gapHighlightMin === 'number' && options.gapHighlightMin >= 0
       ? Math.trunc(options.gapHighlightMin)
       : TOUR_STATS_GAP_HIGHLIGHT_MIN;
+  const bustoutMinGap =
+    typeof options.bustoutMinGap === 'number' && options.bustoutMinGap >= 0
+      ? Math.trunc(options.bustoutMinGap)
+      : SCORING_RULES.BUSTOUT_MIN_GAP;
+  const lifetimePlaysByKey = options.lifetimePlaysByKey ?? null;
   const tourShowCount =
     typeof options.tourShowCount === 'number' && options.tourShowCount >= 0
       ? Math.trunc(options.tourShowCount)
@@ -97,11 +127,12 @@ export function aggregateTourSetlistStats(docs, options = {}) {
     if (titles.length === 0) continue;
     showsWithSetlist += 1;
 
-    const seenThisShow = new Set();
+    /** Normalized keys of songs actually played this show (the display guard). */
+    const playedThisShow = new Set();
     for (const title of titles) {
       const key = normalizeTitle(title);
-      if (!key || seenThisShow.has(key)) continue;
-      seenThisShow.add(key);
+      if (!key || playedThisShow.has(key)) continue;
+      playedThisShow.add(key);
       totalSongPlays += 1;
       const existing = bySong.get(key);
       if (existing) {
@@ -116,46 +147,63 @@ export function aggregateTourSetlistStats(docs, options = {}) {
       }
     }
 
-    const bustoutList = Array.isArray(setlist.bustouts) ? setlist.bustouts : [];
+    const songGaps =
+      setlist.songGaps &&
+      typeof setlist.songGaps === 'object' &&
+      !Array.isArray(setlist.songGaps)
+        ? setlist.songGaps
+        : null;
+
+    // Bustouts: the frozen per-show snapshot, but only for songs that actually
+    // appear in this show's played list. The writer merges `bustouts` with the
+    // prior poll and never removes entries, so a song that briefly showed up in
+    // a live/edited feed can stay frozen here after vanishing from
+    // `officialSetlist`. Guarding on played-this-show drops those stale ghosts.
     const bustoutKeys = new Set();
+    const bustoutList = Array.isArray(setlist.bustouts) ? setlist.bustouts : [];
     for (const raw of bustoutList) {
       const title = String(raw ?? '').trim();
       const key = normalizeTitle(title);
       if (!title || !key || bustoutKeys.has(key)) continue;
+      if (!playedThisShow.has(key)) continue;
       bustoutKeys.add(key);
-      const gaps = setlist.songGaps;
-      const gapRaw =
-        gaps && typeof gaps === 'object' && !Array.isArray(gaps) ? gaps[key] : null;
-      const gap =
-        typeof gapRaw === 'number' && Number.isFinite(gapRaw)
-          ? Math.trunc(gapRaw)
-          : null;
-      bustouts.push({ title, showDate, gap });
+      bustouts.push({ title, showDate, gap: songGaps ? toGap(songGaps[key]) : null });
     }
 
-    const gaps = setlist.songGaps;
-    if (gaps && typeof gaps === 'object' && !Array.isArray(gaps)) {
-      for (const [key, gapRaw] of Object.entries(gaps)) {
-        const gap =
-          typeof gapRaw === 'number' && Number.isFinite(gapRaw)
-            ? Math.trunc(gapRaw)
-            : null;
-        if (gap == null || gap < gapHighlightMin) continue;
-        if (bustoutKeys.has(key)) continue;
+    // Union: a played song whose frozen pre-show gap clears the bustout
+    // threshold is a bustout by definition, even if the frozen `bustouts` array
+    // missed it (snapshot drift). Keeps the two cards internally consistent so
+    // nothing ≥ threshold lands in "high gaps (non-bustout)".
+    if (songGaps) {
+      for (const [key, gapRaw] of Object.entries(songGaps)) {
+        if (!playedThisShow.has(key) || bustoutKeys.has(key)) continue;
+        const gap = toGap(gapRaw);
+        if (gap == null || gap < bustoutMinGap) continue;
+        bustoutKeys.add(key);
         const match = bySong.get(key);
-        const title = match?.title || key;
-        gapHighlights.push({ title, showDate, gap });
+        bustouts.push({ title: match?.title || key, showDate, gap });
+      }
+
+      for (const [key, gapRaw] of Object.entries(songGaps)) {
+        if (!playedThisShow.has(key) || bustoutKeys.has(key)) continue;
+        const gap = toGap(gapRaw);
+        if (gap == null || gap < gapHighlightMin || gap >= bustoutMinGap) continue;
+        const match = bySong.get(key);
+        gapHighlights.push({ title: match?.title || key, showDate, gap });
       }
     }
   }
 
-  const topSongs = [...bySong.values()]
-    .sort((a, b) => {
+  const topSongs = [...bySong.entries()]
+    .sort(([keyA, a], [keyB, b]) => {
       if (b.timesPlayed !== a.timesPlayed) return b.timesPlayed - a.timesPlayed;
+      const lifetimeA = lifetimePlaysFor(lifetimePlaysByKey, keyA);
+      const lifetimeB = lifetimePlaysFor(lifetimePlaysByKey, keyB);
+      if (lifetimeB !== lifetimeA) return lifetimeB - lifetimeA;
       return a.title.localeCompare(b.title);
     })
     .slice(0, topN)
-    .map((row) => ({
+    .map(([, row]) => ({
       title: row.title,
       timesPlayed: row.timesPlayed,
       showDates: [...row.showDates],

--- a/src/features/tour-stats/model/aggregateTourSetlistStats.test.js
+++ b/src/features/tour-stats/model/aggregateTourSetlistStats.test.js
@@ -35,7 +35,7 @@ describe('aggregateTourSetlistStats (#555)', () => {
           },
         },
       ],
-      { tourShowCount: 4, topN: 10, gapHighlightMin: 20 },
+      { tourShowCount: 4, topN: 10, gapHighlightMin: 10 },
     );
 
     expect(stats.showsWithSetlist).toBe(2);
@@ -54,17 +54,91 @@ describe('aggregateTourSetlistStats (#555)', () => {
         {
           showDate: '2026-07-12',
           setlist: {
-            officialSetlist: ['Reba', 'Dinner and a Movie'],
+            officialSetlist: ['Reba', 'Dinner and a Movie', 'Free'],
             bustouts: ['Dinner and a Movie'],
-            songGaps: { reba: 25, 'dinner and a movie': 82 },
+            songGaps: {
+              reba: 25,
+              'dinner and a movie': 82,
+              free: 12,
+            },
           },
         },
       ],
-      { gapHighlightMin: 20 },
+      { gapHighlightMin: 10 },
     );
     expect(stats.gapHighlights).toEqual([
       { title: 'Reba', showDate: '2026-07-12', gap: 25 },
+      { title: 'Free', showDate: '2026-07-12', gap: 12 },
     ]);
     expect(stats.bustouts[0].title).toBe('Dinner and a Movie');
+  });
+
+  it('drops bustouts/gaps for songs not actually played that show (stale snapshot)', () => {
+    const stats = aggregateTourSetlistStats(
+      [
+        {
+          showDate: '2026-07-20',
+          setlist: {
+            officialSetlist: ['Wilson', 'Sample in a Jar'],
+            // Frozen ghosts: the writer unions `bustouts`/`songGaps` across
+            // polls and never removes, so a song from an edited feed can linger
+            // even though it is not in `officialSetlist`.
+            bustouts: ['The Curtain'],
+            songGaps: { 'punch you in the eye': 55, wilson: 3 },
+          },
+        },
+      ],
+      { bustoutMinGap: 30, gapHighlightMin: 10 },
+    );
+    expect(stats.bustouts).toEqual([]);
+    expect(stats.gapHighlights).toEqual([]);
+  });
+
+  it('promotes a played high-gap song to bustout even when missing from the snapshot', () => {
+    const stats = aggregateTourSetlistStats(
+      [
+        {
+          showDate: '2026-07-21',
+          setlist: {
+            officialSetlist: ['Peaches en Regalia', 'Bouncing Around the Room'],
+            bustouts: [],
+            songGaps: {
+              'peaches en regalia': 248,
+              'bouncing around the room': 5,
+            },
+          },
+        },
+      ],
+      { bustoutMinGap: 30, gapHighlightMin: 10 },
+    );
+    expect(stats.bustouts).toEqual([
+      { title: 'Peaches en Regalia', showDate: '2026-07-21', gap: 248 },
+    ]);
+    expect(stats.gapHighlights).toEqual([]);
+  });
+
+  it('breaks Most played ties by lifetime plays from the catalog', () => {
+    const stats = aggregateTourSetlistStats(
+      [
+        {
+          showDate: '2026-07-22',
+          setlist: {
+            officialSetlist: ['Rare Bird', 'You Enjoy Myself'],
+            bustouts: [],
+            songGaps: {},
+          },
+        },
+      ],
+      {
+        lifetimePlaysByKey: new Map([
+          ['you enjoy myself', 623],
+          ['rare bird', 1],
+        ]),
+      },
+    );
+    expect(stats.topSongs.map((r) => r.title)).toEqual([
+      'You Enjoy Myself',
+      'Rare Bird',
+    ]);
   });
 });

--- a/src/features/tour-stats/model/aggregateTourSetlistStats.test.js
+++ b/src/features/tour-stats/model/aggregateTourSetlistStats.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { aggregateTourSetlistStats } from './aggregateTourSetlistStats';
+
+describe('aggregateTourSetlistStats (#555)', () => {
+  it('returns empty stats for empty input', () => {
+    expect(aggregateTourSetlistStats([], { tourShowCount: 3 })).toEqual({
+      tourShowCount: 3,
+      showsWithSetlist: 0,
+      uniqueSongs: 0,
+      totalSongPlays: 0,
+      topSongs: [],
+      bustouts: [],
+      gapHighlights: [],
+    });
+  });
+
+  it('counts unique songs once per show and ranks by frequency', () => {
+    const stats = aggregateTourSetlistStats(
+      [
+        {
+          showDate: '2026-07-10',
+          setlist: {
+            officialSetlist: ['Tweezer', 'Free', 'Tweezer'],
+            bustouts: [],
+            songGaps: { tweezer: 2, free: 5 },
+          },
+        },
+        {
+          showDate: '2026-07-11',
+          setlist: {
+            officialSetlist: ['Free', 'Ghost'],
+            bustouts: ['Ghost'],
+            songGaps: { free: 1, ghost: 40 },
+          },
+        },
+      ],
+      { tourShowCount: 4, topN: 10, gapHighlightMin: 20 },
+    );
+
+    expect(stats.showsWithSetlist).toBe(2);
+    expect(stats.tourShowCount).toBe(4);
+    expect(stats.uniqueSongs).toBe(3);
+    expect(stats.totalSongPlays).toBe(4);
+    expect(stats.topSongs[0]).toMatchObject({ title: 'Free', timesPlayed: 2 });
+    expect(stats.bustouts).toEqual([
+      { title: 'Ghost', showDate: '2026-07-11', gap: 40 },
+    ]);
+  });
+
+  it('surfaces non-bustout gap highlights above the threshold', () => {
+    const stats = aggregateTourSetlistStats(
+      [
+        {
+          showDate: '2026-07-12',
+          setlist: {
+            officialSetlist: ['Reba', 'Dinner and a Movie'],
+            bustouts: ['Dinner and a Movie'],
+            songGaps: { reba: 25, 'dinner and a movie': 82 },
+          },
+        },
+      ],
+      { gapHighlightMin: 20 },
+    );
+    expect(stats.gapHighlights).toEqual([
+      { title: 'Reba', showDate: '2026-07-12', gap: 25 },
+    ]);
+    expect(stats.bustouts[0].title).toBe('Dinner and a Movie');
+  });
+});

--- a/src/features/tour-stats/model/useTourStatsScreen.js
+++ b/src/features/tour-stats/model/useTourStatsScreen.js
@@ -1,0 +1,90 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { todayYmd } from '../../../shared/utils/dateUtils';
+import { useAuth } from '../../auth';
+import { resolveCurrentTour } from '../../scoring';
+import { useShowCalendar } from '../../show-calendar';
+import { computeTourStatsSelfOverlay } from '../api/computeTourStatsSelfOverlay';
+import { fetchTourOfficialSetlists } from '../api/fetchTourOfficialSetlists';
+import { aggregateTourSetlistStats } from './aggregateTourSetlistStats';
+
+/**
+ * Dashboard Tour stats screen (#555): on-demand setlist aggregation + self overlay.
+ *
+ * @param {{
+ *   selectedDate?: string | null,
+ *   tourKey?: string | null,
+ * }} [options]
+ */
+export function useTourStatsScreen(options = {}) {
+  const { user } = useAuth();
+  const { showDatesByTour, loading: calendarLoading } = useShowCalendar();
+  const today = todayYmd();
+
+  const selectedTour = useMemo(() => {
+    const groups = Array.isArray(showDatesByTour) ? showDatesByTour : [];
+    const key = typeof options.tourKey === 'string' ? options.tourKey.trim() : '';
+    if (key) {
+      const match = groups.find((g) => g.tour === key);
+      if (match) return match;
+    }
+    return resolveCurrentTour(options.selectedDate, today, groups);
+  }, [options.selectedDate, options.tourKey, showDatesByTour, today]);
+
+  const showDates = useMemo(
+    () =>
+      selectedTour && Array.isArray(selectedTour.shows)
+        ? selectedTour.shows.map((s) => s.date).filter(Boolean)
+        : [],
+    [selectedTour],
+  );
+
+  const tourName = selectedTour?.tour || '';
+  const uid = user?.uid || '';
+
+  const setlistQuery = useQuery({
+    queryKey: ['tour-stats-setlists', tourName, showDates.join(',')],
+    enabled: !calendarLoading && showDates.length > 0,
+    staleTime: 5 * 60 * 1000,
+    queryFn: () => fetchTourOfficialSetlists(showDates),
+  });
+
+  const stats = useMemo(() => {
+    const docs = setlistQuery.data?.docs || [];
+    return aggregateTourSetlistStats(docs, { tourShowCount: showDates.length });
+  }, [setlistQuery.data, showDates.length]);
+
+  const overlayQuery = useQuery({
+    queryKey: [
+      'tour-stats-self-overlay',
+      uid,
+      tourName,
+      showDates.join(','),
+      stats.topSongs.map((r) => r.title).join('|'),
+    ],
+    enabled:
+      Boolean(uid) &&
+      setlistQuery.isSuccess &&
+      (setlistQuery.data?.docs?.length || 0) > 0,
+    staleTime: 5 * 60 * 1000,
+    queryFn: () =>
+      computeTourStatsSelfOverlay(uid, setlistQuery.data.docs, {
+        topSongTitles: stats.topSongs.map((r) => r.title),
+      }),
+  });
+
+  return {
+    calendarLoading,
+    tourName,
+    showDates,
+    hasTour: Boolean(selectedTour),
+    stats,
+    setlistLoading: setlistQuery.isLoading,
+    setlistError: setlistQuery.error,
+    setlistReads: setlistQuery.data?.setlistReads ?? 0,
+    missingDates: setlistQuery.data?.missingDates ?? [],
+    overlay: overlayQuery.data ?? null,
+    overlayLoading: overlayQuery.isLoading,
+  };
+}

--- a/src/features/tour-stats/model/useTourStatsScreen.js
+++ b/src/features/tour-stats/model/useTourStatsScreen.js
@@ -1,10 +1,7 @@
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
-import { todayYmd } from '../../../shared/utils/dateUtils';
 import { useAuth } from '../../auth';
-import { resolveCurrentTour } from '../../scoring';
-import { useShowCalendar } from '../../show-calendar';
 import { computeTourStatsSelfOverlay } from '../api/computeTourStatsSelfOverlay';
 import { fetchTourOfficialSetlists } from '../api/fetchTourOfficialSetlists';
 import { aggregateTourSetlistStats } from './aggregateTourSetlistStats';
@@ -12,25 +9,18 @@ import { aggregateTourSetlistStats } from './aggregateTourSetlistStats';
 /**
  * Dashboard Tour stats screen (#555): on-demand setlist aggregation + self overlay.
  *
+ * Tour scope is owned by Standings chrome (`useStandingsTourSelection`); pass
+ * the resolved `selectedTour` so any selectable tour can be explored.
+ *
  * @param {{
- *   selectedDate?: string | null,
- *   tourKey?: string | null,
+ *   selectedTour?: { tour: string, shows?: Array<{ date: string }> } | null,
+ *   calendarLoading?: boolean,
  * }} [options]
  */
 export function useTourStatsScreen(options = {}) {
   const { user } = useAuth();
-  const { showDatesByTour, loading: calendarLoading } = useShowCalendar();
-  const today = todayYmd();
-
-  const selectedTour = useMemo(() => {
-    const groups = Array.isArray(showDatesByTour) ? showDatesByTour : [];
-    const key = typeof options.tourKey === 'string' ? options.tourKey.trim() : '';
-    if (key) {
-      const match = groups.find((g) => g.tour === key);
-      if (match) return match;
-    }
-    return resolveCurrentTour(options.selectedDate, today, groups);
-  }, [options.selectedDate, options.tourKey, showDatesByTour, today]);
+  const selectedTour = options.selectedTour ?? null;
+  const calendarLoading = Boolean(options.calendarLoading);
 
   const showDates = useMemo(
     () =>

--- a/src/features/tour-stats/model/useTourStatsScreen.js
+++ b/src/features/tour-stats/model/useTourStatsScreen.js
@@ -2,9 +2,31 @@ import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { useAuth } from '../../auth';
+import { useSongCatalog } from '../../song-catalog';
 import { computeTourStatsSelfOverlay } from '../api/computeTourStatsSelfOverlay';
 import { fetchTourOfficialSetlists } from '../api/fetchTourOfficialSetlists';
 import { aggregateTourSetlistStats } from './aggregateTourSetlistStats';
+
+/**
+ * Normalized (lowercased/trimmed) title → lifetime times-played, from the song
+ * catalog. Used only to break ties in the tour "Most played" list so a pile of
+ * one-off songs orders by overall commonness instead of alphabetically.
+ *
+ * @param {{ name?: string, total?: string }[]} songs
+ * @returns {Map<string, number>}
+ */
+function buildLifetimePlaysByKey(songs) {
+  const map = new Map();
+  if (!Array.isArray(songs)) return map;
+  for (const song of songs) {
+    const key = String(song?.name ?? '').trim().toLowerCase();
+    if (!key) continue;
+    const total = Number(song?.total);
+    if (!Number.isFinite(total)) continue;
+    map.set(key, total);
+  }
+  return map;
+}
 
 /**
  * Dashboard Tour stats screen (#555): on-demand setlist aggregation + self overlay.
@@ -33,6 +55,12 @@ export function useTourStatsScreen(options = {}) {
   const tourName = selectedTour?.tour || '';
   const uid = user?.uid || '';
 
+  const { songs: catalogSongs } = useSongCatalog();
+  const lifetimePlaysByKey = useMemo(
+    () => buildLifetimePlaysByKey(catalogSongs),
+    [catalogSongs],
+  );
+
   const setlistQuery = useQuery({
     queryKey: ['tour-stats-setlists', tourName, showDates.join(',')],
     enabled: !calendarLoading && showDates.length > 0,
@@ -42,8 +70,11 @@ export function useTourStatsScreen(options = {}) {
 
   const stats = useMemo(() => {
     const docs = setlistQuery.data?.docs || [];
-    return aggregateTourSetlistStats(docs, { tourShowCount: showDates.length });
-  }, [setlistQuery.data, showDates.length]);
+    return aggregateTourSetlistStats(docs, {
+      tourShowCount: showDates.length,
+      lifetimePlaysByKey,
+    });
+  }, [setlistQuery.data, showDates.length, lifetimePlaysByKey]);
 
   const overlayQuery = useQuery({
     queryKey: [

--- a/src/features/tour-stats/ui/TourStatsView.jsx
+++ b/src/features/tour-stats/ui/TourStatsView.jsx
@@ -1,10 +1,70 @@
-import React from 'react';
-import { Loader2 } from 'lucide-react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { Info, Loader2 } from 'lucide-react';
 
 import Card from '../../../shared/ui/Card';
 import { SCORING_RULES } from '../../../shared/utils/scoring';
+import { TOUR_STATS_GAP_HIGHLIGHT_MIN } from '../model/aggregateTourSetlistStats';
 
 const { BUSTOUT_MIN_GAP } = SCORING_RULES;
+
+/** Matches Standings content-box shell (`standingsSurfaceClasses.js`). */
+const STANDINGS_CARD_SHELL = '!rounded-xl !p-3.5 md:!p-4';
+const STANDINGS_BOX_EYEBROW = 'text-[10px] font-black uppercase tracking-widest';
+
+/** Invisible 3-col grid: # | Song | Plays — fixed tracks keep columns aligned. */
+const TOP_SONGS_ROW_GRID =
+  'grid grid-cols-[1.5rem_minmax(0,1fr)_3.5rem] items-center gap-x-2 min-h-[1.75rem]';
+
+/** Invisible 3-col grid: Song | Date | Gap. */
+const GAP_ROW_GRID =
+  'grid grid-cols-[minmax(0,1fr)_6.5rem_3rem] items-center gap-x-2 min-h-[1.75rem]';
+
+const COL_HEADER =
+  'mb-0.5 border-b border-brand-primary/20 pb-1 text-[10px] font-black uppercase tracking-wider text-slate-300';
+
+const TOOLTIP_VIEWPORT_PAD = 8;
+const TOOLTIP_MAX_WIDTH = 256;
+const TOOLTIP_GAP = 6;
+
+const MOST_PLAYED_DEF =
+  'Ranked by frequency; songs with the same number of plays this tour are sorted by total # of times played all-time.';
+
+const HIGH_GAPS_DEF = `Gap = shows since last played before that night. Listed when gap ≥ ${TOUR_STATS_GAP_HIGHLIGHT_MIN} and below the bustout threshold.`;
+
+const TILE_DEFS = {
+  unique: {
+    label: 'Unique songs',
+    long: 'Distinct song titles across scored tour dates.',
+  },
+  played: {
+    label: 'Songs played',
+    long: 'Total number of songs played in this tour, including repeats.',
+  },
+  ratio: {
+    label: 'Unique ratio',
+    long: 'Unique songs ÷ songs played. Higher means more variety relative to volume.',
+  },
+  bustouts: {
+    label: 'Bustouts',
+    long: `Songs with a pre-show gap ≥ ${BUSTOUT_MIN_GAP} (Bustout Boost eligible).`,
+  },
+};
+
+/** @type {React.Context<{ openId: string | null, setOpenId: (id: string | null) => void }>} */
+const TourStatsTooltipContext = createContext({
+  openId: null,
+  setOpenId: () => {},
+});
 
 /**
  * @param {{
@@ -23,6 +83,7 @@ const { BUSTOUT_MIN_GAP } = SCORING_RULES;
  *     topSongOverlap: number,
  *   },
  *   overlayLoading: boolean,
+ *   onOpenScoringRules?: () => void,
  * }} props
  */
 export default function TourStatsView({
@@ -32,10 +93,12 @@ export default function TourStatsView({
   setlistLoading,
   setlistError,
   stats,
-  setlistReads,
   overlay,
   overlayLoading,
+  onOpenScoringRules,
 }) {
+  const [openTooltipId, setOpenTooltipId] = useState(/** @type {string | null} */ (null));
+
   if (calendarLoading || setlistLoading) {
     return (
       <div className="flex justify-center py-16">
@@ -46,7 +109,7 @@ export default function TourStatsView({
 
   if (!hasTour) {
     return (
-      <Card className="p-5">
+      <Card variant="frosted" padding="none" className={STANDINGS_CARD_SHELL}>
         <p className="text-sm font-semibold text-content-secondary">
           No tour is available yet. Tour stats appear once a post-launch tour
           has shows on or before today.
@@ -57,7 +120,7 @@ export default function TourStatsView({
 
   if (setlistError) {
     return (
-      <Card className="p-5">
+      <Card variant="danger" padding="none" className={STANDINGS_CARD_SHELL}>
         <p className="text-sm font-semibold text-red-300">
           Couldn’t load tour setlists. Try again in a moment.
         </p>
@@ -66,122 +129,473 @@ export default function TourStatsView({
   }
 
   return (
-    <div className="space-y-4">
-      <p className="text-sm font-semibold text-content-secondary">
-        {tourName} · {stats.showsWithSetlist} of {stats.tourShowCount} shows with
-        setlists · {setlistReads} setlist reads
-      </p>
-
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-        <StatTile label="Unique songs" value={stats.uniqueSongs} />
-        <StatTile label="Song plays" value={stats.totalSongPlays} />
-        <StatTile label="Bustouts" value={stats.bustouts.length} />
-      </div>
-
-      {overlayLoading ? (
-        <Card className="flex items-center gap-2 p-4">
-          <Loader2 className="h-4 w-4 animate-spin text-brand-primary" aria-hidden />
-          <span className="text-sm font-semibold text-content-secondary">
-            Stacking your picks…
+    <TourStatsTooltipContext.Provider
+      value={{ openId: openTooltipId, setOpenId: setOpenTooltipId }}
+    >
+      <div className="space-y-4">
+        <p className="rounded-xl border border-border-subtle/50 bg-surface-panel-strong/60 px-3.5 py-2 text-sm font-bold text-white shadow-inset-glass">
+          {tourName ? (
+            <>
+              <span className="text-brand-primary">{tourName}</span>
+              <span className="text-content-secondary"> · </span>
+            </>
+          ) : null}
+          <span className="tabular-nums">
+            {stats.showsWithSetlist} of {stats.tourShowCount} tour dates
           </span>
-        </Card>
-      ) : overlay ? (
-        <Card className="space-y-2 p-4">
-          <p className="text-[10px] font-black uppercase tracking-wider text-brand-primary">
-            Your picks this tour
-          </p>
-          <div className="grid grid-cols-2 gap-2 text-sm font-semibold text-slate-100 sm:grid-cols-4">
-            <span>{overlay.showsPicked} shows</span>
-            <span>
-              {overlay.slotsCorrect}/{overlay.slotsFilled} correct
+        </p>
+
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <StatTile
+            label={TILE_DEFS.unique.label}
+            value={stats.uniqueSongs}
+            definition={TILE_DEFS.unique.long}
+          />
+          <StatTile
+            label={TILE_DEFS.played.label}
+            value={stats.totalSongPlays}
+            definition={TILE_DEFS.played.long}
+          />
+          <StatTile
+            label={TILE_DEFS.ratio.label}
+            value={formatUniqueRatio(stats.uniqueSongs, stats.totalSongPlays)}
+            definition={TILE_DEFS.ratio.long}
+          />
+          <StatTile
+            label={TILE_DEFS.bustouts.label}
+            value={stats.bustouts.length}
+            definition={TILE_DEFS.bustouts.long}
+            accent="bustout"
+          />
+        </div>
+
+        {overlayLoading ? (
+          <Card
+            variant="frosted"
+            padding="none"
+            className={`${STANDINGS_CARD_SHELL} flex items-center gap-2`}
+          >
+            <Loader2 className="h-4 w-4 animate-spin text-brand-primary" aria-hidden />
+            <span className="text-sm font-semibold text-content-secondary">
+              Stacking your picks…
             </span>
-            <span>{overlay.bustoutHits} bustout hits</span>
-            <span>{overlay.topSongOverlap} in top songs</span>
-          </div>
-        </Card>
-      ) : null}
+          </Card>
+        ) : overlay ? (
+          <TourStatsSectionCard
+            title="Your picks this tour"
+            variant="venue"
+            headerTone="personal"
+          >
+            <div className="grid grid-cols-2 gap-x-4 gap-y-4 sm:grid-cols-4 sm:gap-x-6">
+              <OverlayStat label="Shows" value={overlay.showsPicked} />
+              <OverlayStat
+                label="Correct"
+                value={`${overlay.slotsCorrect}/${overlay.slotsFilled}`}
+              />
+              <OverlayStat label="Bustout hits" value={overlay.bustoutHits} />
+              <OverlayStat label="In most played" value={overlay.topSongOverlap} />
+            </div>
+          </TourStatsSectionCard>
+        ) : null}
 
-      <Card className="space-y-3 p-4">
-        <p className="text-[10px] font-black uppercase tracking-wider text-content-secondary">
-          Most played
-        </p>
-        {stats.topSongs.length === 0 ? (
-          <p className="text-sm text-content-secondary">No setlist songs yet.</p>
-        ) : (
-          <ol className="space-y-1.5">
-            {stats.topSongs.map((row, idx) => (
-              <li
-                key={row.title}
-                className="grid grid-cols-[1.5rem_minmax(0,1fr)_2.5rem] items-center gap-2 text-sm font-semibold text-slate-100"
-              >
-                <span className="tabular-nums text-content-secondary">{idx + 1}</span>
-                <span className="min-w-0 truncate">{row.title}</span>
-                <span className="justify-self-end tabular-nums text-content-secondary">
-                  ×{row.timesPlayed}
-                </span>
-              </li>
-            ))}
-          </ol>
-        )}
-      </Card>
+        <TourStatsSectionCard title="Most played" definition={MOST_PLAYED_DEF}>
+          {stats.topSongs.length === 0 ? (
+            <p className="text-sm text-content-secondary">No setlist songs yet.</p>
+          ) : (
+            <div>
+              <div className={`${TOP_SONGS_ROW_GRID} ${COL_HEADER}`} aria-hidden>
+                <span className="tabular-nums">#</span>
+                <span>Song</span>
+                <span className="justify-self-end">Plays</span>
+              </div>
+              <ol className="space-y-0.5 text-sm font-semibold text-slate-100">
+                {stats.topSongs.map((row, idx) => (
+                  <li key={row.title} className={TOP_SONGS_ROW_GRID}>
+                    <span className="tabular-nums text-brand-primary/80">{idx + 1}</span>
+                    <span className="min-w-0 truncate">{row.title}</span>
+                    <span className="justify-self-end tabular-nums text-brand-primary">
+                      {row.timesPlayed}
+                    </span>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          )}
+        </TourStatsSectionCard>
 
-      <Card className="space-y-3 p-4">
-        <p className="text-[10px] font-black uppercase tracking-wider text-content-secondary">
-          Bustouts
-        </p>
-        {stats.bustouts.length === 0 ? (
-          <p className="text-sm text-content-secondary">No bustouts frozen yet.</p>
-        ) : (
-          <ul className="space-y-1.5">
-            {stats.bustouts.map((row) => (
-              <li
-                key={`${row.showDate}-${row.title}`}
-                className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 text-sm font-semibold text-slate-100"
-              >
-                <span className="min-w-0 truncate">{row.title}</span>
-                <span className="tabular-nums text-content-secondary">{row.showDate}</span>
-                <span className="tabular-nums text-orange-200">
-                  {row.gap != null ? row.gap : '—'}
-                </span>
-              </li>
-            ))}
-          </ul>
-        )}
-        <p className="text-[11px] font-semibold text-content-secondary">
-          Bustout = pre-show gap ≥ {BUSTOUT_MIN_GAP}.
-        </p>
-      </Card>
-
-      {stats.gapHighlights.length > 0 ? (
-        <Card className="space-y-3 p-4">
-          <p className="text-[10px] font-black uppercase tracking-wider text-content-secondary">
-            High gaps (non-bustout)
+        <TourStatsSectionCard title="Bustouts" headerTone="bustout">
+          {stats.bustouts.length === 0 ? (
+            <p className="text-sm text-content-secondary">No bustouts frozen yet.</p>
+          ) : (
+            <div>
+              <div className={`${GAP_ROW_GRID} ${COL_HEADER}`} aria-hidden>
+                <span>Song</span>
+                <span className="justify-self-end">Date</span>
+                <span className="justify-self-end">Gap</span>
+              </div>
+              <ul className="space-y-0.5 text-sm font-semibold text-slate-100">
+                {stats.bustouts.map((row) => (
+                  <li
+                    key={`${row.showDate}-${row.title}`}
+                    className={GAP_ROW_GRID}
+                  >
+                    <span className="min-w-0 truncate">{row.title}</span>
+                    <span className="justify-self-end tabular-nums text-content-secondary">
+                      {row.showDate}
+                    </span>
+                    <span
+                      className="justify-self-end tabular-nums font-bold text-amber-200"
+                      title={
+                        row.gap != null
+                          ? `${row.gap} shows since last played (pre-show gap)`
+                          : undefined
+                      }
+                    >
+                      {row.gap != null ? row.gap : '—'}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          <p className="mt-3 border-t border-border-subtle/40 pt-3 text-[11px] font-semibold leading-relaxed text-content-secondary">
+            Gap = shows since last played before that night. Bustout = gap ≥{' '}
+            {BUSTOUT_MIN_GAP} (Bustout Boost eligible).
+            {typeof onOpenScoringRules === 'function' ? (
+              <>
+                {' '}
+                <button
+                  type="button"
+                  onClick={onOpenScoringRules}
+                  className="text-teal-300 underline decoration-teal-500/50 underline-offset-2 hover:text-white hover:decoration-teal-300"
+                >
+                  What is a bustout?
+                </button>
+              </>
+            ) : null}
           </p>
-          <ul className="space-y-1.5">
-            {stats.gapHighlights.map((row) => (
-              <li
-                key={`${row.showDate}-${row.title}`}
-                className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 text-sm font-semibold text-slate-100"
-              >
-                <span className="min-w-0 truncate">{row.title}</span>
-                <span className="tabular-nums text-content-secondary">{row.showDate}</span>
-                <span className="tabular-nums text-content-secondary">{row.gap}</span>
-              </li>
-            ))}
-          </ul>
-        </Card>
-      ) : null}
+        </TourStatsSectionCard>
+
+        {stats.gapHighlights.length > 0 ? (
+          <TourStatsSectionCard
+            title="High gaps (non-bustout)"
+            definition={HIGH_GAPS_DEF}
+            headerTone="muted"
+          >
+            <div>
+              <div className={`${GAP_ROW_GRID} ${COL_HEADER}`} aria-hidden>
+                <span>Song</span>
+                <span className="justify-self-end">Date</span>
+                <span className="justify-self-end">Gap</span>
+              </div>
+              <ul className="space-y-0.5 text-sm font-semibold text-slate-100">
+                {stats.gapHighlights.map((row) => (
+                  <li
+                    key={`${row.showDate}-${row.title}`}
+                    className={GAP_ROW_GRID}
+                  >
+                    <span className="min-w-0 truncate">{row.title}</span>
+                    <span className="justify-self-end tabular-nums text-content-secondary">
+                      {row.showDate}
+                    </span>
+                    <span
+                      className="justify-self-end tabular-nums text-slate-300"
+                      title={`${row.gap} shows since last played (pre-show gap)`}
+                    >
+                      {row.gap}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </TourStatsSectionCard>
+        ) : null}
+      </div>
+    </TourStatsTooltipContext.Provider>
+  );
+}
+
+function formatUniqueRatio(uniqueSongs, songsPlayed) {
+  if (!songsPlayed || songsPlayed <= 0) return '—';
+  const pct = Math.round((uniqueSongs / songsPlayed) * 100);
+  return `${pct}%`;
+}
+
+const HEADER_TONE = {
+  default: {
+    bar: 'border-brand-primary/35 bg-brand-primary/10',
+    text: 'text-brand-primary',
+  },
+  personal: {
+    bar: 'border-brand-primary/45 bg-gradient-to-r from-brand-primary/15 to-transparent',
+    text: 'text-brand-primary',
+  },
+  bustout: {
+    bar: 'border-amber-500/35 bg-amber-500/10',
+    text: 'text-amber-200',
+  },
+  muted: {
+    bar: 'border-brand-accent-blue/30 bg-brand-accent-blue/10',
+    text: 'text-blue-200',
+  },
+};
+
+/**
+ * @param {{
+ *   title: string,
+ *   definition?: string,
+ *   headerTone?: keyof typeof HEADER_TONE,
+ *   variant?: 'frosted' | 'venue',
+ *   children: React.ReactNode,
+ * }} props
+ */
+function TourStatsSectionCard({
+  title,
+  definition,
+  headerTone = 'default',
+  variant = 'frosted',
+  children,
+}) {
+  const tone = HEADER_TONE[headerTone] ?? HEADER_TONE.default;
+
+  return (
+    <Card variant={variant} padding="none" className={STANDINGS_CARD_SHELL}>
+      <div className={`-mx-3.5 -mt-3.5 mb-3 rounded-t-xl border-b px-3.5 py-2.5 md:-mx-4 md:-mt-4 md:px-4 ${tone.bar}`}>
+        <div className="flex items-center gap-1">
+          <p className={`${STANDINGS_BOX_EYEBROW} ${tone.text}`}>{title}</p>
+          {definition ? (
+            <InfoTooltip label={title} definition={definition} />
+          ) : null}
+        </div>
+      </div>
+      {children}
+    </Card>
+  );
+}
+
+/**
+ * Clamp a fixed-position tooltip so it stays inside the viewport on mobile.
+ * @param {DOMRect} triggerRect
+ * @param {number} tooltipWidth
+ * @param {number} tooltipHeight
+ * @returns {{ top: number, left: number, width: number }}
+ */
+function clampTooltipPosition(triggerRect, tooltipWidth, tooltipHeight) {
+  const vw = typeof window !== 'undefined' ? window.innerWidth : 360;
+  const vh = typeof window !== 'undefined' ? window.innerHeight : 640;
+  const width = Math.min(
+    tooltipWidth,
+    TOOLTIP_MAX_WIDTH,
+    Math.max(120, vw - TOOLTIP_VIEWPORT_PAD * 2),
+  );
+
+  let left = triggerRect.left + triggerRect.width / 2 - width / 2;
+  left = Math.max(
+    TOOLTIP_VIEWPORT_PAD,
+    Math.min(left, vw - width - TOOLTIP_VIEWPORT_PAD),
+  );
+
+  let top = triggerRect.bottom + TOOLTIP_GAP;
+  if (top + tooltipHeight > vh - TOOLTIP_VIEWPORT_PAD) {
+    top = Math.max(
+      TOOLTIP_VIEWPORT_PAD,
+      triggerRect.top - tooltipHeight - TOOLTIP_GAP,
+    );
+  }
+
+  return { top, left, width };
+}
+
+/**
+ * Exclusive, viewport-clamped Info tooltip (one open at a time on this surface).
+ *
+ * @param {{
+ *   label: string,
+ *   definition: string,
+ * }} props
+ */
+function InfoTooltip({ label, definition }) {
+  const reactId = useId();
+  const tooltipId = `tour-stats-tip-${reactId}`;
+  const { openId, setOpenId } = useContext(TourStatsTooltipContext);
+  const open = openId === tooltipId;
+  const triggerRef = useRef(/** @type {HTMLButtonElement | null} */ (null));
+  const panelRef = useRef(/** @type {HTMLDivElement | null} */ (null));
+  const [coords, setCoords] = useState(
+    /** @type {{ top: number, left: number, width: number } | null} */ (null),
+  );
+
+  const close = useCallback(() => {
+    setOpenId((current) => (current === tooltipId ? null : current));
+  }, [setOpenId, tooltipId]);
+
+  const toggle = useCallback(() => {
+    setOpenId((current) => (current === tooltipId ? null : tooltipId));
+  }, [setOpenId, tooltipId]);
+
+  useLayoutEffect(() => {
+    if (!open || !triggerRef.current) {
+      setCoords(null);
+      return undefined;
+    }
+
+    const update = () => {
+      const triggerRect = triggerRef.current?.getBoundingClientRect();
+      if (!triggerRect) return;
+      const panelRect = panelRef.current?.getBoundingClientRect();
+      const height = panelRect?.height || 72;
+      const width = Math.min(
+        TOOLTIP_MAX_WIDTH,
+        Math.max(120, window.innerWidth - TOOLTIP_VIEWPORT_PAD * 2),
+      );
+      setCoords(clampTooltipPosition(triggerRect, width, height));
+    };
+
+    update();
+    // Re-measure after paint so height is accurate for flip-above.
+    const raf = requestAnimationFrame(update);
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update, true);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const onPointerDown = (event) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (triggerRef.current?.contains(target)) return;
+      if (panelRef.current?.contains(target)) return;
+      close();
+    };
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') close();
+    };
+
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open, close]);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="shrink-0 rounded p-0.5 text-brand-primary/85 transition-colors hover:text-brand-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
+        aria-label={`About ${label}`}
+        aria-expanded={open}
+        aria-controls={tooltipId}
+        onClick={toggle}
+      >
+        <Info className="h-3 w-3" strokeWidth={2} aria-hidden />
+      </button>
+      {open && typeof document !== 'undefined'
+        ? createPortal(
+            <div
+              ref={panelRef}
+              id={tooltipId}
+              role="tooltip"
+              style={
+                coords
+                  ? {
+                      position: 'fixed',
+                      top: coords.top,
+                      left: coords.left,
+                      width: coords.width,
+                      zIndex: 80,
+                    }
+                  : {
+                      position: 'fixed',
+                      top: -9999,
+                      left: -9999,
+                      width: Math.min(
+                        TOOLTIP_MAX_WIDTH,
+                        typeof window !== 'undefined'
+                          ? window.innerWidth - TOOLTIP_VIEWPORT_PAD * 2
+                          : TOOLTIP_MAX_WIDTH,
+                      ),
+                      zIndex: 80,
+                      visibility: 'hidden',
+                    }
+              }
+              className="rounded-lg border border-border-muted bg-[rgb(var(--surface-panel-strong))] px-3 py-2 text-left text-xs font-medium leading-snug text-slate-100 shadow-lg"
+            >
+              {definition}
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}
+
+/**
+ * @param {{ label: string, value: React.ReactNode }} props
+ */
+function OverlayStat({ label, value }) {
+  return (
+    <div className="flex min-w-0 flex-col items-center text-center">
+      <p className="flex min-h-[2.25rem] w-full items-end justify-center text-[10px] font-black uppercase leading-tight tracking-wider text-brand-primary/90">
+        {label}
+      </p>
+      <p className="mt-1 w-full text-xl font-black tabular-nums text-white sm:text-2xl">
+        {value}
+      </p>
     </div>
   );
 }
 
-function StatTile({ label, value }) {
+/**
+ * @param {{
+ *   label: string,
+ *   value: React.ReactNode,
+ *   definition: string,
+ *   accent?: 'default' | 'bustout',
+ * }} props
+ */
+function StatTile({ label, value, definition, accent = 'default' }) {
+  const isBustout = accent === 'bustout';
+
   return (
-    <Card className="flex flex-col gap-1 p-3 text-center">
-      <p className="text-[10px] font-black uppercase tracking-wider text-content-secondary">
-        {label}
+    <Card
+      variant="frosted"
+      padding="none"
+      className={`${STANDINGS_CARD_SHELL} flex flex-col gap-1 text-center`}
+    >
+      <div
+        className={`-mx-3.5 -mt-3.5 mb-1 rounded-t-xl border-b px-2 py-2 md:-mx-4 md:-mt-4 ${
+          isBustout
+            ? 'border-amber-500/30 bg-amber-500/10'
+            : 'border-brand-primary/30 bg-brand-primary/10'
+        }`}
+      >
+        <div className="flex items-start justify-center gap-1">
+          <p
+            className={`min-w-0 ${STANDINGS_BOX_EYEBROW} ${
+              isBustout ? 'text-amber-200' : 'text-brand-primary'
+            }`}
+          >
+            {label}
+          </p>
+          <InfoTooltip label={label} definition={definition} />
+        </div>
+      </div>
+      <p
+        className={`px-2 pb-1 pt-0.5 text-2xl font-black tabular-nums ${
+          isBustout ? 'text-amber-200' : 'text-brand-primary'
+        }`}
+      >
+        {value}
       </p>
-      <p className="text-2xl font-black tabular-nums text-brand-primary">{value}</p>
     </Card>
   );
 }

--- a/src/features/tour-stats/ui/TourStatsView.jsx
+++ b/src/features/tour-stats/ui/TourStatsView.jsx
@@ -48,7 +48,8 @@ export default function TourStatsView({
     return (
       <Card className="p-5">
         <p className="text-sm font-semibold text-content-secondary">
-          No tour is selected yet. Pick a show on Standings or wait for the calendar to load.
+          No tour is available yet. Tour stats appear once a post-launch tour
+          has shows on or before today.
         </p>
       </Card>
     );

--- a/src/features/tour-stats/ui/TourStatsView.jsx
+++ b/src/features/tour-stats/ui/TourStatsView.jsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { Loader2 } from 'lucide-react';
+
+import Card from '../../../shared/ui/Card';
+import { SCORING_RULES } from '../../../shared/utils/scoring';
+
+const { BUSTOUT_MIN_GAP } = SCORING_RULES;
+
+/**
+ * @param {{
+ *   tourName: string,
+ *   hasTour: boolean,
+ *   calendarLoading: boolean,
+ *   setlistLoading: boolean,
+ *   setlistError: unknown,
+ *   stats: import('../model/aggregateTourSetlistStats').TourSetlistStats,
+ *   setlistReads: number,
+ *   overlay: null | {
+ *     showsPicked: number,
+ *     slotsFilled: number,
+ *     slotsCorrect: number,
+ *     bustoutHits: number,
+ *     topSongOverlap: number,
+ *   },
+ *   overlayLoading: boolean,
+ * }} props
+ */
+export default function TourStatsView({
+  tourName,
+  hasTour,
+  calendarLoading,
+  setlistLoading,
+  setlistError,
+  stats,
+  setlistReads,
+  overlay,
+  overlayLoading,
+}) {
+  if (calendarLoading || setlistLoading) {
+    return (
+      <div className="flex justify-center py-16">
+        <Loader2 className="h-8 w-8 animate-spin text-brand-primary" aria-label="Loading tour stats" />
+      </div>
+    );
+  }
+
+  if (!hasTour) {
+    return (
+      <Card className="p-5">
+        <p className="text-sm font-semibold text-content-secondary">
+          No tour is selected yet. Pick a show on Standings or wait for the calendar to load.
+        </p>
+      </Card>
+    );
+  }
+
+  if (setlistError) {
+    return (
+      <Card className="p-5">
+        <p className="text-sm font-semibold text-red-300">
+          Couldn’t load tour setlists. Try again in a moment.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm font-semibold text-content-secondary">
+        {tourName} · {stats.showsWithSetlist} of {stats.tourShowCount} shows with
+        setlists · {setlistReads} setlist reads
+      </p>
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <StatTile label="Unique songs" value={stats.uniqueSongs} />
+        <StatTile label="Song plays" value={stats.totalSongPlays} />
+        <StatTile label="Bustouts" value={stats.bustouts.length} />
+      </div>
+
+      {overlayLoading ? (
+        <Card className="flex items-center gap-2 p-4">
+          <Loader2 className="h-4 w-4 animate-spin text-brand-primary" aria-hidden />
+          <span className="text-sm font-semibold text-content-secondary">
+            Stacking your picks…
+          </span>
+        </Card>
+      ) : overlay ? (
+        <Card className="space-y-2 p-4">
+          <p className="text-[10px] font-black uppercase tracking-wider text-brand-primary">
+            Your picks this tour
+          </p>
+          <div className="grid grid-cols-2 gap-2 text-sm font-semibold text-slate-100 sm:grid-cols-4">
+            <span>{overlay.showsPicked} shows</span>
+            <span>
+              {overlay.slotsCorrect}/{overlay.slotsFilled} correct
+            </span>
+            <span>{overlay.bustoutHits} bustout hits</span>
+            <span>{overlay.topSongOverlap} in top songs</span>
+          </div>
+        </Card>
+      ) : null}
+
+      <Card className="space-y-3 p-4">
+        <p className="text-[10px] font-black uppercase tracking-wider text-content-secondary">
+          Most played
+        </p>
+        {stats.topSongs.length === 0 ? (
+          <p className="text-sm text-content-secondary">No setlist songs yet.</p>
+        ) : (
+          <ol className="space-y-1.5">
+            {stats.topSongs.map((row, idx) => (
+              <li
+                key={row.title}
+                className="grid grid-cols-[1.5rem_minmax(0,1fr)_2.5rem] items-center gap-2 text-sm font-semibold text-slate-100"
+              >
+                <span className="tabular-nums text-content-secondary">{idx + 1}</span>
+                <span className="min-w-0 truncate">{row.title}</span>
+                <span className="justify-self-end tabular-nums text-content-secondary">
+                  ×{row.timesPlayed}
+                </span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </Card>
+
+      <Card className="space-y-3 p-4">
+        <p className="text-[10px] font-black uppercase tracking-wider text-content-secondary">
+          Bustouts
+        </p>
+        {stats.bustouts.length === 0 ? (
+          <p className="text-sm text-content-secondary">No bustouts frozen yet.</p>
+        ) : (
+          <ul className="space-y-1.5">
+            {stats.bustouts.map((row) => (
+              <li
+                key={`${row.showDate}-${row.title}`}
+                className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 text-sm font-semibold text-slate-100"
+              >
+                <span className="min-w-0 truncate">{row.title}</span>
+                <span className="tabular-nums text-content-secondary">{row.showDate}</span>
+                <span className="tabular-nums text-orange-200">
+                  {row.gap != null ? row.gap : '—'}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+        <p className="text-[11px] font-semibold text-content-secondary">
+          Bustout = pre-show gap ≥ {BUSTOUT_MIN_GAP}.
+        </p>
+      </Card>
+
+      {stats.gapHighlights.length > 0 ? (
+        <Card className="space-y-3 p-4">
+          <p className="text-[10px] font-black uppercase tracking-wider text-content-secondary">
+            High gaps (non-bustout)
+          </p>
+          <ul className="space-y-1.5">
+            {stats.gapHighlights.map((row) => (
+              <li
+                key={`${row.showDate}-${row.title}`}
+                className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 text-sm font-semibold text-slate-100"
+              >
+                <span className="min-w-0 truncate">{row.title}</span>
+                <span className="tabular-nums text-content-secondary">{row.showDate}</span>
+                <span className="tabular-nums text-content-secondary">{row.gap}</span>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      ) : null}
+    </div>
+  );
+}
+
+function StatTile({ label, value }) {
+  return (
+    <Card className="flex flex-col gap-1 p-3 text-center">
+      <p className="text-[10px] font-black uppercase tracking-wider text-content-secondary">
+        {label}
+      </p>
+      <p className="text-2xl font-black tabular-nums text-brand-primary">{value}</p>
+    </Card>
+  );
+}

--- a/src/pages/tour-stats/TourStatsPage.jsx
+++ b/src/pages/tour-stats/TourStatsPage.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { TourStatsView, useTourStatsScreen } from '../../features/tour-stats';
+
+/**
+ * Dashboard Tour stats explorer (#555) — private, on-demand setlist aggregation.
+ *
+ * @param {{ selectedDate?: string | null }} props
+ */
+export default function TourStatsPage({ selectedDate = null }) {
+  const screen = useTourStatsScreen({ selectedDate });
+  return <TourStatsView {...screen} />;
+}

--- a/src/pages/tour-stats/TourStatsPage.jsx
+++ b/src/pages/tour-stats/TourStatsPage.jsx
@@ -1,13 +1,63 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 
+import {
+  StandingsMobileFixedChrome,
+  StandingsStickyChrome,
+  useScoringRulesModal,
+  useStandingsTourSelection,
+  useStandingsViewChange,
+} from '../../features/scoring';
 import { TourStatsView, useTourStatsScreen } from '../../features/tour-stats';
+import { useShowCalendar } from '../../features/show-calendar';
+import { useDashboardMobileChromePortal } from '../../shared/hooks/useDashboardMobileChromePortal';
+import { ga4Event } from '../../shared/lib/ga4';
 
 /**
- * Dashboard Tour stats explorer (#555) — private, on-demand setlist aggregation.
- *
- * @param {{ selectedDate?: string | null }} props
+ * Dashboard Tour stats explorer (#555) — peer Standings view (Stats tab).
+ * Tour scope uses the same chrome picker + `?tour=` as Standings → Tour.
  */
-export default function TourStatsPage({ selectedDate = null }) {
-  const screen = useTourStatsScreen({ selectedDate });
-  return <TourStatsView {...screen} />;
+export default function TourStatsPage() {
+  const { showDatesByTour, loading: calendarLoading } = useShowCalendar();
+  const { selectedTour, selectableTours } =
+    useStandingsTourSelection(showDatesByTour);
+  const screen = useTourStatsScreen({
+    selectedTour,
+    calendarLoading,
+  });
+  const setView = useStandingsViewChange({ view: 'stats' });
+  const { openScoringRules: openScoringRulesModal } = useScoringRulesModal();
+  const mobileChromeRoot = useDashboardMobileChromePortal();
+
+  const openScoringRules = () => {
+    ga4Event('scoring_rules_opened', { surface: 'tour-stats' });
+    openScoringRulesModal();
+  };
+
+  const mobileFixedChrome = (
+    <StandingsMobileFixedChrome
+      view="stats"
+      onChange={setView}
+      onOpenScoringRules={openScoringRules}
+    />
+  );
+
+  return (
+    <div className="w-full">
+      {mobileChromeRoot
+        ? createPortal(mobileFixedChrome, mobileChromeRoot)
+        : null}
+
+      <StandingsStickyChrome
+        view="stats"
+        onChange={setView}
+        onOpenScoringRules={openScoringRules}
+        pinBelowDesktopDatePicker={selectableTours.length > 0}
+      />
+
+      <div className="mt-4 md:mt-5">
+        <TourStatsView {...screen} />
+      </div>
+    </div>
+  );
 }

--- a/src/pages/tour-stats/TourStatsPage.jsx
+++ b/src/pages/tour-stats/TourStatsPage.jsx
@@ -56,7 +56,7 @@ export default function TourStatsPage() {
       />
 
       <div className="mt-4 md:mt-5">
-        <TourStatsView {...screen} />
+        <TourStatsView {...screen} onOpenScoringRules={openScoringRules} />
       </div>
     </div>
   );

--- a/src/shared/config/dashboardVocabulary.js
+++ b/src/shared/config/dashboardVocabulary.js
@@ -50,6 +50,9 @@ export const NAV_LABEL_NOTIFICATIONS = 'Notifications';
 /** Short tab / mobile context label */
 export const NAV_LABEL_STANDINGS = 'Standings';
 
+/** Tour stats explorer (#555) — secondary route under Standings */
+export const NAV_LABEL_TOUR_STATS = 'Tour stats';
+
 /** Mobile context bar label for a specific pool’s detail route */
 export const NAV_LABEL_POOL_DETAILS = 'Pool Details';
 


### PR DESCRIPTION
Closes #555

## Summary
- Private **Tour stats** explorer on `/dashboard/tour-stats`: on-demand `official_setlists` aggregation (unique songs, frequency, bustouts, gap highlights) + self pick overlay
- **Stats** is a fourth Standings chrome tab (**Show | Tour | Stats | Pools**) — not a buried Tour-only link and not a fifth primary nav tab
- Shares the Standings **tour scope** picker (`?tour=`) so any selectable tour’s stats work (same list as Tour view)
- Standings nav stays active; context title stays **Standings**
- SemVer **1.30.0** (MINOR — new dashboard surface)

## Test plan
- [ ] Hard-refresh localhost (or Vercel preview) after pull
- [ ] Standings chrome shows four tabs: Show / Tour / Stats / Pools (mobile segmented + desktop pills)
- [ ] **Stats** opens `/dashboard/tour-stats` with sticky Standings chrome + tour scope picker (when multiple tours exist)
- [ ] Switch to a **past / last** tour via the tour picker — stats reload for that tour (not stuck on “current” only)
- [ ] Tour ↔ Stats preserves `?tour=`; Show / Pools still work from Stats
- [ ] No buried “Tour stats” text link on Tour view
- [ ] Primary bottom nav still has four tabs (no fifth Stats tab)
- [ ] `npm run verify:dashboard-meta` / lint green in CI