### PR TITLE
feat(analytics): engagement GA4 for live setlist, stats, avatars, badges (#638)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.30.1] — 2026-07-17
+
+### Added
+- **Feature engagement GA4 (#638)** — client events for recent surfaces: `live_setlist_view`, `tour_stats_view`, `avatar_changed`, `badge_shelf_view`; helpers for future `badge_pin_changed` (no pin UI yet) and `feature_spotlight_*` (wired in #639). Wrappers under scoring / tour-stats / profile / feature-discovery.
+
+---
+
 ## [1.30.0] — 2026-07-17
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.30.0  
+**Version:** 1.30.1  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.30.0",
+  "version": "1.30.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/feature-discovery/index.js
+++ b/src/features/feature-discovery/index.js
@@ -1,0 +1,5 @@
+export {
+  trackFeatureSpotlightClick,
+  trackFeatureSpotlightDismissed,
+  trackFeatureSpotlightImpression,
+} from './model/featureDiscoveryAnalytics';

--- a/src/features/feature-discovery/model/featureDiscoveryAnalytics.js
+++ b/src/features/feature-discovery/model/featureDiscoveryAnalytics.js
@@ -1,0 +1,34 @@
+/**
+ * Feature spotlight / “New” marker engagement (#638 contract, UI in #639).
+ *
+ * Wire these from `features/feature-discovery` when markers ship.
+ */
+
+import { ga4Event } from '../../../shared/lib/ga4';
+
+/**
+ * @param {{ feature_id?: string }} [payload]
+ */
+export function trackFeatureSpotlightImpression({ feature_id } = {}) {
+  ga4Event('feature_spotlight_impression', {
+    feature_id: feature_id ?? '',
+  });
+}
+
+/**
+ * @param {{ feature_id?: string }} [payload]
+ */
+export function trackFeatureSpotlightClick({ feature_id } = {}) {
+  ga4Event('feature_spotlight_click', {
+    feature_id: feature_id ?? '',
+  });
+}
+
+/**
+ * @param {{ feature_id?: string }} [payload]
+ */
+export function trackFeatureSpotlightDismissed({ feature_id } = {}) {
+  ga4Event('feature_spotlight_dismissed', {
+    feature_id: feature_id ?? '',
+  });
+}

--- a/src/features/feature-discovery/model/featureDiscoveryAnalytics.test.js
+++ b/src/features/feature-discovery/model/featureDiscoveryAnalytics.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../shared/lib/ga4', () => ({
+  ga4Event: vi.fn(),
+}));
+
+import { ga4Event } from '../../../shared/lib/ga4';
+import {
+  trackFeatureSpotlightClick,
+  trackFeatureSpotlightDismissed,
+  trackFeatureSpotlightImpression,
+} from './featureDiscoveryAnalytics.js';
+
+describe('featureDiscoveryAnalytics', () => {
+  beforeEach(() => {
+    ga4Event.mockClear();
+  });
+
+  it('emits impression / click / dismissed with feature_id', () => {
+    trackFeatureSpotlightImpression({ feature_id: 'tour-stats' });
+    trackFeatureSpotlightClick({ feature_id: 'tour-stats' });
+    trackFeatureSpotlightDismissed({ feature_id: 'live-setlist' });
+
+    expect(ga4Event).toHaveBeenNthCalledWith(1, 'feature_spotlight_impression', {
+      feature_id: 'tour-stats',
+    });
+    expect(ga4Event).toHaveBeenNthCalledWith(2, 'feature_spotlight_click', {
+      feature_id: 'tour-stats',
+    });
+    expect(ga4Event).toHaveBeenNthCalledWith(3, 'feature_spotlight_dismissed', {
+      feature_id: 'live-setlist',
+    });
+  });
+});

