### PR TITLE
fix(profile): season-stats freshness Slice 0 + Your stats tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ No unreleased changes.
 
 ---
 
+## [1.30.1] — 2026-07-17
+
+### Fixed
+- **Profile avg correct on show day (#635 Slice 0)** — live season-stats fallback now preserves `users.careerCorrectSlots`, and `deriveLatestFinalizedShow` excludes today (`d < today`) so an ungraded calendar date no longer falsely stales rollups through yesterday. Multi-day gaps still need the rollup watermark (Slices 1–2).
+
+### Changed
+- **Profile Your stats copy** — removed the footnote under the self-profile averages grid; each tile now uses the same Info tooltips as Standings → Stats (`InfoTooltip` shared UI).
+
+---
+
 ## [1.30.0] — 2026-07-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.30.0",
+  "version": "1.30.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/profile/api/profileSeasonStats.js
+++ b/src/features/profile/api/profileSeasonStats.js
@@ -1,6 +1,7 @@
 import { doc, getDoc } from 'firebase/firestore';
 
 import { db } from '../../../shared/lib/firebase';
+import { todayYmd } from '../../../shared/utils/dateUtils';
 import { pickCountsTowardSeason } from '../../../shared/utils/showAggregation';
 import { fetchGlobalMaxScoreForShow } from '../../scoring';
 
@@ -65,6 +66,8 @@ export const EMPTY_USER_SEASON_STATS_TELEMETRY = Object.freeze({
  *   - `totalPoints` / `shows` — sum of the user's own graded picks.
  *   - `wins` — shows won overall (global high score across every graded,
  *     non-empty pick for that show), not pool-scoped wins. Ties share.
+ *   - `careerCorrectSlots` — preserved from the user doc when present
+ *     (#635 Slice 0); live path does not recompute slot correctness.
  *
  * Also reports per-invocation read-cost counters via the optional
  * `onTelemetry` callback so `useUserSeasonStats` can ship the #220
@@ -177,7 +180,61 @@ export async function computeUserSeasonStats(uid, showDates, options = {}) {
   }
 
   emit();
-  return { totalPoints, shows, wins };
+  // #635 Slice 0: live path only recomputes points/shows/wins. Preserve
+  // rollup/backfill `careerCorrectSlots` so avg correct still renders when
+  // freshness short-circuit fails (ungraded calendar dates, etc.).
+  return withCareerCorrectSlots({ totalPoints, shows, wins }, userData);
+}
+
+/**
+ * Heuristic for "the most recent finalized show the client is aware of" —
+ * the max calendar date **strictly before today**. Used by
+ * `computeUserSeasonStats` (#244) to decide whether the `users/{uid}`
+ * materialized snapshot is fresh enough to short-circuit the
+ * live-compute fallback.
+ *
+ * Today's show is excluded (#635 Slice 0): finalize is still manual, so
+ * treating an ungraded show-day calendar entry as finalized falsely marks
+ * rollups through yesterday as stale. Multi-day calendar gaps still need
+ * the rollup watermark (Slices 1–2 on #635).
+ *
+ * @param {Array<{ date: string }>} showDates
+ * @param {string} [today] YYYY-MM-DD override for unit tests
+ * @returns {string | null}
+ */
+export function deriveLatestFinalizedShow(showDates, today = todayYmd()) {
+  if (!Array.isArray(showDates) || showDates.length === 0) return null;
+  const todayYmdValue =
+    typeof today === 'string' && today ? today : todayYmd();
+  let latest = null;
+  for (const s of showDates) {
+    const d = s && typeof s.date === 'string' ? s.date : '';
+    // Exclude today and future — only prior calendar nights are treated
+    // as potentially finalized.
+    if (!d || d >= todayYmdValue) continue;
+    if (!latest || d > latest) latest = d;
+  }
+  return latest;
+}
+
+/**
+ * Attach `careerCorrectSlots` from a `users/{uid}` snapshot when present.
+ * Used by both the materialized short-circuit and the live fallback so avg
+ * correct (#554 / #635) does not depend on freshness succeeding.
+ *
+ * @param {UserSeasonStats} stats
+ * @param {Record<string, unknown> | null | undefined} userData
+ * @returns {UserSeasonStats}
+ */
+export function withCareerCorrectSlots(stats, userData) {
+  const out = { ...stats };
+  if (
+    typeof userData?.careerCorrectSlots === 'number' &&
+    Number.isFinite(userData.careerCorrectSlots)
+  ) {
+    out.careerCorrectSlots = userData.careerCorrectSlots;
+  }
+  return out;
 }
 
 /**
@@ -214,12 +271,5 @@ export function readMaterializedSeasonStats(userData, latestFinalizedShow) {
       ? userData.seasonStatsThroughShow
       : '';
   if (!through || through < latestFinalizedShow) return null;
-  const out = { totalPoints, shows, wins };
-  if (
-    typeof userData.careerCorrectSlots === 'number' &&
-    Number.isFinite(userData.careerCorrectSlots)
-  ) {
-    out.careerCorrectSlots = userData.careerCorrectSlots;
-  }
-  return out;
+  return withCareerCorrectSlots({ totalPoints, shows, wins }, userData);
 }

--- a/src/features/profile/api/profileSeasonStats.test.js
+++ b/src/features/profile/api/profileSeasonStats.test.js
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { readMaterializedSeasonStats } from './profileSeasonStats';
+import {
+  deriveLatestFinalizedShow,
+  readMaterializedSeasonStats,
+  withCareerCorrectSlots,
+} from './profileSeasonStats';
 
 /**
  * #244 short-circuit decision logic. Kept as a pure predicate so the
@@ -100,5 +104,87 @@ describe('readMaterializedSeasonStats', () => {
         '2026-04-23'
       )
     ).toEqual({ totalPoints: 0, shows: 0, wins: 0 });
+  });
+});
+
+/**
+ * #635 Slice 0: live fallback must keep rollup/backfill careerCorrectSlots
+ * so avg correct still renders when freshness short-circuit fails.
+ */
+describe('withCareerCorrectSlots', () => {
+  const BASE = { totalPoints: 42, shows: 5, wins: 2 };
+
+  it('attaches a finite careerCorrectSlots from the user doc', () => {
+    expect(
+      withCareerCorrectSlots(BASE, { careerCorrectSlots: 18 })
+    ).toEqual({ ...BASE, careerCorrectSlots: 18 });
+  });
+
+  it('preserves zero careerCorrectSlots', () => {
+    expect(
+      withCareerCorrectSlots(BASE, { careerCorrectSlots: 0 })
+    ).toEqual({ ...BASE, careerCorrectSlots: 0 });
+  });
+
+  it('leaves stats unchanged when careerCorrectSlots is missing or invalid', () => {
+    expect(withCareerCorrectSlots(BASE, null)).toEqual(BASE);
+    expect(withCareerCorrectSlots(BASE, {})).toEqual(BASE);
+    expect(
+      withCareerCorrectSlots(BASE, { careerCorrectSlots: '18' })
+    ).toEqual(BASE);
+    expect(
+      withCareerCorrectSlots(BASE, { careerCorrectSlots: Number.NaN })
+    ).toEqual(BASE);
+  });
+
+  it('does not mutate the input stats object', () => {
+    const input = { ...BASE };
+    withCareerCorrectSlots(input, { careerCorrectSlots: 9 });
+    expect(input).toEqual(BASE);
+  });
+});
+
+/**
+ * #635 Slice 0: exclude today so an ungraded show-day calendar entry does
+ * not falsely stale rollups through yesterday.
+ */
+describe('deriveLatestFinalizedShow', () => {
+  it('returns the max calendar date strictly before today', () => {
+    expect(
+      deriveLatestFinalizedShow(
+        [
+          { date: '2026-07-15' },
+          { date: '2026-07-16' },
+          { date: '2026-07-17' },
+        ],
+        '2026-07-17'
+      )
+    ).toBe('2026-07-16');
+  });
+
+  it('skips today even when it is the only calendar date', () => {
+    expect(
+      deriveLatestFinalizedShow([{ date: '2026-07-17' }], '2026-07-17')
+    ).toBeNull();
+  });
+
+  it('skips future dates and empty/invalid entries', () => {
+    expect(
+      deriveLatestFinalizedShow(
+        [
+          { date: '2026-07-14' },
+          { date: '' },
+          null,
+          { date: '2026-07-20' },
+          { date: '2026-07-15' },
+        ],
+        '2026-07-17'
+      )
+    ).toBe('2026-07-15');
+  });
+
+  it('returns null for an empty calendar', () => {
+    expect(deriveLatestFinalizedShow([], '2026-07-17')).toBeNull();
+    expect(deriveLatestFinalizedShow(null, '2026-07-17')).toBeNull();
   });
 });

--- a/src/features/profile/model/useUserSeasonStats.js
+++ b/src/features/profile/model/useUserSeasonStats.js
@@ -1,12 +1,12 @@
 import { useEffect, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
-import { todayYmd } from '../../../shared/utils/dateUtils';
 import { useAuth } from '../../auth';
 import { useShowCalendar } from '../../show-calendar';
 import {
   EMPTY_USER_SEASON_STATS,
   computeUserSeasonStats,
+  deriveLatestFinalizedShow,
 } from '../api/profileSeasonStats';
 import { emitProfileSeasonStatsTelemetry } from './profileStatsTelemetry';
 
@@ -20,34 +20,6 @@ function deriveShowDatesKey(showDates) {
     .map((s) => (s && typeof s.date === 'string' ? s.date : ''))
     .filter(Boolean)
     .join('|');
-}
-
-/**
- * Heuristic for "the most recent finalized show the client is aware of" —
- * the max calendar date on or before today. Used by
- * `computeUserSeasonStats` (#244) to decide whether the `users/{uid}`
- * materialized snapshot is fresh enough to short-circuit the
- * live-compute fallback.
- *
- * Today's show may not have been rolled up yet (finalize is still manual);
- * if that's the case for the most-recent-show user, the snapshot will be
- * stale and they'll fall back to live-compute for one profile view until
- * the next rollup catches up. Acceptable trade-off vs. a second Firestore
- * read to load a global "last rolled up show" marker.
- *
- * @param {Array<{ date: string }>} showDates
- * @returns {string | null}
- */
-function deriveLatestFinalizedShow(showDates) {
-  if (!Array.isArray(showDates) || showDates.length === 0) return null;
-  const today = todayYmd();
-  let latest = null;
-  for (const s of showDates) {
-    const d = s && typeof s.date === 'string' ? s.date : '';
-    if (!d || d > today) continue;
-    if (!latest || d > latest) latest = d;
-  }
-  return latest;
 }
 
 /**

--- a/src/features/profile/ui/ProfileSelfStatsPanel.jsx
+++ b/src/features/profile/ui/ProfileSelfStatsPanel.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 
+import InfoTooltip, {
+  InfoTooltipProvider,
+} from '../../../shared/ui/InfoTooltip';
 import { useSongCatalog } from '../../song-catalog';
 import {
   buildDebutYearBySongName,
@@ -34,26 +37,36 @@ export default function ProfileSelfStatsPanel({ uid }) {
   );
   const avgVintage = formatAvgSongVintage(vintage.avgYear);
 
+  const vintageDefinition =
+    vintage.datedCount > 0
+      ? `Mean debut year of songs in your recent top-picks window (${vintage.datedCount} of ${vintage.uniqueCount} dated).`
+      : 'Mean debut year of songs in your recent top-picks window.';
+
   const columns = [
     {
       key: 'avgPts',
       label: 'Avg pts / show',
       value: avgPoints,
+      definition: 'Mean points per graded show across your career.',
     },
     {
       key: 'avgCorrect',
       label: 'Avg correct / show',
       value: avgCorrect,
+      definition:
+        'Mean correct pick slots per graded show. Shows — until your account has been rolled up after a finalize.',
     },
     {
       key: 'vintage',
       label: 'Avg vintage',
       value: avgVintage,
+      definition: vintageDefinition,
     },
     {
       key: 'shows',
       label: 'Shows',
       value: typeof stats?.shows === 'number' ? stats.shows : 0,
+      definition: 'Number of finalized shows you have graded picks for.',
     },
   ];
 
@@ -65,29 +78,25 @@ export default function ProfileSelfStatsPanel({ uid }) {
         <h2 className="mb-4 text-xs font-black uppercase tracking-widest text-content-secondary">
           Your stats
         </h2>
-        <div className="grid grid-cols-2 gap-3 text-center sm:grid-cols-4">
-          {columns.map(({ key, label, value }) => (
-            <div key={key} className="flex flex-col gap-1.5">
-              <p className="flex flex-1 items-end justify-center px-0.5 text-[10px] font-black uppercase leading-snug tracking-wider text-content-secondary">
-                {label}
-              </p>
-              <div className="flex min-h-[3.25rem] items-center justify-center rounded-2xl border border-border-subtle bg-surface-field px-2 py-3">
-                <span className="text-2xl font-black tabular-nums leading-none tracking-tight text-brand-primary">
-                  {statsLoading && key !== 'vintage' ? '…' : value}
-                </span>
+        <InfoTooltipProvider>
+          <div className="grid grid-cols-2 gap-3 text-center sm:grid-cols-4">
+            {columns.map(({ key, label, value, definition }) => (
+              <div key={key} className="flex flex-col gap-1.5">
+                <div className="flex flex-1 items-end justify-center gap-1 px-0.5">
+                  <p className="text-[10px] font-black uppercase leading-snug tracking-wider text-content-secondary">
+                    {label}
+                  </p>
+                  <InfoTooltip label={label} definition={definition} />
+                </div>
+                <div className="flex min-h-[3.25rem] items-center justify-center rounded-2xl border border-border-subtle bg-surface-field px-2 py-3">
+                  <span className="text-2xl font-black tabular-nums leading-none tracking-tight text-brand-primary">
+                    {statsLoading && key !== 'vintage' ? '…' : value}
+                  </span>
+                </div>
               </div>
-            </div>
-          ))}
-        </div>
-        <p className="mt-3 text-[11px] font-medium leading-relaxed text-content-secondary">
-          Career averages across graded nights. Avg correct needs the
-          finalize rollup field (shows — until backfilled). Vintage is the
-          mean debut year of songs in your recent top-picks window
-          {vintage.datedCount > 0
-            ? ` (${vintage.datedCount} of ${vintage.uniqueCount} dated)`
-            : ''}
-          .
-        </p>
+            ))}
+          </div>
+        </InfoTooltipProvider>
       </section>
 
       <TopPicksFrequencyStrip

--- a/src/features/tour-stats/ui/TourStatsView.jsx
+++ b/src/features/tour-stats/ui/TourStatsView.jsx
@@ -1,17 +1,10 @@
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useId,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
-import { createPortal } from 'react-dom';
-import { Info, Loader2 } from 'lucide-react';
+import React from 'react';
+import { Loader2 } from 'lucide-react';
 
 import Card from '../../../shared/ui/Card';
+import InfoTooltip, {
+  InfoTooltipProvider,
+} from '../../../shared/ui/InfoTooltip';
 import { SCORING_RULES } from '../../../shared/utils/scoring';
 import { TOUR_STATS_GAP_HIGHLIGHT_MIN } from '../model/aggregateTourSetlistStats';
 
@@ -31,10 +24,6 @@ const GAP_ROW_GRID =
 
 const COL_HEADER =
   'mb-0.5 border-b border-brand-primary/20 pb-1 text-[10px] font-black uppercase tracking-wider text-slate-300';
-
-const TOOLTIP_VIEWPORT_PAD = 8;
-const TOOLTIP_MAX_WIDTH = 256;
-const TOOLTIP_GAP = 6;
 
 const MOST_PLAYED_DEF =
   'Ranked by frequency; songs with the same number of plays this tour are sorted by total # of times played all-time.';
@@ -59,12 +48,6 @@ const TILE_DEFS = {
     long: `Songs with a pre-show gap ≥ ${BUSTOUT_MIN_GAP} (Bustout Boost eligible).`,
   },
 };
-
-/** @type {React.Context<{ openId: string | null, setOpenId: (id: string | null) => void }>} */
-const TourStatsTooltipContext = createContext({
-  openId: null,
-  setOpenId: () => {},
-});
 
 /**
  * @param {{
@@ -97,8 +80,6 @@ export default function TourStatsView({
   overlayLoading,
   onOpenScoringRules,
 }) {
-  const [openTooltipId, setOpenTooltipId] = useState(/** @type {string | null} */ (null));
-
   if (calendarLoading || setlistLoading) {
     return (
       <div className="flex justify-center py-16">
@@ -129,9 +110,7 @@ export default function TourStatsView({
   }
 
   return (
-    <TourStatsTooltipContext.Provider
-      value={{ openId: openTooltipId, setOpenId: setOpenTooltipId }}
-    >
+    <InfoTooltipProvider>
       <div className="space-y-4">
         <p className="rounded-xl border border-border-subtle/50 bg-surface-panel-strong/60 px-3.5 py-2 text-sm font-bold text-white shadow-inset-glass">
           {tourName ? (
@@ -311,7 +290,7 @@ export default function TourStatsView({
           </TourStatsSectionCard>
         ) : null}
       </div>
-    </TourStatsTooltipContext.Provider>
+    </InfoTooltipProvider>
   );
 }
 
@@ -370,171 +349,6 @@ function TourStatsSectionCard({
       </div>
       {children}
     </Card>
-  );
-}
-
-/**
- * Clamp a fixed-position tooltip so it stays inside the viewport on mobile.
- * @param {DOMRect} triggerRect
- * @param {number} tooltipWidth
- * @param {number} tooltipHeight
- * @returns {{ top: number, left: number, width: number }}
- */
-function clampTooltipPosition(triggerRect, tooltipWidth, tooltipHeight) {
-  const vw = typeof window !== 'undefined' ? window.innerWidth : 360;
-  const vh = typeof window !== 'undefined' ? window.innerHeight : 640;
-  const width = Math.min(
-    tooltipWidth,
-    TOOLTIP_MAX_WIDTH,
-    Math.max(120, vw - TOOLTIP_VIEWPORT_PAD * 2),
-  );
-
-  let left = triggerRect.left + triggerRect.width / 2 - width / 2;
-  left = Math.max(
-    TOOLTIP_VIEWPORT_PAD,
-    Math.min(left, vw - width - TOOLTIP_VIEWPORT_PAD),
-  );
-
-  let top = triggerRect.bottom + TOOLTIP_GAP;
-  if (top + tooltipHeight > vh - TOOLTIP_VIEWPORT_PAD) {
-    top = Math.max(
-      TOOLTIP_VIEWPORT_PAD,
-      triggerRect.top - tooltipHeight - TOOLTIP_GAP,
-    );
-  }
-
-  return { top, left, width };
-}
-
-/**
- * Exclusive, viewport-clamped Info tooltip (one open at a time on this surface).
- *
- * @param {{
- *   label: string,
- *   definition: string,
- * }} props
- */
-function InfoTooltip({ label, definition }) {
-  const reactId = useId();
-  const tooltipId = `tour-stats-tip-${reactId}`;
-  const { openId, setOpenId } = useContext(TourStatsTooltipContext);
-  const open = openId === tooltipId;
-  const triggerRef = useRef(/** @type {HTMLButtonElement | null} */ (null));
-  const panelRef = useRef(/** @type {HTMLDivElement | null} */ (null));
-  const [coords, setCoords] = useState(
-    /** @type {{ top: number, left: number, width: number } | null} */ (null),
-  );
-
-  const close = useCallback(() => {
-    setOpenId((current) => (current === tooltipId ? null : current));
-  }, [setOpenId, tooltipId]);
-
-  const toggle = useCallback(() => {
-    setOpenId((current) => (current === tooltipId ? null : tooltipId));
-  }, [setOpenId, tooltipId]);
-
-  useLayoutEffect(() => {
-    if (!open || !triggerRef.current) {
-      setCoords(null);
-      return undefined;
-    }
-
-    const update = () => {
-      const triggerRect = triggerRef.current?.getBoundingClientRect();
-      if (!triggerRect) return;
-      const panelRect = panelRef.current?.getBoundingClientRect();
-      const height = panelRect?.height || 72;
-      const width = Math.min(
-        TOOLTIP_MAX_WIDTH,
-        Math.max(120, window.innerWidth - TOOLTIP_VIEWPORT_PAD * 2),
-      );
-      setCoords(clampTooltipPosition(triggerRect, width, height));
-    };
-
-    update();
-    // Re-measure after paint so height is accurate for flip-above.
-    const raf = requestAnimationFrame(update);
-    window.addEventListener('resize', update);
-    window.addEventListener('scroll', update, true);
-    return () => {
-      cancelAnimationFrame(raf);
-      window.removeEventListener('resize', update);
-      window.removeEventListener('scroll', update, true);
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return undefined;
-
-    const onPointerDown = (event) => {
-      const target = event.target;
-      if (!(target instanceof Node)) return;
-      if (triggerRef.current?.contains(target)) return;
-      if (panelRef.current?.contains(target)) return;
-      close();
-    };
-    const onKeyDown = (event) => {
-      if (event.key === 'Escape') close();
-    };
-
-    document.addEventListener('pointerdown', onPointerDown);
-    document.addEventListener('keydown', onKeyDown);
-    return () => {
-      document.removeEventListener('pointerdown', onPointerDown);
-      document.removeEventListener('keydown', onKeyDown);
-    };
-  }, [open, close]);
-
-  return (
-    <>
-      <button
-        ref={triggerRef}
-        type="button"
-        className="shrink-0 rounded p-0.5 text-brand-primary/85 transition-colors hover:text-brand-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
-        aria-label={`About ${label}`}
-        aria-expanded={open}
-        aria-controls={tooltipId}
-        onClick={toggle}
-      >
-        <Info className="h-3 w-3" strokeWidth={2} aria-hidden />
-      </button>
-      {open && typeof document !== 'undefined'
-        ? createPortal(
-            <div
-              ref={panelRef}
-              id={tooltipId}
-              role="tooltip"
-              style={
-                coords
-                  ? {
-                      position: 'fixed',
-                      top: coords.top,
-                      left: coords.left,
-                      width: coords.width,
-                      zIndex: 80,
-                    }
-                  : {
-                      position: 'fixed',
-                      top: -9999,
-                      left: -9999,
-                      width: Math.min(
-                        TOOLTIP_MAX_WIDTH,
-                        typeof window !== 'undefined'
-                          ? window.innerWidth - TOOLTIP_VIEWPORT_PAD * 2
-                          : TOOLTIP_MAX_WIDTH,
-                      ),
-                      zIndex: 80,
-                      visibility: 'hidden',
-                    }
-              }
-              className="rounded-lg border border-border-muted bg-[rgb(var(--surface-panel-strong))] px-3 py-2 text-left text-xs font-medium leading-snug text-slate-100 shadow-lg"
-            >
-              {definition}
-            </div>,
-            document.body,
-          )
-        : null}
-    </>
   );
 }
 

--- a/src/shared/ui/InfoTooltip.jsx
+++ b/src/shared/ui/InfoTooltip.jsx
@@ -1,0 +1,207 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { Info } from 'lucide-react';
+
+const TOOLTIP_VIEWPORT_PAD = 8;
+const TOOLTIP_MAX_WIDTH = 256;
+const TOOLTIP_GAP = 6;
+
+/**
+ * @typedef {{ openId: string | null, setOpenId: React.Dispatch<React.SetStateAction<string | null>> }} InfoTooltipContextValue
+ */
+
+/** @type {React.Context<InfoTooltipContextValue>} */
+const InfoTooltipContext = createContext({
+  openId: null,
+  setOpenId: () => {},
+});
+
+/**
+ * Surface-scoped exclusive tooltip state (one open at a time).
+ * Wrap any cluster of `InfoTooltip` triggers (e.g. stats tiles).
+ *
+ * @param {{ children: React.ReactNode }} props
+ */
+export function InfoTooltipProvider({ children }) {
+  const [openId, setOpenId] = useState(/** @type {string | null} */ (null));
+  return (
+    <InfoTooltipContext.Provider value={{ openId, setOpenId }}>
+      {children}
+    </InfoTooltipContext.Provider>
+  );
+}
+
+/**
+ * Clamp a fixed-position tooltip so it stays inside the viewport on mobile.
+ * @param {DOMRect} triggerRect
+ * @param {number} tooltipWidth
+ * @param {number} tooltipHeight
+ * @returns {{ top: number, left: number, width: number }}
+ */
+function clampTooltipPosition(triggerRect, tooltipWidth, tooltipHeight) {
+  const vw = typeof window !== 'undefined' ? window.innerWidth : 360;
+  const vh = typeof window !== 'undefined' ? window.innerHeight : 640;
+  const width = Math.min(
+    tooltipWidth,
+    TOOLTIP_MAX_WIDTH,
+    Math.max(120, vw - TOOLTIP_VIEWPORT_PAD * 2),
+  );
+
+  let left = triggerRect.left + triggerRect.width / 2 - width / 2;
+  left = Math.max(
+    TOOLTIP_VIEWPORT_PAD,
+    Math.min(left, vw - width - TOOLTIP_VIEWPORT_PAD),
+  );
+
+  let top = triggerRect.bottom + TOOLTIP_GAP;
+  if (top + tooltipHeight > vh - TOOLTIP_VIEWPORT_PAD) {
+    top = Math.max(
+      TOOLTIP_VIEWPORT_PAD,
+      triggerRect.top - tooltipHeight - TOOLTIP_GAP,
+    );
+  }
+
+  return { top, left, width };
+}
+
+/**
+ * Exclusive, viewport-clamped Info tooltip (one open at a time per provider).
+ * Same interaction + chrome as Standings → Stats tiles.
+ *
+ * @param {{
+ *   label: string,
+ *   definition: string,
+ * }} props
+ */
+export default function InfoTooltip({ label, definition }) {
+  const reactId = useId();
+  const tooltipId = `info-tip-${reactId}`;
+  const { openId, setOpenId } = useContext(InfoTooltipContext);
+  const open = openId === tooltipId;
+  const triggerRef = useRef(/** @type {HTMLButtonElement | null} */ (null));
+  const panelRef = useRef(/** @type {HTMLDivElement | null} */ (null));
+  const [coords, setCoords] = useState(
+    /** @type {{ top: number, left: number, width: number } | null} */ (null),
+  );
+
+  const close = useCallback(() => {
+    setOpenId((current) => (current === tooltipId ? null : current));
+  }, [setOpenId, tooltipId]);
+
+  const toggle = useCallback(() => {
+    setOpenId((current) => (current === tooltipId ? null : tooltipId));
+  }, [setOpenId, tooltipId]);
+
+  useLayoutEffect(() => {
+    if (!open || !triggerRef.current) {
+      setCoords(null);
+      return undefined;
+    }
+
+    const update = () => {
+      const triggerRect = triggerRef.current?.getBoundingClientRect();
+      if (!triggerRect) return;
+      const panelRect = panelRef.current?.getBoundingClientRect();
+      const height = panelRect?.height || 72;
+      const width = Math.min(
+        TOOLTIP_MAX_WIDTH,
+        Math.max(120, window.innerWidth - TOOLTIP_VIEWPORT_PAD * 2),
+      );
+      setCoords(clampTooltipPosition(triggerRect, width, height));
+    };
+
+    update();
+    // Re-measure after paint so height is accurate for flip-above.
+    const raf = requestAnimationFrame(update);
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update, true);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const onPointerDown = (event) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (triggerRef.current?.contains(target)) return;
+      if (panelRef.current?.contains(target)) return;
+      close();
+    };
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') close();
+    };
+
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open, close]);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="shrink-0 rounded p-0.5 text-brand-primary/85 transition-colors hover:text-brand-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
+        aria-label={`About ${label}`}
+        aria-expanded={open}
+        aria-controls={tooltipId}
+        onClick={toggle}
+      >
+        <Info className="h-3 w-3" strokeWidth={2} aria-hidden />
+      </button>
+      {open && typeof document !== 'undefined'
+        ? createPortal(
+            <div
+              ref={panelRef}
+              id={tooltipId}
+              role="tooltip"
+              style={
+                coords
+                  ? {
+                      position: 'fixed',
+                      top: coords.top,
+                      left: coords.left,
+                      width: coords.width,
+                      zIndex: 80,
+                    }
+                  : {
+                      position: 'fixed',
+                      top: -9999,
+                      left: -9999,
+                      width: Math.min(
+                        TOOLTIP_MAX_WIDTH,
+                        typeof window !== 'undefined'
+                          ? window.innerWidth - TOOLTIP_VIEWPORT_PAD * 2
+                          : TOOLTIP_MAX_WIDTH,
+                      ),
+                      zIndex: 80,
+                      visibility: 'hidden',
+                    }
+              }
+              className="rounded-lg border border-border-muted bg-[rgb(var(--surface-panel-strong))] px-3 py-2 text-left text-xs font-medium leading-snug text-slate-100 shadow-lg"
+            >
+              {definition}
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}

--- a/src/shared/ui/index.js
+++ b/src/shared/ui/index.js
@@ -9,6 +9,7 @@ export { default as DashboardMobileChromeBar } from './DashboardMobileChromeBar'
 export { default as DashboardRowPill } from './DashboardRowPill';
 export { default as FilterPill } from './FilterPill';
 export { default as GhostPill } from './GhostPill';
+export { default as InfoTooltip, InfoTooltipProvider } from './InfoTooltip';
 export { default as Input } from './Input';
 export { default as MetaChip } from './MetaChip';
 export { default as PageTitle } from './PageTitle';


### PR DESCRIPTION
Closes #635 (Slice 0 only; watermark Slices 1–2 remain)

## Summary
- Preserve `careerCorrectSlots` on the live season-stats fallback so avg correct still renders when freshness short-circuit fails (ungraded calendar dates).
- `deriveLatestFinalizedShow` now uses `d < today` so today’s ungraded show does not false-stale rollups through yesterday.
- Remove the Your stats footnote; each tile uses the shared Standings → Stats Info tooltip (`InfoTooltip`).
- PATCH `1.30.1`.

## Test plan
- [x] Unit tests for `withCareerCorrectSlots` + `deriveLatestFinalizedShow`
- [x] Local spot check: avg correct populates on Profile with ungraded calendar date
- [x] Local spot check: Your stats Info tooltips (no footnote)
- [ ] Vercel preview: Profile avg correct + tooltips after hard refresh (React Query may cache)


Made with [Cursor](https://cursor.com)