### PR TITLE
feat(feature-discovery): New markers + engagement GA4 (#639, #638)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.30.1] — 2026-07-17
+
+### Added
+- **Feature engagement GA4 (#638)** — client events for recent surfaces: `live_setlist_view`, `tour_stats_view`, `avatar_changed`, `badge_shelf_view`; helpers for future `badge_pin_changed` (no pin UI yet) and `feature_spotlight_*` (wired in #639). Wrappers under scoring / tour-stats / profile / feature-discovery.
+
+---
+
 ## [1.30.0] — 2026-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.31.0] — 2026-07-17
+
+### Added
+- **Feature discovery “New” markers (#639)** — client spotlight registry (`features/feature-discovery`) with soft **New** labels on Standings **Stats**, live/official setlist card, and Profile avatar/badges. Clears on visit/interaction; expires `until` 2026-08-31; localStorage per uid. Wires `feature_spotlight_*` GA4 from #638.
+
+---
+
 ## [1.30.1] — 2026-07-17
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.30.1  
+**Version:** 1.31.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.30.0  
+**Version:** 1.30.1  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 

--- a/docs/DASHBOARD_IA.md
+++ b/docs/DASHBOARD_IA.md
@@ -19,6 +19,16 @@ Single reference for **support**, **product**, and **engineering** when adding r
 |-------|------|-------|
 | **Stats** (Standings peer tab) | `/dashboard/tour-stats` | Private explorer: unique songs, frequency, bustouts, self pick overlay. Discovered via Standings chrome **Show \| Tour \| Stats \| Pools** (not a 5th primary nav tab). Standings tab stays active. Shares the chrome **tour scope** picker with Tour view (`?tour=`). No global date picker. |
 
+### Feature discovery “New” markers (#639)
+
+Soft **New** labels (not coachmarks) may appear temporarily on:
+
+- Standings chrome **Stats** pill → clears after visiting `/dashboard/tour-stats` (compact corner **dot**, not a “New” text label — keeps the Stats word readable in the four-tab chrome)
+- Official setlist card on Standings → clears when the card is toggled open/closed
+- Profile **Avatar** / **Badges** headings → clears after picking an avatar
+
+Markers auto-expire by catalog `until` date and persist dismissals in `localStorage` per signed-in uid. Support can tell users: clear site data for the origin if a marker is stuck; otherwise ignore — they vanish by end of the window.
+
 ### Profile cluster (#418)
 
 | Sub-nav | Path | Responsibility |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.30.1",
+  "version": "1.31.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.30.0",
+  "version": "1.30.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/feature-discovery/index.js
+++ b/src/features/feature-discovery/index.js
@@ -1,0 +1,5 @@
+export {
+  trackFeatureSpotlightClick,
+  trackFeatureSpotlightDismissed,
+  trackFeatureSpotlightImpression,
+} from './model/featureDiscoveryAnalytics';

--- a/src/features/feature-discovery/index.js
+++ b/src/features/feature-discovery/index.js
@@ -3,3 +3,15 @@ export {
   trackFeatureSpotlightDismissed,
   trackFeatureSpotlightImpression,
 } from './model/featureDiscoveryAnalytics';
+export {
+  FEATURE_SPOTLIGHTS,
+  getFeatureSpotlight,
+  isSpotlightActive,
+  isSpotlightInWindow,
+  localYmd,
+  readSpotlightSeen,
+  spotlightStorageKey,
+  writeSpotlightSeen,
+} from './model/featureSpotlights';
+export { useFeatureSpotlight } from './model/useFeatureSpotlight';
+export { default as FeatureNewBadge } from './ui/FeatureNewBadge';

--- a/src/features/feature-discovery/model/featureDiscoveryAnalytics.js
+++ b/src/features/feature-discovery/model/featureDiscoveryAnalytics.js
@@ -1,0 +1,34 @@
+/**
+ * Feature spotlight / “New” marker engagement (#638 contract, UI in #639).
+ *
+ * Wire these from `features/feature-discovery` when markers ship.
+ */
+
+import { ga4Event } from '../../../shared/lib/ga4';
+
+/**
+ * @param {{ feature_id?: string }} [payload]
+ */
+export function trackFeatureSpotlightImpression({ feature_id } = {}) {
+  ga4Event('feature_spotlight_impression', {
+    feature_id: feature_id ?? '',
+  });
+}
+
+/**
+ * @param {{ feature_id?: string }} [payload]
+ */
+export function trackFeatureSpotlightClick({ feature_id } = {}) {
+  ga4Event('feature_spotlight_click', {
+    feature_id: feature_id ?? '',
+  });
+}
+
+/**
+ * @param {{ feature_id?: string }} [payload]
+ */
+export function trackFeatureSpotlightDismissed({ feature_id } = {}) {
+  ga4Event('feature_spotlight_dismissed', {
+    feature_id: feature_id ?? '',
+  });
+}

--- a/src/features/feature-discovery/model/featureDiscoveryAnalytics.test.js
+++ b/src/features/feature-discovery/model/featureDiscoveryAnalytics.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../shared/lib/ga4', () => ({
+  ga4Event: vi.fn(),
+}));
+
+import { ga4Event } from '../../../shared/lib/ga4';
+import {
+  trackFeatureSpotlightClick,
+  trackFeatureSpotlightDismissed,
+  trackFeatureSpotlightImpression,
+} from './featureDiscoveryAnalytics.js';
+
+describe('featureDiscoveryAnalytics', () => {
+  beforeEach(() => {
+    ga4Event.mockClear();
+  });
+
+  it('emits impression / click / dismissed with feature_id', () => {
+    trackFeatureSpotlightImpression({ feature_id: 'tour-stats' });
+    trackFeatureSpotlightClick({ feature_id: 'tour-stats' });
+    trackFeatureSpotlightDismissed({ feature_id: 'live-setlist' });
+
+    expect(ga4Event).toHaveBeenNthCalledWith(1, 'feature_spotlight_impression', {
+      feature_id: 'tour-stats',
+    });
+    expect(ga4Event).toHaveBeenNthCalledWith(2, 'feature_spotlight_click', {
+      feature_id: 'tour-stats',
+    });
+    expect(ga4Event).toHaveBeenNthCalledWith(3, 'feature_spotlight_dismissed', {
+      feature_id: 'live-setlist',
+    });
+  });
+});

