### PR TITLE
docs: preserve scoring & prediction analysis from canvases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.30.1] — 2026-07-17
+
+### Added
+
+- `docs/scoring-analysis/` — durable repo docs for scoring/prediction canvas research (slot odds, significance, calibration, combos, greenfield model, predictive picker framework); links issues #645–#653.
+
 # Changelog
 
 All notable changes to Setlist Pick'em are documented here.

--- a/docs/scoring-analysis/01-slot-odds-and-ev.md
+++ b/docs/scoring-analysis/01-slot-odds-and-ev.md
@@ -1,0 +1,59 @@
+# Slot odds and expected value
+
+Snapshot ~2026-07-18. Join of graded `picks` × `official_setlists`, scored with production `scoringCore`.
+
+## Headline
+
+Under the live rule **encore exact = any song in `encoreSongs[]`**, encore has the **highest** exact-hit rate among positional slots—not the lowest. Aggregate EV is only slightly above the mean (~3–5%); the larger issue is **mis-distribution** (first and later encore songs pay the same 15).
+
+## User hit rates (n ≈ 203–204 filled picks / slot)
+
+| Slot | Exact % | In-setlist % | Miss % | Avg base pts (EV) |
+|------|---------|--------------|--------|-------------------|
+| S2 Closer | 2.94% | 21% | 76% | 1.35 |
+| S2 Opener | 3.43% | 23% | 74% | 1.49 |
+| S1 Opener | 3.94% | 19% | 77% | 1.35 |
+| S1 Closer | 5.39% | 24% | 71% | **1.71** |
+| Encore (any) | **6.37%** | 11% | 82% | 1.52 |
+| Wildcard | — | hit 14.3% | 85.7% | ~1.43 base / ~1.92 w/ bustout |
+
+Absolute exact counts (any-encore rule): encore **13**, s1c **11**, s1o **8**, s2o **7**, s2c **6**.
+
+## Points fairness vs S1 opener @ 10
+
+Implied fair exact pts ≈ `10 × (s1oExactRate / slotExactRate)`.
+
+| Slot | Exact rate | Awarded | Implied fair exact pts vs S1O@10 | Difficulty vs S1O |
+|------|------------|---------|----------------------------------|-------------------|
+| S2 Closer | 2.94% | 10 | 13.4 | 1.34× harder |
+| S2 Opener | 3.43% | 10 | 11.5 | 1.15× harder |
+| S1 Opener | 3.94% | 10 | 10.0 | baseline |
+| S1 Closer | 5.39% | 10 | 7.3 | easier |
+| Encore (any) | 6.37% | 15 | ~6.2 | easiest exact |
+
+Exact-tier EV contribution: S1 opener ~0.39 vs encore ~0.96 (~2.5×).
+
+## Flat encore X to match mean EV (~1.47)
+
+`EV(X) = 0.0637×X + 0.1127×5`
+
+| Flat encore X | Encore EV |
+|---------------|-----------|
+| 10 | 1.20 |
+| 12 | 1.33 |
+| **14** | **~1.46 ≈ mean** |
+| 15 (current) | 1.52 |
+
+## Framework note (stats layer)
+
+Today picks persist `score` and aggregate `correctSlotsCredited`, not per-slot kinds. For durable odds/stats: persist `slotResults` at grade time; roll up show/tour/global slot rates. See epic #646 measurement workstream and issue #645.
+
+## Scoring rules at snapshot
+
+```text
+EXACT_SLOT = 10
+ENCORE_EXACT = 15   # any encoreSongs[] match
+IN_SETLIST = 5
+WILDCARD_HIT = 10
+BUSTOUT_BOOST = 20  # gap ≥ 30 on frozen bustouts snapshot
+```