--- a/src/features/profile/model/profileEngagementAnalytics.js
+++ b/src/features/profile/model/profileEngagementAnalytics.js
@@ -1,0 +1,37 @@
+import { ga4Event } from '../../../shared/lib/ga4';
+
+/**
+ * User successfully saved a different curated avatar (#638).
+ *
+ * @param {{ avatar_id?: string }} [payload]
+ */
+export function trackAvatarChanged({ avatar_id } = {}) {
+  ga4Event('avatar_changed', {
+    avatar_id: avatar_id ?? '',
+  });
+}
+
+/**
+ * Badge shelf section is visible on profile or public profile (#638).
+ *
+ * @param {{ surface?: 'profile' | 'public_profile', badge_count?: number }} [payload]
+ */
+export function trackBadgeShelfView({ surface, badge_count } = {}) {
+  ga4Event('badge_shelf_view', {
+    surface: surface === 'public_profile' ? 'public_profile' : 'profile',
+    badge_count: Math.max(0, Number(badge_count) || 0),
+  });
+}
+
+/**
+ * User pins/unpins a badge for standings display (#638).
+ * Exported for the future pin UX — no client UI wires this yet.
+ *
+ * @param {{ badge_id?: string, action?: 'pin' | 'unpin' }} [payload]
+ */
+export function trackBadgePinChanged({ badge_id, action } = {}) {
+  ga4Event('badge_pin_changed', {
+    badge_id: badge_id ?? '',
+    action: action === 'unpin' ? 'unpin' : 'pin',
+  });
+}

--- a/src/features/profile/model/profileEngagementAnalytics.test.js
+++ b/src/features/profile/model/profileEngagementAnalytics.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../shared/lib/ga4', () => ({
+  ga4Event: vi.fn(),
+}));
+
+import { ga4Event } from '../../../shared/lib/ga4';
+import {
+  trackAvatarChanged,
+  trackBadgePinChanged,
+  trackBadgeShelfView,
+} from './profileEngagementAnalytics.js';
+
+describe('profileEngagementAnalytics', () => {
+  beforeEach(() => {
+    ga4Event.mockClear();
+  });
+
+  it('trackAvatarChanged emits avatar_id', () => {
+    trackAvatarChanged({ avatar_id: 'disc' });
+    expect(ga4Event).toHaveBeenCalledWith('avatar_changed', {
+      avatar_id: 'disc',
+    });
+  });
+
+  it('trackBadgeShelfView normalizes surface and count', () => {
+    trackBadgeShelfView({ surface: 'public_profile', badge_count: 3 });
+    expect(ga4Event).toHaveBeenCalledWith('badge_shelf_view', {
+      surface: 'public_profile',
+      badge_count: 3,
+    });
+
+    trackBadgeShelfView({ surface: 'other', badge_count: -1 });
+    expect(ga4Event).toHaveBeenLastCalledWith('badge_shelf_view', {
+      surface: 'profile',
+      badge_count: 0,
+    });
+  });
+
+  it('trackBadgePinChanged defaults action to pin', () => {
+    trackBadgePinChanged({ badge_id: 'win_1', action: 'unpin' });
+    expect(ga4Event).toHaveBeenCalledWith('badge_pin_changed', {
+      badge_id: 'win_1',
+      action: 'unpin',
+    });
+
+    trackBadgePinChanged({ badge_id: 'shows_played_1' });
+    expect(ga4Event).toHaveBeenLastCalledWith('badge_pin_changed', {
+      badge_id: 'shows_played_1',
+      action: 'pin',
+    });
+  });
+});

--- a/src/features/profile/model/useUserProfile.js
+++ b/src/features/profile/model/useUserProfile.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useAuth } from '../../auth';
 import { formatMonthYear } from '../../../shared';
@@ -8,6 +8,7 @@ import {
 } from '../api/profileApi';
 import { showSuccessToast } from '../../../shared/ui/toast';
 import { DEFAULT_AVATAR_ID, normalizeAvatarId } from './avatarCatalog';
