### PR TITLE
feat(picks): doors-based lock + Phish.com schedule enrichment (#522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ No unreleased changes.
 
 ---
 
+## [1.31.0] — 2026-07-18
+
+### Added
+- **Doors-based picks lock (#522)** — wall-clock lock is now `doors + (tour avg doors→start − safety)` when doors are known (Summer Tour 2026 setlist.fm avg 1h59m, safety 19 → **doors+1:40**). The daily Phish.net calendar sync now enriches upcoming dates from first-party Phish.com date pages (`Doors Open` / advertised `Show Time`), preserves prior timing on transient failures, and retains seeded Summer Tour doors as a client/Functions fallback. Unknown doors use the conservative **7:30 PM** venue-local fallback. Client + Functions + `picks_lock_reminder` share the same resolver. Lock toast copy: “Picks locked, almost showtime!”
+
+### Changed
+- War Room show-date panel shows the resolved per-show lock time and source (doors / explicit / fallback).
+- Picks and pre-lock Standings now show a dismissible, session-scoped timing notice with the resolved cutoff and, when known, its relationship to the published doors time. It is the top notice on Standings and stays dismissed for that show across both surfaces. Cutoff-related comms use only relative `time_to_lock` wording; tour countdown copy no longer repeats an absolute deadline.
+
+---
+
 ## [1.30.0] — 2026-07-17
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -95,6 +95,24 @@ Also hosts the per-user daily email fatigue cap (#453): doc ID `email_cap:{uid}:
 
 Tour and show date metadata. Read by `resolveCurrentTour` and `resolveSelectableTours`.
 
+`show_calendar/snapshot` show rows (Phish.net sync) include at minimum:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `date` | string | `YYYY-MM-DD` |
+| `venue` | string | Display venue line |
+| `city` | string? | City |
+| `timeZone` | string | IANA venue timezone |
+| `doorsLocal` | string? | Venue-local doors `HH:mm` from first-party Phish.com date page (client/Functions also seed known Summer Tour 2026 dates) |
+| `scheduledStartLocal` | string? | Advertised venue-local show time `HH:mm` from Phish.com; informational, not the picks lock |
+| `scheduleSource` | `'phish.com'`? | Timing provenance |
+| `scheduleSourceUrl` | string? | Official date-page URL |
+| `picksLockLocal` | string? | Venue-local picks lock `HH:mm` when materialized/overridden |
+
+**Picks wall-clock lock (#522):** when `doorsLocal` (or a seeded doors time) is known, lock = doors + (tour avg doors→start − safety). Summer Tour 2026 defaults: avg **119** min, safety **19** → **doors + 100 min**. When doors are unknown, fallback is **19:30** venue-local. Admin `show_lock_state` and (planned) setlist `s1o` still win as earlier signals.
+
+`scheduledPhishnetShowCalendar` runs daily at 06:00 ET. Phish.net is canonical for dates/tours/venues; the sync then fetches Phish.com upcoming date pages for timing. A Phish.com failure does not fail or erase the calendar: prior timing is preserved.
+
 ### 1.9 `email_suppression/{sha256(email)}`
 
 Server-only email suppression list (issue #442). Document ID is SHA-256 of the normalized recipient address. Presence of `{ suppressed: true }` blocks comms email sends. Written by `commsResendWebhook` and `commsEmailUnsubscribe`.
@@ -270,7 +288,7 @@ Automated comms delivery triggered by Firestore writes, post-rollup hooks, live-
 | Live-scoring hook | `score_first_points`, `score_leader` | `recomputeLiveScoresForShow` |
 | `scheduledTourCountdownComms` | `tour_countdown` | Daily 9am PT cron (T-10/T-5/T-3/T-1) |
 | `scheduledTourRankingsDailyComms` | `tour_rankings_daily` | Daily 8am PT cron (morning-after show) |
-| `scheduledPicksLockReminder` | `picks_lock_reminder` | Every 15 min; venue-local show day **T-3h–lock** (16:55–19:54 when lock is 19:55); **not** gated by `COMMS_EVENT_ADAPTERS_ENABLED` (v1.19.0+) |
+| `scheduledPicksLockReminder` | `picks_lock_reminder` | Every 15 min; venue-local show day **T-3h–lock** (window tracks per-show lock from doors+offset or 19:30 fallback); **not** gated by `COMMS_EVENT_ADAPTERS_ENABLED` (v1.19.0+) |
 
 Trigger specs and channels: `docs/comms-triggers/catalog.json`. Admin canary/replay: `runCommsTrigger` (§2.2).
 

--- a/docs/PICKS_LOCK_ADMIN_RUNBOOK.md
+++ b/docs/PICKS_LOCK_ADMIN_RUNBOOK.md
@@ -27,7 +27,7 @@ Operational guide for **`lockPicksForShowNow`** — the War Room **Lock picks no
 1. Admin clicks **Lock picks now** in War Room while the show is `NEXT`.
 2. Client calls `lockPicksForShowNow({ showDate })`.
 3. Callable writes `show_lock_state/{showDate}` with `lockReason: admin_override`.
-4. All clients subscribed to that doc treat picks as locked even before the 7:55 PM venue-local wall clock.
+4. All clients subscribed to that doc treat picks as locked even before the per-show wall clock (doors+1:40 when doors known; else 7:30 PM venue-local).
 
 Idempotent: re-running on an already-stamped doc returns `{ alreadyLocked: true }` without rewriting timestamps.
 
@@ -103,8 +103,27 @@ node scripts/lockPicksForShowNow.js --showDate=2026-07-08 --lockedBy=pat@road2me
 
 ---
 
-## 5. Related docs
+## 5. Cloud Run invoker (browser callable)
 
-- [`docs/API.md`](./API.md) §1.10 (`show_lock_state`), §2.2b (`lockPicksForShowNow`)
+Gen 2 callables need public invoker so browser CORS preflights succeed (Firebase Auth is still checked in the handler). After deploy, verify:
+
+```bash
+gcloud run services get-iam-policy lockpicksforshownow \
+  --project=set-picks --region=us-central1
+# Expect: allUsers → roles/run.invoker
+```
+
+If missing (OPTIONS → 403, empty Authorization header in logs):
+
+```bash
+gcloud run services add-iam-policy-binding lockpicksforshownow \
+  --project=set-picks --region=us-central1 \
+  --member="allUsers" --role="roles/run.invoker"
+```
+
+## 6. Related docs
+
+- [`docs/API.md`](./API.md) §1.8 (doors / picksLockLocal), §1.10 (`show_lock_state`), §2.2b (`lockPicksForShowNow`)
 - [`docs/ADMIN_CLAIMS_RUNBOOK.md`](./ADMIN_CLAIMS_RUNBOOK.md) — admin claim bootstrap
 - [`docs/PHISHNET_CALLABLE_RUNBOOK.md`](./PHISHNET_CALLABLE_RUNBOOK.md) — phishnet deploy bundle
+- Issue [#522](https://github.com/pat792/set-picks/issues/522) — doors-based wall clock + remaining setlist poll lock

--- a/docs/comms-triggers/TRIGGER_CATALOG.md
+++ b/docs/comms-triggers/TRIGGER_CATALOG.md
@@ -41,7 +41,7 @@ Every template draws from this shared set. Each trigger declares the subset it u
 | `{{venue_name}}` | `show_calendar` snapshot | — |
 | `{{venue_city}}` | `show_calendar` snapshot | — |
 | `{{time_to_lock}}` | Computed at send time | — |
-| `{{lock_time_local}}` | Computed (19:55 venue-local) | `7:55 PM` |
+| `{{lock_time_local}}` | Computed (doors+1:40 when doors known; else 19:30 venue-local) | `7:30 PM` |
 | `{{tour_name}}` | Tour metadata | — |
 | `{{days_remaining}}` | Computed from tour start date | — |
 | `{{first_show_date}}` | Tour first show | — |
@@ -199,18 +199,18 @@ Every template draws from this shared set. Each trigger declares the subset it u
 
 **Heading:** `{{tour_name}} is tomorrow, {{handle}}`
 
-**Body:** {{first_show_venue}}, {{first_show_city}} — tomorrow night. If you haven't made your picks yet, the window closes at {{lock_time_local}}. Don't go into show 1 without picks on the board.
+**Body:** {{first_show_venue}}, {{first_show_city}} — tomorrow night. Get your picks ready before the first downbeat.
 
 **CTA:** `Lock in your picks →`
 
 #### Template — Email (T-1 only; T-10 and T-5 optional)
 
 **Subject (T-1):** `Last call — {{tour_name}} starts tomorrow`  
-**Preview:** `Picks close at {{lock_time_local}}. {{first_show_venue}}, {{first_show_city}}.`
+**Preview:** `{{first_show_venue}}, {{first_show_city}} — get your picks ready.`
 
 **Body sections:**
 1. Tomorrow is show 1 — set the scene (venue, city, date).
-2. Picks deadline reminder — closes at {{lock_time_local}}.
+2. Get picks ready before the first downbeat.
 3. CTA button: `Make your picks`
 
 ---
@@ -427,7 +427,7 @@ Up next: {{next_show_venue}} on {{next_show_date}}. Picks open now.
 |-------|-------|
 | **Status** | `shipped` |
 | **Automation** | `automated` |
-| **Schedule** | Every 15 min on show days, venue-local **T-3h through lock** (16:55–19:54 when lock is 19:55) |
+| **Schedule** | Every 15 min on show days, venue-local **T-3h through lock** (window tracks per-show lock) |
 | **Channels** | `inApp`, `push`, `email` |
 | **Audience** | Users with a handle and **no picks** for tonight's show |
 | **Prefs key** | `reminders` (push + in-app only) |
@@ -451,20 +451,20 @@ Production `picks_lock_reminder` **skips** users with non-empty picks for tonigh
 
 #### Template — In-App
 
-**Heading:** `Don't miss tonight's show, {{handle}}`
+**Heading:** `{{time_to_lock}} until picks lock`
 
-**Body:** Picks for {{venue_name}} close at {{lock_time_local}} — {{time_to_lock}} from now. You're not on the board yet for {{show_date}}.
+**Body:** {{handle}}, lock in your picks for {{venue_name}}. You're not on the board yet for {{show_date}}.
 
 **CTA:** `Make your picks` (or `View / Edit picks` when `picks_secured`)
 
 #### Template — Email
 
 **Subject:** `Picks close in {{time_to_lock}} — {{venue_city}} tonight`  
-**Preview:** `{{venue_name}} · Lock closes at {{lock_time_local}}`
+**Preview:** `{{venue_name}} · {{time_to_lock}} until picks lock`
 
 **Body sections:**
 1. Tonight's show — venue, date.
-2. You haven't picked yet — close at {{lock_time_local}}.
+2. You haven't picked yet — {{time_to_lock}} until picks lock.
 3. CTA button: `Lock in your picks`
 
 ---

--- a/docs/comms-triggers/catalog.json
+++ b/docs/comms-triggers/catalog.json
@@ -45,7 +45,7 @@
       "githubIssue": null,
       "variants": ["t10", "t5", "t3", "t1"],
       "inAppDeepLink": "/dashboard/picks",
-      "note": "In-app CTA label varies by days_remaining; T-5/T-3/T-1 switch to View / Edit picks when picks_secured (#509). Push/email use open-app phrasing.",
+      "note": "In-app CTA label varies by days_remaining; T-5/T-3/T-1 switch to View / Edit picks when picks_secured (#509). Countdown copy does not state an absolute cutoff; the show-day lock reminder owns relative cutoff messaging.",
       "variables": [
         { "name": "handle", "source": "users/{uid}.handle", "fallback": "Picker" },
         { "name": "tour_name", "source": "tour metadata", "fallback": null },
@@ -53,7 +53,7 @@
         { "name": "first_show_date", "source": "tour first show", "fallback": null },
         { "name": "first_show_venue", "source": "tour first show venue", "fallback": null },
         { "name": "first_show_city", "source": "tour first show city", "fallback": null },
-        { "name": "lock_time_local", "source": "computed (19:55 venue-local)", "fallback": "7:55 PM" },
+        { "name": "lock_time_local", "source": "computed (doors+offset or 19:30 venue-local)", "fallback": "7:30 PM" },
         { "name": "picks_secured", "source": "picks where showDate=first_show + hasNonEmptyPicksObject", "fallback": false }
       ]
     },
@@ -256,7 +256,7 @@
       "family": "show_calendar",
       "priority": "P0",
       "automation": "automated",
-      "schedule": "every 15min on show days, venue-local T-3h through lock (16:55–19:54 when lock is 19:55)",
+      "schedule": "every 15min on show days, venue-local T-3h through lock (per-show lock from doors+offset or 19:30 fallback)",
       "audience": "users_no_picks_tonight",
       "channels": ["inApp", "push", "email"],
       "prefKeys": ["reminders"],
@@ -265,14 +265,14 @@
       "templateId": "picks-lock-reminder",
       "implementationModule": "functions/picksLockReminder.js",
       "githubIssue": 524,
-      "note": "Email is transactional (CAN-SPAM): bypasses reminders pref but respects email_suppression. Push/in-app still use reminders pref. Audience excludes users with picks; in-app registry still branches on picks_secured for preview (#509).",
+      "note": "Email is transactional (CAN-SPAM): bypasses reminders pref but respects email_suppression. Push/in-app still use reminders pref. Audience excludes users with picks; in-app registry still branches on picks_secured for preview (#509). All channel copy uses only relative time_to_lock, never the absolute local cutoff.",
       "variables": [
         { "name": "handle", "source": "users/{uid}.handle", "fallback": "Picker" },
         { "name": "show_date", "source": "show_calendar", "fallback": null },
         { "name": "venue_name", "source": "show_calendar", "fallback": null },
         { "name": "venue_city", "source": "show_calendar", "fallback": null },
         { "name": "time_to_lock", "source": "computed at send time", "fallback": null },
-        { "name": "lock_time_local", "source": "computed (19:55 venue-local)", "fallback": "7:55 PM" },
+        { "name": "lock_time_local", "source": "computed (doors+offset or 19:30 venue-local)", "fallback": "7:30 PM" },
         { "name": "picks_secured", "source": "preview/edge only — production fanout skips users with picks", "fallback": false }
       ]
     },

--- a/functions/commsEventAdapters.js
+++ b/functions/commsEventAdapters.js
@@ -178,7 +178,7 @@ function findTourCountdownTargets(calendarShows, now, countdownDays = COUNTDOWN_
         first_show_venue: show.venue || "",
         first_show_city: show.city || "",
         timeZone: tz,
-        lock_time_local: "7:55 PM",
+        lock_time_local: "7:30 PM",
       });
     }
   }

--- a/functions/commsTemplates.js
+++ b/functions/commsTemplates.js
@@ -205,14 +205,14 @@ const BUILDERS = {
       [
         `${handleOf(p)}, the run kicks off ${when}.`,
         firstShow ? `First show: ${firstShow}.` : "",
-        `Picks lock at ${p.lock_time_local || "7:55 PM"} local on show night.`,
+        "Get your picks ready before the first downbeat.",
       ],
       { ctaUrl: PICKS_CTA_URL }
     );
     return {
       push: {
         title: `${p.tour_name || "The tour"} starts ${when}`,
-        body: `Get your picks ready — locks at ${p.lock_time_local || "7:55 PM"} local.`,
+        body: "Get your picks ready for the first show.",
       },
       email: {
         subject: `${p.tour_name || "The tour"} starts ${when}`,
@@ -398,26 +398,26 @@ const BUILDERS = {
   },
 
   "picks-lock-reminder": (p) => {
-    const venue = venueLine(p);
-    const lockLabel = p.lock_time_local || "7:55 PM";
-    const timePhrase = p.time_to_lock ? ` in ${p.time_to_lock}` : "";
+    const timeToLock = p.time_to_lock || "a few hours";
     const ctaUrl = picksCtaUrl(p);
     const assembled = assembleServiceEmail(
       [
-        `${handleOf(p)}, ${p.venue_name || "tonight's show"} locks at ${lockLabel} local${timePhrase}.`,
+        `${handleOf(p)}, ${timeToLock} until picks lock${
+          p.venue_name ? ` for ${p.venue_name}` : ""
+        }.`,
         "You haven't locked picks yet — don't get shut out.",
       ],
       { ctaUrl, signOff: "See you on tour!" }
     );
     return {
       push: {
-        title: "Tonight's picks lock soon",
-        body: `Lock in your picks${p.venue_name ? ` for ${p.venue_name}` : ""} before ${lockLabel} local.`,
+        title: `${timeToLock} until picks lock`,
+        body: `Lock in your picks${p.venue_name ? ` for ${p.venue_name}` : ""}.`,
       },
       email: {
-        subject: p.time_to_lock
-          ? `Picks close in ${p.time_to_lock}${p.venue_city ? ` — ${p.venue_city} tonight` : ""}`
-          : `Lock in your picks${venue ? ` — ${venue}` : ""}`,
+        subject: `${timeToLock} until picks lock${
+          p.venue_city ? ` — ${p.venue_city} tonight` : ""
+        }`,
         text: assembled.text,
         signOff: assembled.signOff,
         ctaUrl,

--- a/functions/commsTemplates.test.js
+++ b/functions/commsTemplates.test.js
@@ -49,6 +49,31 @@ test("picks-lock-reminder email CTA includes showDate when YYYY-MM-DD (#535)", a
   assert.match(out.email.ctaUrl, /\/dashboard\/picks\?showDate=2026-07-18/);
 });
 
+test("picks-lock-reminder uses relative cutoff only (#522)", async () => {
+  const out = await renderCommsTemplate("picks-lock-reminder", {
+    handle: "HotDogBilly",
+    show_date: "2026-07-18",
+    venue_name: "MSG",
+    venue_city: "New York, NY",
+    time_to_lock: "2h 15m",
+    lock_time_local: "7:30 PM",
+  });
+  const rendered = `${out.push.title} ${out.push.body} ${out.email.subject} ${out.email.text}`;
+  assert.match(rendered, /2h 15m/);
+  assert.doesNotMatch(rendered, /7:30 PM/);
+});
+
+test("tour countdown does not repeat an absolute picks cutoff (#522)", async () => {
+  const out = await renderCommsTemplate("tour-countdown", {
+    handle: "HotDogBilly",
+    tour_name: "Summer Tour",
+    days_remaining: 1,
+    lock_time_local: "7:30 PM",
+  });
+  const rendered = `${out.push.title} ${out.push.body} ${out.email.subject} ${out.email.text}`;
+  assert.doesNotMatch(rendered, /7:30 PM|picks lock/i);
+});
+
 test("picks-lock-reminder email CTA omits showDate for display labels", async () => {
   const out = await renderCommsTemplate("picks-lock-reminder", {
     handle: "HotDogBilly",

--- a/functions/index.js
+++ b/functions/index.js
@@ -1569,7 +1569,9 @@ exports.backfillBustoutsForShows = onCall(
  */
 exports.scheduledPhishnetShowCalendar = onSchedule(
   {
-    schedule: "0 6 1 * *",
+    // Daily: new tour dates can publish at any point in the month. Phish.net
+    // supplies canonical dates/tours; Phish.com enriches doors/show time.
+    schedule: "0 6 * * *",
     timeZone: "America/New_York",
     region: PHISHNET_FUNCTIONS_REGION,
     secrets: [phishnetApiKey],

--- a/functions/phishOfficialSchedule.js
+++ b/functions/phishOfficialSchedule.js
@@ -1,0 +1,156 @@
+"use strict";
+
+/**
+ * First-party Phish.com schedule enrichment for `show_calendar` (#522).
+ *
+ * Phish.net remains canonical for dates/tours/venues. Phish.com date pages add
+ * the fields its API does not expose: "Doors Open" and advertised "Show Time".
+ */
+
+const PHISH_TOURS_URL = "https://phish.com/tours/";
+const USER_AGENT = "SetlistPickEm/1.0 (+https://www.setlistpickem.com)";
+
+/**
+ * @param {string} html
+ * @returns {string[]}
+ */
+function extractOfficialDateUrls(html) {
+  if (typeof html !== "string") return [];
+  const urls = new Set();
+  const pattern =
+    /href=["'](https:\/\/phish\.com\/tours\/dates\/[^"'?#]+\/?)["']/gi;
+  for (const match of html.matchAll(pattern)) {
+    urls.add(match[1].endsWith("/") ? match[1] : `${match[1]}/`);
+  }
+  return [...urls];
+}
+
+/**
+ * @param {string} url
+ * @returns {string | null}
+ */
+function showDateFromOfficialUrl(url) {
+  const match = String(url).match(
+    /\/tours\/dates\/[a-z]+-(\d{4})-(\d{1,2})-(\d{1,2})-/i
+  );
+  if (!match) return null;
+  return `${match[1]}-${String(match[2]).padStart(2, "0")}-${String(
+    match[3]
+  ).padStart(2, "0")}`;
+}
+
+/**
+ * @param {string} value
+ * @returns {string | null} `HH:mm`
+ */
+function normalizeOfficialLocalTime(value) {
+  const match = String(value)
+    .trim()
+    .match(/^(\d{1,2}):(\d{2})\s*([ap])\.?m\.?$/i);
+  if (!match) return null;
+  let hour = Number(match[1]);
+  const minute = Number(match[2]);
+  if (hour < 1 || hour > 12 || minute < 0 || minute > 59) return null;
+  const isPm = match[3].toLowerCase() === "p";
+  if (isPm && hour !== 12) hour += 12;
+  if (!isPm && hour === 12) hour = 0;
+  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(
+    2,
+    "0"
+  )}`;
+}
+
+/**
+ * @param {string} html
+ * @param {string} sourceUrl
+ * @returns {{ date: string, doorsLocal?: string, scheduledStartLocal?: string, scheduleSource: 'phish.com', scheduleSourceUrl: string } | null}
+ */
+function parseOfficialDatePage(html, sourceUrl) {
+  const date = showDateFromOfficialUrl(sourceUrl);
+  if (!date || typeof html !== "string") return null;
+  const doorsMatch = html.match(
+    /Doors\s+Open:\s*(\d{1,2}:\d{2}\s*[ap]\.?m\.?)/i
+  );
+  const showMatch = html.match(
+    /Show\s+Time:\s*(\d{1,2}:\d{2}\s*[ap]\.?m\.?)/i
+  );
+  const doorsLocal = doorsMatch
+    ? normalizeOfficialLocalTime(doorsMatch[1])
+    : null;
+  const scheduledStartLocal = showMatch
+    ? normalizeOfficialLocalTime(showMatch[1])
+    : null;
+  if (!doorsLocal && !scheduledStartLocal) return null;
+  return {
+    date,
+    ...(doorsLocal ? { doorsLocal } : {}),
+    ...(scheduledStartLocal ? { scheduledStartLocal } : {}),
+    scheduleSource: "phish.com",
+    scheduleSourceUrl: sourceUrl,
+  };
+}
+
+/**
+ * Fetches official upcoming date pages in small batches.
+ *
+ * @param {{ fetchImpl?: typeof fetch, logger?: { warn?: Function, info?: Function } }} [opts]
+ * @returns {Promise<Map<string, { date: string, doorsLocal?: string, scheduledStartLocal?: string, scheduleSource: 'phish.com', scheduleSourceUrl: string }>>}
+ */
+async function fetchOfficialPhishSchedule({
+  fetchImpl = fetch,
+  logger,
+} = {}) {
+  const indexRes = await fetchImpl(PHISH_TOURS_URL, {
+    headers: { Accept: "text/html", "User-Agent": USER_AGENT },
+  });
+  if (!indexRes.ok) {
+    throw new Error(`Phish.com tours: HTTP ${indexRes.status}`);
+  }
+  const dateUrls = extractOfficialDateUrls(await indexRes.text());
+  const schedule = new Map();
+
+  for (let i = 0; i < dateUrls.length; i += 6) {
+    const batch = dateUrls.slice(i, i + 6);
+    const rows = await Promise.all(
+      batch.map(async (url) => {
+        try {
+          const res = await fetchImpl(url, {
+            headers: { Accept: "text/html", "User-Agent": USER_AGENT },
+          });
+          if (!res.ok) {
+            logger?.warn?.("phish.com date page fetch failed", {
+              url,
+              status: res.status,
+            });
+            return null;
+          }
+          return parseOfficialDatePage(await res.text(), url);
+        } catch (error) {
+          logger?.warn?.("phish.com date page fetch failed", {
+            url,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return null;
+        }
+      })
+    );
+    for (const row of rows) {
+      if (row) schedule.set(row.date, row);
+    }
+  }
+
+  logger?.info?.("phish.com schedule fetch ok", {
+    datePages: dateUrls.length,
+    timedShows: schedule.size,
+  });
+  return schedule;
+}
+
+module.exports = {
+  PHISH_TOURS_URL,
+  extractOfficialDateUrls,
+  fetchOfficialPhishSchedule,
+  normalizeOfficialLocalTime,
+  parseOfficialDatePage,
+  showDateFromOfficialUrl,
+};

--- a/functions/phishOfficialSchedule.test.js
+++ b/functions/phishOfficialSchedule.test.js
@@ -1,0 +1,67 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  extractOfficialDateUrls,
+  fetchOfficialPhishSchedule,
+  normalizeOfficialLocalTime,
+  parseOfficialDatePage,
+  showDateFromOfficialUrl,
+} = require("./phishOfficialSchedule");
+
+const SYRACUSE_URL =
+  "https://phish.com/tours/dates/tue-2026-7-21-empower-federal-credit-union-amphitheater-at-lakeview/";
+
+test("extractOfficialDateUrls dedupes Phish date links", () => {
+  const html = `<a href="${SYRACUSE_URL}">one</a>
+    <a href="${SYRACUSE_URL}">duplicate</a>`;
+  assert.deepEqual(extractOfficialDateUrls(html), [SYRACUSE_URL]);
+});
+
+test("normalizes official local times", () => {
+  assert.equal(normalizeOfficialLocalTime("5:30 pm"), "17:30");
+  assert.equal(normalizeOfficialLocalTime("12:05 AM"), "00:05");
+  assert.equal(normalizeOfficialLocalTime("bad"), null);
+});
+
+test("parses date and official doors/show time", () => {
+  assert.equal(showDateFromOfficialUrl(SYRACUSE_URL), "2026-07-21");
+  assert.deepEqual(
+    parseOfficialDatePage(
+      `<ul><li>Show Time: 7:00 pm</li><li>Doors Open: 5:30 pm</li></ul>`,
+      SYRACUSE_URL
+    ),
+    {
+      date: "2026-07-21",
+      doorsLocal: "17:30",
+      scheduledStartLocal: "19:00",
+      scheduleSource: "phish.com",
+      scheduleSourceUrl: SYRACUSE_URL,
+    }
+  );
+});
+
+test("fetchOfficialPhishSchedule tolerates one failed date page", async () => {
+  const failedUrl =
+    "https://phish.com/tours/dates/wed-2026-7-22-madison-square-garden/";
+  const responses = new Map([
+    [
+      "https://phish.com/tours/",
+      `<a href="${SYRACUSE_URL}">Syracuse</a><a href="${failedUrl}">MSG</a>`,
+    ],
+    [
+      SYRACUSE_URL,
+      `<li>Show Time: 7:00 pm</li><li>Doors Open: 5:30 pm</li>`,
+    ],
+  ]);
+  const fetchImpl = async (url) => ({
+    ok: responses.has(url),
+    status: responses.has(url) ? 200 : 503,
+    text: async () => responses.get(url) || "",
+  });
+
+  const out = await fetchOfficialPhishSchedule({ fetchImpl });
+  assert.equal(out.size, 1);
+  assert.equal(out.get("2026-07-21").doorsLocal, "17:30");
+});

--- a/functions/phishnetLiveSetlistAutomation.js
+++ b/functions/phishnetLiveSetlistAutomation.js
@@ -219,7 +219,7 @@ function parseShowCalendarSnapshotToShows(snapshotData) {
             ? item.timezone.trim()
             : ""
         : "";
-    /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour_name?: string, tour?: string }} */
+    /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour_name?: string, tour?: string, doorsLocal?: string, picksLockLocal?: string }} */
     const show = { date, timeZone: explicitTz || DEFAULT_SHOW_TIME_ZONE };
     if (item && typeof item === "object") {
       if (typeof item.venue === "string" && item.venue.trim()) {
@@ -233,6 +233,12 @@ function parseShowCalendarSnapshotToShows(snapshotData) {
       }
       if (typeof item.tour === "string" && item.tour.trim()) {
         show.tour = item.tour.trim();
+      }
+      if (typeof item.doorsLocal === "string" && item.doorsLocal.trim()) {
+        show.doorsLocal = item.doorsLocal.trim();
+      }
+      if (typeof item.picksLockLocal === "string" && item.picksLockLocal.trim()) {
+        show.picksLockLocal = item.picksLockLocal.trim();
       }
     }
     shows.push(show);
@@ -298,7 +304,7 @@ function parseShowCalendarSnapshotToShowsByTour(snapshotData) {
           : typeof item.timezone === "string" && item.timezone.trim()
             ? item.timezone.trim()
             : "";
-      /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour?: string, tour_name?: string }} */
+      /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour?: string, tour_name?: string, doorsLocal?: string, picksLockLocal?: string }} */
       const show = {
         date,
         timeZone: explicitTz || DEFAULT_SHOW_TIME_ZONE,
@@ -310,6 +316,12 @@ function parseShowCalendarSnapshotToShowsByTour(snapshotData) {
       }
       if (typeof item.city === "string" && item.city.trim()) {
         show.city = item.city.trim();
+      }
+      if (typeof item.doorsLocal === "string" && item.doorsLocal.trim()) {
+        show.doorsLocal = item.doorsLocal.trim();
+      }
+      if (typeof item.picksLockLocal === "string" && item.picksLockLocal.trim()) {
+        show.picksLockLocal = item.picksLockLocal.trim();
       }
       shows.push(show);
     }

--- a/functions/phishnetShowCalendar.js
+++ b/functions/phishnetShowCalendar.js
@@ -8,6 +8,10 @@
  * `exclude_from_stats` (omit soundchecks / non-counting rows when truthy).
  */
 
+const {
+  fetchOfficialPhishSchedule,
+} = require("./phishOfficialSchedule");
+
 const MONTHS = [
   "Jan",
   "Feb",
@@ -213,6 +217,67 @@ function flattenSnapshotTourByDate(prevData) {
     }
   }
   return map;
+}
+
+/**
+ * Preserve official timing when Phish.com is temporarily unavailable.
+ *
+ * @param {import('firebase-admin').firestore.DocumentData | null | undefined} prevData
+ * @returns {Map<string, {
+ *   doorsLocal?: string,
+ *   scheduledStartLocal?: string,
+ *   scheduleSource?: string,
+ *   scheduleSourceUrl?: string
+ * }>}
+ */
+function flattenSnapshotScheduleByDate(prevData) {
+  const out = new Map();
+  const raw = Array.isArray(prevData?.showDates) ? prevData.showDates : [];
+  for (const show of raw) {
+    if (!show || typeof show !== "object") continue;
+    const date = typeof show.date === "string" ? show.date.trim() : "";
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) continue;
+    const timing = {};
+    for (const field of [
+      "doorsLocal",
+      "scheduledStartLocal",
+      "scheduleSource",
+      "scheduleSourceUrl",
+    ]) {
+      if (typeof show[field] === "string" && show[field].trim()) {
+        timing[field] = show[field].trim();
+      }
+    }
+    if (Object.keys(timing).length > 0) out.set(date, timing);
+  }
+  return out;
+}
+
+/**
+ * @param {{ tour: string, shows: Record<string, unknown>[] }[]} groups
+ * @param {Map<string, Record<string, unknown>>} officialByDate
+ * @param {Map<string, Record<string, unknown>>} previousByDate
+ */
+function enrichGroupsWithOfficialSchedule(
+  groups,
+  officialByDate,
+  previousByDate
+) {
+  return groups.map((group) => ({
+    ...group,
+    shows: group.shows.map((show) => {
+      const timing =
+        officialByDate.get(String(show.date)) ??
+        previousByDate.get(String(show.date)) ??
+        null;
+      if (!timing) return show;
+      const {
+        date: _sourceDate,
+        ...timingFields
+      } = timing;
+      return { ...show, ...timingFields };
+    }),
+  }));
 }
 
 /**
@@ -587,6 +652,9 @@ async function syncPhishnetShowCalendarToFirestore(db, apiKey, ctx) {
     const prevTourByDate = flattenSnapshotTourByDate(
       prevSnap.exists ? prevSnap.data() : null
     );
+    const prevScheduleByDate = flattenSnapshotScheduleByDate(
+      prevSnap.exists ? prevSnap.data() : null
+    );
     const overridesByDate = parseTourOverridesDoc(
       overridesSnap.exists ? overridesSnap.data() : null
     );
@@ -595,7 +663,7 @@ async function syncPhishnetShowCalendarToFirestore(db, apiKey, ctx) {
 
     const shows = await fetchAllShowsNormalized({ apiKey });
     const computedGroups = buildShowDatesByTour(shows);
-    const { showDatesByTour, reviewQueue } =
+    const { showDatesByTour: groupedShows, reviewQueue } =
       mergeToursWithSnapshotPreservation(
         shows,
         computedGroups,
@@ -603,12 +671,28 @@ async function syncPhishnetShowCalendarToFirestore(db, apiKey, ctx) {
         overridesByDate,
         { isFirstSnapshot }
       );
+    let officialScheduleByDate = new Map();
+    try {
+      officialScheduleByDate = await fetchOfficialPhishSchedule({ logger });
+    } catch (scheduleError) {
+      logger?.warn?.("phish.com schedule enrichment failed; preserving prior timing", {
+        error:
+          scheduleError instanceof Error
+            ? scheduleError.message
+            : String(scheduleError),
+      });
+    }
+    const showDatesByTour = enrichGroupsWithOfficialSchedule(
+      groupedShows,
+      officialScheduleByDate,
+      prevScheduleByDate
+    );
     const flat = showDatesByTour.flatMap((g) => g.shows);
 
     await ref.set(
       {
         schemaVersion: 2,
-        source: "phishnet",
+        source: "phishnet+phish.com",
         updatedAt: new Date(),
         showDatesByTour,
         showDates: flat,
@@ -623,6 +707,8 @@ async function syncPhishnetShowCalendarToFirestore(db, apiKey, ctx) {
       groups: showDatesByTour.length,
       reviewNewDates: reviewQueue.length,
       preservedDates: prevTourByDate.size,
+      officialTimedShows: officialScheduleByDate.size,
+      preservedTimedShows: prevScheduleByDate.size,
     });
     return { showCount: flat.length, groupCount: showDatesByTour.length };
   } catch (e) {
@@ -645,7 +731,9 @@ module.exports = {
   buildShowDatesByTour,
   buildVenueLine,
   fetchAllShowsNormalized,
+  flattenSnapshotScheduleByDate,
   flattenSnapshotTourByDate,
+  enrichGroupsWithOfficialSchedule,
   labelGenericCluster,
   mergeToursWithSnapshotPreservation,
   normalizePhishShows,

--- a/functions/phishnetShowCalendar.test.js
+++ b/functions/phishnetShowCalendar.test.js
@@ -4,11 +4,50 @@ const assert = require("node:assert/strict");
 const {
   labelGenericCluster,
   buildShowDatesByTour,
+  enrichGroupsWithOfficialSchedule,
+  flattenSnapshotScheduleByDate,
   flattenSnapshotTourByDate,
   mergeToursWithSnapshotPreservation,
   normalizePhishShows,
   parseTourOverridesDoc,
 } = require("./phishnetShowCalendar");
+
+test("official schedule enrichment prefers fresh data and preserves prior timing", () => {
+  const groups = [
+    {
+      tour: "Summer Tour 2026",
+      shows: [
+        { date: "2026-07-21", venue: "Syracuse" },
+        { date: "2026-07-22", venue: "MSG" },
+      ],
+    },
+  ];
+  const fresh = new Map([
+    [
+      "2026-07-21",
+      {
+        date: "2026-07-21",
+        doorsLocal: "17:30",
+        scheduledStartLocal: "19:00",
+        scheduleSource: "phish.com",
+      },
+    ],
+  ]);
+  const previous = flattenSnapshotScheduleByDate({
+    showDates: [
+      {
+        date: "2026-07-22",
+        doorsLocal: "18:30",
+        scheduleSource: "phish.com",
+      },
+    ],
+  });
+
+  const enriched = enrichGroupsWithOfficialSchedule(groups, fresh, previous);
+  assert.equal(enriched[0].shows[0].doorsLocal, "17:30");
+  assert.equal(enriched[0].shows[0].date, "2026-07-21");
+  assert.equal(enriched[0].shows[1].doorsLocal, "18:30");
+});
 
 test("labelGenericCluster: Sphere Run", () => {
   const shows = [

--- a/functions/picksLockReminder.js
+++ b/functions/picksLockReminder.js
@@ -9,11 +9,10 @@ const {
 const { hasNonEmptyPicksObject } = require("./rollupSeasonAggregates");
 const { createCommsAdapterRuntime } = require("./commsAdapterRuntime");
 const { resolveDedupKey } = require("./commsCatalog");
-
-/** Mirrors `src/shared/utils/timeLogic.js` (7:55pm local). */
-const SHOW_PICKS_LOCK_HOUR = 19;
-const SHOW_PICKS_LOCK_MINUTE = 55;
-const LOCK_TIME_LOCAL_LABEL = "7:55 PM";
+const {
+  formatLockTimeLocalLabel,
+  resolvePicksLockHm,
+} = require("./picksLockTime");
 
 const DEFAULT_SHOW_TIME_ZONE = "America/Los_Angeles";
 /** Reminder window opens this many minutes before venue-local lock. */
@@ -55,14 +54,24 @@ function localClockParts(showTimeZone, now) {
 }
 
 /**
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null | undefined} show
+ * @returns {number} minutes from midnight
+ */
+function lockMinutesForShow(show) {
+  const lock = resolvePicksLockHm(show);
+  return lock.hour * 60 + lock.minute;
+}
+
+/**
  * @param {string} showYmd
  * @param {string} showTimeZone
  * @param {Date} now
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null} [show]
  */
-function isPastPicksLock(showYmd, showTimeZone, now) {
+function isPastPicksLock(showYmd, showTimeZone, now, show = null) {
   const clock = localClockParts(showTimeZone, now);
   if (!clock || clock.ymd !== showYmd) return false;
-  const lockMinutes = SHOW_PICKS_LOCK_HOUR * 60 + SHOW_PICKS_LOCK_MINUTE;
+  const lockMinutes = lockMinutesForShow(show || { date: showYmd });
   return clock.minutesOfDay >= lockMinutes;
 }
 
@@ -72,11 +81,12 @@ function isPastPicksLock(showYmd, showTimeZone, now) {
  * @param {string} showYmd
  * @param {string} showTimeZone
  * @param {Date} now
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null} [show]
  */
-function isWithinReminderWindow(showYmd, showTimeZone, now) {
+function isWithinReminderWindow(showYmd, showTimeZone, now, show = null) {
   const clock = localClockParts(showTimeZone, now);
   if (!clock || clock.ymd !== showYmd) return false;
-  const lockMinutes = SHOW_PICKS_LOCK_HOUR * 60 + SHOW_PICKS_LOCK_MINUTE;
+  const lockMinutes = lockMinutesForShow(show || { date: showYmd });
   const startMinutes = lockMinutes - REMINDER_LEAD_MINUTES;
   return clock.minutesOfDay >= startMinutes && clock.minutesOfDay < lockMinutes;
 }
@@ -85,13 +95,14 @@ function isWithinReminderWindow(showYmd, showTimeZone, now) {
  * @param {string} showYmd `YYYY-MM-DD`
  * @param {string} showTimeZone IANA tz
  * @param {Date} now
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null} [show]
  * @returns {string}
  */
-function formatTimeToLock(showYmd, showTimeZone, now) {
+function formatTimeToLock(showYmd, showTimeZone, now, show = null) {
   const clock = localClockParts(showTimeZone, now);
   if (!clock || clock.ymd !== showYmd) return "tonight";
 
-  const lockMinutes = SHOW_PICKS_LOCK_HOUR * 60 + SHOW_PICKS_LOCK_MINUTE;
+  const lockMinutes = lockMinutesForShow(show || { date: showYmd });
   const diff = lockMinutes - clock.minutesOfDay;
   if (diff <= 0) return "soon";
 
@@ -103,9 +114,9 @@ function formatTimeToLock(showYmd, showTimeZone, now) {
 }
 
 /**
- * @param {Array<{ date: string, timeZone?: string, venue?: string, city?: string }>} calendarShows
+ * @param {Array<{ date: string, timeZone?: string, venue?: string, city?: string, doorsLocal?: string, picksLockLocal?: string }>} calendarShows
  * @param {Date} now
- * @returns {{ showDate: string, timeZone: string, venue_name: string, venue_city: string } | null}
+ * @returns {{ showDate: string, timeZone: string, venue_name: string, venue_city: string, lock_time_local: string, show: object } | null}
  */
 function findReminderTonightShow(calendarShows, now) {
   if (!Array.isArray(calendarShows) || calendarShows.length === 0) return null;
@@ -117,12 +128,15 @@ function findReminderTonightShow(calendarShows, now) {
       typeof show.timeZone === "string" && show.timeZone.trim()
         ? show.timeZone.trim()
         : DEFAULT_SHOW_TIME_ZONE;
-    if (!isWithinReminderWindow(date, tz, now)) continue;
+    if (!isWithinReminderWindow(date, tz, now, show)) continue;
+    const lockHm = resolvePicksLockHm(show);
     return {
       showDate: date,
       timeZone: tz,
       venue_name: typeof show.venue === "string" ? show.venue.trim() : "",
       venue_city: typeof show.city === "string" ? show.city.trim() : "",
+      lock_time_local: formatLockTimeLocalLabel(lockHm),
+      show,
     };
   }
   return null;
@@ -166,6 +180,10 @@ function buildPicksLockReminderRecipients({
 }) {
   /** @type {Array<{ uid: string, userData: Record<string, unknown>, payload: Record<string, unknown>, vars: Record<string, unknown> }>} */
   const recipients = [];
+  const lockLabel =
+    typeof showMeta.lock_time_local === "string" && showMeta.lock_time_local.trim()
+      ? showMeta.lock_time_local.trim()
+      : formatLockTimeLocalLabel(resolvePicksLockHm({ date: showDate }));
   for (const userDoc of userDocs) {
     if (recipients.length >= cap) break;
     const uid = userDoc.id;
@@ -180,8 +198,13 @@ function buildPicksLockReminderRecipients({
         show_date: showDate,
         venue_name: showMeta.venue_name,
         venue_city: showMeta.venue_city,
-        time_to_lock: formatTimeToLock(showDate, showMeta.timeZone, now),
-        lock_time_local: LOCK_TIME_LOCAL_LABEL,
+        time_to_lock: formatTimeToLock(
+          showDate,
+          showMeta.timeZone,
+          now,
+          showMeta.show || { date: showDate }
+        ),
+        lock_time_local: lockLabel,
       },
       vars: { uid, showYmd: showDate },
     });

--- a/functions/picksLockReminder.test.js
+++ b/functions/picksLockReminder.test.js
@@ -16,7 +16,7 @@ test("reminderLogDocId", () => {
 
 test("findReminderTonightShow returns null before T-3h window", () => {
   const shows = [{ date: "2099-06-15", timeZone: "America/Los_Angeles" }];
-  // 4:00pm PDT — still before 4:55pm (lock 7:55 − 3h).
+  // 4:00pm PDT — still before 4:30pm (lock 7:30 − 3h).
   const now = new Date("2099-06-15T23:00:00.000Z");
   assert.equal(findReminderTonightShow(shows, now), null);
 });
@@ -30,7 +30,7 @@ test("findReminderTonightShow returns show in T-3h–lock window with venue meta
       city: "New York, NY",
     },
   ];
-  // 5:30pm PDT — inside 4:55–7:55 window.
+  // 5:30pm PDT — inside 4:30–7:30 window.
   const now = new Date("2099-06-16T00:30:00.000Z");
   const out = findReminderTonightShow(shows, now);
   assert.ok(out);
@@ -48,8 +48,8 @@ test("isPastPicksLock is true after local lock", () => {
 });
 
 test("formatTimeToLock returns 3 hours at window open", () => {
-  // 4:55pm PDT on show day → exactly 3 hours until 7:55pm lock.
-  const now = new Date("2099-06-15T23:55:00.000Z");
+  // 4:30pm PDT on show day → exactly 3 hours until 7:30pm lock.
+  const now = new Date("2099-06-15T23:30:00.000Z");
   assert.equal(formatTimeToLock("2099-06-15", "America/Los_Angeles", now), "3 hours");
 });
 

--- a/functions/picksLockTime.js
+++ b/functions/picksLockTime.js
@@ -1,0 +1,167 @@
+/**
+ * Per-show picks wall-clock lock (#522) — CommonJS mirror of
+ * `src/shared/utils/picksLockTime.js` (Functions cannot import the ESM client module).
+ *
+ * Keep in sync with the client module when constants or formula change.
+ */
+
+const DEFAULT_PICKS_LOCK_HM = Object.freeze({ hour: 19, minute: 30 });
+const TOUR_AVG_DOORS_TO_START_MIN = 119;
+const PICKS_LOCK_SAFETY_MIN = 19;
+
+const SHOW_DOORS_LOCAL_BY_DATE = Object.freeze({
+  "2026-07-18": "17:30",
+  "2026-07-19": "17:30",
+  "2026-07-21": "17:30",
+  "2026-07-22": "18:30",
+  "2026-07-24": "18:30",
+  "2026-07-25": "18:30",
+  "2026-07-27": "18:30",
+  "2026-07-29": "18:30",
+  "2026-07-31": "17:00",
+  "2026-08-01": "17:00",
+  "2026-09-04": "18:00",
+  "2026-09-05": "18:00",
+  "2026-09-06": "18:00",
+});
+
+/**
+ * @param {string | null | undefined} value
+ * @returns {{ hour: number, minute: number } | null}
+ */
+function parseLocalHm(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const h24 = trimmed.match(/^(\d{1,2}):(\d{2})$/);
+  if (h24) {
+    const hour = Number(h24[1]);
+    const minute = Number(h24[2]);
+    if (
+      Number.isInteger(hour) &&
+      Number.isInteger(minute) &&
+      hour >= 0 &&
+      hour <= 23 &&
+      minute >= 0 &&
+      minute <= 59
+    ) {
+      return { hour, minute };
+    }
+    return null;
+  }
+
+  const h12 = trimmed.match(/^(\d{1,2}):(\d{2})\s*([AaPp][Mm])$/);
+  if (!h12) return null;
+  let hour = Number(h12[1]);
+  const minute = Number(h12[2]);
+  const ap = h12[3].toUpperCase();
+  if (
+    !Number.isInteger(hour) ||
+    !Number.isInteger(minute) ||
+    hour < 1 ||
+    hour > 12 ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return null;
+  }
+  if (ap === "AM") {
+    if (hour === 12) hour = 0;
+  } else if (hour !== 12) {
+    hour += 12;
+  }
+  return { hour, minute };
+}
+
+/**
+ * @param {{ hour: number, minute: number }} hm
+ * @returns {string}
+ */
+function formatLocalHm24(hm) {
+  return `${String(hm.hour).padStart(2, "0")}:${String(hm.minute).padStart(2, "0")}`;
+}
+
+/**
+ * @param {{ hour: number, minute: number }} hm
+ * @returns {string}
+ */
+function formatLockTimeLocalLabel(hm) {
+  const hour12 = ((hm.hour + 11) % 12) + 1;
+  const suffix = hm.hour >= 12 ? "PM" : "AM";
+  return `${hour12}:${String(hm.minute).padStart(2, "0")} ${suffix}`;
+}
+
+/**
+ * @param {{ hour: number, minute: number }} doors
+ * @param {{ tourAvgDoorsToStartMin?: number, safetyMin?: number }} [opts]
+ */
+function lockHmFromDoors(
+  doors,
+  {
+    tourAvgDoorsToStartMin = TOUR_AVG_DOORS_TO_START_MIN,
+    safetyMin = PICKS_LOCK_SAFETY_MIN,
+  } = {}
+) {
+  const offset = Math.max(0, tourAvgDoorsToStartMin - safetyMin);
+  const total = doors.hour * 60 + doors.minute + offset;
+  const wrapped = ((total % (24 * 60)) + 24 * 60) % (24 * 60);
+  return { hour: Math.floor(wrapped / 60), minute: wrapped % 60 };
+}
+
+/**
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null | undefined} show
+ * @param {{
+ *   doorsByDate?: Record<string, string>,
+ *   tourAvgDoorsToStartMin?: number,
+ *   safetyMin?: number,
+ *   fallback?: { hour: number, minute: number },
+ * }} [opts]
+ */
+function resolvePicksLockHm(show, opts = {}) {
+  const fallback = opts.fallback ?? DEFAULT_PICKS_LOCK_HM;
+  const doorsByDate = opts.doorsByDate ?? SHOW_DOORS_LOCAL_BY_DATE;
+
+  const explicitLock = parseLocalHm(show?.picksLockLocal);
+  if (explicitLock) {
+    return {
+      ...explicitLock,
+      source: "picksLockLocal",
+      doorsLocal:
+        typeof show?.doorsLocal === "string" ? show.doorsLocal.trim() || null : null,
+    };
+  }
+
+  const date = typeof show?.date === "string" ? show.date.trim() : "";
+  const doorsRaw =
+    (typeof show?.doorsLocal === "string" && show.doorsLocal.trim()) ||
+    (date && doorsByDate[date]) ||
+    null;
+  const doors = parseLocalHm(doorsRaw);
+  if (doors) {
+    const lock = lockHmFromDoors(doors, opts);
+    return {
+      ...lock,
+      source: "doors",
+      doorsLocal: formatLocalHm24(doors),
+    };
+  }
+
+  return {
+    ...fallback,
+    source: "fallback",
+    doorsLocal: null,
+  };
+}
+
+module.exports = {
+  DEFAULT_PICKS_LOCK_HM,
+  PICKS_LOCK_SAFETY_MIN,
+  SHOW_DOORS_LOCAL_BY_DATE,
+  TOUR_AVG_DOORS_TO_START_MIN,
+  formatLocalHm24,
+  formatLockTimeLocalLabel,
+  lockHmFromDoors,
+  parseLocalHm,
+  resolvePicksLockHm,
+};

--- a/functions/picksLockTime.test.js
+++ b/functions/picksLockTime.test.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  DEFAULT_PICKS_LOCK_HM,
+  lockHmFromDoors,
+  resolvePicksLockHm,
+} = require("./picksLockTime");
+
+test("lockHmFromDoors uses doors+100 for Summer Tour 2026 defaults", () => {
+  assert.deepEqual(lockHmFromDoors({ hour: 17, minute: 30 }), {
+    hour: 19,
+    minute: 10,
+  });
+});
+
+test("resolvePicksLockHm seeds Merriweather and falls back", () => {
+  assert.deepEqual(resolvePicksLockHm({ date: "2026-07-18" }), {
+    hour: 19,
+    minute: 10,
+    source: "doors",
+    doorsLocal: "17:30",
+  });
+  assert.deepEqual(resolvePicksLockHm({ date: "2099-01-01" }), {
+    ...DEFAULT_PICKS_LOCK_HM,
+    source: "fallback",
+    doorsLocal: null,
+  });
+});

--- a/functions/showFinalizationGate.js
+++ b/functions/showFinalizationGate.js
@@ -7,10 +7,9 @@
  * or the admin passes `force: true`.
  */
 
-const DEFAULT_SHOW_TIME_ZONE = "America/Los_Angeles";
+const { resolvePicksLockHm } = require("./picksLockTime");
 
-const SHOW_PICKS_LOCK_HOUR_LOCAL = 19;
-const SHOW_PICKS_LOCK_MINUTE_LOCAL = 55;
+const DEFAULT_SHOW_TIME_ZONE = "America/Los_Angeles";
 
 function resolveShowTimeZone(show, fallback = DEFAULT_SHOW_TIME_ZONE) {
   const explicit =
@@ -51,14 +50,25 @@ function showClockOnShowYmd(showYmd, showTimeZone, now = new Date()) {
   return { hour: Number(map.hour), minute: Number(map.minute) };
 }
 
-function isPastPicksLock(showYmd, showTimeZone = DEFAULT_SHOW_TIME_ZONE, now = new Date()) {
+function isPastPicksLock(
+  showYmd,
+  showTimeZone = DEFAULT_SHOW_TIME_ZONE,
+  now = new Date(),
+  showOrLockHm = null
+) {
   const clock = showClockOnShowYmd(showYmd, showTimeZone, now);
   if (!clock) return false;
+  const lockHm =
+    showOrLockHm && typeof showOrLockHm === "object"
+      ? resolvePicksLockHm({
+          date:
+            typeof showOrLockHm.date === "string" ? showOrLockHm.date : showYmd,
+          doorsLocal: showOrLockHm.doorsLocal,
+          picksLockLocal: showOrLockHm.picksLockLocal,
+        })
+      : resolvePicksLockHm({ date: showYmd });
   const { hour, minute } = clock;
-  return (
-    hour > SHOW_PICKS_LOCK_HOUR_LOCAL ||
-    (hour === SHOW_PICKS_LOCK_HOUR_LOCAL && minute >= SHOW_PICKS_LOCK_MINUTE_LOCAL)
-  );
+  return hour > lockHm.hour || (hour === lockHm.hour && minute >= lockHm.minute);
 }
 
 /**
@@ -91,7 +101,16 @@ function getShowStatus(selectedDate, showDates, now = new Date()) {
   if (selectedDate < today) return "PAST";
   if (selectedDate === nextShow.date) {
     if (selectedDate === today) {
-      if (isPastPicksLock(selectedDate, selectedTimeZone, now)) return "LIVE";
+      if (
+        isPastPicksLock(
+          selectedDate,
+          selectedTimeZone,
+          now,
+          selectedShow || { date: selectedDate }
+        )
+      ) {
+        return "LIVE";
+      }
     }
     return "NEXT";
   }

--- a/functions/tourCountdownRecoveryDelivery.js
+++ b/functions/tourCountdownRecoveryDelivery.js
@@ -15,7 +15,7 @@ const { hasNonEmptyPicksObject } = require("./rollupSeasonAggregates");
 
 const TRIGGER_ID = "tour_countdown";
 const DEFAULT_SHOW_TIME_ZONE = "America/Los_Angeles";
-const DEFAULT_LOCK_TIME_LOCAL = "7:55 PM";
+const DEFAULT_LOCK_TIME_LOCAL = "7:30 PM";
 
 /**
  * @param {unknown} data

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setlistpickem",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setlistpickem",
-      "version": "1.30.0",
+      "version": "1.31.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "firebase": "10.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.30.0",
+  "version": "1.31.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/admin/ui/AdminForm.jsx
+++ b/src/features/admin/ui/AdminForm.jsx
@@ -180,7 +180,7 @@ export default function AdminForm({ user, selectedDate }) {
             <AdminActionToggle
               id="admin-picks-lock"
               title="Picks lock"
-              description="One-click override when the show starts before 7:55 PM local or Phish.net is slow."
+              description="One-click override when the show starts before the resolved lock or Phish.net is slow."
               open={picksLockOpen}
               onOpenChange={setPicksLockOpen}
             >

--- a/src/features/admin/ui/AdminPicksLockControls.jsx
+++ b/src/features/admin/ui/AdminPicksLockControls.jsx
@@ -15,7 +15,7 @@ export default function AdminPicksLockControls({
   const canLock = showStatus === 'NEXT' && !picksAlreadyLocked && !disabled;
 
   let helperText =
-    'Picks lock at 7:55 PM venue-local, when set 1 starts on Phish.net, or when you lock them here.';
+    'Picks lock at doors + ~1:40 (tour avg start − safety), at fallback 7:30 PM venue-local when doors are unknown, when set 1 starts on Phish.net, or when you lock them here.';
   if (showStatus && showStatus !== 'NEXT') {
     helperText = 'Lock picks now is only available while this show is NEXT (before wall-clock lock).';
   } else if (adminLockActive) {

--- a/src/features/admin/ui/AdminWarRoomShowDate.jsx
+++ b/src/features/admin/ui/AdminWarRoomShowDate.jsx
@@ -1,15 +1,9 @@
 import React from 'react';
 import { CalendarRange } from 'lucide-react';
 import {
-  SHOW_PICKS_LOCK_HOUR_LOCAL,
-  SHOW_PICKS_LOCK_MINUTE_LOCAL,
-} from '../../../shared/utils/timeLogic';
-
-function formatLockTime(hour24, minute) {
-  const hour12 = ((hour24 + 11) % 12) + 1;
-  const suffix = hour24 >= 12 ? 'PM' : 'AM';
-  return `${hour12}:${String(minute).padStart(2, '0')} ${suffix}`;
-}
+  formatLockTimeLocalLabel,
+  resolvePicksLockHm,
+} from '../../../shared/utils/picksLockTime';
 
 /**
  * Admin-only: pick the Firestore `official_setlists/{showDate}` key independently of the
@@ -23,7 +17,14 @@ export default function AdminWarRoomShowDate({
   disabled = false,
   timeZone,
 }) {
-  const lockTimeLabel = formatLockTime(SHOW_PICKS_LOCK_HOUR_LOCAL, SHOW_PICKS_LOCK_MINUTE_LOCAL);
+  const lockHm = resolvePicksLockHm({ date: value });
+  const lockTimeLabel = formatLockTimeLocalLabel(lockHm);
+  const lockSourceNote =
+    lockHm.source === 'doors'
+      ? `doors ${lockHm.doorsLocal} + tour avg − safety`
+      : lockHm.source === 'picksLockLocal'
+        ? 'explicit picksLockLocal'
+        : 'fallback 7:30 PM (doors unknown)';
 
   return (
     <div className="rounded-xl border border-border-subtle bg-[rgb(var(--surface-field)_/_0.35)] px-4 py-3 ring-1 ring-border-glass/20">
@@ -51,6 +52,9 @@ export default function AdminWarRoomShowDate({
           <p className="text-[11px] font-bold leading-relaxed text-content-secondary">
             Picks lock: <span className="text-content-primary">{lockTimeLabel}</span>{' '}
             <span className="text-slate-400">({timeZone})</span>
+            <span className="block text-slate-500 font-medium normal-case tracking-normal">
+              {lockSourceNote}
+            </span>
           </p>
         </div>
       </div>

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
@@ -169,8 +169,8 @@ export const COMMS_TEMPLATE_REGISTRY = {
           `${handleOf(p)}, the run kicks off ${dayLabel}.`,
           venueLine(p, { dateKey: 'first_show_date', venueKey: 'first_show_venue', cityKey: 'first_show_city' })
             ? `First show: ${venueLine(p, { dateKey: 'first_show_date', venueKey: 'first_show_venue', cityKey: 'first_show_city' })}.`
-            : 'Get your picks ready before the first downbeat.',
-          `Picks lock at ${p.lock_time_local || '7:55 PM'} local on show night — don't get shut out.`,
+            : 'The first show is coming up.',
+          'Get your picks ready before the first downbeat.',
         ],
         cta: tourCountdownInAppCta(p),
       };
@@ -185,7 +185,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           first_show_date: 'Jul 18',
           first_show_venue: 'MSG',
           first_show_city: 'New York, NY',
-          lock_time_local: '7:55 PM',
+          lock_time_local: '7:30 PM',
         },
       },
       {
@@ -197,7 +197,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           first_show_date: 'Jul 18',
           first_show_venue: 'MSG',
           first_show_city: 'New York, NY',
-          lock_time_local: '7:55 PM',
+          lock_time_local: '7:30 PM',
         },
       },
       {
@@ -209,7 +209,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           first_show_date: 'Jul 7',
           first_show_venue: 'Kohl Center',
           first_show_city: 'Madison, WI',
-          lock_time_local: '7:55 PM',
+          lock_time_local: '7:30 PM',
         },
       },
       {
@@ -232,7 +232,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           first_show_date: 'Jul 7',
           first_show_venue: 'Kohl Center',
           first_show_city: 'Madison, WI',
-          lock_time_local: '7:55 PM',
+          lock_time_local: '7:30 PM',
           picks_secured: true,
         },
       },
@@ -605,23 +605,24 @@ export const COMMS_TEMPLATE_REGISTRY = {
   'picks-lock-reminder': {
     triggerId: 'picks_lock_reminder',
     displayName: 'Lock reminder',
-    build: (p) => ({
-      icon: AlarmClock,
-      accentClassName: 'text-rose-300',
-      eyebrow: 'Picks lock soon',
-      title: 'Lock in your picks',
-      paragraphs: [
-        `${handleOf(p)}, ${venueLine(p) || "tonight's show"} locks at ${p.lock_time_local || '7:55 PM'} local${
-          p.time_to_lock ? ` — about ${p.time_to_lock} away` : ''
-        }.`,
-        isPicksSecured(p)
-          ? 'Your picks are on the board — open them any time before lock to tweak.'
-          : "You haven't locked picks yet. Don't get shut out of the night.",
-      ],
-      cta: isPicksSecured(p)
-        ? { ...VIEW_EDIT_PICKS_CTA }
-        : { label: 'Make your picks', href: PICKS_HREF },
-    }),
+    build: (p) => {
+      const timeToLock = p.time_to_lock || 'A few hours';
+      return {
+        icon: AlarmClock,
+        accentClassName: 'text-rose-300',
+        eyebrow: 'Picks lock soon',
+        title: `${timeToLock} until picks lock`,
+        paragraphs: [
+          `${handleOf(p)}, lock in your picks${venueLine(p) ? ` for ${venueLine(p)}` : ''}.`,
+          isPicksSecured(p)
+            ? 'Your picks are on the board — open them any time before lock to tweak.'
+            : "You haven't locked picks yet. Don't get shut out of the night.",
+        ],
+        cta: isPicksSecured(p)
+          ? { ...VIEW_EDIT_PICKS_CTA }
+          : { label: 'Make your picks', href: PICKS_HREF },
+      };
+    },
     samples: [
       {
         name: 'Lock reminder',
@@ -631,7 +632,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           venue_name: 'MSG',
           venue_city: 'New York, NY',
           time_to_lock: '3 hours',
-          lock_time_local: '7:55 PM',
+          lock_time_local: '7:30 PM',
         },
       },
       {
@@ -642,7 +643,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           venue_name: 'MSG',
           venue_city: 'New York, NY',
           time_to_lock: '3 hours',
-          lock_time_local: '7:55 PM',
+          lock_time_local: '7:30 PM',
           picks_secured: true,
         },
       },

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.test.js
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.test.js
@@ -91,6 +91,32 @@ describe('comms template registry', () => {
     );
   });
 
+  it('picks lock reminder uses relative cutoff only (#522)', () => {
+    const entry = getCommsTemplateEntry('picks-lock-reminder');
+    const result = entry.build({
+      handle: 'HotDogBilly',
+      venue_name: 'MSG',
+      venue_city: 'New York, NY',
+      time_to_lock: '2h 15m',
+      lock_time_local: '7:30 PM',
+    });
+    const text = [result.title, ...result.paragraphs].join(' ');
+    expect(text).toContain('2h 15m until picks lock');
+    expect(text).not.toContain('7:30 PM');
+  });
+
+  it('tour countdown omits an absolute picks cutoff (#522)', () => {
+    const entry = getCommsTemplateEntry('tour-countdown');
+    const result = entry.build({
+      handle: 'HotDogBilly',
+      days_remaining: 1,
+      lock_time_local: '7:30 PM',
+    });
+    const text = [result.title, ...result.paragraphs].join(' ');
+    expect(text).not.toContain('7:30 PM');
+    expect(text).not.toMatch(/picks lock/i);
+  });
+
   it('tour engagement reminder uses in-app picks CTA (not "Open the app")', () => {
     const entry = getCommsTemplateEntry('tour-engagement-reminder');
     expect(entry.build({}).cta).toEqual({

--- a/src/features/picks/index.js
+++ b/src/features/picks/index.js
@@ -4,6 +4,7 @@ export { default as PastShowLockBanner } from './ui/PastShowLockBanner';
 export { default as TooEarlyBanner } from './ui/TooEarlyBanner';
 export { default as PicksFieldsForm } from './ui/PicksFieldsForm';
 export { default as PicksMobileFixedChrome } from './ui/PicksMobileFixedChrome';
+export { default as PicksLockTimingBanner } from './ui/PicksLockTimingBanner';
 export { default as PicksSubmitButton } from './ui/PicksSubmitButton';
 export { default as PicksSelfRecapSection } from './ui/PicksSelfRecapSection';
 export { default as usePicksForm } from './model/usePicksForm';

--- a/src/features/picks/model/useSetlistLockToast.js
+++ b/src/features/picks/model/useSetlistLockToast.js
@@ -8,7 +8,7 @@ import { showSuccessToast } from '../../../shared/ui/toast';
  *
  * Handles the common case where the user has the dashboard open around show
  * time: without a page reload, the status changes live and the toast fires
- * when 7:55 pm local arrives.  A hard reload after lock (initial status
+ * when the resolved venue-local lock arrives. A hard reload after lock (initial status
  * already 'LIVE') does not re-fire the toast.
  *
  * @param {string|null} showStatus - Result of getShowStatus() for the active
@@ -22,7 +22,7 @@ export function useSetlistLockToast(showStatus) {
     prevStatusRef.current = showStatus;
 
     if (prev === 'NEXT' && showStatus === 'LIVE') {
-      showSuccessToast("Picks are locked — show time! 🎸");
+      showSuccessToast('Picks locked, almost showtime!');
     }
   }, [showStatus]);
 }

--- a/src/features/picks/ui/PicksLockTimingBanner.jsx
+++ b/src/features/picks/ui/PicksLockTimingBanner.jsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import { Clock3, X } from 'lucide-react';
+
+import {
+  PICKS_LOCK_SAFETY_MIN,
+  TOUR_AVG_DOORS_TO_START_MIN,
+  formatLockTimeLocalLabel,
+  parseLocalHm,
+  resolvePicksLockHm,
+} from '../../../shared/utils/picksLockTime';
+
+function durationWords(minutes) {
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  const parts = [];
+  if (hours > 0) parts.push(`${hours} hour${hours === 1 ? '' : 's'}`);
+  if (mins > 0) parts.push(`${mins} minute${mins === 1 ? '' : 's'}`);
+  return parts.join(' ');
+}
+
+/**
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string, picksLockSource?: string } | null | undefined} show
+ */
+export function buildPicksLockTimingMessage(show) {
+  const lock = resolvePicksLockHm(show);
+  const lockLabel = formatLockTimeLocalLabel(lock);
+  const doors = parseLocalHm(lock.doorsLocal);
+  const isDoorsBased =
+    lock.source === 'doors' || show?.picksLockSource === 'doors';
+
+  if (doors && isDoorsBased) {
+    const offsetMinutes =
+      TOUR_AVG_DOORS_TO_START_MIN - PICKS_LOCK_SAFETY_MIN;
+    return `Picks lock at ${lockLabel} — ${durationWords(
+      offsetMinutes
+    )} after tonight’s published doors time (${formatLockTimeLocalLabel(doors)}).`;
+  }
+
+  return `Picks lock at ${lockLabel} venue-local.`;
+}
+
+function dismissalKey(showDate) {
+  return `picks-lock-timing-dismissed:${showDate}`;
+}
+
+function wasDismissed(showDate) {
+  if (!showDate || typeof window === 'undefined') return false;
+  try {
+    return window.sessionStorage.getItem(dismissalKey(showDate)) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function rememberDismissal(showDate) {
+  if (!showDate || typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(dismissalKey(showDate), '1');
+  } catch {
+    // Storage can be disabled; local state still dismisses for this mount.
+  }
+}
+
+/**
+ * Small pre-lock timing notice shared by Picks and Standings.
+ *
+ * @param {{
+ *   show: { date?: string, doorsLocal?: string, picksLockLocal?: string, picksLockSource?: string } | null | undefined,
+ *   showStatus: string | null | undefined
+ * }} props
+ */
+export default function PicksLockTimingBanner({ show, showStatus }) {
+  const showDate = typeof show?.date === 'string' ? show.date : '';
+  const [dismissed, setDismissed] = useState(() => wasDismissed(showDate));
+
+  if (!show || showStatus !== 'NEXT' || dismissed) return null;
+
+  const dismiss = () => {
+    setDismissed(true);
+    rememberDismissal(showDate);
+  };
+
+  return (
+    <div
+      className="mb-4 flex items-start gap-2.5 rounded-md border border-sky-400/30 bg-sky-400/10 p-3 text-sm text-sky-100/90"
+      role="status"
+    >
+      <Clock3 className="mt-0.5 h-5 w-5 shrink-0 text-sky-300" aria-hidden />
+      <span className="min-w-0 flex-1">{buildPicksLockTimingMessage(show)}</span>
+      <button
+        type="button"
+        onClick={dismiss}
+        className="-mr-1 -mt-1 rounded-md p-1 text-sky-200/70 transition hover:bg-sky-300/10 hover:text-sky-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300/70"
+        aria-label="Dismiss picks lock timing"
+      >
+        <X className="h-4 w-4" aria-hidden />
+      </button>
+    </div>
+  );
+}

--- a/src/features/picks/ui/PicksLockTimingBanner.test.js
+++ b/src/features/picks/ui/PicksLockTimingBanner.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildPicksLockTimingMessage } from './PicksLockTimingBanner';
+
+describe('buildPicksLockTimingMessage', () => {
+  it('explains the doors-based lock for tonight', () => {
+    expect(
+      buildPicksLockTimingMessage({
+        date: '2026-07-18',
+        doorsLocal: '17:30',
+        picksLockLocal: '19:10',
+        picksLockSource: 'doors',
+      })
+    ).toBe(
+      'Picks lock at 7:10 PM — 1 hour 40 minutes after tonight’s published doors time (5:30 PM).'
+    );
+  });
+
+  it('shows only the venue-local fallback when doors are unknown', () => {
+    expect(buildPicksLockTimingMessage({ date: '2099-01-01' })).toBe(
+      'Picks lock at 7:30 PM venue-local.'
+    );
+  });
+});

--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -183,10 +183,13 @@ export function useStandingsScreen(selectedDate, options = {}) {
 
   // Card / banner surfaces have room for the full city/venue token —
   // do not use the 40-char compact picker truncate here (#609 follow-up).
-  const showLabel = useMemo(() => {
-    const show = showDates.find((s) => s.date === selectedDate);
-    return show ? showOptionLabelDesktop(show) : selectedDate;
-  }, [selectedDate, showDates]);
+  const selectedShow = useMemo(
+    () => showDates.find((show) => show.date === selectedDate) ?? null,
+    [selectedDate, showDates]
+  );
+  const showLabel = selectedShow
+    ? showOptionLabelDesktop(selectedShow)
+    : selectedDate;
 
   const activePoolName = useMemo(() => {
     if (view !== 'pools' || !poolId) return null;
@@ -262,6 +265,7 @@ export function useStandingsScreen(selectedDate, options = {}) {
     loading,
     showStatus,
     showLabel,
+    selectedShow,
     selectedDate,
     isShowToday,
     picks,

--- a/src/features/scoring/ui/StandingsShowOrPoolView.jsx
+++ b/src/features/scoring/ui/StandingsShowOrPoolView.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Inbox, Loader2, Music } from 'lucide-react';
 
+import { PicksLockTimingBanner } from '../../picks';
 import Card from '../../../shared/ui/Card';
 import PageTitle from '../../../shared/ui/PageTitle';
 import StandingsSelfRecapCard from './StandingsSelfRecapCard';
@@ -34,6 +35,7 @@ export default function StandingsShowOrPoolView({ screen }) {
     loading,
     showStatus,
     showLabel,
+    selectedShow,
     selectedDate,
     isShowToday,
     picks,
@@ -100,6 +102,11 @@ export default function StandingsShowOrPoolView({ screen }) {
   if (isShowView && showStatus === 'NEXT') {
     return (
       <>
+        <PicksLockTimingBanner
+          key={selectedDate}
+          show={selectedShow}
+          showStatus={showStatus}
+        />
         {showLastShowWinnerBanner ? (
           <StandingsWinnerOfTheNightBanner
             variant="lastShow"

--- a/src/features/show-calendar/model/normalizeShowCalendarDoc.js
+++ b/src/features/show-calendar/model/normalizeShowCalendarDoc.js
@@ -1,9 +1,37 @@
+import { enrichShowWithPicksLock } from '../../../shared/utils/picksLockTime';
 import { resolveShowTimeZone } from '../../../shared/utils/showTimeZone';
 
 /**
+ * @param {Record<string, unknown>} s
+ * @returns {{ date: string, venue: string, timeZone: string, doorsLocal?: string, picksLockLocal?: string, picksLockSource?: string } | null}
+ */
+function normalizeShowRow(s) {
+  if (!s || typeof s !== 'object') return null;
+  const date = typeof s.date === 'string' ? s.date.trim() : '';
+  const venue = typeof s.venue === 'string' ? s.venue.trim() : '';
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || !venue) return null;
+  /** @type {{ date: string, venue: string, timeZone: string, doorsLocal?: string, picksLockLocal?: string }} */
+  const base = {
+    date,
+    venue,
+    timeZone: resolveShowTimeZone(
+      /** @type {{ timeZone?: string, timezone?: string, venue: string }} */ (s)
+    ),
+  };
+  if (typeof s.doorsLocal === 'string' && s.doorsLocal.trim()) {
+    base.doorsLocal = s.doorsLocal.trim();
+  }
+  if (typeof s.picksLockLocal === 'string' && s.picksLockLocal.trim()) {
+    base.picksLockLocal = s.picksLockLocal.trim();
+  }
+  return enrichShowWithPicksLock(base);
+}
+
+/**
  * Validates Firestore `show_calendar/snapshot` written by Cloud Functions (issue #160).
+ * Enriches each show with `doorsLocal` / `picksLockLocal` (#522 doors-based lock).
  * @param {import('firebase/firestore').DocumentData | null | undefined} data
- * @returns {{ showDatesByTour: { tour: string, shows: { date: string, venue: string, timeZone: string }[] }[], showDates: { date: string, venue: string, timeZone: string }[], syncError?: string | null } | null}
+ * @returns {{ showDatesByTour: { tour: string, shows: { date: string, venue: string, timeZone: string, doorsLocal?: string, picksLockLocal?: string }[] }[], showDates: { date: string, venue: string, timeZone: string, doorsLocal?: string, picksLockLocal?: string }[], syncError?: string | null } | null}
  */
 export function normalizeShowCalendarDoc(data) {
   if (!data || typeof data !== 'object') return null;
@@ -23,17 +51,9 @@ export function normalizeShowCalendarDoc(data) {
       if (!tour || !Array.isArray(shows) || shows.length === 0) return null;
       const normShows = [];
       for (const s of shows) {
-        if (!s || typeof s !== 'object') return null;
-        const date = typeof s.date === 'string' ? s.date.trim() : '';
-        const venue = typeof s.venue === 'string' ? s.venue.trim() : '';
-        if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || !venue) return null;
-        normShows.push({
-          date,
-          venue,
-          timeZone: resolveShowTimeZone(
-            /** @type {{ timeZone?: string, timezone?: string, venue: string }} */ (s)
-          ),
-        });
+        const row = normalizeShowRow(/** @type {Record<string, unknown>} */ (s));
+        if (!row) return null;
+        normShows.push(row);
       }
       groups.push({ tour, shows: normShows });
     }
@@ -45,17 +65,9 @@ export function normalizeShowCalendarDoc(data) {
   if (Array.isArray(flatOnly) && flatOnly.length > 0) {
     const flat = [];
     for (const s of flatOnly) {
-      if (!s || typeof s !== 'object') return null;
-      const date = typeof s.date === 'string' ? s.date.trim() : '';
-      const venue = typeof s.venue === 'string' ? s.venue.trim() : '';
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || !venue) return null;
-      flat.push({
-        date,
-        venue,
-        timeZone: resolveShowTimeZone(
-          /** @type {{ timeZone?: string, timezone?: string, venue: string }} */ (s)
-        ),
-      });
+      const row = normalizeShowRow(/** @type {Record<string, unknown>} */ (s));
+      if (!row) return null;
+      flat.push(row);
     }
     return {
       showDatesByTour: [{ tour: 'Scheduled shows', shows: flat }],

--- a/src/pages/picks/PicksPage.jsx
+++ b/src/pages/picks/PicksPage.jsx
@@ -6,6 +6,7 @@ import { CheckCircle2, Lock, Scale } from 'lucide-react';
 import { logCommsEmailLanded } from '../../features/comms';
 import {
   PicksFieldsForm,
+  PicksLockTimingBanner,
   PicksMobileFixedChrome,
   PicksSelfRecapSection,
   PicksSubmitButton,
@@ -34,6 +35,7 @@ export default function PicksPage({ user, selectedDate }) {
     isLoadingPicks,
     isLocked,
     hasExistingPicks,
+    showStatus,
     saveFeedback,
     pickConstraintMessage,
   } = usePicksForm({ user, selectedDate, showDates, showDatesByTour });
@@ -105,6 +107,11 @@ export default function PicksPage({ user, selectedDate }) {
         </DashboardActionRow>
       </div>
       <div className="relative">
+        <PicksLockTimingBanner
+          key={selectedDate}
+          show={showForShare}
+          showStatus={showStatus}
+        />
         {shouldShowStatus ? (
           <>
             <div id={statusContentId} className={isMobileStatusExpanded ? 'md:block' : 'hidden md:block'}>

--- a/src/shared/utils/picksLockTime.js
+++ b/src/shared/utils/picksLockTime.js
@@ -1,0 +1,199 @@
+/**
+ * Per-show picks wall-clock lock (#522).
+ *
+ * When doors are known: lock = doors + (tourAvgDoorsToStart − safety).
+ * Summer Tour 2026 setlist.fm avg doors→start is 1h59m (119); safety 19 → doors+100.
+ * Fallback when doors unknown: 19:30 venue-local.
+ */
+
+/** @type {{ hour: number, minute: number }} */
+export const DEFAULT_PICKS_LOCK_HM = Object.freeze({ hour: 19, minute: 30 });
+
+/** Back-compat aliases for callers that still import fixed hour/minute. */
+export const SHOW_PICKS_LOCK_HOUR_LOCAL = DEFAULT_PICKS_LOCK_HM.hour;
+export const SHOW_PICKS_LOCK_MINUTE_LOCAL = DEFAULT_PICKS_LOCK_HM.minute;
+
+/** setlist.fm Summer Tour 2026 “Avg start time after doors”. */
+export const TOUR_AVG_DOORS_TO_START_MIN = 119;
+
+/** Minutes before average start to lock picks (doors+100 when avg is 119). */
+export const PICKS_LOCK_SAFETY_MIN = 19;
+
+/**
+ * Known doors times (venue-local 24h `HH:mm`) from setlist.fm / tickets.
+ * Ops: extend as future dates publish. Calendar fields `doorsLocal` /
+ * `picksLockLocal` override this seed when present.
+ *
+ * @type {Readonly<Record<string, string>>}
+ */
+export const SHOW_DOORS_LOCAL_BY_DATE = Object.freeze({
+  '2026-07-18': '17:30', // Merriweather
+  '2026-07-19': '17:30',
+  '2026-07-21': '17:30', // Syracuse
+  '2026-07-22': '18:30', // MSG
+  '2026-07-24': '18:30',
+  '2026-07-25': '18:30',
+  '2026-07-27': '18:30',
+  '2026-07-29': '18:30',
+  '2026-07-31': '17:00', // Fenway
+  '2026-08-01': '17:00',
+  '2026-09-04': '18:00', // Dick's
+  '2026-09-05': '18:00',
+  '2026-09-06': '18:00',
+});
+
+/**
+ * @param {string | null | undefined} value
+ * @returns {{ hour: number, minute: number } | null}
+ */
+export function parseLocalHm(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const h24 = trimmed.match(/^(\d{1,2}):(\d{2})$/);
+  if (h24) {
+    const hour = Number(h24[1]);
+    const minute = Number(h24[2]);
+    if (
+      Number.isInteger(hour) &&
+      Number.isInteger(minute) &&
+      hour >= 0 &&
+      hour <= 23 &&
+      minute >= 0 &&
+      minute <= 59
+    ) {
+      return { hour, minute };
+    }
+    return null;
+  }
+
+  const h12 = trimmed.match(/^(\d{1,2}):(\d{2})\s*([AaPp][Mm])$/);
+  if (!h12) return null;
+  let hour = Number(h12[1]);
+  const minute = Number(h12[2]);
+  const ap = h12[3].toUpperCase();
+  if (
+    !Number.isInteger(hour) ||
+    !Number.isInteger(minute) ||
+    hour < 1 ||
+    hour > 12 ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return null;
+  }
+  if (ap === 'AM') {
+    if (hour === 12) hour = 0;
+  } else if (hour !== 12) {
+    hour += 12;
+  }
+  return { hour, minute };
+}
+
+/**
+ * @param {{ hour: number, minute: number }} hm
+ * @returns {string} `HH:mm` 24h
+ */
+export function formatLocalHm24(hm) {
+  return `${String(hm.hour).padStart(2, '0')}:${String(hm.minute).padStart(2, '0')}`;
+}
+
+/**
+ * @param {{ hour: number, minute: number }} hm
+ * @returns {string} e.g. `7:10 PM`
+ */
+export function formatLockTimeLocalLabel(hm) {
+  const hour12 = ((hm.hour + 11) % 12) + 1;
+  const suffix = hm.hour >= 12 ? 'PM' : 'AM';
+  return `${hour12}:${String(hm.minute).padStart(2, '0')} ${suffix}`;
+}
+
+/**
+ * @param {{ hour: number, minute: number }} doors
+ * @param {{ tourAvgDoorsToStartMin?: number, safetyMin?: number }} [opts]
+ * @returns {{ hour: number, minute: number }}
+ */
+export function lockHmFromDoors(
+  doors,
+  {
+    tourAvgDoorsToStartMin = TOUR_AVG_DOORS_TO_START_MIN,
+    safetyMin = PICKS_LOCK_SAFETY_MIN,
+  } = {}
+) {
+  const offset = Math.max(0, tourAvgDoorsToStartMin - safetyMin);
+  const total = doors.hour * 60 + doors.minute + offset;
+  const wrapped = ((total % (24 * 60)) + 24 * 60) % (24 * 60);
+  return { hour: Math.floor(wrapped / 60), minute: wrapped % 60 };
+}
+
+/**
+ * Resolve venue-local picks lock for a show.
+ *
+ * Priority:
+ * 1. `show.picksLockLocal` (materialized / override)
+ * 2. `show.doorsLocal` or seeded doors for `show.date` → doors + (avg − safety)
+ * 3. Default 19:30
+ *
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null | undefined} show
+ * @param {{
+ *   doorsByDate?: Record<string, string>,
+ *   tourAvgDoorsToStartMin?: number,
+ *   safetyMin?: number,
+ *   fallback?: { hour: number, minute: number },
+ * }} [opts]
+ * @returns {{ hour: number, minute: number, source: 'picksLockLocal' | 'doors' | 'fallback', doorsLocal: string | null }}
+ */
+export function resolvePicksLockHm(show, opts = {}) {
+  const fallback = opts.fallback ?? DEFAULT_PICKS_LOCK_HM;
+  const doorsByDate = opts.doorsByDate ?? SHOW_DOORS_LOCAL_BY_DATE;
+
+  const explicitLock = parseLocalHm(show?.picksLockLocal);
+  if (explicitLock) {
+    return {
+      ...explicitLock,
+      source: 'picksLockLocal',
+      doorsLocal: typeof show?.doorsLocal === 'string' ? show.doorsLocal.trim() || null : null,
+    };
+  }
+
+  const date = typeof show?.date === 'string' ? show.date.trim() : '';
+  const doorsRaw =
+    (typeof show?.doorsLocal === 'string' && show.doorsLocal.trim()) ||
+    (date && doorsByDate[date]) ||
+    null;
+  const doors = parseLocalHm(doorsRaw);
+  if (doors) {
+    const lock = lockHmFromDoors(doors, opts);
+    return {
+      ...lock,
+      source: 'doors',
+      doorsLocal: formatLocalHm24(doors),
+    };
+  }
+
+  return {
+    ...fallback,
+    source: 'fallback',
+    doorsLocal: null,
+  };
+}
+
+/**
+ * Enrich a show row with resolved lock fields (idempotent).
+ * @param {{ date: string, venue?: string, timeZone?: string, doorsLocal?: string, picksLockLocal?: string }} show
+ */
+export function enrichShowWithPicksLock(show) {
+  if (!show || typeof show !== 'object') return show;
+  const resolved = resolvePicksLockHm(show);
+  if (resolved.source === 'fallback') return { ...show };
+
+  const enriched = {
+    ...show,
+    picksLockLocal: show.picksLockLocal || formatLocalHm24(resolved),
+    picksLockSource: resolved.source,
+  };
+  const doorsLocal = show.doorsLocal || resolved.doorsLocal;
+  if (doorsLocal) enriched.doorsLocal = doorsLocal;
+  return enriched;
+}

--- a/src/shared/utils/picksLockTime.test.js
+++ b/src/shared/utils/picksLockTime.test.js
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_PICKS_LOCK_HM,
+  formatLockTimeLocalLabel,
+  formatLocalHm24,
+  lockHmFromDoors,
+  parseLocalHm,
+  resolvePicksLockHm,
+} from './picksLockTime';
+
+describe('parseLocalHm', () => {
+  it('parses 24h and 12h strings', () => {
+    expect(parseLocalHm('17:30')).toEqual({ hour: 17, minute: 30 });
+    expect(parseLocalHm('7:10 PM')).toEqual({ hour: 19, minute: 10 });
+    expect(parseLocalHm('12:05 AM')).toEqual({ hour: 0, minute: 5 });
+    expect(parseLocalHm('bad')).toBeNull();
+  });
+});
+
+describe('lockHmFromDoors', () => {
+  it('locks doors+100 when avg=119 and safety=19', () => {
+    expect(lockHmFromDoors({ hour: 17, minute: 30 })).toEqual({ hour: 19, minute: 10 });
+    expect(lockHmFromDoors({ hour: 18, minute: 30 })).toEqual({ hour: 20, minute: 10 });
+    expect(lockHmFromDoors({ hour: 17, minute: 0 })).toEqual({ hour: 18, minute: 40 });
+  });
+});
+
+describe('resolvePicksLockHm (#522)', () => {
+  it('uses seeded doors for Merriweather / MSG / Fenway', () => {
+    expect(resolvePicksLockHm({ date: '2026-07-18' })).toMatchObject({
+      hour: 19,
+      minute: 10,
+      source: 'doors',
+      doorsLocal: '17:30',
+    });
+    expect(resolvePicksLockHm({ date: '2026-07-22' })).toMatchObject({
+      hour: 20,
+      minute: 10,
+      source: 'doors',
+    });
+    expect(resolvePicksLockHm({ date: '2026-07-31' })).toMatchObject({
+      hour: 18,
+      minute: 40,
+      source: 'doors',
+    });
+  });
+
+  it('falls back to 19:30 when doors unknown', () => {
+    expect(resolvePicksLockHm({ date: '2099-01-01' })).toEqual({
+      ...DEFAULT_PICKS_LOCK_HM,
+      source: 'fallback',
+      doorsLocal: null,
+    });
+  });
+
+  it('prefers picksLockLocal then doorsLocal on the show', () => {
+    expect(
+      resolvePicksLockHm({
+        date: '2026-07-18',
+        picksLockLocal: '19:40',
+        doorsLocal: '17:30',
+      })
+    ).toMatchObject({ hour: 19, minute: 40, source: 'picksLockLocal' });
+
+    expect(
+      resolvePicksLockHm({
+        date: '2099-01-01',
+        doorsLocal: '18:00',
+      })
+    ).toMatchObject({ hour: 19, minute: 40, source: 'doors', doorsLocal: '18:00' });
+  });
+
+  it('formats labels', () => {
+    expect(formatLocalHm24({ hour: 19, minute: 10 })).toBe('19:10');
+    expect(formatLockTimeLocalLabel({ hour: 19, minute: 10 })).toBe('7:10 PM');
+  });
+});

--- a/src/shared/utils/timeLogic.js
+++ b/src/shared/utils/timeLogic.js
@@ -1,17 +1,25 @@
 // src/shared/utils/timeLogic.js
 import { ymdInTimeZone } from './dateUtils';
+import {
+  DEFAULT_PICKS_LOCK_HM,
+  formatLockTimeLocalLabel,
+  resolvePicksLockHm,
+  SHOW_PICKS_LOCK_HOUR_LOCAL,
+  SHOW_PICKS_LOCK_MINUTE_LOCAL,
+} from './picksLockTime';
 import { DEFAULT_SHOW_TIME_ZONE, resolveShowTimeZone } from './showTimeZone';
 
 /** Fallback when a show does not carry an explicit `timeZone` field. */
 export const SHOW_SCHEDULE_TIMEZONE = DEFAULT_SHOW_TIME_ZONE;
 
-/**
- * Picks lock at this local time on the show's calendar date in the show's local timezone.
- * Temporary: 7:55pm venue-local (was 7:30). Revert / replace with first-song /
- * admin-configurable lock when that lands.
- */
-export const SHOW_PICKS_LOCK_HOUR_LOCAL = 19;
-export const SHOW_PICKS_LOCK_MINUTE_LOCAL = 55;
+// Re-export lock constants / resolver for existing imports.
+export {
+  DEFAULT_PICKS_LOCK_HM,
+  formatLockTimeLocalLabel,
+  resolvePicksLockHm,
+  SHOW_PICKS_LOCK_HOUR_LOCAL,
+  SHOW_PICKS_LOCK_MINUTE_LOCAL,
+};
 // Back-compat aliases for existing imports.
 export const SHOW_PICKS_LOCK_HOUR_PT = SHOW_PICKS_LOCK_HOUR_LOCAL;
 export const SHOW_PICKS_LOCK_MINUTE_PT = SHOW_PICKS_LOCK_MINUTE_LOCAL;
@@ -46,15 +54,51 @@ function showClockOnShowYmd(showYmd, showTimeZone, now = new Date()) {
  * DST fall-back ambiguity is handled by deriving wall-clock parts from a real
  * instant (`now`) in the show's timezone; both repeated local hours map to the
  * same show date boundary and compare consistently against lock hh:mm.
+ *
+ * @param {string} showYmd
+ * @param {string} [showTimeZone]
+ * @param {Date} [now]
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | { hour: number, minute: number } | null} [showOrLockHm]
+ *   Show row (preferred) or explicit `{ hour, minute }` lock. Defaults to 19:30.
  */
-export function isPastPicksLock(showYmd, showTimeZone = SHOW_SCHEDULE_TIMEZONE, now = new Date()) {
+export function isPastPicksLock(
+  showYmd,
+  showTimeZone = SHOW_SCHEDULE_TIMEZONE,
+  now = new Date(),
+  showOrLockHm = null
+) {
   const clock = showClockOnShowYmd(showYmd, showTimeZone, now);
   if (!clock) return false;
+
+  const lockHm = coercePicksLockHm(showYmd, showOrLockHm);
   const { hour, minute } = clock;
-  return (
-    hour > SHOW_PICKS_LOCK_HOUR_LOCAL ||
-    (hour === SHOW_PICKS_LOCK_HOUR_LOCAL && minute >= SHOW_PICKS_LOCK_MINUTE_LOCAL)
-  );
+  return hour > lockHm.hour || (hour === lockHm.hour && minute >= lockHm.minute);
+}
+
+/**
+ * @param {string} showYmd
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | { hour: number, minute: number } | null | undefined} showOrLockHm
+ */
+function coercePicksLockHm(showYmd, showOrLockHm) {
+  if (
+    showOrLockHm &&
+    typeof showOrLockHm === 'object' &&
+    Number.isInteger(showOrLockHm.hour) &&
+    Number.isInteger(showOrLockHm.minute) &&
+    showOrLockHm.date === undefined &&
+    showOrLockHm.doorsLocal === undefined &&
+    showOrLockHm.picksLockLocal === undefined
+  ) {
+    return { hour: showOrLockHm.hour, minute: showOrLockHm.minute };
+  }
+  if (showOrLockHm && typeof showOrLockHm === 'object') {
+    return resolvePicksLockHm({
+      date: typeof showOrLockHm.date === 'string' ? showOrLockHm.date : showYmd,
+      doorsLocal: showOrLockHm.doorsLocal,
+      picksLockLocal: showOrLockHm.picksLockLocal,
+    });
+  }
+  return resolvePicksLockHm({ date: showYmd });
 }
 // Back-compat alias.
 export const isPastPicksLockPacific = isPastPicksLock;
@@ -78,7 +122,7 @@ export function getNextShow(showDates) {
 
 /**
  * NEXT — only date users can enter picks (the upcoming show from each show's local "today", before lock).
- * LIVE — selected show date in local timezone and wall time there is at/after picks lock ({@link SHOW_PICKS_LOCK_HOUR_LOCAL}:{@link SHOW_PICKS_LOCK_MINUTE_LOCAL} local): picks locked, live standings UX.
+ * LIVE — selected show date in local timezone and wall time there is at/after picks lock: picks locked, live standings UX.
  * PAST — calendar date before local "today" in the selected show timezone (show already happened there).
  * FUTURE — any other listed date (e.g. later tour nights): too early until that show becomes "next".
  */
@@ -97,7 +141,7 @@ export function getShowBeforeDate(ymd, showDates) {
 
 /**
  * @param {string} selectedDate — YYYY-MM-DD
- * @param {{ date: string }[]} showDates
+ * @param {{ date: string, doorsLocal?: string, picksLockLocal?: string }[]} showDates
  */
 export const getShowStatus = (selectedDate, showDates) => {
   const nextShow = getNextShow(showDates);
@@ -108,7 +152,16 @@ export const getShowStatus = (selectedDate, showDates) => {
   if (selectedDate < today) return 'PAST';
   if (selectedDate === nextShow.date) {
     if (selectedDate === today) {
-      if (isPastPicksLock(selectedDate, selectedTimeZone)) return 'LIVE';
+      if (
+        isPastPicksLock(
+          selectedDate,
+          selectedTimeZone,
+          new Date(),
+          selectedShow || { date: selectedDate }
+        )
+      ) {
+        return 'LIVE';
+      }
     }
     return 'NEXT';
   }

--- a/src/shared/utils/timeLogic.test.js
+++ b/src/shared/utils/timeLogic.test.js
@@ -56,15 +56,46 @@ describe('venue-local lock + status (#278)', () => {
     expect(getNextShow(shows)).toEqual(shows[1]);
   });
 
-  it('marks a show LIVE at 7:55 in the venue timezone on show date', () => {
+  it('marks a show LIVE at fallback 7:30 in the venue timezone on show date', () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-07-11T00:56:00.000Z'));
+    vi.setSystemTime(new Date('2099-06-16T00:31:00.000Z'));
 
     const shows = [
-      { date: '2026-07-10', venue: 'Kohl Center, Madison, WI', timeZone: 'America/Chicago' },
+      { date: '2099-06-15', venue: 'Kohl Center, Madison, WI', timeZone: 'America/Chicago' },
     ];
 
-    expect(getShowStatus('2026-07-10', shows)).toBe('LIVE');
+    expect(getShowStatus('2099-06-15', shows)).toBe('LIVE');
+  });
+
+  it('locks Merriweather at doors+100 (7:10 PM ET) before fallback 7:30', () => {
+    vi.useFakeTimers();
+    // 2026-07-18 23:15Z = 7:15 PM ET → past 7:10 lock, before 7:30 fallback.
+    vi.setSystemTime(new Date('2026-07-18T23:15:00.000Z'));
+
+    const shows = [
+      {
+        date: '2026-07-18',
+        venue: 'Merriweather Post Pavilion, Columbia, MD',
+        timeZone: 'America/New_York',
+      },
+    ];
+
+    expect(getShowStatus('2026-07-18', shows)).toBe('LIVE');
+  });
+
+  it('keeps Merriweather NEXT at 7:00 PM ET (before doors+100 lock)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-18T23:00:00.000Z'));
+
+    const shows = [
+      {
+        date: '2026-07-18',
+        venue: 'Merriweather Post Pavilion, Columbia, MD',
+        timeZone: 'America/New_York',
+      },
+    ];
+
+    expect(getShowStatus('2026-07-18', shows)).toBe('NEXT');
   });
 
   it('keeps fallback venue parsing for old docs without explicit timeZone', () => {


### PR DESCRIPTION
Closes #522

## Summary
- Replaces the fixed 7:55 venue-local picks lock with a doors-based wall clock: **doors + 1:40** when `doorsLocal` is known, **19:30** venue-local fallback when doors are unknown.
- Enriches `show_calendar` from Phish.com date pages (`doorsLocal`, `scheduledStartLocal`, timing provenance) during calendar sync; schedule bumped monthly → **daily 06:00 ET**. Preserves prior timing if scrape fails; seeded Summer Tour map remains a client/Functions fallback.
- Adds dismissible `PicksLockTimingBanner` on Picks + Standings (sessionStorage per show date); lock toast copy → “Picks locked, almost showtime!”
- Comms cutoff copy uses relative `time_to_lock`; tour-countdown drops absolute lock clock. Docs/API/runbook/trigger catalog updated. SemVer **MINOR `1.31.0`**.

## Out of scope (still on #522 follow-ups)
- Setlist LIVE / `s1o` poll lock
- Server-side Firestore picks-lock enforcement
- Cloud Run invoker IAM drift guard

## Test plan
- [ ] Frontend: `npm test` (picksLockTime, timeLogic, banner, comms registry)
- [ ] Functions: `cd functions && npm test` (picksLockTime, phishOfficialSchedule, phishnetShowCalendar, picksLockReminder, commsTemplates)
- [ ] Lint / verify:dashboard-ui / build green on CI
- [ ] Admin War Room shows computed lock time from doors when present
- [ ] Picks + Standings show lock-timing banner; dismiss persists for the session/show date
- [ ] After Functions deploy: calendar sync writes `doorsLocal` for upcoming shows; unknown doors → 19:30 lock
- [ ] Preview smoke: lock toast fires near computed wall clock for a known-doors date


Made with [Cursor](https://cursor.com)