--- a/docs/scoring-analysis/02-significance-and-variability.md
+++ b/docs/scoring-analysis/02-significance-and-variability.md
@@ -1,0 +1,44 @@
+# Significance and setlist variability
+
+## Are observed encore odds statistically significant?
+
+**No.** Across five positional slots (exact rates), omnibus χ² ≈ 3.94, df = 4, **p ≈ 0.41**. Largest pairwise gap (encore 6.37% vs S2 closer 2.94%): z ≈ 1.65, **p ≈ 0.10** (Fisher ≈ 0.16).
+
+- ~204 picks / slot come from only **17 shows** (~12 picks/show) → clustering; effective n roughly **64–132**, not 204.
+- Power: detecting those gaps at 80% would need ~**600–1300** independent picks / slot (before design effect).
+
+**Do not rebalance scoring solely from this user-hit ranking.** Prefer supply-side setlist variability and larger samples.
+
+## Supply-side variability (Phish.net, Phish-only)
+
+### Last 24 months (~105 shows)
+
+| Slot | Shows | Unique songs | Entropy (bits) | Effective # songs | Match prob (HHI %) | Mode top-1 % |
+|------|-------|--------------|----------------|-------------------|--------------------|--------------|
+| S1 Opener | 105 | 51 | 5.32 | 39.9 | 3.20 | 7.6 |
+| S1 Closer | 105 | 48 | 5.16 | 35.7 | 3.66 | 8.6 |
+| S2 Opener | 100 | 54 | 5.49 | 44.9 | 2.66 | 6.0 |
+| S2 Closer | 100 | 39 | 4.96 | 31.2 | 3.94 | 9.0 |
+| Encore (1st) | 102 | 64 | 5.72 | **52.9** | **2.40** | 6.9 |
+
+**First encore is the most variable single song** (highest entropy / effective N). Closers are the most concentrated.
+
+### Encore “two chances”
+
+- Multi-encore shows: **~85%**; avg encore length **~2.16** songs (last 24 mo).
+- Best first-encore mode guess ≈ **6.9%** hit.
+- Best any-encore mode guess (e.g. Tweezer Reprise) ≈ **15.7%** hit (~2.3× on supply side).
+
+### Same user guesses, two scoring rules (n = 204)
+
+| Rule | Exact-hit rate | Absolute hits |
+|------|----------------|---------------|
+| First encore only | **1.96%** | 4 |
+| Avg positional exact | 3.93% | — |
+| Any encore (today) | **6.37%** | 13 |
+
+Realized **3.25×** multiplier from any-of-2 vs first-only (larger than raw song count because popular guesses often land in the **second** encore).
+
+**Tug-of-war:** bigger encore pool (~40% more effective songs) is real → first-encore is hardest. The any-of-2 rule more than offsets it → net easiest exact under current scoring.
+
+Paired bootstrap HHI: encore distinguishes from closers (p ≈ 0.02); not from openers at 105 shows.

--- a/docs/scoring-analysis/03-scoring-calibration.md
+++ b/docs/scoring-analysis/03-scoring-calibration.md
@@ -1,0 +1,62 @@
+# Scoring calibration (encore & bustouts)
+
+## Calibration method
+
+Points ∝ `1 / P(exact)`, anchored so geometric mean of four positional slots ≈ 10, then snapped to round multiples of 5 (floor at 10 so exact beats in-setlist 5).
+
+Supply odds = best single-song (“mode”) guess from last-24-mo setlists.
+
+## Positional slots
+
+Odds cluster in a **6–9%** band → at round-5 granularity, exacts stay **flat 10**. Provisional future premium: S2 opener (hardest supply-side).
+
+## Encore tiers (Model X — recommended)
+
+| Event | User hit rate | Calibrated | Round pts |
+|-------|---------------|------------|-----------|
+| 1st encore exact | 1.96% | ~20 | **15** |
+| Later encore song | 4.41% | ~9 | **10** |
+| In-setlist only | 11.3% | ~3.5 | **5** |
+
+- Model Y (later = 5) underpays a ~1-in-23 event.
+- Model X encore-slot EV ≈ **1.30** (vs positional avg ~1.47).
+- Current any = 15 → EV **1.52** (slight overpay vs mean; large overpay vs S1 opener on exact difficulty).
+
+## Wildcard
+
+~14% hit rate → calibrates toward **5** if fairness-primary; keep **10** only as intentional safe-points.
+
+## Bustout variability (economy-aware)
+
+Perfect clean night ≈ **65** under Model X base (4×10 + 15 + 10). Today’s flat **+20** is already **2× a slot** (~31% of a night).
+
+Gap distribution (Phish, last 24 mo, ~1868 played rows):
+
+| Gap band | Share of songs | Avg fires / show |
+|----------|----------------|------------------|
+| 30–74 | 6.7% | 1.95 |
+| 75–149 | 2.5% | 0.76 |
+| 150–299 | 1.0% | 0.31 |
+| 300+ | 0.7% | 0.13 |
+
+### Flat models
+
+| Tier | Gap | Current flat | Scaled flat (recommended) |
+|------|-----|--------------|---------------------------|
+| Bustout | 30–74 | +20 | **+15** |
+| Rarity | 75–149 | +20 | **+20** |
+| Deep cut | 150–299 | +20 | **+30** |
+| Vault | 300+ | +20 | **+40** |
+
+### Multiplier model (1.5× / 2× / 3× / 4× of base)
+
+Bonus on a 5 / 10 / 15 base compounds. Cap bonus at **+40** or prefer scaled flat—otherwise a 15-pt first-encore vault can total **75** (> clean night).
+
+Only ~5 bustout boosts fired across 204 historical picks—rare moments if the song must also be correctly picked.
+
+## Implementation notes
+
+- Client/server parity: `src/shared/utils/scoring.js`, `functions/scoringCore.js`.
+- Model X needs primary `setlist.enc` vs other `encoreSongs[]`.
+- Bustout tiers need gap bands (`songGaps` or tiered snapshot)—see `docs/OFFICIAL_SETLISTS_SCHEMA.md`.
+- SemVer: scoring rule change = **MINOR**; regrade vs grandfather TBD.