--- a/src/features/feature-discovery/model/featureSpotlights.js
+++ b/src/features/feature-discovery/model/featureSpotlights.js
@@ -1,0 +1,118 @@
+/**
+ * Client-side feature spotlight catalog (#639).
+ * Soft “New” markers; dismissals persist in localStorage (per uid).
+ */
+
+/**
+ * @typedef {{
+ *   id: string,
+ *   since: string,
+ *   until: string,
+ *   surfaces: string[],
+ *   path: string,
+ * }} FeatureSpotlight
+ */
+
+/** @type {readonly FeatureSpotlight[]} */
+export const FEATURE_SPOTLIGHTS = Object.freeze([
+  {
+    id: 'tour-stats',
+    since: '2026-06-01',
+    until: '2026-08-31',
+    surfaces: ['standings-stats-tab'],
+    path: '/dashboard/tour-stats',
+  },
+  {
+    id: 'live-setlist',
+    since: '2026-06-01',
+    until: '2026-08-31',
+    surfaces: ['standings-setlist-card'],
+    path: '/dashboard/standings',
+  },
+  {
+    id: 'profile-identity',
+    since: '2026-06-01',
+    until: '2026-08-31',
+    surfaces: ['profile-avatar', 'profile-badges'],
+    path: '/dashboard/profile',
+  },
+]);
+
+const BY_ID = new Map(FEATURE_SPOTLIGHTS.map((s) => [s.id, s]));
+
+/**
+ * @param {string} featureId
+ * @returns {FeatureSpotlight | null}
+ */
+export function getFeatureSpotlight(featureId) {
+  return BY_ID.get(featureId) || null;
+}
+
+/**
+ * Calendar date YYYY-MM-DD in local time (for since/until window).
+ * @param {Date} [now]
+ * @returns {string}
+ */
+export function localYmd(now = new Date()) {
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * True when today is within [since, until] inclusive.
+ * @param {FeatureSpotlight} spot
+ * @param {string} [todayYmd]
+ */
+export function isSpotlightInWindow(spot, todayYmd = localYmd()) {
+  if (!spot?.since || !spot?.until) return false;
+  return todayYmd >= spot.since && todayYmd <= spot.until;
+}
+
+/**
+ * @param {string} uid
+ * @param {string} featureId
+ */
+export function spotlightStorageKey(uid, featureId) {
+  return `set-picks-feature-spotlight:${uid}:${featureId}`;
+}
+
+/**
+ * @param {string | null | undefined} uid
+ * @param {string} featureId
+ */
+export function readSpotlightSeen(uid, featureId) {
+  if (!uid || typeof window === 'undefined') return true;
+  try {
+    return window.localStorage.getItem(spotlightStorageKey(uid, featureId)) === '1';
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * @param {string | null | undefined} uid
+ * @param {string} featureId
+ */
+export function writeSpotlightSeen(uid, featureId) {
+  if (!uid || typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(spotlightStorageKey(uid, featureId), '1');
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+/**
+ * Whether the spotlight should show (in window, not seen, signed-in).
+ * @param {string} featureId
+ * @param {{ uid?: string | null, todayYmd?: string }} [opts]
+ */
+export function isSpotlightActive(featureId, opts = {}) {
+  const { uid = null, todayYmd = localYmd() } = opts;
+  if (!uid) return false;
+  const spot = getFeatureSpotlight(featureId);
+  if (!spot || !isSpotlightInWindow(spot, todayYmd)) return false;
+  return !readSpotlightSeen(uid, featureId);
+}

--- a/src/features/feature-discovery/model/featureSpotlights.test.js
+++ b/src/features/feature-discovery/model/featureSpotlights.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import {
+  FEATURE_SPOTLIGHTS,
+  getFeatureSpotlight,
+  isSpotlightActive,
+  isSpotlightInWindow,
+  localYmd,
+  readSpotlightSeen,
+  spotlightStorageKey,
+  writeSpotlightSeen,
+} from './featureSpotlights.js';
+
+function installMemoryLocalStorage() {
+  /** @type {Map<string, string>} */
+  const store = new Map();
+  const memory = {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => {
+      store.set(String(key), String(value));
+    },
+    removeItem: (key) => {
+      store.delete(String(key));
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+  globalThis.localStorage = memory;
+  globalThis.window = { localStorage: memory };
+}
+
+describe('featureSpotlights', () => {
+  const uid = 'user-abc';
+
+  beforeEach(() => {
+    installMemoryLocalStorage();
+  });
+
+  afterEach(() => {
+    delete globalThis.localStorage;
+    delete globalThis.window;
+  });
+
+  it('includes the three summer discovery features', () => {
+    expect(FEATURE_SPOTLIGHTS.map((s) => s.id).sort()).toEqual([
+      'live-setlist',
+      'profile-identity',
+      'tour-stats',
+    ]);
+  });
+
+  it('isSpotlightInWindow is inclusive on since/until', () => {
+    const spot = getFeatureSpotlight('tour-stats');
+    expect(isSpotlightInWindow(spot, '2026-06-01')).toBe(true);
+    expect(isSpotlightInWindow(spot, '2026-08-31')).toBe(true);
+    expect(isSpotlightInWindow(spot, '2026-05-31')).toBe(false);
+    expect(isSpotlightInWindow(spot, '2026-09-01')).toBe(false);
+  });
+
+  it('localYmd formats local calendar date', () => {
+    expect(localYmd(new Date(2026, 6, 17))).toBe('2026-07-17');
+  });
+
+  it('isSpotlightActive requires uid, window, and unseen', () => {
+    expect(
+      isSpotlightActive('tour-stats', { uid: null, todayYmd: '2026-07-17' }),
+    ).toBe(false);
+    expect(
+      isSpotlightActive('tour-stats', { uid, todayYmd: '2026-07-17' }),
+    ).toBe(true);
+
+    writeSpotlightSeen(uid, 'tour-stats');
+    expect(readSpotlightSeen(uid, 'tour-stats')).toBe(true);
+    expect(
+      isSpotlightActive('tour-stats', { uid, todayYmd: '2026-07-17' }),
+    ).toBe(false);
+    expect(localStorage.getItem(spotlightStorageKey(uid, 'tour-stats'))).toBe(
+      '1',
+    );
+  });
+
+  it('expires after until even if unseen', () => {
+    expect(
+      isSpotlightActive('live-setlist', { uid, todayYmd: '2026-09-15' }),
+    ).toBe(false);
+  });
+});

--- a/src/features/feature-discovery/model/useFeatureSpotlight.js
+++ b/src/features/feature-discovery/model/useFeatureSpotlight.js
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useAuth } from '../../auth';
+import {
+  trackFeatureSpotlightClick,
+  trackFeatureSpotlightDismissed,
+  trackFeatureSpotlightImpression,
+} from './featureDiscoveryAnalytics';
+import {
+  getFeatureSpotlight,
+  isSpotlightActive,
+  writeSpotlightSeen,
+} from './featureSpotlights';
+
+/**
+ * Soft “New” spotlight for one catalog feature (#639).
+ *
+ * @param {string} featureId
+ * @param {{ trackImpression?: boolean }} [options]
+ */
+export function useFeatureSpotlight(featureId, options = {}) {
+  const { trackImpression = true } = options;
+  const { user } = useAuth();
+  const uid = user?.uid || null;
+  const [tick, setTick] = useState(0);
+  const impressedRef = useRef(false);
+
+  const spot = useMemo(() => getFeatureSpotlight(featureId), [featureId]);
+
+  const active = useMemo(() => {
+    void tick;
+    return isSpotlightActive(featureId, { uid });
+  }, [featureId, uid, tick]);
+
+  useEffect(() => {
+    if (!trackImpression || !active || !featureId) return;
+    if (impressedRef.current) return;
+    impressedRef.current = true;
+    trackFeatureSpotlightImpression({ feature_id: featureId });
+  }, [active, featureId, trackImpression]);
+
+  const markSeen = useCallback(() => {
+    if (!uid || !featureId) return;
+    if (!isSpotlightActive(featureId, { uid })) return;
+    writeSpotlightSeen(uid, featureId);
+    trackFeatureSpotlightDismissed({ feature_id: featureId });
+    setTick((t) => t + 1);
+  }, [uid, featureId]);
+
+  const trackClick = useCallback(() => {
+    if (!featureId) return;
+    trackFeatureSpotlightClick({ feature_id: featureId });
+  }, [featureId]);
+
+  return {
+    featureId,
+    path: spot?.path || '',
+    active,
+    markSeen,
+    trackClick,
+  };
+}

--- a/src/features/feature-discovery/ui/FeatureNewBadge.jsx
+++ b/src/features/feature-discovery/ui/FeatureNewBadge.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+/**
+ * Soft discovery chrome (#639).
+ * - `label` — “New” micro-pill (section headings, roomy chrome)
+ * - `dot` — corner accent for tight controls (e.g. Standings Stats tab)
+ *
+ * @param {{
+ *   className?: string,
+ *   title?: string,
+ *   variant?: 'label' | 'dot',
+ * }} [props]
+ */
+export default function FeatureNewBadge({
+  className = '',
+  title = 'New feature',
+  variant = 'label',
+}) {
+  if (variant === 'dot') {
+    return (
+      <span
+        title={title}
+        className={[
+          'pointer-events-none absolute right-1 top-1 inline-flex items-center justify-center',
+          className,
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        <span className="sr-only">{title}</span>
+        <span
+          className="h-1.5 w-1.5 shrink-0 rounded-full bg-brand-primary shadow-[0_0_0_1px_rgba(0,0,0,0.35)]"
+          aria-hidden
+        />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      title={title}
+      className={[
+        'inline-block shrink-0 rounded-md border border-brand-primary/35 bg-brand-primary/15 px-1 py-0.5 text-[9px] font-black uppercase tracking-wider text-brand-primary',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      New
+    </span>
+  );
+}

--- a/src/features/profile/model/profileEngagementAnalytics.js
+++ b/src/features/profile/model/profileEngagementAnalytics.js
@@ -1,0 +1,37 @@
+import { ga4Event } from '../../../shared/lib/ga4';
+
+/**
+ * User successfully saved a different curated avatar (#638).
+ *
+ * @param {{ avatar_id?: string }} [payload]
+ */
+export function trackAvatarChanged({ avatar_id } = {}) {
+  ga4Event('avatar_changed', {
+    avatar_id: avatar_id ?? '',
+  });
+}
+
+/**
+ * Badge shelf section is visible on profile or public profile (#638).
+ *
+ * @param {{ surface?: 'profile' | 'public_profile', badge_count?: number }} [payload]
+ */
+export function trackBadgeShelfView({ surface, badge_count } = {}) {
+  ga4Event('badge_shelf_view', {
+    surface: surface === 'public_profile' ? 'public_profile' : 'profile',
+    badge_count: Math.max(0, Number(badge_count) || 0),
+  });
+}
+
+/**
+ * User pins/unpins a badge for standings display (#638).
+ * Exported for the future pin UX — no client UI wires this yet.
+ *
+ * @param {{ badge_id?: string, action?: 'pin' | 'unpin' }} [payload]
+ */
+export function trackBadgePinChanged({ badge_id, action } = {}) {
+  ga4Event('badge_pin_changed', {
+    badge_id: badge_id ?? '',
+    action: action === 'unpin' ? 'unpin' : 'pin',
+  });
+}

--- a/src/features/profile/model/profileEngagementAnalytics.test.js
+++ b/src/features/profile/model/profileEngagementAnalytics.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../shared/lib/ga4', () => ({
+  ga4Event: vi.fn(),
+}));
+
+import { ga4Event } from '../../../shared/lib/ga4';
+import {
+  trackAvatarChanged,
+  trackBadgePinChanged,
+  trackBadgeShelfView,
+} from './profileEngagementAnalytics.js';
+
+describe('profileEngagementAnalytics', () => {
+  beforeEach(() => {
+    ga4Event.mockClear();
+  });
+
+  it('trackAvatarChanged emits avatar_id', () => {
+    trackAvatarChanged({ avatar_id: 'disc' });
+    expect(ga4Event).toHaveBeenCalledWith('avatar_changed', {
+      avatar_id: 'disc',
+    });
+  });
+
+  it('trackBadgeShelfView normalizes surface and count', () => {
+    trackBadgeShelfView({ surface: 'public_profile', badge_count: 3 });
+    expect(ga4Event).toHaveBeenCalledWith('badge_shelf_view', {
+      surface: 'public_profile',
+      badge_count: 3,
+    });
+
+    trackBadgeShelfView({ surface: 'other', badge_count: -1 });
+    expect(ga4Event).toHaveBeenLastCalledWith('badge_shelf_view', {
+      surface: 'profile',
+      badge_count: 0,
+    });
+  });
+
+  it('trackBadgePinChanged defaults action to pin', () => {
+    trackBadgePinChanged({ badge_id: 'win_1', action: 'unpin' });
+    expect(ga4Event).toHaveBeenCalledWith('badge_pin_changed', {
+      badge_id: 'win_1',
+      action: 'unpin',
+    });
+
+    trackBadgePinChanged({ badge_id: 'shows_played_1' });
+    expect(ga4Event).toHaveBeenLastCalledWith('badge_pin_changed', {
+      badge_id: 'shows_played_1',
+      action: 'pin',
+    });
+  });
+});

--- a/src/features/profile/model/useUserProfile.js
+++ b/src/features/profile/model/useUserProfile.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useAuth } from '../../auth';
 import { formatMonthYear } from '../../../shared';
@@ -8,6 +8,7 @@ import {
 } from '../api/profileApi';
 import { showSuccessToast } from '../../../shared/ui/toast';
 import { DEFAULT_AVATAR_ID, normalizeAvatarId } from './avatarCatalog';
+import { trackAvatarChanged } from './profileEngagementAnalytics';
 
 /**
  * Loads the signed-in user's profile, holds edit form state, and persists updates.
@@ -25,6 +26,8 @@ export function useUserProfile(user) {
   const [isLoading, setIsLoading] = useState(!!uid);
   const [isSaving, setIsSaving] = useState(false);
   const [message, setMessage] = useState({ text: '', type: '' });
+  /** Last persisted avatar — used to detect real changes on save (#638). */
+  const persistedAvatarIdRef = useRef(DEFAULT_AVATAR_ID);
 
   useEffect(() => {
     if (!uid) {
@@ -34,6 +37,7 @@ export function useUserProfile(user) {
       setAvatarId(DEFAULT_AVATAR_ID);
       setBadges(null);
       setJoinDate('');
+      persistedAvatarIdRef.current = DEFAULT_AVATAR_ID;
       return;
     }
 
@@ -45,7 +49,9 @@ export function useUserProfile(user) {
       if (data) {
         setHandle(data.handle || '');
         setFavoriteSong(data.favoriteSong || '');
-        setAvatarId(normalizeAvatarId(data.avatarId));
+        const nextAvatar = normalizeAvatarId(data.avatarId);
+        setAvatarId(nextAvatar);
+        persistedAvatarIdRef.current = nextAvatar;
         setBadges(
           data.badges && typeof data.badges === 'object' && !Array.isArray(data.badges)
             ? data.badges
@@ -55,6 +61,7 @@ export function useUserProfile(user) {
         setHandle('');
         setFavoriteSong('');
         setAvatarId(DEFAULT_AVATAR_ID);
+        persistedAvatarIdRef.current = DEFAULT_AVATAR_ID;
         setBadges(null);
       }
     };
@@ -112,12 +119,17 @@ export function useUserProfile(user) {
 
       try {
         const nextAvatarId = normalizeAvatarId(avatarId);
+        const avatarChanged = nextAvatarId !== persistedAvatarIdRef.current;
         await updateUserProfileWithPickHandles(uid, {
           handle: trimmedHandle,
           favoriteSong,
           avatarId: nextAvatarId,
         });
         setAvatarId(nextAvatarId);
+        persistedAvatarIdRef.current = nextAvatarId;
+        if (avatarChanged) {
+          trackAvatarChanged({ avatar_id: nextAvatarId });
+        }
         setMessage({ text: 'Profile updated successfully! 🎸', type: 'success' });
         showSuccessToast('Profile updated! 🎸');
         return true;

--- a/src/features/profile/ui/AvatarPicker.jsx
+++ b/src/features/profile/ui/AvatarPicker.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { FeatureNewBadge } from '../../feature-discovery';
 import { PROFILE_AVATARS } from '../model/avatarCatalog';
 import ProfileAvatar from './ProfileAvatar';
 
@@ -10,13 +11,20 @@ import ProfileAvatar from './ProfileAvatar';
  *   value: string,
  *   onChange: (avatarId: string) => void,
  *   disabled?: boolean,
+ *   showNewBadge?: boolean,
  * }} props
  */
-export default function AvatarPicker({ value, onChange, disabled = false }) {
+export default function AvatarPicker({
+  value,
+  onChange,
+  disabled = false,
+  showNewBadge = false,
+}) {
   return (
     <fieldset disabled={disabled} className="min-w-0">
-      <legend className="mb-2 ml-1 text-xs font-bold uppercase tracking-widest text-slate-400">
+      <legend className="mb-2 ml-1 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-slate-400">
         Avatar
+        {showNewBadge ? <FeatureNewBadge title="New: profile avatars" /> : null}
       </legend>
       <div className="mb-3 flex items-center gap-3">
         <ProfileAvatar avatarId={value} size="lg" />

--- a/src/features/profile/ui/BadgeShelf.jsx
+++ b/src/features/profile/ui/BadgeShelf.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 
+import { FeatureNewBadge } from '../../feature-discovery';
 import { resolveEarnedBadges } from '../model/badgeCatalog';
 import { trackBadgeShelfView } from '../model/profileEngagementAnalytics';
 
@@ -10,12 +11,14 @@ import { trackBadgeShelfView } from '../model/profileEngagementAnalytics';
  *   badges?: Record<string, unknown> | null,
  *   emptyLabel?: string,
  *   surface?: 'profile' | 'public_profile',
+ *   showNewBadge?: boolean,
  * }} props
  */
 export default function BadgeShelf({
   badges = null,
   emptyLabel = 'No badges yet — play a scored show to start earning.',
   surface = 'profile',
+  showNewBadge = false,
 }) {
   const earned = resolveEarnedBadges(badges);
   const viewLoggedRef = useRef(false);
@@ -31,8 +34,9 @@ export default function BadgeShelf({
 
   return (
     <section className="mt-6 rounded-3xl border border-border-subtle bg-surface-panel p-6 shadow-inset-glass">
-      <h2 className="mb-3 text-xs font-black uppercase tracking-widest text-content-secondary">
+      <h2 className="mb-3 flex items-center gap-2 text-xs font-black uppercase tracking-widest text-content-secondary">
         Badges
+        {showNewBadge ? <FeatureNewBadge title="New: milestone badges" /> : null}
       </h2>
       {earned.length === 0 ? (
         <p className="text-sm font-bold text-content-secondary">{emptyLabel}</p>

--- a/src/features/profile/ui/BadgeShelf.jsx
+++ b/src/features/profile/ui/BadgeShelf.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import { resolveEarnedBadges } from '../model/badgeCatalog';
+import { trackBadgeShelfView } from '../model/profileEngagementAnalytics';
 
 /**
  * Earned milestone badges shelf (#568).
@@ -8,13 +9,25 @@ import { resolveEarnedBadges } from '../model/badgeCatalog';
  * @param {{
  *   badges?: Record<string, unknown> | null,
  *   emptyLabel?: string,
+ *   surface?: 'profile' | 'public_profile',
  * }} props
  */
 export default function BadgeShelf({
   badges = null,
   emptyLabel = 'No badges yet — play a scored show to start earning.',
+  surface = 'profile',
 }) {
   const earned = resolveEarnedBadges(badges);
+  const viewLoggedRef = useRef(false);
+
+  useEffect(() => {
+    if (viewLoggedRef.current) return;
+    viewLoggedRef.current = true;
+    trackBadgeShelfView({
+      surface,
+      badge_count: earned.length,
+    });
+  }, [surface, earned.length]);
 
   return (
     <section className="mt-6 rounded-3xl border border-border-subtle bg-surface-panel p-6 shadow-inset-glass">

--- a/src/features/profile/ui/ProfileEditForm.jsx
+++ b/src/features/profile/ui/ProfileEditForm.jsx
@@ -6,6 +6,20 @@ import AvatarPicker from './AvatarPicker';
 
 /**
  * Editable profile fields (avatar, handle, favorite song) for the signed-in user.
+ *
+ * @param {{
+ *   handle: string,
+ *   favoriteSong: string,
+ *   avatarId: string,
+ *   onHandleChange: (v: string) => void,
+ *   onFavoriteSongChange: (v: string) => void,
+ *   onAvatarChange: (avatarId: string) => void,
+ *   onSave: (e: React.FormEvent) => void,
+ *   isSaving: boolean,
+ *   isLoading?: boolean,
+ *   message: { text: string, type: string },
+ *   showAvatarNewBadge?: boolean,
+ * }} props
  */
 export default function ProfileEditForm({
   handle,
@@ -18,6 +32,7 @@ export default function ProfileEditForm({
   isSaving,
   isLoading = false,
   message,
+  showAvatarNewBadge = false,
 }) {
   return (
     <form
@@ -28,6 +43,7 @@ export default function ProfileEditForm({
         value={avatarId}
         onChange={onAvatarChange}
         disabled={isLoading || isSaving}
+        showNewBadge={showAvatarNewBadge}
       />
 
       <div className="flex flex-col">

--- a/src/features/profile/ui/PublicProfileView.jsx
+++ b/src/features/profile/ui/PublicProfileView.jsx
@@ -154,6 +154,7 @@ export default function PublicProfileView({
         <BadgeShelf
           badges={profile.badges}
           emptyLabel="No badges earned yet."
+          surface="public_profile"
         />
       </div>
     </div>

--- a/src/features/scoring/model/standingsAnalytics.js
+++ b/src/features/scoring/model/standingsAnalytics.js
@@ -1,0 +1,25 @@
+import { ga4Event } from '../../../shared/lib/ga4';
+
+/**
+ * Map Standings show status → live setlist engagement status (#638).
+ *
+ * @param {string} [showStatus]
+ * @returns {'live' | 'final' | 'waiting'}
+ */
+export function resolveLiveSetlistStatus(showStatus) {
+  if (showStatus === 'LIVE') return 'live';
+  if (showStatus === 'PAST') return 'final';
+  return 'waiting';
+}
+
+/**
+ * Official / live setlist card is shown on Standings (#638).
+ *
+ * @param {{ show_date?: string, setlist_status?: string }} [payload]
+ */
+export function trackLiveSetlistView({ show_date, setlist_status } = {}) {
+  ga4Event('live_setlist_view', {
+    show_date: show_date ?? '',
+    setlist_status: setlist_status ?? 'waiting',
+  });
+}

--- a/src/features/scoring/model/standingsAnalytics.test.js
+++ b/src/features/scoring/model/standingsAnalytics.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../shared/lib/ga4', () => ({
+  ga4Event: vi.fn(),
+}));
+
+import { ga4Event } from '../../../shared/lib/ga4';
+import {
+  resolveLiveSetlistStatus,
+  trackLiveSetlistView,
+} from './standingsAnalytics.js';
+
+describe('resolveLiveSetlistStatus', () => {
+  it('maps LIVE / PAST / other', () => {
+    expect(resolveLiveSetlistStatus('LIVE')).toBe('live');
+    expect(resolveLiveSetlistStatus('PAST')).toBe('final');
+    expect(resolveLiveSetlistStatus('NEXT')).toBe('waiting');
+    expect(resolveLiveSetlistStatus('')).toBe('waiting');
+  });
+});
+
+describe('trackLiveSetlistView', () => {
+  beforeEach(() => {
+    ga4Event.mockClear();
+  });
+
+  it('emits live_setlist_view with show_date and setlist_status', () => {
+    trackLiveSetlistView({
+      show_date: '2026-07-15',
+      setlist_status: 'live',
+    });
+    expect(ga4Event).toHaveBeenCalledWith('live_setlist_view', {
+      show_date: '2026-07-15',
+      setlist_status: 'live',
+    });
+  });
+
+  it('defaults empty date and waiting status', () => {
+    trackLiveSetlistView();
+    expect(ga4Event).toHaveBeenCalledWith('live_setlist_view', {
+      show_date: '',
+      setlist_status: 'waiting',
+    });
+  });
+});

--- a/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
+++ b/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useRef } from 'react';
 import { ChevronDown, ExternalLink, ListMusic } from 'lucide-react';
 
+import {
+  FeatureNewBadge,
+  useFeatureSpotlight,
+} from '../../feature-discovery';
 import Card from '../../../shared/ui/Card';
 import { SCORING_RULES } from '../../../shared/utils/scoring';
 import { buildPhishNetSetlistUrl } from '../model/buildPhishNetSetlistUrl';
@@ -115,10 +119,12 @@ export default function StandingsOfficialSetlistCard({
   const bustoutTitleSet = buildBustoutTitleSet(actualSetlist);
   const gapMap = buildSongGapMap(actualSetlist);
   const viewLoggedRef = useRef('');
+  const setlistSpotlight = useFeatureSpotlight('live-setlist');
 
   const hasContent =
     Boolean(actualSetlist) &&
     (grouped.hasSongs || grouped.hasOfficialSlots);
+  const isLive = showStatus === 'LIVE';
 
   useEffect(() => {
     if (!hasContent) return;
@@ -136,9 +142,14 @@ export default function StandingsOfficialSetlistCard({
     return null;
   }
 
-  const isLive = showStatus === 'LIVE';
   const statusLabel = isLive ? 'Live' : showStatus === 'PAST' ? 'Final' : 'Official';
   const phishNetHref = buildPhishNetSetlistUrl(showDate);
+
+  const onDetailsToggle = () => {
+    if (setlistSpotlight.active) {
+      setlistSpotlight.markSeen();
+    }
+  };
 
   return (
     <Card
@@ -147,7 +158,11 @@ export default function StandingsOfficialSetlistCard({
       padding="none"
       className={`mb-3 ${STANDINGS_CARD_SHELL} ${className}`.trim()}
     >
-      <details className="group" defaultOpen={isLive}>
+      <details
+        className="group"
+        defaultOpen={isLive}
+        onToggle={onDetailsToggle}
+      >
         <summary className="flex cursor-pointer list-none items-start justify-between gap-3 [&::-webkit-details-marker]:hidden">
           <div className="min-w-0 space-y-1">
             <div className="flex flex-wrap items-center gap-2">
@@ -167,6 +182,9 @@ export default function StandingsOfficialSetlistCard({
               >
                 {statusLabel}
               </span>
+              {setlistSpotlight.active ? (
+                <FeatureNewBadge title="New: live official setlist" />
+              ) : null}
             </div>
             {showLabel ? (
               <p className={`truncate ${STANDINGS_BOX_TITLE}`}>{showLabel}</p>

--- a/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
+++ b/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { ChevronDown, ExternalLink, ListMusic } from 'lucide-react';
 
 import Card from '../../../shared/ui/Card';
@@ -11,6 +11,10 @@ import {
   groupOfficialSetlistBySet,
   isOfficialSetlistBustout,
 } from '../model/groupOfficialSetlistBySet';
+import {
+  resolveLiveSetlistStatus,
+  trackLiveSetlistView,
+} from '../model/standingsAnalytics';
 import OfficialPickSlotsGrid from './OfficialPickSlotsGrid';
 import {
   STANDINGS_BOX_BODY,
@@ -110,8 +114,25 @@ export default function StandingsOfficialSetlistCard({
   const grouped = groupOfficialSetlistBySet(actualSetlist);
   const bustoutTitleSet = buildBustoutTitleSet(actualSetlist);
   const gapMap = buildSongGapMap(actualSetlist);
+  const viewLoggedRef = useRef('');
 
-  if (!actualSetlist || (!grouped.hasSongs && !grouped.hasOfficialSlots)) {
+  const hasContent =
+    Boolean(actualSetlist) &&
+    (grouped.hasSongs || grouped.hasOfficialSlots);
+
+  useEffect(() => {
+    if (!hasContent) return;
+    const setlistStatus = resolveLiveSetlistStatus(showStatus);
+    const sig = `${showDate}|${setlistStatus}`;
+    if (viewLoggedRef.current === sig) return;
+    viewLoggedRef.current = sig;
+    trackLiveSetlistView({
+      show_date: showDate || '',
+      setlist_status: setlistStatus,
+    });
+  }, [hasContent, showDate, showStatus]);
+
+  if (!hasContent) {
     return null;
   }
 

--- a/src/features/scoring/ui/StandingsViewToggle.jsx
+++ b/src/features/scoring/ui/StandingsViewToggle.jsx
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { BarChart3, CalendarDays, ListOrdered, Users } from 'lucide-react';
 
+import {
+  FeatureNewBadge,
+  useFeatureSpotlight,
+} from '../../feature-discovery';
 import ChromeSegmentedControl from '../../../shared/ui/ChromeSegmentedControl';
 
 const OPTIONS = [
@@ -11,7 +15,7 @@ const OPTIONS = [
 ];
 
 const baseClass =
-  'shrink-0 inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-semibold tracking-tight transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg';
+  'relative shrink-0 inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-semibold tracking-tight transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg';
 
 /**
  * Active state mirrors `Button variant="primary"` (teal fill, dark text,
@@ -44,13 +48,31 @@ const unselectedClass =
  * }} props
  */
 export default function StandingsViewToggle({ view, onChange, className = '' }) {
+  const tourStatsSpotlight = useFeatureSpotlight('tour-stats');
+
+  const handleChange = (next) => {
+    if (next === 'stats' && tourStatsSpotlight.active) {
+      tourStatsSpotlight.trackClick();
+    }
+    onChange(next);
+  };
+
+  const items = useMemo(() => {
+    const badge = tourStatsSpotlight.active ? (
+      <FeatureNewBadge variant="dot" title="New: Tour Stats" />
+    ) : null;
+    return OPTIONS.map((opt) =>
+      opt.id === 'stats' ? { ...opt, badge } : opt,
+    );
+  }, [tourStatsSpotlight.active]);
+
   return (
     <>
       <ChromeSegmentedControl
         ariaLabel="Standings view"
         value={view}
-        onChange={onChange}
-        items={OPTIONS}
+        onChange={handleChange}
+        items={items}
         className={['md:hidden', className].filter(Boolean).join(' ')}
       />
 
@@ -64,7 +86,7 @@ export default function StandingsViewToggle({ view, onChange, className = '' }) 
           .filter(Boolean)
           .join(' ')}
       >
-        {OPTIONS.map(({ id, label, icon: Icon }) => {
+        {items.map(({ id, label, icon: Icon, badge }) => {
           const selected = view === id;
           return (
             <button
@@ -72,7 +94,7 @@ export default function StandingsViewToggle({ view, onChange, className = '' }) 
               type="button"
               role="tab"
               aria-selected={selected}
-              onClick={() => onChange(id)}
+              onClick={() => handleChange(id)}
               className={[
                 baseClass,
                 selected ? selectedClass : unselectedClass,
@@ -81,6 +103,7 @@ export default function StandingsViewToggle({ view, onChange, className = '' }) 
             >
               <Icon className="h-4 w-4 shrink-0" aria-hidden />
               {label}
+              {badge}
             </button>
           );
         })}

--- a/src/features/tour-stats/model/tourStatsAnalytics.js
+++ b/src/features/tour-stats/model/tourStatsAnalytics.js
@@ -1,0 +1,12 @@
+import { ga4Event } from '../../../shared/lib/ga4';
+
+/**
+ * Tour Stats explorer content is ready for the selected tour (#638).
+ *
+ * @param {{ tour?: string }} [payload]
+ */
+export function trackTourStatsView({ tour } = {}) {
+  ga4Event('tour_stats_view', {
+    tour: tour ?? '',
+  });
+}

--- a/src/features/tour-stats/model/tourStatsAnalytics.test.js
+++ b/src/features/tour-stats/model/tourStatsAnalytics.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../shared/lib/ga4', () => ({
+  ga4Event: vi.fn(),
+}));
+
+import { ga4Event } from '../../../shared/lib/ga4';
+import { trackTourStatsView } from './tourStatsAnalytics.js';
+
+describe('trackTourStatsView', () => {
+  beforeEach(() => {
+    ga4Event.mockClear();
+  });
+
+  it('emits tour_stats_view with tour scope', () => {
+    trackTourStatsView({ tour: 'Summer Tour 2026' });
+    expect(ga4Event).toHaveBeenCalledWith('tour_stats_view', {
+      tour: 'Summer Tour 2026',
+    });
+  });
+
+  it('defaults empty tour', () => {
+    trackTourStatsView();
+    expect(ga4Event).toHaveBeenCalledWith('tour_stats_view', { tour: '' });
+  });
+});

--- a/src/features/tour-stats/model/useTourStatsScreen.js
+++ b/src/features/tour-stats/model/useTourStatsScreen.js
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { useAuth } from '../../auth';
@@ -6,6 +6,7 @@ import { useSongCatalog } from '../../song-catalog';
 import { computeTourStatsSelfOverlay } from '../api/computeTourStatsSelfOverlay';
 import { fetchTourOfficialSetlists } from '../api/fetchTourOfficialSetlists';
 import { aggregateTourSetlistStats } from './aggregateTourSetlistStats';
+import { trackTourStatsView } from './tourStatsAnalytics';
 
 /**
  * Normalized (lowercased/trimmed) title → lifetime times-played, from the song
@@ -94,6 +95,23 @@ export function useTourStatsScreen(options = {}) {
         topSongTitles: stats.topSongs.map((r) => r.title),
       }),
   });
+
+  const tourViewLoggedRef = useRef('');
+  useEffect(() => {
+    if (calendarLoading || !selectedTour || !tourName) return;
+    if (setlistQuery.isLoading || setlistQuery.isError) return;
+    if (!setlistQuery.isSuccess) return;
+    if (tourViewLoggedRef.current === tourName) return;
+    tourViewLoggedRef.current = tourName;
+    trackTourStatsView({ tour: tourName });
+  }, [
+    calendarLoading,
+    selectedTour,
+    tourName,
+    setlistQuery.isLoading,
+    setlistQuery.isError,
+    setlistQuery.isSuccess,
+  ]);
 
   return {
     calendarLoading,

--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -61,7 +61,7 @@ export default function ProfilePage({ user: userProp }) {
 
       <ProfileSelfStatsPanel uid={user?.uid} />
 
-      <BadgeShelf badges={badges} />
+      {!isLoading ? <BadgeShelf badges={badges} surface="profile" /> : null}
 
       <div className="mt-6">
         <ProfileEditForm

--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Link, useOutletContext } from 'react-router-dom';
 import { ExternalLink } from 'lucide-react';
 
+import { useFeatureSpotlight } from '../../features/feature-discovery';
 import { InstallAppCard } from '../../features/install';
 import {
   BadgeShelf,
@@ -19,6 +20,7 @@ import DashboardRowPill from '../../shared/ui/DashboardRowPill';
 export default function ProfilePage({ user: userProp }) {
   const outlet = useOutletContext();
   const user = userProp ?? outlet?.user;
+  const identitySpotlight = useFeatureSpotlight('profile-identity');
 
   const {
     handle,
@@ -34,6 +36,17 @@ export default function ProfilePage({ user: userProp }) {
     setAvatarId,
     saveProfile,
   } = useUserProfile(user);
+
+  const onAvatarChange = useCallback(
+    (nextId) => {
+      setAvatarId(nextId);
+      if (identitySpotlight.active) {
+        identitySpotlight.trackClick();
+        identitySpotlight.markSeen();
+      }
+    },
+    [setAvatarId, identitySpotlight],
+  );
 
   return (
     <div>
@@ -61,7 +74,13 @@ export default function ProfilePage({ user: userProp }) {
 
       <ProfileSelfStatsPanel uid={user?.uid} />
 
-      {!isLoading ? <BadgeShelf badges={badges} surface="profile" /> : null}
+      {!isLoading ? (
+        <BadgeShelf
+          badges={badges}
+          surface="profile"
+          showNewBadge={identitySpotlight.active}
+        />
+      ) : null}
 
       <div className="mt-6">
         <ProfileEditForm
@@ -70,11 +89,12 @@ export default function ProfilePage({ user: userProp }) {
           avatarId={avatarId}
           onHandleChange={setHandle}
           onFavoriteSongChange={setFavoriteSong}
-          onAvatarChange={setAvatarId}
+          onAvatarChange={onAvatarChange}
           onSave={saveProfile}
           isSaving={isSaving}
           isLoading={isLoading}
           message={message}
+          showAvatarNewBadge={identitySpotlight.active}
         />
       </div>
 

--- a/src/pages/tour-stats/TourStatsPage.jsx
+++ b/src/pages/tour-stats/TourStatsPage.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 
+import { useFeatureSpotlight } from '../../features/feature-discovery';
 import {
   StandingsMobileFixedChrome,
   StandingsStickyChrome,
@@ -28,6 +29,13 @@ export default function TourStatsPage() {
   const setView = useStandingsViewChange({ view: 'stats' });
   const { openScoringRules: openScoringRulesModal } = useScoringRulesModal();
   const mobileChromeRoot = useDashboardMobileChromePortal();
+  const tourStatsSpotlight = useFeatureSpotlight('tour-stats', {
+    trackImpression: false,
+  });
+
+  useEffect(() => {
+    tourStatsSpotlight.markSeen();
+  }, [tourStatsSpotlight.markSeen]);
 
   const openScoringRules = () => {
     ga4Event('scoring_rules_opened', { surface: 'tour-stats' });

--- a/src/shared/ui/ChromeSegmentedControl.jsx
+++ b/src/shared/ui/ChromeSegmentedControl.jsx
@@ -5,7 +5,7 @@ const trayClass =
   'flex w-full min-w-0 gap-1 rounded-xl border border-border-subtle/60 bg-surface-panel-strong p-1 shadow-inset-glass';
 
 const segmentBase =
-  'flex min-w-0 flex-1 items-center justify-center gap-1 rounded-lg px-2 py-2 text-center text-[11px] font-black uppercase tracking-widest transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg';
+  'relative flex min-w-0 flex-1 items-center justify-center gap-1 rounded-lg px-2 py-2 text-center text-[11px] font-black uppercase tracking-widest transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg';
 
 const segmentActive =
   'bg-brand-primary/15 text-brand-primary ring-1 ring-inset ring-brand-primary/35';
@@ -28,6 +28,7 @@ const segmentInactive =
  *     end?: boolean,
  *     label: string,
  *     icon?: React.ComponentType<{ className?: string, 'aria-hidden'?: boolean }>,
+ *     badge?: React.ReactNode,
  *   }>,
  * }} props
  */
@@ -46,7 +47,7 @@ export default function ChromeSegmentedControl({
         className={[trayClass, className].filter(Boolean).join(' ')}
         aria-label={ariaLabel}
       >
-        {items.map(({ to, label, end, icon: Icon }) => (
+        {items.map(({ to, label, end, icon: Icon, badge }) => (
           <NavLink
             key={to}
             to={to}
@@ -57,6 +58,7 @@ export default function ChromeSegmentedControl({
           >
             {Icon ? <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden /> : null}
             <span className="truncate">{label}</span>
+            {badge}
           </NavLink>
         ))}
       </nav>
@@ -69,7 +71,7 @@ export default function ChromeSegmentedControl({
       aria-label={ariaLabel}
       className={[trayClass, className].filter(Boolean).join(' ')}
     >
-      {items.map(({ id, label, icon: Icon }) => {
+      {items.map(({ id, label, icon: Icon, badge }) => {
         const selected = value === id;
         return (
           <button
@@ -82,6 +84,7 @@ export default function ChromeSegmentedControl({
           >
             {Icon ? <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden /> : null}
             <span className="truncate">{label}</span>
+            {badge}
           </button>
         );
       })}


### PR DESCRIPTION
Closes #639
Closes #638

## Summary
- **#639** — Soft feature-discovery “New” markers via `features/feature-discovery` (registry, hook, badge). Placements: Standings **Stats** (corner **dot**), official setlist card, Profile avatar/badges. Clears on visit/interaction; expires 2026-08-31; localStorage per uid. Wires `feature_spotlight_*` GA4.
- **#638** — Included as the parent commit on this branch (engagement events for live setlist, tour stats, avatars, badge shelf). Supersedes open PR #641 so staging gets one reviewable stack.

**Epic:** #637  
**SemVer:** MINOR **1.31.0** (user-visible chrome; includes 1.30.1 telemetry from #638)

## Test plan
- [x] Unit tests for spotlight registry + analytics helpers
- [x] `npm run lint` / `verify:dashboard-meta`
- [x] Local spot-check: Stats dot, setlist/profile New labels, dismiss persistence
- [ ] CI `verify` green
- [ ] Signed-in: clear `set-picks-feature-spotlight:*` keys and confirm markers return, then clear on Stats visit / setlist toggle / avatar pick

## Note
Hold promote through pre-show window if desired — safe on staging; no rush to main.

Made with [Cursor](https://cursor.com)