+import { trackAvatarChanged } from './profileEngagementAnalytics';
 
 /**
  * Loads the signed-in user's profile, holds edit form state, and persists updates.
@@ -25,6 +26,8 @@ export function useUserProfile(user) {
   const [isLoading, setIsLoading] = useState(!!uid);
   const [isSaving, setIsSaving] = useState(false);
   const [message, setMessage] = useState({ text: '', type: '' });
+  /** Last persisted avatar — used to detect real changes on save (#638). */
+  const persistedAvatarIdRef = useRef(DEFAULT_AVATAR_ID);
 
   useEffect(() => {
     if (!uid) {
@@ -34,6 +37,7 @@ export function useUserProfile(user) {
       setAvatarId(DEFAULT_AVATAR_ID);
       setBadges(null);
       setJoinDate('');
+      persistedAvatarIdRef.current = DEFAULT_AVATAR_ID;
       return;
     }
 
@@ -45,7 +49,9 @@ export function useUserProfile(user) {
       if (data) {
         setHandle(data.handle || '');
         setFavoriteSong(data.favoriteSong || '');
-        setAvatarId(normalizeAvatarId(data.avatarId));
+        const nextAvatar = normalizeAvatarId(data.avatarId);
+        setAvatarId(nextAvatar);
+        persistedAvatarIdRef.current = nextAvatar;
         setBadges(
           data.badges && typeof data.badges === 'object' && !Array.isArray(data.badges)
             ? data.badges
@@ -55,6 +61,7 @@ export function useUserProfile(user) {
         setHandle('');
         setFavoriteSong('');
         setAvatarId(DEFAULT_AVATAR_ID);
+        persistedAvatarIdRef.current = DEFAULT_AVATAR_ID;
         setBadges(null);
       }
     };
@@ -112,12 +119,17 @@ export function useUserProfile(user) {
 
       try {
         const nextAvatarId = normalizeAvatarId(avatarId);
+        const avatarChanged = nextAvatarId !== persistedAvatarIdRef.current;
         await updateUserProfileWithPickHandles(uid, {
           handle: trimmedHandle,
           favoriteSong,
           avatarId: nextAvatarId,
         });
         setAvatarId(nextAvatarId);
+        persistedAvatarIdRef.current = nextAvatarId;
+        if (avatarChanged) {
+          trackAvatarChanged({ avatar_id: nextAvatarId });
+        }
         setMessage({ text: 'Profile updated successfully! 🎸', type: 'success' });
         showSuccessToast('Profile updated! 🎸');
         return true;

--- a/src/features/profile/ui/BadgeShelf.jsx
+++ b/src/features/profile/ui/BadgeShelf.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import { resolveEarnedBadges } from '../model/badgeCatalog';
+import { trackBadgeShelfView } from '../model/profileEngagementAnalytics';
 
 /**
  * Earned milestone badges shelf (#568).
@@ -8,13 +9,25 @@ import { resolveEarnedBadges } from '../model/badgeCatalog';
  * @param {{
  *   badges?: Record<string, unknown> | null,
  *   emptyLabel?: string,
+ *   surface?: 'profile' | 'public_profile',
  * }} props
  */
 export default function BadgeShelf({
   badges = null,
   emptyLabel = 'No badges yet — play a scored show to start earning.',
+  surface = 'profile',
 }) {
   const earned = resolveEarnedBadges(badges);
+  const viewLoggedRef = useRef(false);
+
+  useEffect(() => {
+    if (viewLoggedRef.current) return;
+    viewLoggedRef.current = true;
+    trackBadgeShelfView({
+      surface,
+      badge_count: earned.length,
+    });
+  }, [surface, earned.length]);
 
   return (
     <section className="mt-6 rounded-3xl border border-border-subtle bg-surface-panel p-6 shadow-inset-glass">

--- a/src/features/profile/ui/PublicProfileView.jsx
+++ b/src/features/profile/ui/PublicProfileView.jsx
@@ -154,6 +154,7 @@ export default function PublicProfileView({
         <BadgeShelf
           badges={profile.badges}
           emptyLabel="No badges earned yet."
+          surface="public_profile"
         />
       </div>
     </div>

--- a/src/features/scoring/model/standingsAnalytics.js
+++ b/src/features/scoring/model/standingsAnalytics.js
@@ -1,0 +1,25 @@
+import { ga4Event } from '../../../shared/lib/ga4';
+
+/**
+ * Map Standings show status → live setlist engagement status (#638).
+ *
+ * @param {string} [showStatus]
+ * @returns {'live' | 'final' | 'waiting'}
+ */
+export function resolveLiveSetlistStatus(showStatus) {
+  if (showStatus === 'LIVE') return 'live';
+  if (showStatus === 'PAST') return 'final';
+  return 'waiting';
+}
+
+/**
+ * Official / live setlist card is shown on Standings (#638).
+ *
+ * @param {{ show_date?: string, setlist_status?: string }} [payload]
+ */
+export function trackLiveSetlistView({ show_date, setlist_status } = {}) {
+  ga4Event('live_setlist_view', {
+    show_date: show_date ?? '',
+    setlist_status: setlist_status ?? 'waiting',
+  });
+}

--- a/src/features/scoring/model/standingsAnalytics.test.js
+++ b/src/features/scoring/model/standingsAnalytics.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../shared/lib/ga4', () => ({
+  ga4Event: vi.fn(),
+}));
+
+import { ga4Event } from '../../../shared/lib/ga4';
+import {
+  resolveLiveSetlistStatus,
+  trackLiveSetlistView,
+} from './standingsAnalytics.js';
+
+describe('resolveLiveSetlistStatus', () => {
+  it('maps LIVE / PAST / other', () => {
+    expect(resolveLiveSetlistStatus('LIVE')).toBe('live');
+    expect(resolveLiveSetlistStatus('PAST')).toBe('final');
+    expect(resolveLiveSetlistStatus('NEXT')).toBe('waiting');
+    expect(resolveLiveSetlistStatus('')).toBe('waiting');
+  });
+});
+
+describe('trackLiveSetlistView', () => {
+  beforeEach(() => {
+    ga4Event.mockClear();
+  });
+
+  it('emits live_setlist_view with show_date and setlist_status', () => {
+    trackLiveSetlistView({
+      show_date: '2026-07-15',
+      setlist_status: 'live',
+    });
+    expect(ga4Event).toHaveBeenCalledWith('live_setlist_view', {
+      show_date: '2026-07-15',
+      setlist_status: 'live',
+    });
+  });
+
+  it('defaults empty date and waiting status', () => {
+    trackLiveSetlistView();
+    expect(ga4Event).toHaveBeenCalledWith('live_setlist_view', {
+      show_date: '',
+      setlist_status: 'waiting',
+    });
+  });
+});

--- a/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
+++ b/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { ChevronDown, ExternalLink, ListMusic } from 'lucide-react';
 
 import Card from '../../../shared/ui/Card';
@@ -11,6 +11,10 @@ import {
   groupOfficialSetlistBySet,
   isOfficialSetlistBustout,
 } from '../model/groupOfficialSetlistBySet';
+import {
+  resolveLiveSetlistStatus,
+  trackLiveSetlistView,
+} from '../model/standingsAnalytics';
 import OfficialPickSlotsGrid from './OfficialPickSlotsGrid';
 import {
   STANDINGS_BOX_BODY,
@@ -110,8 +114,25 @@ export default function StandingsOfficialSetlistCard({
   const grouped = groupOfficialSetlistBySet(actualSetlist);
   const bustoutTitleSet = buildBustoutTitleSet(actualSetlist);
   const gapMap = buildSongGapMap(actualSetlist);
+  const viewLoggedRef = useRef('');
 
-  if (!actualSetlist || (!grouped.hasSongs && !grouped.hasOfficialSlots)) {
+  const hasContent =
+    Boolean(actualSetlist) &&
+    (grouped.hasSongs || grouped.hasOfficialSlots);
+
+  useEffect(() => {
+    if (!hasContent) return;
+    const setlistStatus = resolveLiveSetlistStatus(showStatus);
+    const sig = `${showDate}|${setlistStatus}`;
+    if (viewLoggedRef.current === sig) return;
+    viewLoggedRef.current = sig;
+    trackLiveSetlistView({
+      show_date: showDate || '',
+      setlist_status: setlistStatus,
+    });
+  }, [hasContent, showDate, showStatus]);
+
+  if (!hasContent) {
     return null;
   }
 

--- a/src/features/tour-stats/model/tourStatsAnalytics.js
+++ b/src/features/tour-stats/model/tourStatsAnalytics.js
@@ -1,0 +1,12 @@
+import { ga4Event } from '../../../shared/lib/ga4';
+
+/**
+ * Tour Stats explorer content is ready for the selected tour (#638).
+ *
+ * @param {{ tour?: string }} [payload]
+ */
+export function trackTourStatsView({ tour } = {}) {
+  ga4Event('tour_stats_view', {
+    tour: tour ?? '',
+  });
+}

--- a/src/features/tour-stats/model/tourStatsAnalytics.test.js
+++ b/src/features/tour-stats/model/tourStatsAnalytics.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../shared/lib/ga4', () => ({
+  ga4Event: vi.fn(),
+}));
+
+import { ga4Event } from '../../../shared/lib/ga4';
+import { trackTourStatsView } from './tourStatsAnalytics.js';
+
+describe('trackTourStatsView', () => {
+  beforeEach(() => {
+    ga4Event.mockClear();
+  });
+
+  it('emits tour_stats_view with tour scope', () => {
+    trackTourStatsView({ tour: 'Summer Tour 2026' });
+    expect(ga4Event).toHaveBeenCalledWith('tour_stats_view', {
+      tour: 'Summer Tour 2026',
+    });
+  });
+
+  it('defaults empty tour', () => {
+    trackTourStatsView();
+    expect(ga4Event).toHaveBeenCalledWith('tour_stats_view', { tour: '' });
+  });
+});

--- a/src/features/tour-stats/model/useTourStatsScreen.js
+++ b/src/features/tour-stats/model/useTourStatsScreen.js
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { useAuth } from '../../auth';
@@ -6,6 +6,7 @@ import { useSongCatalog } from '../../song-catalog';
 import { computeTourStatsSelfOverlay } from '../api/computeTourStatsSelfOverlay';
 import { fetchTourOfficialSetlists } from '../api/fetchTourOfficialSetlists';
 import { aggregateTourSetlistStats } from './aggregateTourSetlistStats';
+import { trackTourStatsView } from './tourStatsAnalytics';
 
 /**
  * Normalized (lowercased/trimmed) title → lifetime times-played, from the song
@@ -94,6 +95,23 @@ export function useTourStatsScreen(options = {}) {
         topSongTitles: stats.topSongs.map((r) => r.title),
       }),
   });
+
+  const tourViewLoggedRef = useRef('');
+  useEffect(() => {
+    if (calendarLoading || !selectedTour || !tourName) return;
+    if (setlistQuery.isLoading || setlistQuery.isError) return;
+    if (!setlistQuery.isSuccess) return;
+    if (tourViewLoggedRef.current === tourName) return;
+    tourViewLoggedRef.current = tourName;
+    trackTourStatsView({ tour: tourName });
+  }, [
+    calendarLoading,
+    selectedTour,
+    tourName,
+    setlistQuery.isLoading,
+    setlistQuery.isError,
+    setlistQuery.isSuccess,
+  ]);
 
   return {
     calendarLoading,

--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -61,7 +61,7 @@ export default function ProfilePage({ user: userProp }) {
 
       <ProfileSelfStatsPanel uid={user?.uid} />
 
-      <BadgeShelf badges={badges} />
+      {!isLoading ? <BadgeShelf badges={badges} surface="profile" /> : null}
 
       <div className="mt-6">
         <ProfileEditForm


### PR DESCRIPTION
Closes #638

## Summary
- Add client GA4 engagement events: `live_setlist_view`, `tour_stats_view`, `avatar_changed`, `badge_shelf_view`
- Stub `badge_pin_changed` (no pin UI yet) and `feature_spotlight_*` for #639
- PATCH **1.30.1** — telemetry only, no user-visible UI

**Epic:** #637

## Test plan
- [x] Unit tests for analytics helpers (`npm test` on new `*Analytics.test.js`)
- [x] `npm run lint`
- [ ] CI `verify` green on this PR
- [ ] After merge → staging deploy: optional DebugView smoke on prod hostname after promote (events are prod-hostname gated)

## Promote note
Safe for staged → main promote after staging checks pass (no UI/copy risk). Tag/release only on explicit request after promote.

Made with [Cursor](https://cursor.com)