--- a/docs/scoring-analysis/04-card-combos-and-engagement.md
+++ b/docs/scoring-analysis/04-card-combos-and-engagement.md
@@ -1,0 +1,85 @@
+# Card combos, zeros, and predictive coupling
+
+## Nightly score distribution (204 graded picks)
+
+| Score | Share |
+|-------|-------|
+| 0 | **27.5%** |
+| 1–5 | 28.9% |
+| 6–10 | 13.2% |
+| 11–20 | 17.6% |
+| 21–35 | 9.3% |
+| 36+ | 3.4% |
+
+- Mean **10.0**, median **5**, P90 **25**, max **55**.
+- Gini ≈ **0.565**; top/median ≈ **11×**.
+
+## Engagement floor vs encore leniency
+
+| Mechanic | Rescues from zero | Share |
+|----------|-------------------|-------|
+| Encore (any-of-2) | 8 | 3.9% |
+| Wildcard | 5 | 2.5% |
+
+Zeros mostly miss **all** songs in the show. Encore leniency barely moves the floor; **predictive nudges** and consolation design matter more for zeros.
+
+## Breadth (“N slots scoring”) incidence
+
+“Correct” = any points on a slot (matches `correctSlotsCredited` semantics).
+
+| Slots scoring | Share |
+|---------------|-------|
+| 0 | 27.5% |
+| 1 | 36.3% |
+| 2 | 19.6% |
+| 3 | 9.8% |
+| 4 | 5.4% |
+| 5 | 1.0% |
+| 6 | 0.5% |
+
+Exact counts (wild excluded): 0 exact 80.4%; 1 exact 17.2%; 2 exact 2.5%; 3+ exact **0**.
+
+Set sweeps (both S1 or both S2 any points): either ≈ 11.8%. Both positions exact in a set: **0**.
+
+## Recommended breadth ladder (highest tier only)
+
+Never cumulative.
+
+| Slots scoring | Bonus | Notes |
+|---------------|-------|-------|
+| 0–1 | 0 | |
+| 2 | Badge only (or tiny +2) | Becomes routine if predictions lift hit rates |
+| 3 | +5 | First leaderboard combo |
+| 4 | +10 | |
+| 5 | +15 | |
+| 6 | +20 | Perfect-card jackpot |
+
+Historical sim (if +2 at 2 and above ladder): ~36% get some bonus; mean +~1.7 pts; zeros unchanged.
+
+Round-5-only (no points at 2): ~17% get bonus; mean +~1.3 pts.
+
+## Precision companion
+
+| Exact slots | Bonus |
+|-------------|-------|
+| 2 | +5 |
+| 3 | +10 |
+| 4 | +15 |
+| 5 | +25 |
+
+Cap **card + precision ≤ +25**. Bustout stacks separately with a rarity ceiling.
+
+## Coupling with predictive picker (#646)
+
+If per-slot any-points rate rises from ~22% → ~28–35%, share of cards with 2+ hits rises ~40% → ~54–68%, and breadth EV rises. Recalibrate **after** Prediction Lab evidence.
+
+Principles when coupled:
+
+- Scoring identical for manual vs recommended picks.
+- Engine predicts song/slot likelihood—not leaderboard points.
+- Offer Safe / Slot-fit / Long-shot to reduce herding.
+- Prefer points starting at **3** breadth hits if recommendations work.
+
+## Avoid stacking
+
+Do not ship breadth + set-sweep + precision + uncapped bustout multipliers without shared caps. Prefer badges for overlapping thematic milestones.

