### PR TITLE
docs(comms): Optimize autonomy L0 playbook (#573)

### DIFF
--- a/.cursor/skills/comms-analyst/SKILL.md
+++ b/.cursor/skills/comms-analyst/SKILL.md
@@ -14,10 +14,23 @@ You analyze user behavior and comms performance to inform trigger design, copy o
 ## Read first
 
 1. `docs/comms-triggers/FRAMEWORK.md` — TTDMOM phases
-2. `docs/comms-triggers/TRIGGER_CATALOG.md` + `catalog.json`
-3. `docs/comms-triggers/MEASUREMENT_PLAN.md`
-4. `docs/AUTH_TELEMETRY_RUNBOOK.md` — auth events overlap with lifecycle triggers
-5. `content/comms/README.md` — what is shipped vs draft
+2. `docs/comms-triggers/OPTIMIZE_AUTONOMY.md` — Optimize loop + PM pack template (#573 L0)
+3. `docs/comms-triggers/TRIGGER_CATALOG.md` + `catalog.json`
+4. `docs/comms-triggers/MEASUREMENT_PLAN.md`
+5. `docs/AUTH_TELEMETRY_RUNBOOK.md` — auth events overlap with lifecycle triggers
+6. `content/comms/README.md` — what is shipped vs draft
+7. Data spine (facts only): `docs/OFFICIAL_SETLISTS_SCHEMA.md`, `docs/COMMS_SHOW_CONTEXT_SCHEMA.md`
+
+## Optimize cycle (#573)
+
+When asked to **run Optimize** (goal + date window):
+
+1. You go **first** — funnels, gaps, recommendations for `optimize_for=…`
+2. Hand off: **triggers → drafter → architect → PM** (see `OPTIMIZE_AUTONOMY.md`)
+3. Output the **PM review pack** template from that doc (post on epic #573)
+4. **Draft-only:** open PRs to **`staging`**; never merge or deploy
+
+**Night vs tour:** #572 `show_recap` (single night) ≠ #510 `tour_recap` (end of tour). Do not conflate metrics or recommendations.
 
 ## Data sources
 
@@ -81,13 +94,21 @@ Follow `docs/comms-triggers/EXPERIMENT_PLAYBOOK.md`. Report variant, sample size
 
 ## Handoffs
 
+### Optimize cycle order (#573)
+
+`comms-analyst` (you) → **comms-triggers** → **comms-drafter** → **comms-architect** → **PM**
+
+### Standing handoffs
+
 - **New trigger ideas** → comms-triggers skill (Trigger Spec)
 - **Copy underperformance** → comms-drafter skill (variant draft)
 - **Channel or rollout changes** → comms-architect skill
-- **GitHub tracking** → issue with `[SKIP-PRD]` under #272
+- **GitHub tracking** → `[SKIP-PRD]` issue under #272 / #573 as appropriate
 
 ## Constraints
 
 - Never print secrets, FCM tokens, or per-user PII in reports
 - GA4 on production only for user-facing events; note when staging data is unavailable
 - Do not approve production deploys — recommend only
+- Do not invent setlist facts; cite spine docs / delivery logs
+- PR base when filing draft changes: **staging**

--- a/.cursor/skills/comms-architect/SKILL.md
+++ b/.cursor/skills/comms-architect/SKILL.md
@@ -30,6 +30,8 @@ You design and implement **how** triggered messages reach users safely and at sc
 6. `firestore.rules` — `commsInbox`, `fcm_notification_log`
 7. `src/features/notifications/api/commsInboxApi.js`
 8. `docs/comms-triggers/ECOSYSTEM.md` — flow diagram + process descriptions
+9. `docs/comms-triggers/OPTIMIZE_AUTONOMY.md` — Optimize loop, draft-only gate, night vs tour (#573)
+10. Spine: `docs/OFFICIAL_SETLISTS_SCHEMA.md`, `docs/COMMS_SHOW_CONTEXT_SCHEMA.md` (#572 facts → `setlist_highlight`)
 
 ## Architecture — full automation (epic #441)
 
@@ -186,6 +188,16 @@ gcloud functions describe <export> --gen2 --region=us-central1 --project=set-pic
 
 ## Handoffs
 
+### Optimize cycle (#573)
+
+Order: analyst → triggers → drafter → **architect (you)** → **PM**.
+
+- Flag missing ingest / adapter / var wiring for draft PRs
+- Dry-run / canary notes only — never auto-merge or production-deploy from Optimize
+- Keep #572 night adapters separate from #510 tour_recap fan-out
+
+### Standing handoffs
+
 - Missing Trigger Spec → **comms-triggers**
 - Copy/builders → **comms-drafter**
 - Post-ship metrics → **comms-analyst**
@@ -196,3 +208,4 @@ gcloud functions describe <export> --gen2 --region=us-central1 --project=set-pic
 - Deploy functions per `functions/package.json` scripts; **comms** exports use `npm run comms:deploy:*` (manifest-driven — see **Release + deploy tooling**)
 - Fatigue: max 2 push/user/show day (document in catalog notes)
 - Commercial slots only via `COMMERCIAL_PHASE3.md` gates
+- Optimize writes are **draft-only** until PM approves; no agent-initiated production send

--- a/.cursor/skills/comms-drafter/SKILL.md
+++ b/.cursor/skills/comms-drafter/SKILL.md
@@ -14,9 +14,11 @@ You draft and ship editorial copy for triggered communications.
 ## Read first
 
 1. `content/comms/README.md` — authoritative edit/ship workflow
-2. `docs/comms-triggers/TRIGGER_CATALOG.md` — which templateId you are writing for
-3. `src/features/comms/registry.js` — channels and paths
-4. Existing reference: `content/comms/tours/sphere-2026-inaugural.md`
+2. `docs/comms-triggers/OPTIMIZE_AUTONOMY.md` — draft-only Optimize + PM pack (#573)
+3. `docs/comms-triggers/TRIGGER_CATALOG.md` — which templateId you are writing for
+4. `src/features/comms/registry.js` — channels and paths
+5. Existing reference: `content/comms/tours/sphere-2026-inaugural.md` (tour edition archive; production path is #510 `tour_recap`)
+6. Night narrative facts: `docs/COMMS_SHOW_CONTEXT_SCHEMA.md` + `docs/OFFICIAL_SETLISTS_SCHEMA.md` (#572) — deterministic `setlist_highlight`; no LLM v1
 
 ## Channel copy rules
 
@@ -54,7 +56,15 @@ Use `{{variable}}` in Markdown drafts. Document variables in file metadata table
 | 2 | Sync strings to `implementationModule` from registry |
 | 3 | Update builders for each channel (inApp, push, email) |
 | 4 | Run `npm run lint` and `npm test` (feature tests) |
-| 5 | PR to **staging** with catalog sync if new templateId |
+| 5 | Open **draft** PR to **staging** with catalog sync if new templateId — never auto-merge |
+
+## Optimize cycle (#573)
+
+Order: analyst → triggers → **drafter (you)** → architect → PM.
+
+- Only open draft PRs when the pack justifies a copy change
+- Night (#572 `show_recap`) vs tour (#510 `tour_recap`) stay separate files / templateIds
+- Canary IDs belong in the PM pack; you do not production-deploy
 
 ## Ship workflow (new template)
 
@@ -103,3 +113,5 @@ When **comms-analyst** requests A/B copy:
 - One recap edition per file; clear filenames
 - Commercial copy requires disclosure per `COMMERCIAL_PHASE3.md`
 - Same PR for Markdown + JS sync (one-PR rule from content/comms README)
+- **Draft-only** write surface for Optimize: PR base **staging**; PM merges; no `comms:deploy` from this skill
+- Never invent bustouts / gaps / setlist order — sync from spine or leave placeholder vars

--- a/.cursor/skills/comms-triggers/SKILL.md
+++ b/.cursor/skills/comms-triggers/SKILL.md
@@ -14,10 +14,12 @@ You own the **trigger catalog** — what fires, for whom, when, through which ch
 ## Read first
 
 1. `docs/comms-triggers/FRAMEWORK.md`
-2. `docs/comms-triggers/TRIGGER_CATALOG.md`
-3. `docs/comms-triggers/catalog.json`
-4. `src/features/comms/registry.js` — templateId linkage
-5. Game logic: `src/shared/utils/timeLogic.js`, `show_calendar`, picks lock (#303: 19:55 local)
+2. `docs/comms-triggers/OPTIMIZE_AUTONOMY.md` — Optimize loop + night vs tour (#573)
+3. `docs/comms-triggers/TRIGGER_CATALOG.md`
+4. `docs/comms-triggers/catalog.json`
+5. `src/features/comms/registry.js` — templateId linkage
+6. Game logic: `src/shared/utils/timeLogic.js`, `show_calendar`, picks lock (#303: 19:55 local)
+7. Spine: `docs/OFFICIAL_SETLISTS_SCHEMA.md`, `docs/COMMS_SHOW_CONTEXT_SCHEMA.md`
 
 ## Trigger Spec checklist
 
@@ -54,8 +56,16 @@ Every new trigger needs **both** catalog files updated in the same PR:
 | Show day, no picks, T-3h before lock | `picks_lock_reminder` (shipped) |
 | 24h before lock | `picks_lock_t24h` |
 | Show graded, user won | `post_show_win` (shipped) |
-| Tour segment complete | `tour_recap_*` |
+| Tour segment complete | `tour_recap` (#510 — end of tour; not night `show_recap` #572) |
 | 14d no login, show upcoming | `return_after_14d` |
+
+## Optimize cycle (#573)
+
+Order: **analyst → triggers (you) → drafter → architect → PM**.
+
+- Propose catalog rows / experiments that serve the stated `optimize_for`
+- Keep **#572 night** vs **#510 tour** triggers separate
+- File `[SKIP-PRD]` children; PR base **`staging`**; draft-only (no auto-merge)
 
 ## Workflow: add a trigger
 
@@ -92,3 +102,5 @@ Every new trigger needs **both** catalog files updated in the same PR:
 - Never add copy to catalog — templateId only
 - Keep `catalog.json` valid JSON (no trailing commas)
 - Align show dates with `src/shared/data/showDates.js` for tour-specific triggers
+- PR base: **staging**; draft proposals only — PM merges
+- Do not invent setlist/tour facts; point at spine docs when proposing uniqueness triggers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ## [Unreleased]
 
+### Added
+- **Comms Optimize autonomy playbook (#573 L0)** — `docs/comms-triggers/OPTIMIZE_AUTONOMY.md` plus squad skill handoffs (analyst → triggers → drafter → architect → PM), PM pack template, draft-only/`staging` gate, and #572 night vs #510 tour boundary.
+
 ---
 
 ## [1.30.0] — 2026-07-17

--- a/docs/RELEASE_TRAIN_SPRINT_9.md
+++ b/docs/RELEASE_TRAIN_SPRINT_9.md
@@ -156,3 +156,4 @@ Incomplete features must land dark, behind absent UX, flags, or forward-only fie
 | 2026-07-17 | 3–4 | #622 + #623 merged | Badges/avatars (**1.28.1**) + setlist gaps (**1.29.0**); staging tip **1.29.0** |
 | 2026-07-17 | 4 | #555 in flight | Dashboard Tour stats explorer → **1.30.0** |
 | 2026-07-17 | 4 | #625 merged | Tour stats explorer + Stats tab (**1.30.0**); staging tip **1.30.0**. Wave 4 complete. Follow-up scrub: #626. |
+| 2026-07-17 | 5 | #573 Phase 0 in flight | Optimize autonomy L0 playbook + skills alignment |

--- a/docs/comms-triggers/ECOSYSTEM.md
+++ b/docs/comms-triggers/ECOSYSTEM.md
@@ -134,11 +134,11 @@ change regardless of which agent (or human) makes it.
 
 ### 3.4 Optimize (feedback loop)
 
-`comms-analyst` report → `comms-triggers` updates catalog → `comms-drafter`
-revises copy (new semver) → `comms-architect` adjusts channel mix / runs an A/B
-→ `comms-analyst` measures. Variant assignment is a stable
-`hash(uid + experimentId) % 100` bucket; every event already carries
-`comms_variant` (default `control`) so experiments are drop‑in.
+Canonical playbook: **[OPTIMIZE_AUTONOMY.md](./OPTIMIZE_AUTONOMY.md)** (#573 L0).
+
+Cycle order: `comms-analyst` → `comms-triggers` → `comms-drafter` → `comms-architect` → **PM**.
+
+Agents produce a **PM review pack** (template in the playbook), may open **draft** PRs to **`staging`**, and never auto-merge or production-deploy. Night uniqueness (#572 `show_recap`) stays separate from end-of-tour (#510 `tour_recap`). Variant assignment is a stable `hash(uid + experimentId) % 100` bucket; every event already carries `comms_variant` (default `control`) so experiments are drop‑in.
 
 ---
 

--- a/docs/comms-triggers/ECOSYSTEM.md
+++ b/docs/comms-triggers/ECOSYSTEM.md
@@ -8,6 +8,7 @@ message across in‑app, push, and email — fully automated, with **no manual
 It complements the other comms docs:
 
 - [`FRAMEWORK.md`](./FRAMEWORK.md) — the TTDMOM operating model (Trigger → Template → Deliver → Measure → Optimize → Monetize)
+- [`OPTIMIZE_AUTONOMY.md`](./OPTIMIZE_AUTONOMY.md) — Optimize autonomy L0 playbook + PM pack (#573)
 - [`catalog.json`](./catalog.json) / [`TRIGGER_CATALOG.md`](./TRIGGER_CATALOG.md) — the machine + human trigger registry
 - [`MEASUREMENT_PLAN.md`](./MEASUREMENT_PLAN.md) — the GA4 events & funnels
 

--- a/docs/comms-triggers/OPTIMIZE_AUTONOMY.md
+++ b/docs/comms-triggers/OPTIMIZE_AUTONOMY.md
@@ -1,0 +1,124 @@
+# Comms Optimize autonomy (L0 playbook)
+
+**Epic:** [#573](https://github.com/pat792/set-picks/issues/573)  
+**Status:** L0 — playbook documented. Agents run Optimize when invoked; PM still kicks every session.  
+**Does not replace:** automated **delivery** (`deliverCommsTrigger` / epic #441). This doc is the **editorial + measurement + recommendation** loop.
+
+---
+
+## Kickoff
+
+```text
+Run Optimize for goal <optimize_for> covering <date window / show dates>
+```
+
+| Input | Examples |
+|-------|----------|
+| `optimize_for` | `picks_lock` · `return_14d` · `tour_retention` · `push_opt_in` · `email_open` · `show_recap_uniqueness` |
+| Window | Show dates (YYYY-MM-DD…) or “last completed show week” |
+| Constraints | Draft-only; PR base **`staging`**; never `comms:deploy` / never merge without PM |
+
+Post the finished pack as a comment on **#573** (and link any draft PRs).
+
+---
+
+## Cycle order (always)
+
+```text
+comms-analyst → comms-triggers → comms-drafter → comms-architect → PM
+```
+
+| Step | Skill | Does |
+|------|-------|------|
+| 1 | **analyst** | GA4 + delivery-log funnels, gaps, recommendations slot |
+| 2 | **triggers** | Catalog proposals (new / deprecate / experiment) tied to goal |
+| 3 | **drafter** | Optional **draft** PR for low-risk copy (`content/comms` + builders) |
+| 4 | **architect** | Flag missing ingest / adapter / var wiring; dry-run notes |
+| 5 | **PM** | Approve/reject PRs + recommendations; set next `optimize_for` |
+
+Agents **open draft PRs and proposal issues only**. They do **not** auto-merge, auto-approve, or production-deploy.
+
+---
+
+## Night vs tour boundary
+
+| Surface | Issue | Trigger / template | When |
+|---------|-------|--------------------|------|
+| **Night show recap** | [#572](https://github.com/pat792/set-picks/issues/572) | `show_recap` (+ morning absorb) | After a single show grades |
+| **End-of-tour recap** | [#510](https://github.com/pat792/set-picks/issues/510) | `tour_recap` (generalize Sphere edition) | When a tour’s final show grades |
+
+Do **not** put tour-length narrative into night `show_recap`, or night setlist flow into `tour_recap`. Sphere ’26 is an **edition archive / QA replay**, not the permanent production trigger.
+
+---
+
+## Data spine (facts only — no invented setlist lore)
+
+| Source | Path / doc | Use in Optimize |
+|--------|------------|-----------------|
+| Official setlists | `docs/OFFICIAL_SETLISTS_SCHEMA.md` · `official_setlists/{showDate}` | Slots, `officialSetlist`, `bustouts`, `songGaps` |
+| Tour calendar | `show_calendar` / `showDatesByTour` | Tour membership, final-show detection |
+| Show context | `docs/COMMS_SHOW_CONTEXT_SCHEMA.md` · `comms_show_context/{showDate}` | Deterministic night highlights (#572) |
+| Measurement | `docs/comms-triggers/MEASUREMENT_PLAN.md` | Deliver → open → CTA |
+| Delivery | `functions/commsDelivery.js` + workers | Prefs, dedup, fatigue, canary/`dryRun` |
+
+**Composer rule (v1):** build `setlist_highlight` (and related vars) **deterministically** from the spine. No LLM freeform “what the night felt like” until L3+ and only on approved fact slots.
+
+---
+
+## Draft-only write surface
+
+| Allowed | Forbidden |
+|---------|-----------|
+| Draft PR to **`staging`** | Merge without PM |
+| `[SKIP-PRD]` child issues / catalog `planned` rows | Production `comms:deploy` from an agent |
+| War Room / `runCommsTrigger` canaries (`dryRun` default) | Resend MCP / ad-hoc production sends |
+| Pack comment on #573 | Changing prefs/caps/dedup without architect + PM |
+
+---
+
+## PM review pack template (every cycle)
+
+Agents **must** use this shape:
+
+```markdown
+## Comms Optimize pack — <YYYY-MM-DD> (goal: <goal>)
+
+### Summary
+<2–3 sentences>
+
+### Funnels
+| trigger_id | delivered | opened | CTA | Δ vs prior |
+
+### Gaps
+- …
+
+### Draft changes
+- PR(s): …
+- Canaries: …
+
+### Recommendations (new / change)
+1. … → goal: … → metric: …
+2. …
+
+### Show-recap uniqueness (when #572 ready)
+- tags/branches: …
+- samples: …
+- canaries: …
+
+### Maturity note
+- Current ladder level: L0–L4
+- Blockers to next level: …
+
+### Ask for PM
+- [ ] Approve / request changes on draft PR(s)
+- [ ] Accept / reject recommendations (log on epic)
+- [ ] Pick goal inputs for next cycle
+```
+
+---
+
+## Maturity ladder (pointer)
+
+Full L0→L4 table lives on [#573](https://github.com/pat792/set-picks/issues/573). This playbook exits **L0**. Next: **L1** on-demand pack end-to-end (Action 2 on the epic).
+
+Related Wave 5 siblings: [#512](https://github.com/pat792/set-picks/issues/512) (email open signal), [#513](https://github.com/pat792/set-picks/issues/513) (prefs hub).

--- a/docs/comms-triggers/README.md
+++ b/docs/comms-triggers/README.md
@@ -13,6 +13,7 @@ This directory is the **canonical home** for triggered, templated communications
 | [MEASUREMENT_PLAN.md](./MEASUREMENT_PLAN.md) | GA4 comms events, dimensions, funnels |
 | [CTA_ROUTE_AUDIT.md](./CTA_ROUTE_AUDIT.md) | In-app/email CTA label ↔ destination matrix (#551) |
 | [EXPERIMENT_PLAYBOOK.md](./EXPERIMENT_PLAYBOOK.md) | A/B rules, variant assignment, ship/kill criteria |
+| [OPTIMIZE_AUTONOMY.md](./OPTIMIZE_AUTONOMY.md) | **Optimize autonomy L0** — cycle order, PM pack template, draft-only gate (#573) |
 | [EMAIL_INBOX_BADGE.md](./EMAIL_INBOX_BADGE.md) | Inbox sender badge (BIMI/DMARC) vs in-body email logo (#498) |
 | [COMMERCIAL_PHASE3.md](./COMMERCIAL_PHASE3.md) | Sponsor / affiliate / offer gates (Phase 3) |
 
@@ -44,6 +45,7 @@ Fully **automated and event-driven** (no manual War Room sends in production): s
 - **#272** — Push / in-app / email channel epic
 - **#120** — In-app comms (inbox, toasts)
 - **#370** / **#371** — Scheduled recap automation follow-ups
+- **#573** — Optimize autonomy (playbook → scheduled packs → decisioning); start at [OPTIMIZE_AUTONOMY.md](./OPTIMIZE_AUTONOMY.md)
 
 ## Invoke the squad in Cursor
 


### PR DESCRIPTION
[SKIP-PRD]

Closes nothing yet — Phase 0 of #573 (L0 playbook). Phase 1 (first on-demand pack) remains on the epic.

## Summary
- Add `docs/comms-triggers/OPTIMIZE_AUTONOMY.md` (cycle order, PM pack template, draft-only gate, #572 vs #510 boundary, data spine)
- Patch `comms-{analyst,triggers,drafter,architect}` skills with Optimize handoffs
- Link from `ECOSYSTEM.md` + `README.md`; log Wave 5 start on the Sprint 9 train

## Test plan
- [ ] Docs/skills only — no runtime change
- [ ] Spot-check skill “Optimize cycle” sections match `OPTIMIZE_AUTONOMY.md`

Made with [Cursor](https://cursor.com)