--- a/docs/scoring-analysis/05-scoring-from-scratch.md
+++ b/docs/scoring-analysis/05-scoring-from-scratch.md
@@ -1,0 +1,76 @@
+# Scoring model from scratch (proposal)
+
+Greenfield design for engagement + economics. Anchor: target mean ~**9–11**, median near current ~5, explainable live scoring.
+
+## Thesis
+
+Use **recommendations** to raise the engagement floor; use **scoring** to distinguish skill and create memorable upside. Do not fix zeros with broad free points; do not create surprise via hidden randomness.
+
+## Layer 1 — base outcomes
+
+| Outcome | Points | Role |
+|---------|--------|------|
+| Song elsewhere in show | 5 | Accessible floor |
+| Exact S1/S2 position | 10 | Primary skill |
+| Later encore song | 10 | Matches realized difficulty |
+| First encore song | 15 | Signature premium |
+| Wildcard anywhere | 5 | Safe floor, not premium |
+| Miss | 0 | Legible; no negatives |
+
+## Layer 2 — card completion (highest tier only)
+
+| Breadth | Reward |
+|---------|--------|
+| 2 scoring slots | Badge only |
+| 3 | +5 |
+| 4 | +10 |
+| 5 | +15 |
+| All 6 | +20 |
+
+## Layer 3 — precision
+
+| Exact slots | Bonus |
+|-------------|-------|
+| 2 | +5 |
+| 3 | +10 |
+| 4 | +15 |
+| 5 | +25 |
+
+Combined card + precision cap: **+25**.
+
+## Layer 4 — rarity (fixed adds, not uncapped multipliers)
+
+| Gap | Boost |
+|-----|-------|
+| 30–74 | +15 |
+| 75–149 | +20 |
+| 150–299 | +30 |
+| 300+ | +40 |
+
+Rarity may stack with base/card; rarity ceiling **+40**.
+
+## Player agency — Spotlight Pick (experiment)
+
+Before lock, mark one of four **positional** slots as Spotlight:
+
+- Exact on Spotlight → additional **+5**
+- Otherwise normal scoring
+- Exclude wildcard and encore
+
+Small EV (~0.2–0.3 expected), high personalization / live rooting interest.
+
+## Predictive engine fit
+
+Suggestions help users get on the board. Because 2-hit cards become more common, **points for breadth start at 3**. Recalibrate after adoption, concentration, and tie metrics.
+
+## Engagement without more points
+
+Live progress (“one slot from card bonus”), Spotlight status, bustout-tier reveals, first exact / set sweep / perfect-card recap badges and animations.
+
+## Avoid in core model
+
+- Random / mystery points
+- Uncapped multipliers that let one song beat a full card
+- Crowd-consensus multipliers before privacy/gaming are solved
+- Negative points
+- Stacking breadth + set-sweep + precision without a shared cap

--- a/docs/scoring-analysis/06-predictive-picker-framework.md
+++ b/docs/scoring-analysis/06-predictive-picker-framework.md
@@ -1,0 +1,65 @@
+# Predictive song picker framework
+
+Epic: [#646](https://github.com/pat792/set-picks/issues/646). Children: #647–#653. Complements scoring analysis #645.
+
+## Product model
+
+One recommendation engine, two opt-in surfaces:
+
+1. **Prediction Lab panel** — Safe / Slot-fit / Long-shot, reasons, “Use for this slot.” Preferred first UI.
+2. **Predictive Mode** — default-off; focus shows 5–8 slot-aware suggestions; typed search uses same score.
+
+Rules:
+
+- Manual search remains default; never auto-fill.
+- Do **not** use current-show user picks as model input (consensus / feedback loop).
+- Cross-slot uniqueness unchanged.
+
+## Ranking (leakage-safe)
+
+### Play likelihood
+
+Recency (10/25/50 shows), lifetime frequency with shrinkage, nonlinear gap vs song cadence, last-played, run/tour repeat penalties, calendar (tour, venue/run, days since prior).
+
+### Slot affinity
+
+Smoothed affinity for s1o/s1c/s2o/s2c/first encore/later encore/wildcard.
+
+```text
+slotScore = calibratedPlayProbability × smoothedSlotAffinity
+wildcardScore = calibratedPlayProbability
+```
+
+Bustout upside as **Long-shot** band, not mixed into “most likely.”
+
+Gap ≠ “lowest first.” Current autocomplete in `rankCatalogSongMatches.js` is a search heuristic; gap 0 after prior night can *reduce* next-show odds.
+
+## Critical data constraint
+
+`song-catalog.json` is overwritten every ~6 hours → historical pre-show `gap`/`last`/`total` cannot be reconstructed from today’s file. Target-night `songGaps` only lists songs that played → never use as candidate features for that night.
+
+Backtest v1: prior `official_setlists` + calendar + bounded Phish.net history. In parallel: **archive dated catalog snapshots** (#647).
+
+## Artifact
+
+Versioned Storage JSON (alongside catalog), e.g. `pick-recommendations.json`: `generatedAt`, `modelVersion`, target show, per-song per-slot ranks, confidence, risk band, explanation components. Refresh during tours / after finalize. Client: Storage + TTL + stale/fallback like song catalog—not Firestore per keystroke.
+
+## FSD
+
+Keep in `features/picks` (api/model/ui). Extend `SongAutocomplete` only with generic featured options / injected ranker. Pages stay composition-only.
+
+## Rollout
+
+1. Offline backtest (#648–#649)  
+2. Artifact (#650)  
+3. Prediction Lab (#651)  
+4. Predictive Mode if panel evidence OK (#652)  
+5. Provenance + metrics + tour recalibration (#653)
+
+## Measurement
+
+Zero-score rate, selection rate, recommended-pick outcomes, pick entropy/concentration, ties. Optional pick provenance: `manual` | `panel` | `predictive_mode` + modelVersion/rank.
+
+## SemVer / docs when shipping
+
+MINOR bump; CHANGELOG; `docs/API.md`; update `docs/SONG_CATALOG.md` schedule/cache wording; model methodology doc.

--- a/docs/scoring-analysis/README.md
+++ b/docs/scoring-analysis/README.md
@@ -1,0 +1,38 @@
+# Scoring & prediction analysis (2026-07)
+
+Preserved design research from Cursor canvases and live Firestore / Phish.net analysis. Canvases live only under Cursor’s local project folder (`~/.cursor/projects/.../canvases/`) and are **not** in git; **Canvas Publish** requires a Teams or Enterprise plan and stores a share snapshot on Cursor’s dashboard—not this repository.
+
+This folder is the durable, repo-backed record of that work.
+
+## GitHub tracking
+
+| Issue | Topic |
+|-------|--------|
+| [#645](https://github.com/pat792/set-picks/issues/645) | Scoring considerations (encore fairness, EV, bustouts, combos) |
+| [#646](https://github.com/pat792/set-picks/issues/646) | Epic: predictive song picker |
+| [#647](https://github.com/pat792/set-picks/issues/647)–[#653](https://github.com/pat792/set-picks/issues/653) | Child slices for the prediction epic |
+
+## Documents
+
+| Doc | Source canvas / topic |
+|-----|------------------------|
+| [01-slot-odds-and-ev.md](./01-slot-odds-and-ev.md) | Slot hit rates, EV, points fairness |
+| [02-significance-and-variability.md](./02-significance-and-variability.md) | Statistical significance; 2-year setlist variability |
+| [03-scoring-calibration.md](./03-scoring-calibration.md) | Encore 15/10/5, bustout tiers, multipliers |
+| [04-card-combos-and-engagement.md](./04-card-combos-and-engagement.md) | Breadth bonuses, zeros, predictive coupling |
+| [05-scoring-from-scratch.md](./05-scoring-from-scratch.md) | Greenfield scoring proposal |
+| [06-predictive-picker-framework.md](./06-predictive-picker-framework.md) | Recommendation engine + two UX surfaces |
+
+## Snapshot metadata
+
+- **Analysis date:** ~2026-07-18
+- **Graded picks:** 204 pick docs across 17 shows
+- **Official setlists:** 21 docs (4 without picks in that window)
+- **Supply window:** Phish.net Phish-only setlists, last 24 months (~105 shows) and 2022–2026 (~211 shows)
+- **Scoring constants at analysis time:** exact opener/closer 10 · encore any 15 · in-setlist 5 · wildcard 10 · bustout +20 (gap ≥ 30)
+
+## Caveats
+
+- Slot-to-slot exact-rate differences were **not statistically significant** at this sample size.
+- User hit rates partly reflect crowd skill/consensus, not only slot difficulty.
+- Coupling recommendations with card bonuses will change bonus incidence; recalibrate after Prediction Lab ships.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.30.0",
+  "version": "1.30.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Adds `docs/scoring-analysis/` capturing research previously only in Cursor canvases (slot odds/EV, significance, encore/bustout calibration, card combos, greenfield scoring proposal, predictive picker framework).
- Links GitHub issues #645–#653; documents that Canvas Publish is Teams/Enterprise-only and not a repo archive.
- PATCH SemVer + CHANGELOG for docs-only research package.

## Test plan
- [ ] Skim `docs/scoring-analysis/README.md` and linked issue comments on #645 / #646
- [ ] Confirm docs render on GitHub after merge

Made with [Cursor](https://cursor.com)