### PR TITLE
release: promote v1.31.0 — doors lock + discovery + profile freshness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.30.1] — 2026-07-17
+
+### Added
+- **Feature engagement GA4 (#638)** — client events for recent surfaces: `live_setlist_view`, `tour_stats_view`, `avatar_changed`, `badge_shelf_view`; helpers for future `badge_pin_changed` (no pin UI yet) and `feature_spotlight_*` (wired in #639). Wrappers under scoring / tour-stats / profile / feature-discovery.
+
+---
+
 ## [1.30.0] — 2026-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ No unreleased changes.
 
 ---
 
+## [1.31.0] — 2026-07-18
+
+### Added
+- **Doors-based picks lock (#522)** — wall-clock lock is now `doors + (tour avg doors→start − safety)` when doors are known (Summer Tour 2026 setlist.fm avg 1h59m, safety 19 → **doors+1:40**). The daily Phish.net calendar sync now enriches upcoming dates from first-party Phish.com date pages (`Doors Open` / advertised `Show Time`), preserves prior timing on transient failures, and retains seeded Summer Tour doors as a client/Functions fallback. Unknown doors use the conservative **7:30 PM** venue-local fallback. Client + Functions + `picks_lock_reminder` share the same resolver. Lock toast copy: “Picks locked, almost showtime!”
+
+### Changed
+- War Room show-date panel shows the resolved per-show lock time and source (doors / explicit / fallback).
+- Picks and pre-lock Standings now show a dismissible, session-scoped timing notice with the resolved cutoff and, when known, its relationship to the published doors time. It is the top notice on Standings and stays dismissed for that show across both surfaces. Cutoff-related comms use only relative `time_to_lock` wording; tour countdown copy no longer repeats an absolute deadline.
+
+---
+
 ## [1.30.0] — 2026-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.30.1] — 2026-07-17
+
+### Added
+
+- `docs/scoring-analysis/` — durable repo docs for scoring/prediction canvas research (slot odds, significance, calibration, combos, greenfield model, predictive picker framework); links issues #645–#653.
+
 # Changelog
 
 All notable changes to Setlist Pick'em are documented here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ No unreleased changes.
 
 ---
 
+## [1.30.1] — 2026-07-17
+
+### Fixed
+- **Profile avg correct on show day (#635 Slice 0)** — live season-stats fallback now preserves `users.careerCorrectSlots`, and `deriveLatestFinalizedShow` excludes today (`d < today`) so an ungraded calendar date no longer falsely stales rollups through yesterday. Multi-day gaps still need the rollup watermark (Slices 1–2).
+
+### Changed
+- **Profile Your stats copy** — removed the footnote under the self-profile averages grid; each tile now uses the same Info tooltips as Standings → Stats (`InfoTooltip` shared UI).
+
+---
+
 ## [1.30.0] — 2026-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.31.0] — 2026-07-17
+
+### Added
+- **Feature discovery “New” markers (#639)** — client spotlight registry (`features/feature-discovery`) with soft **New** labels on Standings **Stats**, live/official setlist card, and Profile avatar/badges. Clears on visit/interaction; expires `until` 2026-08-31; localStorage per uid. Wires `feature_spotlight_*` GA4 from #638.
+
+---
+
 ## [1.30.1] — 2026-07-17
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.30.1  
+**Version:** 1.31.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -95,6 +95,24 @@ Also hosts the per-user daily email fatigue cap (#453): doc ID `email_cap:{uid}:
 
 Tour and show date metadata. Read by `resolveCurrentTour` and `resolveSelectableTours`.
 
+`show_calendar/snapshot` show rows (Phish.net sync) include at minimum:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `date` | string | `YYYY-MM-DD` |
+| `venue` | string | Display venue line |
+| `city` | string? | City |
+| `timeZone` | string | IANA venue timezone |
+| `doorsLocal` | string? | Venue-local doors `HH:mm` from first-party Phish.com date page (client/Functions also seed known Summer Tour 2026 dates) |
+| `scheduledStartLocal` | string? | Advertised venue-local show time `HH:mm` from Phish.com; informational, not the picks lock |
+| `scheduleSource` | `'phish.com'`? | Timing provenance |
+| `scheduleSourceUrl` | string? | Official date-page URL |
+| `picksLockLocal` | string? | Venue-local picks lock `HH:mm` when materialized/overridden |
+
+**Picks wall-clock lock (#522):** when `doorsLocal` (or a seeded doors time) is known, lock = doors + (tour avg doors→start − safety). Summer Tour 2026 defaults: avg **119** min, safety **19** → **doors + 100 min**. When doors are unknown, fallback is **19:30** venue-local. Admin `show_lock_state` and (planned) setlist `s1o` still win as earlier signals.
+
+`scheduledPhishnetShowCalendar` runs daily at 06:00 ET. Phish.net is canonical for dates/tours/venues; the sync then fetches Phish.com upcoming date pages for timing. A Phish.com failure does not fail or erase the calendar: prior timing is preserved.
+
 ### 1.9 `email_suppression/{sha256(email)}`
 
 Server-only email suppression list (issue #442). Document ID is SHA-256 of the normalized recipient address. Presence of `{ suppressed: true }` blocks comms email sends. Written by `commsResendWebhook` and `commsEmailUnsubscribe`.
@@ -270,7 +288,7 @@ Automated comms delivery triggered by Firestore writes, post-rollup hooks, live-
 | Live-scoring hook | `score_first_points`, `score_leader` | `recomputeLiveScoresForShow` |
 | `scheduledTourCountdownComms` | `tour_countdown` | Daily 9am PT cron (T-10/T-5/T-3/T-1) |
 | `scheduledTourRankingsDailyComms` | `tour_rankings_daily` | Daily 8am PT cron (morning-after show) |
-| `scheduledPicksLockReminder` | `picks_lock_reminder` | Every 15 min; venue-local show day **T-3h–lock** (16:55–19:54 when lock is 19:55); **not** gated by `COMMS_EVENT_ADAPTERS_ENABLED` (v1.19.0+) |
+| `scheduledPicksLockReminder` | `picks_lock_reminder` | Every 15 min; venue-local show day **T-3h–lock** (window tracks per-show lock from doors+offset or 19:30 fallback); **not** gated by `COMMS_EVENT_ADAPTERS_ENABLED` (v1.19.0+) |
 
 Trigger specs and channels: `docs/comms-triggers/catalog.json`. Admin canary/replay: `runCommsTrigger` (§2.2).
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.30.0  
+**Version:** 1.30.1  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 

--- a/docs/DASHBOARD_IA.md
+++ b/docs/DASHBOARD_IA.md
@@ -19,6 +19,16 @@ Single reference for **support**, **product**, and **engineering** when adding r
 |-------|------|-------|
 | **Stats** (Standings peer tab) | `/dashboard/tour-stats` | Private explorer: unique songs, frequency, bustouts, self pick overlay. Discovered via Standings chrome **Show \| Tour \| Stats \| Pools** (not a 5th primary nav tab). Standings tab stays active. Shares the chrome **tour scope** picker with Tour view (`?tour=`). No global date picker. |
 
+### Feature discovery “New” markers (#639)
+
+Soft **New** labels (not coachmarks) may appear temporarily on:
+
+- Standings chrome **Stats** pill → clears after visiting `/dashboard/tour-stats` (compact corner **dot**, not a “New” text label — keeps the Stats word readable in the four-tab chrome)
+- Official setlist card on Standings → clears when the card is toggled open/closed
+- Profile **Avatar** / **Badges** headings → clears after picking an avatar
+
+Markers auto-expire by catalog `until` date and persist dismissals in `localStorage` per signed-in uid. Support can tell users: clear site data for the origin if a marker is stuck; otherwise ignore — they vanish by end of the window.
+
 ### Profile cluster (#418)
 
 | Sub-nav | Path | Responsibility |

--- a/docs/PICKS_LOCK_ADMIN_RUNBOOK.md
+++ b/docs/PICKS_LOCK_ADMIN_RUNBOOK.md
@@ -27,7 +27,7 @@ Operational guide for **`lockPicksForShowNow`** — the War Room **Lock picks no
 1. Admin clicks **Lock picks now** in War Room while the show is `NEXT`.
 2. Client calls `lockPicksForShowNow({ showDate })`.
 3. Callable writes `show_lock_state/{showDate}` with `lockReason: admin_override`.
-4. All clients subscribed to that doc treat picks as locked even before the 7:55 PM venue-local wall clock.
+4. All clients subscribed to that doc treat picks as locked even before the per-show wall clock (doors+1:40 when doors known; else 7:30 PM venue-local).
 
 Idempotent: re-running on an already-stamped doc returns `{ alreadyLocked: true }` without rewriting timestamps.
 
@@ -103,8 +103,27 @@ node scripts/lockPicksForShowNow.js --showDate=2026-07-08 --lockedBy=pat@road2me
 
 ---
 
-## 5. Related docs
+## 5. Cloud Run invoker (browser callable)
 
-- [`docs/API.md`](./API.md) §1.10 (`show_lock_state`), §2.2b (`lockPicksForShowNow`)
+Gen 2 callables need public invoker so browser CORS preflights succeed (Firebase Auth is still checked in the handler). After deploy, verify:
+
+```bash
+gcloud run services get-iam-policy lockpicksforshownow \
+  --project=set-picks --region=us-central1
+# Expect: allUsers → roles/run.invoker
+```
+
+If missing (OPTIONS → 403, empty Authorization header in logs):
+
+```bash
+gcloud run services add-iam-policy-binding lockpicksforshownow \
+  --project=set-picks --region=us-central1 \
+  --member="allUsers" --role="roles/run.invoker"
+```
+
+## 6. Related docs
+
+- [`docs/API.md`](./API.md) §1.8 (doors / picksLockLocal), §1.10 (`show_lock_state`), §2.2b (`lockPicksForShowNow`)
 - [`docs/ADMIN_CLAIMS_RUNBOOK.md`](./ADMIN_CLAIMS_RUNBOOK.md) — admin claim bootstrap
 - [`docs/PHISHNET_CALLABLE_RUNBOOK.md`](./PHISHNET_CALLABLE_RUNBOOK.md) — phishnet deploy bundle
+- Issue [#522](https://github.com/pat792/set-picks/issues/522) — doors-based wall clock + remaining setlist poll lock

--- a/docs/comms-triggers/TRIGGER_CATALOG.md
+++ b/docs/comms-triggers/TRIGGER_CATALOG.md
@@ -41,7 +41,7 @@ Every template draws from this shared set. Each trigger declares the subset it u
 | `{{venue_name}}` | `show_calendar` snapshot | — |
 | `{{venue_city}}` | `show_calendar` snapshot | — |
 | `{{time_to_lock}}` | Computed at send time | — |
-| `{{lock_time_local}}` | Computed (19:55 venue-local) | `7:55 PM` |
+| `{{lock_time_local}}` | Computed (doors+1:40 when doors known; else 19:30 venue-local) | `7:30 PM` |
 | `{{tour_name}}` | Tour metadata | — |
 | `{{days_remaining}}` | Computed from tour start date | — |
 | `{{first_show_date}}` | Tour first show | — |
@@ -199,18 +199,18 @@ Every template draws from this shared set. Each trigger declares the subset it u
 
 **Heading:** `{{tour_name}} is tomorrow, {{handle}}`
 
-**Body:** {{first_show_venue}}, {{first_show_city}} — tomorrow night. If you haven't made your picks yet, the window closes at {{lock_time_local}}. Don't go into show 1 without picks on the board.
+**Body:** {{first_show_venue}}, {{first_show_city}} — tomorrow night. Get your picks ready before the first downbeat.
 
 **CTA:** `Lock in your picks →`
 
 #### Template — Email (T-1 only; T-10 and T-5 optional)
 
 **Subject (T-1):** `Last call — {{tour_name}} starts tomorrow`  
-**Preview:** `Picks close at {{lock_time_local}}. {{first_show_venue}}, {{first_show_city}}.`
+**Preview:** `{{first_show_venue}}, {{first_show_city}} — get your picks ready.`
 
 **Body sections:**
 1. Tomorrow is show 1 — set the scene (venue, city, date).
-2. Picks deadline reminder — closes at {{lock_time_local}}.
+2. Get picks ready before the first downbeat.
 3. CTA button: `Make your picks`
 
 ---
@@ -427,7 +427,7 @@ Up next: {{next_show_venue}} on {{next_show_date}}. Picks open now.
 |-------|-------|
 | **Status** | `shipped` |
 | **Automation** | `automated` |
-| **Schedule** | Every 15 min on show days, venue-local **T-3h through lock** (16:55–19:54 when lock is 19:55) |
+| **Schedule** | Every 15 min on show days, venue-local **T-3h through lock** (window tracks per-show lock) |
 | **Channels** | `inApp`, `push`, `email` |
 | **Audience** | Users with a handle and **no picks** for tonight's show |
 | **Prefs key** | `reminders` (push + in-app only) |
@@ -451,20 +451,20 @@ Production `picks_lock_reminder` **skips** users with non-empty picks for tonigh
 
 #### Template — In-App
 
-**Heading:** `Don't miss tonight's show, {{handle}}`
+**Heading:** `{{time_to_lock}} until picks lock`
 
-**Body:** Picks for {{venue_name}} close at {{lock_time_local}} — {{time_to_lock}} from now. You're not on the board yet for {{show_date}}.
+**Body:** {{handle}}, lock in your picks for {{venue_name}}. You're not on the board yet for {{show_date}}.
 
 **CTA:** `Make your picks` (or `View / Edit picks` when `picks_secured`)
 
 #### Template — Email
 
 **Subject:** `Picks close in {{time_to_lock}} — {{venue_city}} tonight`  
-**Preview:** `{{venue_name}} · Lock closes at {{lock_time_local}}`
+**Preview:** `{{venue_name}} · {{time_to_lock}} until picks lock`
 
 **Body sections:**
 1. Tonight's show — venue, date.
-2. You haven't picked yet — close at {{lock_time_local}}.
+2. You haven't picked yet — {{time_to_lock}} until picks lock.
 3. CTA button: `Lock in your picks`
 
 ---

--- a/docs/comms-triggers/catalog.json
+++ b/docs/comms-triggers/catalog.json
@@ -45,7 +45,7 @@
       "githubIssue": null,
       "variants": ["t10", "t5", "t3", "t1"],
       "inAppDeepLink": "/dashboard/picks",
-      "note": "In-app CTA label varies by days_remaining; T-5/T-3/T-1 switch to View / Edit picks when picks_secured (#509). Push/email use open-app phrasing.",
+      "note": "In-app CTA label varies by days_remaining; T-5/T-3/T-1 switch to View / Edit picks when picks_secured (#509). Countdown copy does not state an absolute cutoff; the show-day lock reminder owns relative cutoff messaging.",
       "variables": [
         { "name": "handle", "source": "users/{uid}.handle", "fallback": "Picker" },
         { "name": "tour_name", "source": "tour metadata", "fallback": null },
@@ -53,7 +53,7 @@
         { "name": "first_show_date", "source": "tour first show", "fallback": null },
         { "name": "first_show_venue", "source": "tour first show venue", "fallback": null },
         { "name": "first_show_city", "source": "tour first show city", "fallback": null },
-        { "name": "lock_time_local", "source": "computed (19:55 venue-local)", "fallback": "7:55 PM" },
+        { "name": "lock_time_local", "source": "computed (doors+offset or 19:30 venue-local)", "fallback": "7:30 PM" },
         { "name": "picks_secured", "source": "picks where showDate=first_show + hasNonEmptyPicksObject", "fallback": false }
       ]
     },
@@ -256,7 +256,7 @@
       "family": "show_calendar",
       "priority": "P0",
       "automation": "automated",
-      "schedule": "every 15min on show days, venue-local T-3h through lock (16:55–19:54 when lock is 19:55)",
+      "schedule": "every 15min on show days, venue-local T-3h through lock (per-show lock from doors+offset or 19:30 fallback)",
       "audience": "users_no_picks_tonight",
       "channels": ["inApp", "push", "email"],
       "prefKeys": ["reminders"],
@@ -265,14 +265,14 @@
       "templateId": "picks-lock-reminder",
       "implementationModule": "functions/picksLockReminder.js",
       "githubIssue": 524,
-      "note": "Email is transactional (CAN-SPAM): bypasses reminders pref but respects email_suppression. Push/in-app still use reminders pref. Audience excludes users with picks; in-app registry still branches on picks_secured for preview (#509).",
+      "note": "Email is transactional (CAN-SPAM): bypasses reminders pref but respects email_suppression. Push/in-app still use reminders pref. Audience excludes users with picks; in-app registry still branches on picks_secured for preview (#509). All channel copy uses only relative time_to_lock, never the absolute local cutoff.",
       "variables": [
         { "name": "handle", "source": "users/{uid}.handle", "fallback": "Picker" },
         { "name": "show_date", "source": "show_calendar", "fallback": null },
         { "name": "venue_name", "source": "show_calendar", "fallback": null },
         { "name": "venue_city", "source": "show_calendar", "fallback": null },
         { "name": "time_to_lock", "source": "computed at send time", "fallback": null },
-        { "name": "lock_time_local", "source": "computed (19:55 venue-local)", "fallback": "7:55 PM" },
+        { "name": "lock_time_local", "source": "computed (doors+offset or 19:30 venue-local)", "fallback": "7:30 PM" },
         { "name": "picks_secured", "source": "preview/edge only — production fanout skips users with picks", "fallback": false }
       ]
     },

--- a/docs/scoring-analysis/01-slot-odds-and-ev.md
+++ b/docs/scoring-analysis/01-slot-odds-and-ev.md
@@ -1,0 +1,59 @@
+# Slot odds and expected value
+
+Snapshot ~2026-07-18. Join of graded `picks` × `official_setlists`, scored with production `scoringCore`.
+
+## Headline
+
+Under the live rule **encore exact = any song in `encoreSongs[]`**, encore has the **highest** exact-hit rate among positional slots—not the lowest. Aggregate EV is only slightly above the mean (~3–5%); the larger issue is **mis-distribution** (first and later encore songs pay the same 15).
+
+## User hit rates (n ≈ 203–204 filled picks / slot)
+
+| Slot | Exact % | In-setlist % | Miss % | Avg base pts (EV) |
+|------|---------|--------------|--------|-------------------|
+| S2 Closer | 2.94% | 21% | 76% | 1.35 |
+| S2 Opener | 3.43% | 23% | 74% | 1.49 |
+| S1 Opener | 3.94% | 19% | 77% | 1.35 |
+| S1 Closer | 5.39% | 24% | 71% | **1.71** |
+| Encore (any) | **6.37%** | 11% | 82% | 1.52 |
+| Wildcard | — | hit 14.3% | 85.7% | ~1.43 base / ~1.92 w/ bustout |
+
+Absolute exact counts (any-encore rule): encore **13**, s1c **11**, s1o **8**, s2o **7**, s2c **6**.
+
+## Points fairness vs S1 opener @ 10
+
+Implied fair exact pts ≈ `10 × (s1oExactRate / slotExactRate)`.
+
+| Slot | Exact rate | Awarded | Implied fair exact pts vs S1O@10 | Difficulty vs S1O |
+|------|------------|---------|----------------------------------|-------------------|
+| S2 Closer | 2.94% | 10 | 13.4 | 1.34× harder |
+| S2 Opener | 3.43% | 10 | 11.5 | 1.15× harder |
+| S1 Opener | 3.94% | 10 | 10.0 | baseline |
+| S1 Closer | 5.39% | 10 | 7.3 | easier |
+| Encore (any) | 6.37% | 15 | ~6.2 | easiest exact |
+
+Exact-tier EV contribution: S1 opener ~0.39 vs encore ~0.96 (~2.5×).
+
+## Flat encore X to match mean EV (~1.47)
+
+`EV(X) = 0.0637×X + 0.1127×5`
+
+| Flat encore X | Encore EV |
+|---------------|-----------|
+| 10 | 1.20 |
+| 12 | 1.33 |
+| **14** | **~1.46 ≈ mean** |
+| 15 (current) | 1.52 |
+
+## Framework note (stats layer)
+
+Today picks persist `score` and aggregate `correctSlotsCredited`, not per-slot kinds. For durable odds/stats: persist `slotResults` at grade time; roll up show/tour/global slot rates. See epic #646 measurement workstream and issue #645.
+
+## Scoring rules at snapshot
+
+```text
+EXACT_SLOT = 10
+ENCORE_EXACT = 15   # any encoreSongs[] match
+IN_SETLIST = 5
+WILDCARD_HIT = 10
+BUSTOUT_BOOST = 20  # gap ≥ 30 on frozen bustouts snapshot
+```

--- a/docs/scoring-analysis/02-significance-and-variability.md
+++ b/docs/scoring-analysis/02-significance-and-variability.md
@@ -1,0 +1,44 @@
+# Significance and setlist variability
+
+## Are observed encore odds statistically significant?
+
+**No.** Across five positional slots (exact rates), omnibus χ² ≈ 3.94, df = 4, **p ≈ 0.41**. Largest pairwise gap (encore 6.37% vs S2 closer 2.94%): z ≈ 1.65, **p ≈ 0.10** (Fisher ≈ 0.16).
+
+- ~204 picks / slot come from only **17 shows** (~12 picks/show) → clustering; effective n roughly **64–132**, not 204.
+- Power: detecting those gaps at 80% would need ~**600–1300** independent picks / slot (before design effect).
+
+**Do not rebalance scoring solely from this user-hit ranking.** Prefer supply-side setlist variability and larger samples.
+
+## Supply-side variability (Phish.net, Phish-only)
+
+### Last 24 months (~105 shows)
+
+| Slot | Shows | Unique songs | Entropy (bits) | Effective # songs | Match prob (HHI %) | Mode top-1 % |
+|------|-------|--------------|----------------|-------------------|--------------------|--------------|
+| S1 Opener | 105 | 51 | 5.32 | 39.9 | 3.20 | 7.6 |
+| S1 Closer | 105 | 48 | 5.16 | 35.7 | 3.66 | 8.6 |
+| S2 Opener | 100 | 54 | 5.49 | 44.9 | 2.66 | 6.0 |
+| S2 Closer | 100 | 39 | 4.96 | 31.2 | 3.94 | 9.0 |
+| Encore (1st) | 102 | 64 | 5.72 | **52.9** | **2.40** | 6.9 |
+
+**First encore is the most variable single song** (highest entropy / effective N). Closers are the most concentrated.
+
+### Encore “two chances”
+
+- Multi-encore shows: **~85%**; avg encore length **~2.16** songs (last 24 mo).
+- Best first-encore mode guess ≈ **6.9%** hit.
+- Best any-encore mode guess (e.g. Tweezer Reprise) ≈ **15.7%** hit (~2.3× on supply side).
+
+### Same user guesses, two scoring rules (n = 204)
+
+| Rule | Exact-hit rate | Absolute hits |
+|------|----------------|---------------|
+| First encore only | **1.96%** | 4 |
+| Avg positional exact | 3.93% | — |
+| Any encore (today) | **6.37%** | 13 |
+
+Realized **3.25×** multiplier from any-of-2 vs first-only (larger than raw song count because popular guesses often land in the **second** encore).
+
+**Tug-of-war:** bigger encore pool (~40% more effective songs) is real → first-encore is hardest. The any-of-2 rule more than offsets it → net easiest exact under current scoring.
+
+Paired bootstrap HHI: encore distinguishes from closers (p ≈ 0.02); not from openers at 105 shows.

--- a/docs/scoring-analysis/03-scoring-calibration.md
+++ b/docs/scoring-analysis/03-scoring-calibration.md
@@ -1,0 +1,62 @@
+# Scoring calibration (encore & bustouts)
+
+## Calibration method
+
+Points ∝ `1 / P(exact)`, anchored so geometric mean of four positional slots ≈ 10, then snapped to round multiples of 5 (floor at 10 so exact beats in-setlist 5).
+
+Supply odds = best single-song (“mode”) guess from last-24-mo setlists.
+
+## Positional slots
+
+Odds cluster in a **6–9%** band → at round-5 granularity, exacts stay **flat 10**. Provisional future premium: S2 opener (hardest supply-side).
+
+## Encore tiers (Model X — recommended)
+
+| Event | User hit rate | Calibrated | Round pts |
+|-------|---------------|------------|-----------|
+| 1st encore exact | 1.96% | ~20 | **15** |
+| Later encore song | 4.41% | ~9 | **10** |
+| In-setlist only | 11.3% | ~3.5 | **5** |
+
+- Model Y (later = 5) underpays a ~1-in-23 event.
+- Model X encore-slot EV ≈ **1.30** (vs positional avg ~1.47).
+- Current any = 15 → EV **1.52** (slight overpay vs mean; large overpay vs S1 opener on exact difficulty).
+
+## Wildcard
+
+~14% hit rate → calibrates toward **5** if fairness-primary; keep **10** only as intentional safe-points.
+
+## Bustout variability (economy-aware)
+
+Perfect clean night ≈ **65** under Model X base (4×10 + 15 + 10). Today’s flat **+20** is already **2× a slot** (~31% of a night).
+
+Gap distribution (Phish, last 24 mo, ~1868 played rows):
+
+| Gap band | Share of songs | Avg fires / show |
+|----------|----------------|------------------|
+| 30–74 | 6.7% | 1.95 |
+| 75–149 | 2.5% | 0.76 |
+| 150–299 | 1.0% | 0.31 |
+| 300+ | 0.7% | 0.13 |
+
+### Flat models
+
+| Tier | Gap | Current flat | Scaled flat (recommended) |
+|------|-----|--------------|---------------------------|
+| Bustout | 30–74 | +20 | **+15** |
+| Rarity | 75–149 | +20 | **+20** |
+| Deep cut | 150–299 | +20 | **+30** |
+| Vault | 300+ | +20 | **+40** |
+
+### Multiplier model (1.5× / 2× / 3× / 4× of base)
+
+Bonus on a 5 / 10 / 15 base compounds. Cap bonus at **+40** or prefer scaled flat—otherwise a 15-pt first-encore vault can total **75** (> clean night).
+
+Only ~5 bustout boosts fired across 204 historical picks—rare moments if the song must also be correctly picked.
+
+## Implementation notes
+
+- Client/server parity: `src/shared/utils/scoring.js`, `functions/scoringCore.js`.
+- Model X needs primary `setlist.enc` vs other `encoreSongs[]`.
+- Bustout tiers need gap bands (`songGaps` or tiered snapshot)—see `docs/OFFICIAL_SETLISTS_SCHEMA.md`.
+- SemVer: scoring rule change = **MINOR**; regrade vs grandfather TBD.

--- a/docs/scoring-analysis/04-card-combos-and-engagement.md
+++ b/docs/scoring-analysis/04-card-combos-and-engagement.md
@@ -1,0 +1,85 @@
+# Card combos, zeros, and predictive coupling
+
+## Nightly score distribution (204 graded picks)
+
+| Score | Share |
+|-------|-------|
+| 0 | **27.5%** |
+| 1–5 | 28.9% |
+| 6–10 | 13.2% |
+| 11–20 | 17.6% |
+| 21–35 | 9.3% |
+| 36+ | 3.4% |
+
+- Mean **10.0**, median **5**, P90 **25**, max **55**.
+- Gini ≈ **0.565**; top/median ≈ **11×**.
+
+## Engagement floor vs encore leniency
+
+| Mechanic | Rescues from zero | Share |
+|----------|-------------------|-------|
+| Encore (any-of-2) | 8 | 3.9% |
+| Wildcard | 5 | 2.5% |
+
+Zeros mostly miss **all** songs in the show. Encore leniency barely moves the floor; **predictive nudges** and consolation design matter more for zeros.
+
+## Breadth (“N slots scoring”) incidence
+
+“Correct” = any points on a slot (matches `correctSlotsCredited` semantics).
+
+| Slots scoring | Share |
+|---------------|-------|
+| 0 | 27.5% |
+| 1 | 36.3% |
+| 2 | 19.6% |
+| 3 | 9.8% |
+| 4 | 5.4% |
+| 5 | 1.0% |
+| 6 | 0.5% |
+
+Exact counts (wild excluded): 0 exact 80.4%; 1 exact 17.2%; 2 exact 2.5%; 3+ exact **0**.
+
+Set sweeps (both S1 or both S2 any points): either ≈ 11.8%. Both positions exact in a set: **0**.
+
+## Recommended breadth ladder (highest tier only)
+
+Never cumulative.
+
+| Slots scoring | Bonus | Notes |
+|---------------|-------|-------|
+| 0–1 | 0 | |
+| 2 | Badge only (or tiny +2) | Becomes routine if predictions lift hit rates |
+| 3 | +5 | First leaderboard combo |
+| 4 | +10 | |
+| 5 | +15 | |
+| 6 | +20 | Perfect-card jackpot |
+
+Historical sim (if +2 at 2 and above ladder): ~36% get some bonus; mean +~1.7 pts; zeros unchanged.
+
+Round-5-only (no points at 2): ~17% get bonus; mean +~1.3 pts.
+
+## Precision companion
+
+| Exact slots | Bonus |
+|-------------|-------|
+| 2 | +5 |
+| 3 | +10 |
+| 4 | +15 |
+| 5 | +25 |
+
+Cap **card + precision ≤ +25**. Bustout stacks separately with a rarity ceiling.
+
+## Coupling with predictive picker (#646)
+
+If per-slot any-points rate rises from ~22% → ~28–35%, share of cards with 2+ hits rises ~40% → ~54–68%, and breadth EV rises. Recalibrate **after** Prediction Lab evidence.
+
+Principles when coupled:
+
+- Scoring identical for manual vs recommended picks.
+- Engine predicts song/slot likelihood—not leaderboard points.
+- Offer Safe / Slot-fit / Long-shot to reduce herding.
+- Prefer points starting at **3** breadth hits if recommendations work.
+
+## Avoid stacking
+
+Do not ship breadth + set-sweep + precision + uncapped bustout multipliers without shared caps. Prefer badges for overlapping thematic milestones.

--- a/docs/scoring-analysis/05-scoring-from-scratch.md
+++ b/docs/scoring-analysis/05-scoring-from-scratch.md
@@ -1,0 +1,76 @@
+# Scoring model from scratch (proposal)
+
+Greenfield design for engagement + economics. Anchor: target mean ~**9–11**, median near current ~5, explainable live scoring.
+
+## Thesis
+
+Use **recommendations** to raise the engagement floor; use **scoring** to distinguish skill and create memorable upside. Do not fix zeros with broad free points; do not create surprise via hidden randomness.
+
+## Layer 1 — base outcomes
+
+| Outcome | Points | Role |
+|---------|--------|------|
+| Song elsewhere in show | 5 | Accessible floor |
+| Exact S1/S2 position | 10 | Primary skill |
+| Later encore song | 10 | Matches realized difficulty |
+| First encore song | 15 | Signature premium |
+| Wildcard anywhere | 5 | Safe floor, not premium |
+| Miss | 0 | Legible; no negatives |
+
+## Layer 2 — card completion (highest tier only)
+
+| Breadth | Reward |
+|---------|--------|
+| 2 scoring slots | Badge only |
+| 3 | +5 |
+| 4 | +10 |
+| 5 | +15 |
+| All 6 | +20 |
+
+## Layer 3 — precision
+
+| Exact slots | Bonus |
+|-------------|-------|
+| 2 | +5 |
+| 3 | +10 |
+| 4 | +15 |
+| 5 | +25 |
+
+Combined card + precision cap: **+25**.
+
+## Layer 4 — rarity (fixed adds, not uncapped multipliers)
+
+| Gap | Boost |
+|-----|-------|
+| 30–74 | +15 |
+| 75–149 | +20 |
+| 150–299 | +30 |
+| 300+ | +40 |
+
+Rarity may stack with base/card; rarity ceiling **+40**.
+
+## Player agency — Spotlight Pick (experiment)
+
+Before lock, mark one of four **positional** slots as Spotlight:
+
+- Exact on Spotlight → additional **+5**
+- Otherwise normal scoring
+- Exclude wildcard and encore
+
+Small EV (~0.2–0.3 expected), high personalization / live rooting interest.
+
+## Predictive engine fit
+
+Suggestions help users get on the board. Because 2-hit cards become more common, **points for breadth start at 3**. Recalibrate after adoption, concentration, and tie metrics.
+
+## Engagement without more points
+
+Live progress (“one slot from card bonus”), Spotlight status, bustout-tier reveals, first exact / set sweep / perfect-card recap badges and animations.
+
+## Avoid in core model
+
+- Random / mystery points
+- Uncapped multipliers that let one song beat a full card
+- Crowd-consensus multipliers before privacy/gaming are solved
+- Negative points
+- Stacking breadth + set-sweep + precision without a shared cap

--- a/docs/scoring-analysis/06-predictive-picker-framework.md
+++ b/docs/scoring-analysis/06-predictive-picker-framework.md
@@ -1,0 +1,65 @@
+# Predictive song picker framework
+
+Epic: [#646](https://github.com/pat792/set-picks/issues/646). Children: #647–#653. Complements scoring analysis #645.
+
+## Product model
+
+One recommendation engine, two opt-in surfaces:
+
+1. **Prediction Lab panel** — Safe / Slot-fit / Long-shot, reasons, “Use for this slot.” Preferred first UI.
+2. **Predictive Mode** — default-off; focus shows 5–8 slot-aware suggestions; typed search uses same score.
+
+Rules:
+
+- Manual search remains default; never auto-fill.
+- Do **not** use current-show user picks as model input (consensus / feedback loop).
+- Cross-slot uniqueness unchanged.
+
+## Ranking (leakage-safe)
+
+### Play likelihood
+
+Recency (10/25/50 shows), lifetime frequency with shrinkage, nonlinear gap vs song cadence, last-played, run/tour repeat penalties, calendar (tour, venue/run, days since prior).
+
+### Slot affinity
+
+Smoothed affinity for s1o/s1c/s2o/s2c/first encore/later encore/wildcard.
+
+```text
+slotScore = calibratedPlayProbability × smoothedSlotAffinity
+wildcardScore = calibratedPlayProbability
+```
+
+Bustout upside as **Long-shot** band, not mixed into “most likely.”
+
+Gap ≠ “lowest first.” Current autocomplete in `rankCatalogSongMatches.js` is a search heuristic; gap 0 after prior night can *reduce* next-show odds.
+
+## Critical data constraint
+
+`song-catalog.json` is overwritten every ~6 hours → historical pre-show `gap`/`last`/`total` cannot be reconstructed from today’s file. Target-night `songGaps` only lists songs that played → never use as candidate features for that night.
+
+Backtest v1: prior `official_setlists` + calendar + bounded Phish.net history. In parallel: **archive dated catalog snapshots** (#647).
+
+## Artifact
+
+Versioned Storage JSON (alongside catalog), e.g. `pick-recommendations.json`: `generatedAt`, `modelVersion`, target show, per-song per-slot ranks, confidence, risk band, explanation components. Refresh during tours / after finalize. Client: Storage + TTL + stale/fallback like song catalog—not Firestore per keystroke.
+
+## FSD
+
+Keep in `features/picks` (api/model/ui). Extend `SongAutocomplete` only with generic featured options / injected ranker. Pages stay composition-only.
+
+## Rollout
+
+1. Offline backtest (#648–#649)  
+2. Artifact (#650)  
+3. Prediction Lab (#651)  
+4. Predictive Mode if panel evidence OK (#652)  
+5. Provenance + metrics + tour recalibration (#653)
+
+## Measurement
+
+Zero-score rate, selection rate, recommended-pick outcomes, pick entropy/concentration, ties. Optional pick provenance: `manual` | `panel` | `predictive_mode` + modelVersion/rank.
+
+## SemVer / docs when shipping
+
+MINOR bump; CHANGELOG; `docs/API.md`; update `docs/SONG_CATALOG.md` schedule/cache wording; model methodology doc.

--- a/docs/scoring-analysis/README.md
+++ b/docs/scoring-analysis/README.md
@@ -1,0 +1,38 @@
+# Scoring & prediction analysis (2026-07)
+
+Preserved design research from Cursor canvases and live Firestore / Phish.net analysis. Canvases live only under Cursor’s local project folder (`~/.cursor/projects/.../canvases/`) and are **not** in git; **Canvas Publish** requires a Teams or Enterprise plan and stores a share snapshot on Cursor’s dashboard—not this repository.
+
+This folder is the durable, repo-backed record of that work.
+
+## GitHub tracking
+
+| Issue | Topic |
+|-------|--------|
+| [#645](https://github.com/pat792/set-picks/issues/645) | Scoring considerations (encore fairness, EV, bustouts, combos) |
+| [#646](https://github.com/pat792/set-picks/issues/646) | Epic: predictive song picker |
+| [#647](https://github.com/pat792/set-picks/issues/647)–[#653](https://github.com/pat792/set-picks/issues/653) | Child slices for the prediction epic |
+
+## Documents
+
+| Doc | Source canvas / topic |
+|-----|------------------------|
+| [01-slot-odds-and-ev.md](./01-slot-odds-and-ev.md) | Slot hit rates, EV, points fairness |
+| [02-significance-and-variability.md](./02-significance-and-variability.md) | Statistical significance; 2-year setlist variability |
+| [03-scoring-calibration.md](./03-scoring-calibration.md) | Encore 15/10/5, bustout tiers, multipliers |
+| [04-card-combos-and-engagement.md](./04-card-combos-and-engagement.md) | Breadth bonuses, zeros, predictive coupling |
+| [05-scoring-from-scratch.md](./05-scoring-from-scratch.md) | Greenfield scoring proposal |
+| [06-predictive-picker-framework.md](./06-predictive-picker-framework.md) | Recommendation engine + two UX surfaces |
+
+## Snapshot metadata
+
+- **Analysis date:** ~2026-07-18
+- **Graded picks:** 204 pick docs across 17 shows
+- **Official setlists:** 21 docs (4 without picks in that window)
+- **Supply window:** Phish.net Phish-only setlists, last 24 months (~105 shows) and 2022–2026 (~211 shows)
+- **Scoring constants at analysis time:** exact opener/closer 10 · encore any 15 · in-setlist 5 · wildcard 10 · bustout +20 (gap ≥ 30)
+
+## Caveats
+
+- Slot-to-slot exact-rate differences were **not statistically significant** at this sample size.
+- User hit rates partly reflect crowd skill/consensus, not only slot difficulty.
+- Coupling recommendations with card bonuses will change bonus incidence; recalibrate after Prediction Lab ships.

--- a/functions/commsEventAdapters.js
+++ b/functions/commsEventAdapters.js
@@ -178,7 +178,7 @@ function findTourCountdownTargets(calendarShows, now, countdownDays = COUNTDOWN_
         first_show_venue: show.venue || "",
         first_show_city: show.city || "",
         timeZone: tz,
-        lock_time_local: "7:55 PM",
+        lock_time_local: "7:30 PM",
       });
     }
   }

--- a/functions/commsTemplates.js
+++ b/functions/commsTemplates.js
@@ -205,14 +205,14 @@ const BUILDERS = {
       [
         `${handleOf(p)}, the run kicks off ${when}.`,
         firstShow ? `First show: ${firstShow}.` : "",
-        `Picks lock at ${p.lock_time_local || "7:55 PM"} local on show night.`,
+        "Get your picks ready before the first downbeat.",
       ],
       { ctaUrl: PICKS_CTA_URL }
     );
     return {
       push: {
         title: `${p.tour_name || "The tour"} starts ${when}`,
-        body: `Get your picks ready — locks at ${p.lock_time_local || "7:55 PM"} local.`,
+        body: "Get your picks ready for the first show.",
       },
       email: {
         subject: `${p.tour_name || "The tour"} starts ${when}`,
@@ -398,26 +398,26 @@ const BUILDERS = {
   },
 
   "picks-lock-reminder": (p) => {
-    const venue = venueLine(p);
-    const lockLabel = p.lock_time_local || "7:55 PM";
-    const timePhrase = p.time_to_lock ? ` in ${p.time_to_lock}` : "";
+    const timeToLock = p.time_to_lock || "a few hours";
     const ctaUrl = picksCtaUrl(p);
     const assembled = assembleServiceEmail(
       [
-        `${handleOf(p)}, ${p.venue_name || "tonight's show"} locks at ${lockLabel} local${timePhrase}.`,
+        `${handleOf(p)}, ${timeToLock} until picks lock${
+          p.venue_name ? ` for ${p.venue_name}` : ""
+        }.`,
         "You haven't locked picks yet — don't get shut out.",
       ],
       { ctaUrl, signOff: "See you on tour!" }
     );
     return {
       push: {
-        title: "Tonight's picks lock soon",
-        body: `Lock in your picks${p.venue_name ? ` for ${p.venue_name}` : ""} before ${lockLabel} local.`,
+        title: `${timeToLock} until picks lock`,
+        body: `Lock in your picks${p.venue_name ? ` for ${p.venue_name}` : ""}.`,
       },
       email: {
-        subject: p.time_to_lock
-          ? `Picks close in ${p.time_to_lock}${p.venue_city ? ` — ${p.venue_city} tonight` : ""}`
-          : `Lock in your picks${venue ? ` — ${venue}` : ""}`,
+        subject: `${timeToLock} until picks lock${
+          p.venue_city ? ` — ${p.venue_city} tonight` : ""
+        }`,
         text: assembled.text,
         signOff: assembled.signOff,
         ctaUrl,

--- a/functions/commsTemplates.test.js
+++ b/functions/commsTemplates.test.js
@@ -49,6 +49,31 @@ test("picks-lock-reminder email CTA includes showDate when YYYY-MM-DD (#535)", a
   assert.match(out.email.ctaUrl, /\/dashboard\/picks\?showDate=2026-07-18/);
 });
 
+test("picks-lock-reminder uses relative cutoff only (#522)", async () => {
+  const out = await renderCommsTemplate("picks-lock-reminder", {
+    handle: "HotDogBilly",
+    show_date: "2026-07-18",
+    venue_name: "MSG",
+    venue_city: "New York, NY",
+    time_to_lock: "2h 15m",
+    lock_time_local: "7:30 PM",
+  });
+  const rendered = `${out.push.title} ${out.push.body} ${out.email.subject} ${out.email.text}`;
+  assert.match(rendered, /2h 15m/);
+  assert.doesNotMatch(rendered, /7:30 PM/);
+});
+
+test("tour countdown does not repeat an absolute picks cutoff (#522)", async () => {
+  const out = await renderCommsTemplate("tour-countdown", {
+    handle: "HotDogBilly",
+    tour_name: "Summer Tour",
+    days_remaining: 1,
+    lock_time_local: "7:30 PM",
+  });
+  const rendered = `${out.push.title} ${out.push.body} ${out.email.subject} ${out.email.text}`;
+  assert.doesNotMatch(rendered, /7:30 PM|picks lock/i);
+});
+
 test("picks-lock-reminder email CTA omits showDate for display labels", async () => {
   const out = await renderCommsTemplate("picks-lock-reminder", {
     handle: "HotDogBilly",

--- a/functions/index.js
+++ b/functions/index.js
@@ -1569,7 +1569,9 @@ exports.backfillBustoutsForShows = onCall(
  */
 exports.scheduledPhishnetShowCalendar = onSchedule(
   {
-    schedule: "0 6 1 * *",
+    // Daily: new tour dates can publish at any point in the month. Phish.net
+    // supplies canonical dates/tours; Phish.com enriches doors/show time.
+    schedule: "0 6 * * *",
     timeZone: "America/New_York",
     region: PHISHNET_FUNCTIONS_REGION,
     secrets: [phishnetApiKey],

--- a/functions/phishOfficialSchedule.js
+++ b/functions/phishOfficialSchedule.js
@@ -1,0 +1,156 @@
+"use strict";
+
+/**
+ * First-party Phish.com schedule enrichment for `show_calendar` (#522).
+ *
+ * Phish.net remains canonical for dates/tours/venues. Phish.com date pages add
+ * the fields its API does not expose: "Doors Open" and advertised "Show Time".
+ */
+
+const PHISH_TOURS_URL = "https://phish.com/tours/";
+const USER_AGENT = "SetlistPickEm/1.0 (+https://www.setlistpickem.com)";
+
+/**
+ * @param {string} html
+ * @returns {string[]}
+ */
+function extractOfficialDateUrls(html) {
+  if (typeof html !== "string") return [];
+  const urls = new Set();
+  const pattern =
+    /href=["'](https:\/\/phish\.com\/tours\/dates\/[^"'?#]+\/?)["']/gi;
+  for (const match of html.matchAll(pattern)) {
+    urls.add(match[1].endsWith("/") ? match[1] : `${match[1]}/`);
+  }
+  return [...urls];
+}
+
+/**
+ * @param {string} url
+ * @returns {string | null}
+ */
+function showDateFromOfficialUrl(url) {
+  const match = String(url).match(
+    /\/tours\/dates\/[a-z]+-(\d{4})-(\d{1,2})-(\d{1,2})-/i
+  );
+  if (!match) return null;
+  return `${match[1]}-${String(match[2]).padStart(2, "0")}-${String(
+    match[3]
+  ).padStart(2, "0")}`;
+}
+
+/**
+ * @param {string} value
+ * @returns {string | null} `HH:mm`
+ */
+function normalizeOfficialLocalTime(value) {
+  const match = String(value)
+    .trim()
+    .match(/^(\d{1,2}):(\d{2})\s*([ap])\.?m\.?$/i);
+  if (!match) return null;
+  let hour = Number(match[1]);
+  const minute = Number(match[2]);
+  if (hour < 1 || hour > 12 || minute < 0 || minute > 59) return null;
+  const isPm = match[3].toLowerCase() === "p";
+  if (isPm && hour !== 12) hour += 12;
+  if (!isPm && hour === 12) hour = 0;
+  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(
+    2,
+    "0"
+  )}`;
+}
+
+/**
+ * @param {string} html
+ * @param {string} sourceUrl
+ * @returns {{ date: string, doorsLocal?: string, scheduledStartLocal?: string, scheduleSource: 'phish.com', scheduleSourceUrl: string } | null}
+ */
+function parseOfficialDatePage(html, sourceUrl) {
+  const date = showDateFromOfficialUrl(sourceUrl);
+  if (!date || typeof html !== "string") return null;
+  const doorsMatch = html.match(
+    /Doors\s+Open:\s*(\d{1,2}:\d{2}\s*[ap]\.?m\.?)/i
+  );
+  const showMatch = html.match(
+    /Show\s+Time:\s*(\d{1,2}:\d{2}\s*[ap]\.?m\.?)/i
+  );
+  const doorsLocal = doorsMatch
+    ? normalizeOfficialLocalTime(doorsMatch[1])
+    : null;
+  const scheduledStartLocal = showMatch
+    ? normalizeOfficialLocalTime(showMatch[1])
+    : null;
+  if (!doorsLocal && !scheduledStartLocal) return null;
+  return {
+    date,
+    ...(doorsLocal ? { doorsLocal } : {}),
+    ...(scheduledStartLocal ? { scheduledStartLocal } : {}),
+    scheduleSource: "phish.com",
+    scheduleSourceUrl: sourceUrl,
+  };
+}
+
+/**
+ * Fetches official upcoming date pages in small batches.
+ *
+ * @param {{ fetchImpl?: typeof fetch, logger?: { warn?: Function, info?: Function } }} [opts]
+ * @returns {Promise<Map<string, { date: string, doorsLocal?: string, scheduledStartLocal?: string, scheduleSource: 'phish.com', scheduleSourceUrl: string }>>}
+ */
+async function fetchOfficialPhishSchedule({
+  fetchImpl = fetch,
+  logger,
+} = {}) {
+  const indexRes = await fetchImpl(PHISH_TOURS_URL, {
+    headers: { Accept: "text/html", "User-Agent": USER_AGENT },
+  });
+  if (!indexRes.ok) {
+    throw new Error(`Phish.com tours: HTTP ${indexRes.status}`);
+  }
+  const dateUrls = extractOfficialDateUrls(await indexRes.text());
+  const schedule = new Map();
+
+  for (let i = 0; i < dateUrls.length; i += 6) {
+    const batch = dateUrls.slice(i, i + 6);
+    const rows = await Promise.all(
+      batch.map(async (url) => {
+        try {
+          const res = await fetchImpl(url, {
+            headers: { Accept: "text/html", "User-Agent": USER_AGENT },
+          });
+          if (!res.ok) {
+            logger?.warn?.("phish.com date page fetch failed", {
+              url,
+              status: res.status,
+            });
+            return null;
+          }
+          return parseOfficialDatePage(await res.text(), url);
+        } catch (error) {
+          logger?.warn?.("phish.com date page fetch failed", {
+            url,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return null;
+        }
+      })
+    );
+    for (const row of rows) {
+      if (row) schedule.set(row.date, row);
+    }
+  }
+
+  logger?.info?.("phish.com schedule fetch ok", {
+    datePages: dateUrls.length,
+    timedShows: schedule.size,
+  });
+  return schedule;
+}
+
+module.exports = {
+  PHISH_TOURS_URL,
+  extractOfficialDateUrls,
+  fetchOfficialPhishSchedule,
+  normalizeOfficialLocalTime,
+  parseOfficialDatePage,
+  showDateFromOfficialUrl,
+};

--- a/functions/phishOfficialSchedule.test.js
+++ b/functions/phishOfficialSchedule.test.js
@@ -1,0 +1,67 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  extractOfficialDateUrls,
+  fetchOfficialPhishSchedule,
+  normalizeOfficialLocalTime,
+  parseOfficialDatePage,
+  showDateFromOfficialUrl,
+} = require("./phishOfficialSchedule");
+
+const SYRACUSE_URL =
+  "https://phish.com/tours/dates/tue-2026-7-21-empower-federal-credit-union-amphitheater-at-lakeview/";
+
+test("extractOfficialDateUrls dedupes Phish date links", () => {
+  const html = `<a href="${SYRACUSE_URL}">one</a>
+    <a href="${SYRACUSE_URL}">duplicate</a>`;
+  assert.deepEqual(extractOfficialDateUrls(html), [SYRACUSE_URL]);
+});
+
+test("normalizes official local times", () => {
+  assert.equal(normalizeOfficialLocalTime("5:30 pm"), "17:30");
+  assert.equal(normalizeOfficialLocalTime("12:05 AM"), "00:05");
+  assert.equal(normalizeOfficialLocalTime("bad"), null);
+});
+
+test("parses date and official doors/show time", () => {
+  assert.equal(showDateFromOfficialUrl(SYRACUSE_URL), "2026-07-21");
+  assert.deepEqual(
+    parseOfficialDatePage(
+      `<ul><li>Show Time: 7:00 pm</li><li>Doors Open: 5:30 pm</li></ul>`,
+      SYRACUSE_URL
+    ),
+    {
+      date: "2026-07-21",
+      doorsLocal: "17:30",
+      scheduledStartLocal: "19:00",
+      scheduleSource: "phish.com",
+      scheduleSourceUrl: SYRACUSE_URL,
+    }
+  );
+});
+
+test("fetchOfficialPhishSchedule tolerates one failed date page", async () => {
+  const failedUrl =
+    "https://phish.com/tours/dates/wed-2026-7-22-madison-square-garden/";
+  const responses = new Map([
+    [
+      "https://phish.com/tours/",
+      `<a href="${SYRACUSE_URL}">Syracuse</a><a href="${failedUrl}">MSG</a>`,
+    ],
+    [
+      SYRACUSE_URL,
+      `<li>Show Time: 7:00 pm</li><li>Doors Open: 5:30 pm</li>`,
+    ],
+  ]);
+  const fetchImpl = async (url) => ({
+    ok: responses.has(url),
+    status: responses.has(url) ? 200 : 503,
+    text: async () => responses.get(url) || "",
+  });
+
+  const out = await fetchOfficialPhishSchedule({ fetchImpl });
+  assert.equal(out.size, 1);
+  assert.equal(out.get("2026-07-21").doorsLocal, "17:30");
+});

--- a/functions/phishnetLiveSetlistAutomation.js
+++ b/functions/phishnetLiveSetlistAutomation.js
@@ -219,7 +219,7 @@ function parseShowCalendarSnapshotToShows(snapshotData) {
             ? item.timezone.trim()
             : ""
         : "";
-    /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour_name?: string, tour?: string }} */
+    /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour_name?: string, tour?: string, doorsLocal?: string, picksLockLocal?: string }} */
     const show = { date, timeZone: explicitTz || DEFAULT_SHOW_TIME_ZONE };
     if (item && typeof item === "object") {
       if (typeof item.venue === "string" && item.venue.trim()) {
@@ -233,6 +233,12 @@ function parseShowCalendarSnapshotToShows(snapshotData) {
       }
       if (typeof item.tour === "string" && item.tour.trim()) {
         show.tour = item.tour.trim();
+      }
+      if (typeof item.doorsLocal === "string" && item.doorsLocal.trim()) {
+        show.doorsLocal = item.doorsLocal.trim();
+      }
+      if (typeof item.picksLockLocal === "string" && item.picksLockLocal.trim()) {
+        show.picksLockLocal = item.picksLockLocal.trim();
       }
     }
     shows.push(show);
@@ -298,7 +304,7 @@ function parseShowCalendarSnapshotToShowsByTour(snapshotData) {
           : typeof item.timezone === "string" && item.timezone.trim()
             ? item.timezone.trim()
             : "";
-      /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour?: string, tour_name?: string }} */
+      /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour?: string, tour_name?: string, doorsLocal?: string, picksLockLocal?: string }} */
       const show = {
         date,
         timeZone: explicitTz || DEFAULT_SHOW_TIME_ZONE,
@@ -310,6 +316,12 @@ function parseShowCalendarSnapshotToShowsByTour(snapshotData) {
       }
       if (typeof item.city === "string" && item.city.trim()) {
         show.city = item.city.trim();
+      }
+      if (typeof item.doorsLocal === "string" && item.doorsLocal.trim()) {
+        show.doorsLocal = item.doorsLocal.trim();
+      }
+      if (typeof item.picksLockLocal === "string" && item.picksLockLocal.trim()) {
+        show.picksLockLocal = item.picksLockLocal.trim();
       }
       shows.push(show);
     }

--- a/functions/phishnetShowCalendar.js
+++ b/functions/phishnetShowCalendar.js
@@ -8,6 +8,10 @@
  * `exclude_from_stats` (omit soundchecks / non-counting rows when truthy).
  */
 
+const {
+  fetchOfficialPhishSchedule,
+} = require("./phishOfficialSchedule");
+
 const MONTHS = [
   "Jan",
   "Feb",
@@ -213,6 +217,67 @@ function flattenSnapshotTourByDate(prevData) {
     }
   }
   return map;
+}
+
+/**
+ * Preserve official timing when Phish.com is temporarily unavailable.
+ *
+ * @param {import('firebase-admin').firestore.DocumentData | null | undefined} prevData
+ * @returns {Map<string, {
+ *   doorsLocal?: string,
+ *   scheduledStartLocal?: string,
+ *   scheduleSource?: string,
+ *   scheduleSourceUrl?: string
+ * }>}
+ */
+function flattenSnapshotScheduleByDate(prevData) {
+  const out = new Map();
+  const raw = Array.isArray(prevData?.showDates) ? prevData.showDates : [];
+  for (const show of raw) {
+    if (!show || typeof show !== "object") continue;
+    const date = typeof show.date === "string" ? show.date.trim() : "";
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) continue;
+    const timing = {};
+    for (const field of [
+      "doorsLocal",
+      "scheduledStartLocal",
+      "scheduleSource",
+      "scheduleSourceUrl",
+    ]) {
+      if (typeof show[field] === "string" && show[field].trim()) {
+        timing[field] = show[field].trim();
+      }
+    }
+    if (Object.keys(timing).length > 0) out.set(date, timing);
+  }
+  return out;
+}
+
+/**
+ * @param {{ tour: string, shows: Record<string, unknown>[] }[]} groups
+ * @param {Map<string, Record<string, unknown>>} officialByDate
+ * @param {Map<string, Record<string, unknown>>} previousByDate
+ */
+function enrichGroupsWithOfficialSchedule(
+  groups,
+  officialByDate,
+  previousByDate
+) {
+  return groups.map((group) => ({
+    ...group,
+    shows: group.shows.map((show) => {
+      const timing =
+        officialByDate.get(String(show.date)) ??
+        previousByDate.get(String(show.date)) ??
+        null;
+      if (!timing) return show;
+      const {
+        date: _sourceDate,
+        ...timingFields
+      } = timing;
+      return { ...show, ...timingFields };
+    }),
+  }));
 }
 
 /**
@@ -587,6 +652,9 @@ async function syncPhishnetShowCalendarToFirestore(db, apiKey, ctx) {
     const prevTourByDate = flattenSnapshotTourByDate(
       prevSnap.exists ? prevSnap.data() : null
     );
+    const prevScheduleByDate = flattenSnapshotScheduleByDate(
+      prevSnap.exists ? prevSnap.data() : null
+    );
     const overridesByDate = parseTourOverridesDoc(
       overridesSnap.exists ? overridesSnap.data() : null
     );
@@ -595,7 +663,7 @@ async function syncPhishnetShowCalendarToFirestore(db, apiKey, ctx) {
 
     const shows = await fetchAllShowsNormalized({ apiKey });
     const computedGroups = buildShowDatesByTour(shows);
-    const { showDatesByTour, reviewQueue } =
+    const { showDatesByTour: groupedShows, reviewQueue } =
       mergeToursWithSnapshotPreservation(
         shows,
         computedGroups,
@@ -603,12 +671,28 @@ async function syncPhishnetShowCalendarToFirestore(db, apiKey, ctx) {
         overridesByDate,
         { isFirstSnapshot }
       );
+    let officialScheduleByDate = new Map();
+    try {
+      officialScheduleByDate = await fetchOfficialPhishSchedule({ logger });
+    } catch (scheduleError) {
+      logger?.warn?.("phish.com schedule enrichment failed; preserving prior timing", {
+        error:
+          scheduleError instanceof Error
+            ? scheduleError.message
+            : String(scheduleError),
+      });
+    }
+    const showDatesByTour = enrichGroupsWithOfficialSchedule(
+      groupedShows,
+      officialScheduleByDate,
+      prevScheduleByDate
+    );
     const flat = showDatesByTour.flatMap((g) => g.shows);
 
     await ref.set(
       {
         schemaVersion: 2,
-        source: "phishnet",
+        source: "phishnet+phish.com",
         updatedAt: new Date(),
         showDatesByTour,
         showDates: flat,
@@ -623,6 +707,8 @@ async function syncPhishnetShowCalendarToFirestore(db, apiKey, ctx) {
       groups: showDatesByTour.length,
       reviewNewDates: reviewQueue.length,
       preservedDates: prevTourByDate.size,
+      officialTimedShows: officialScheduleByDate.size,
+      preservedTimedShows: prevScheduleByDate.size,
     });
     return { showCount: flat.length, groupCount: showDatesByTour.length };
   } catch (e) {
@@ -645,7 +731,9 @@ module.exports = {
   buildShowDatesByTour,
   buildVenueLine,
   fetchAllShowsNormalized,
+  flattenSnapshotScheduleByDate,
   flattenSnapshotTourByDate,
+  enrichGroupsWithOfficialSchedule,
   labelGenericCluster,
   mergeToursWithSnapshotPreservation,
   normalizePhishShows,

--- a/functions/phishnetShowCalendar.test.js
+++ b/functions/phishnetShowCalendar.test.js
@@ -4,11 +4,50 @@ const assert = require("node:assert/strict");
 const {
   labelGenericCluster,
   buildShowDatesByTour,
+  enrichGroupsWithOfficialSchedule,
+  flattenSnapshotScheduleByDate,
   flattenSnapshotTourByDate,
   mergeToursWithSnapshotPreservation,
   normalizePhishShows,
   parseTourOverridesDoc,
 } = require("./phishnetShowCalendar");
+
+test("official schedule enrichment prefers fresh data and preserves prior timing", () => {
+  const groups = [
+    {
+      tour: "Summer Tour 2026",
+      shows: [
+        { date: "2026-07-21", venue: "Syracuse" },
+        { date: "2026-07-22", venue: "MSG" },
+      ],
+    },
+  ];
+  const fresh = new Map([
+    [
+      "2026-07-21",
+      {
+        date: "2026-07-21",
+        doorsLocal: "17:30",
+        scheduledStartLocal: "19:00",
+        scheduleSource: "phish.com",
+      },
+    ],
+  ]);
+  const previous = flattenSnapshotScheduleByDate({
+    showDates: [
+      {
+        date: "2026-07-22",
+        doorsLocal: "18:30",
+        scheduleSource: "phish.com",
+      },
+    ],
+  });
+
+  const enriched = enrichGroupsWithOfficialSchedule(groups, fresh, previous);
+  assert.equal(enriched[0].shows[0].doorsLocal, "17:30");
+  assert.equal(enriched[0].shows[0].date, "2026-07-21");
+  assert.equal(enriched[0].shows[1].doorsLocal, "18:30");
+});
 
 test("labelGenericCluster: Sphere Run", () => {
   const shows = [

--- a/functions/picksLockReminder.js
+++ b/functions/picksLockReminder.js
@@ -9,11 +9,10 @@ const {
 const { hasNonEmptyPicksObject } = require("./rollupSeasonAggregates");
 const { createCommsAdapterRuntime } = require("./commsAdapterRuntime");
 const { resolveDedupKey } = require("./commsCatalog");
-
-/** Mirrors `src/shared/utils/timeLogic.js` (7:55pm local). */
-const SHOW_PICKS_LOCK_HOUR = 19;
-const SHOW_PICKS_LOCK_MINUTE = 55;
-const LOCK_TIME_LOCAL_LABEL = "7:55 PM";
+const {
+  formatLockTimeLocalLabel,
+  resolvePicksLockHm,
+} = require("./picksLockTime");
 
 const DEFAULT_SHOW_TIME_ZONE = "America/Los_Angeles";
 /** Reminder window opens this many minutes before venue-local lock. */
@@ -55,14 +54,24 @@ function localClockParts(showTimeZone, now) {
 }
 
 /**
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null | undefined} show
+ * @returns {number} minutes from midnight
+ */
+function lockMinutesForShow(show) {
+  const lock = resolvePicksLockHm(show);
+  return lock.hour * 60 + lock.minute;
+}
+
+/**
  * @param {string} showYmd
  * @param {string} showTimeZone
  * @param {Date} now
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null} [show]
  */
-function isPastPicksLock(showYmd, showTimeZone, now) {
+function isPastPicksLock(showYmd, showTimeZone, now, show = null) {
   const clock = localClockParts(showTimeZone, now);
   if (!clock || clock.ymd !== showYmd) return false;
-  const lockMinutes = SHOW_PICKS_LOCK_HOUR * 60 + SHOW_PICKS_LOCK_MINUTE;
+  const lockMinutes = lockMinutesForShow(show || { date: showYmd });
   return clock.minutesOfDay >= lockMinutes;
 }
 
@@ -72,11 +81,12 @@ function isPastPicksLock(showYmd, showTimeZone, now) {
  * @param {string} showYmd
  * @param {string} showTimeZone
  * @param {Date} now
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null} [show]
  */
-function isWithinReminderWindow(showYmd, showTimeZone, now) {
+function isWithinReminderWindow(showYmd, showTimeZone, now, show = null) {
   const clock = localClockParts(showTimeZone, now);
   if (!clock || clock.ymd !== showYmd) return false;
-  const lockMinutes = SHOW_PICKS_LOCK_HOUR * 60 + SHOW_PICKS_LOCK_MINUTE;
+  const lockMinutes = lockMinutesForShow(show || { date: showYmd });
   const startMinutes = lockMinutes - REMINDER_LEAD_MINUTES;
   return clock.minutesOfDay >= startMinutes && clock.minutesOfDay < lockMinutes;
 }
@@ -85,13 +95,14 @@ function isWithinReminderWindow(showYmd, showTimeZone, now) {
  * @param {string} showYmd `YYYY-MM-DD`
  * @param {string} showTimeZone IANA tz
  * @param {Date} now
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null} [show]
  * @returns {string}
  */
-function formatTimeToLock(showYmd, showTimeZone, now) {
+function formatTimeToLock(showYmd, showTimeZone, now, show = null) {
   const clock = localClockParts(showTimeZone, now);
   if (!clock || clock.ymd !== showYmd) return "tonight";
 
-  const lockMinutes = SHOW_PICKS_LOCK_HOUR * 60 + SHOW_PICKS_LOCK_MINUTE;
+  const lockMinutes = lockMinutesForShow(show || { date: showYmd });
   const diff = lockMinutes - clock.minutesOfDay;
   if (diff <= 0) return "soon";
 
@@ -103,9 +114,9 @@ function formatTimeToLock(showYmd, showTimeZone, now) {
 }
 
 /**
- * @param {Array<{ date: string, timeZone?: string, venue?: string, city?: string }>} calendarShows
+ * @param {Array<{ date: string, timeZone?: string, venue?: string, city?: string, doorsLocal?: string, picksLockLocal?: string }>} calendarShows
  * @param {Date} now
- * @returns {{ showDate: string, timeZone: string, venue_name: string, venue_city: string } | null}
+ * @returns {{ showDate: string, timeZone: string, venue_name: string, venue_city: string, lock_time_local: string, show: object } | null}
  */
 function findReminderTonightShow(calendarShows, now) {
   if (!Array.isArray(calendarShows) || calendarShows.length === 0) return null;
@@ -117,12 +128,15 @@ function findReminderTonightShow(calendarShows, now) {
       typeof show.timeZone === "string" && show.timeZone.trim()
         ? show.timeZone.trim()
         : DEFAULT_SHOW_TIME_ZONE;
-    if (!isWithinReminderWindow(date, tz, now)) continue;
+    if (!isWithinReminderWindow(date, tz, now, show)) continue;
+    const lockHm = resolvePicksLockHm(show);
     return {
       showDate: date,
       timeZone: tz,
       venue_name: typeof show.venue === "string" ? show.venue.trim() : "",
       venue_city: typeof show.city === "string" ? show.city.trim() : "",
+      lock_time_local: formatLockTimeLocalLabel(lockHm),
+      show,
     };
   }
   return null;
@@ -166,6 +180,10 @@ function buildPicksLockReminderRecipients({
 }) {
   /** @type {Array<{ uid: string, userData: Record<string, unknown>, payload: Record<string, unknown>, vars: Record<string, unknown> }>} */
   const recipients = [];
+  const lockLabel =
+    typeof showMeta.lock_time_local === "string" && showMeta.lock_time_local.trim()
+      ? showMeta.lock_time_local.trim()
+      : formatLockTimeLocalLabel(resolvePicksLockHm({ date: showDate }));
   for (const userDoc of userDocs) {
     if (recipients.length >= cap) break;
     const uid = userDoc.id;
@@ -180,8 +198,13 @@ function buildPicksLockReminderRecipients({
         show_date: showDate,
         venue_name: showMeta.venue_name,
         venue_city: showMeta.venue_city,
-        time_to_lock: formatTimeToLock(showDate, showMeta.timeZone, now),
-        lock_time_local: LOCK_TIME_LOCAL_LABEL,
+        time_to_lock: formatTimeToLock(
+          showDate,
+          showMeta.timeZone,
+          now,
+          showMeta.show || { date: showDate }
+        ),
+        lock_time_local: lockLabel,
       },
       vars: { uid, showYmd: showDate },
     });

--- a/functions/picksLockReminder.test.js
+++ b/functions/picksLockReminder.test.js
@@ -16,7 +16,7 @@ test("reminderLogDocId", () => {
 
 test("findReminderTonightShow returns null before T-3h window", () => {
   const shows = [{ date: "2099-06-15", timeZone: "America/Los_Angeles" }];
-  // 4:00pm PDT — still before 4:55pm (lock 7:55 − 3h).
+  // 4:00pm PDT — still before 4:30pm (lock 7:30 − 3h).
   const now = new Date("2099-06-15T23:00:00.000Z");
   assert.equal(findReminderTonightShow(shows, now), null);
 });
@@ -30,7 +30,7 @@ test("findReminderTonightShow returns show in T-3h–lock window with venue meta
       city: "New York, NY",
     },
   ];
-  // 5:30pm PDT — inside 4:55–7:55 window.
+  // 5:30pm PDT — inside 4:30–7:30 window.
   const now = new Date("2099-06-16T00:30:00.000Z");
   const out = findReminderTonightShow(shows, now);
   assert.ok(out);
@@ -48,8 +48,8 @@ test("isPastPicksLock is true after local lock", () => {
 });
 
 test("formatTimeToLock returns 3 hours at window open", () => {
-  // 4:55pm PDT on show day → exactly 3 hours until 7:55pm lock.
-  const now = new Date("2099-06-15T23:55:00.000Z");
+  // 4:30pm PDT on show day → exactly 3 hours until 7:30pm lock.
+  const now = new Date("2099-06-15T23:30:00.000Z");
   assert.equal(formatTimeToLock("2099-06-15", "America/Los_Angeles", now), "3 hours");
 });
 

--- a/functions/picksLockTime.js
+++ b/functions/picksLockTime.js
@@ -1,0 +1,167 @@
+/**
+ * Per-show picks wall-clock lock (#522) — CommonJS mirror of
+ * `src/shared/utils/picksLockTime.js` (Functions cannot import the ESM client module).
+ *
+ * Keep in sync with the client module when constants or formula change.
+ */
+
+const DEFAULT_PICKS_LOCK_HM = Object.freeze({ hour: 19, minute: 30 });
+const TOUR_AVG_DOORS_TO_START_MIN = 119;
+const PICKS_LOCK_SAFETY_MIN = 19;
+
+const SHOW_DOORS_LOCAL_BY_DATE = Object.freeze({
+  "2026-07-18": "17:30",
+  "2026-07-19": "17:30",
+  "2026-07-21": "17:30",
+  "2026-07-22": "18:30",
+  "2026-07-24": "18:30",
+  "2026-07-25": "18:30",
+  "2026-07-27": "18:30",
+  "2026-07-29": "18:30",
+  "2026-07-31": "17:00",
+  "2026-08-01": "17:00",
+  "2026-09-04": "18:00",
+  "2026-09-05": "18:00",
+  "2026-09-06": "18:00",
+});
+
+/**
+ * @param {string | null | undefined} value
+ * @returns {{ hour: number, minute: number } | null}
+ */
+function parseLocalHm(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const h24 = trimmed.match(/^(\d{1,2}):(\d{2})$/);
+  if (h24) {
+    const hour = Number(h24[1]);
+    const minute = Number(h24[2]);
+    if (
+      Number.isInteger(hour) &&
+      Number.isInteger(minute) &&
+      hour >= 0 &&
+      hour <= 23 &&
+      minute >= 0 &&
+      minute <= 59
+    ) {
+      return { hour, minute };
+    }
+    return null;
+  }
+
+  const h12 = trimmed.match(/^(\d{1,2}):(\d{2})\s*([AaPp][Mm])$/);
+  if (!h12) return null;
+  let hour = Number(h12[1]);
+  const minute = Number(h12[2]);
+  const ap = h12[3].toUpperCase();
+  if (
+    !Number.isInteger(hour) ||
+    !Number.isInteger(minute) ||
+    hour < 1 ||
+    hour > 12 ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return null;
+  }
+  if (ap === "AM") {
+    if (hour === 12) hour = 0;
+  } else if (hour !== 12) {
+    hour += 12;
+  }
+  return { hour, minute };
+}
+
+/**
+ * @param {{ hour: number, minute: number }} hm
+ * @returns {string}
+ */
+function formatLocalHm24(hm) {
+  return `${String(hm.hour).padStart(2, "0")}:${String(hm.minute).padStart(2, "0")}`;
+}
+
+/**
+ * @param {{ hour: number, minute: number }} hm
+ * @returns {string}
+ */
+function formatLockTimeLocalLabel(hm) {
+  const hour12 = ((hm.hour + 11) % 12) + 1;
+  const suffix = hm.hour >= 12 ? "PM" : "AM";
+  return `${hour12}:${String(hm.minute).padStart(2, "0")} ${suffix}`;
+}
+
+/**
+ * @param {{ hour: number, minute: number }} doors
+ * @param {{ tourAvgDoorsToStartMin?: number, safetyMin?: number }} [opts]
+ */
+function lockHmFromDoors(
+  doors,
+  {
+    tourAvgDoorsToStartMin = TOUR_AVG_DOORS_TO_START_MIN,
+    safetyMin = PICKS_LOCK_SAFETY_MIN,
+  } = {}
+) {
+  const offset = Math.max(0, tourAvgDoorsToStartMin - safetyMin);
+  const total = doors.hour * 60 + doors.minute + offset;
+  const wrapped = ((total % (24 * 60)) + 24 * 60) % (24 * 60);
+  return { hour: Math.floor(wrapped / 60), minute: wrapped % 60 };
+}
+
+/**
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null | undefined} show
+ * @param {{
+ *   doorsByDate?: Record<string, string>,
+ *   tourAvgDoorsToStartMin?: number,
+ *   safetyMin?: number,
+ *   fallback?: { hour: number, minute: number },
+ * }} [opts]
+ */
+function resolvePicksLockHm(show, opts = {}) {
+  const fallback = opts.fallback ?? DEFAULT_PICKS_LOCK_HM;
+  const doorsByDate = opts.doorsByDate ?? SHOW_DOORS_LOCAL_BY_DATE;
+
+  const explicitLock = parseLocalHm(show?.picksLockLocal);
+  if (explicitLock) {
+    return {
+      ...explicitLock,
+      source: "picksLockLocal",
+      doorsLocal:
+        typeof show?.doorsLocal === "string" ? show.doorsLocal.trim() || null : null,
+    };
+  }
+
+  const date = typeof show?.date === "string" ? show.date.trim() : "";
+  const doorsRaw =
+    (typeof show?.doorsLocal === "string" && show.doorsLocal.trim()) ||
+    (date && doorsByDate[date]) ||
+    null;
+  const doors = parseLocalHm(doorsRaw);
+  if (doors) {
+    const lock = lockHmFromDoors(doors, opts);
+    return {
+      ...lock,
+      source: "doors",
+      doorsLocal: formatLocalHm24(doors),
+    };
+  }
+
+  return {
+    ...fallback,
+    source: "fallback",
+    doorsLocal: null,
+  };
+}
+
+module.exports = {
+  DEFAULT_PICKS_LOCK_HM,
+  PICKS_LOCK_SAFETY_MIN,
+  SHOW_DOORS_LOCAL_BY_DATE,
+  TOUR_AVG_DOORS_TO_START_MIN,
+  formatLocalHm24,
+  formatLockTimeLocalLabel,
+  lockHmFromDoors,
+  parseLocalHm,
+  resolvePicksLockHm,
+};

--- a/functions/picksLockTime.test.js
+++ b/functions/picksLockTime.test.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  DEFAULT_PICKS_LOCK_HM,
+  lockHmFromDoors,
+  resolvePicksLockHm,
+} = require("./picksLockTime");
+
+test("lockHmFromDoors uses doors+100 for Summer Tour 2026 defaults", () => {
+  assert.deepEqual(lockHmFromDoors({ hour: 17, minute: 30 }), {
+    hour: 19,
+    minute: 10,
+  });
+});
+
+test("resolvePicksLockHm seeds Merriweather and falls back", () => {
+  assert.deepEqual(resolvePicksLockHm({ date: "2026-07-18" }), {
+    hour: 19,
+    minute: 10,
+    source: "doors",
+    doorsLocal: "17:30",
+  });
+  assert.deepEqual(resolvePicksLockHm({ date: "2099-01-01" }), {
+    ...DEFAULT_PICKS_LOCK_HM,
+    source: "fallback",
+    doorsLocal: null,
+  });
+});

--- a/functions/showFinalizationGate.js
+++ b/functions/showFinalizationGate.js
@@ -7,10 +7,9 @@
  * or the admin passes `force: true`.
  */
 
-const DEFAULT_SHOW_TIME_ZONE = "America/Los_Angeles";
+const { resolvePicksLockHm } = require("./picksLockTime");
 
-const SHOW_PICKS_LOCK_HOUR_LOCAL = 19;
-const SHOW_PICKS_LOCK_MINUTE_LOCAL = 55;
+const DEFAULT_SHOW_TIME_ZONE = "America/Los_Angeles";
 
 function resolveShowTimeZone(show, fallback = DEFAULT_SHOW_TIME_ZONE) {
   const explicit =
@@ -51,14 +50,25 @@ function showClockOnShowYmd(showYmd, showTimeZone, now = new Date()) {
   return { hour: Number(map.hour), minute: Number(map.minute) };
 }
 
-function isPastPicksLock(showYmd, showTimeZone = DEFAULT_SHOW_TIME_ZONE, now = new Date()) {
+function isPastPicksLock(
+  showYmd,
+  showTimeZone = DEFAULT_SHOW_TIME_ZONE,
+  now = new Date(),
+  showOrLockHm = null
+) {
   const clock = showClockOnShowYmd(showYmd, showTimeZone, now);
   if (!clock) return false;
+  const lockHm =
+    showOrLockHm && typeof showOrLockHm === "object"
+      ? resolvePicksLockHm({
+          date:
+            typeof showOrLockHm.date === "string" ? showOrLockHm.date : showYmd,
+          doorsLocal: showOrLockHm.doorsLocal,
+          picksLockLocal: showOrLockHm.picksLockLocal,
+        })
+      : resolvePicksLockHm({ date: showYmd });
   const { hour, minute } = clock;
-  return (
-    hour > SHOW_PICKS_LOCK_HOUR_LOCAL ||
-    (hour === SHOW_PICKS_LOCK_HOUR_LOCAL && minute >= SHOW_PICKS_LOCK_MINUTE_LOCAL)
-  );
+  return hour > lockHm.hour || (hour === lockHm.hour && minute >= lockHm.minute);
 }
 
 /**
@@ -91,7 +101,16 @@ function getShowStatus(selectedDate, showDates, now = new Date()) {
   if (selectedDate < today) return "PAST";
   if (selectedDate === nextShow.date) {
     if (selectedDate === today) {
-      if (isPastPicksLock(selectedDate, selectedTimeZone, now)) return "LIVE";
+      if (
+        isPastPicksLock(
+          selectedDate,
+          selectedTimeZone,
+          now,
+          selectedShow || { date: selectedDate }
+        )
+      ) {
+        return "LIVE";
+      }
     }
     return "NEXT";
   }

--- a/functions/tourCountdownRecoveryDelivery.js
+++ b/functions/tourCountdownRecoveryDelivery.js
@@ -15,7 +15,7 @@ const { hasNonEmptyPicksObject } = require("./rollupSeasonAggregates");
 
 const TRIGGER_ID = "tour_countdown";
 const DEFAULT_SHOW_TIME_ZONE = "America/Los_Angeles";
-const DEFAULT_LOCK_TIME_LOCAL = "7:55 PM";
+const DEFAULT_LOCK_TIME_LOCAL = "7:30 PM";
 
 /**
  * @param {unknown} data

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setlistpickem",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setlistpickem",
-      "version": "1.30.0",
+      "version": "1.31.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "firebase": "10.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.30.1",
+  "version": "1.31.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.30.0",
+  "version": "1.31.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.30.0",
+  "version": "1.30.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/admin/ui/AdminForm.jsx
+++ b/src/features/admin/ui/AdminForm.jsx
@@ -180,7 +180,7 @@ export default function AdminForm({ user, selectedDate }) {
             <AdminActionToggle
               id="admin-picks-lock"
               title="Picks lock"
-              description="One-click override when the show starts before 7:55 PM local or Phish.net is slow."
+              description="One-click override when the show starts before the resolved lock or Phish.net is slow."
               open={picksLockOpen}
               onOpenChange={setPicksLockOpen}
             >

--- a/src/features/admin/ui/AdminPicksLockControls.jsx
+++ b/src/features/admin/ui/AdminPicksLockControls.jsx
@@ -15,7 +15,7 @@ export default function AdminPicksLockControls({
   const canLock = showStatus === 'NEXT' && !picksAlreadyLocked && !disabled;
 
   let helperText =
-    'Picks lock at 7:55 PM venue-local, when set 1 starts on Phish.net, or when you lock them here.';
+    'Picks lock at doors + ~1:40 (tour avg start − safety), at fallback 7:30 PM venue-local when doors are unknown, when set 1 starts on Phish.net, or when you lock them here.';
   if (showStatus && showStatus !== 'NEXT') {
     helperText = 'Lock picks now is only available while this show is NEXT (before wall-clock lock).';
   } else if (adminLockActive) {

--- a/src/features/admin/ui/AdminWarRoomShowDate.jsx
+++ b/src/features/admin/ui/AdminWarRoomShowDate.jsx
@@ -1,15 +1,9 @@
 import React from 'react';
 import { CalendarRange } from 'lucide-react';
 import {
-  SHOW_PICKS_LOCK_HOUR_LOCAL,
-  SHOW_PICKS_LOCK_MINUTE_LOCAL,
-} from '../../../shared/utils/timeLogic';
-
-function formatLockTime(hour24, minute) {
-  const hour12 = ((hour24 + 11) % 12) + 1;
-  const suffix = hour24 >= 12 ? 'PM' : 'AM';
-  return `${hour12}:${String(minute).padStart(2, '0')} ${suffix}`;
-}
+  formatLockTimeLocalLabel,
+  resolvePicksLockHm,
+} from '../../../shared/utils/picksLockTime';
 
 /**
  * Admin-only: pick the Firestore `official_setlists/{showDate}` key independently of the
@@ -23,7 +17,14 @@ export default function AdminWarRoomShowDate({
   disabled = false,
   timeZone,
 }) {
-  const lockTimeLabel = formatLockTime(SHOW_PICKS_LOCK_HOUR_LOCAL, SHOW_PICKS_LOCK_MINUTE_LOCAL);
+  const lockHm = resolvePicksLockHm({ date: value });
+  const lockTimeLabel = formatLockTimeLocalLabel(lockHm);
+  const lockSourceNote =
+    lockHm.source === 'doors'
+      ? `doors ${lockHm.doorsLocal} + tour avg − safety`
+      : lockHm.source === 'picksLockLocal'
+        ? 'explicit picksLockLocal'
+        : 'fallback 7:30 PM (doors unknown)';
 
   return (
     <div className="rounded-xl border border-border-subtle bg-[rgb(var(--surface-field)_/_0.35)] px-4 py-3 ring-1 ring-border-glass/20">
@@ -51,6 +52,9 @@ export default function AdminWarRoomShowDate({
           <p className="text-[11px] font-bold leading-relaxed text-content-secondary">
             Picks lock: <span className="text-content-primary">{lockTimeLabel}</span>{' '}
             <span className="text-slate-400">({timeZone})</span>
+            <span className="block text-slate-500 font-medium normal-case tracking-normal">
+              {lockSourceNote}
+            </span>
           </p>
         </div>
       </div>

--- a/src/features/feature-discovery/index.js
+++ b/src/features/feature-discovery/index.js
@@ -1,0 +1,5 @@
+export {
+  trackFeatureSpotlightClick,
+  trackFeatureSpotlightDismissed,
+  trackFeatureSpotlightImpression,
+} from './model/featureDiscoveryAnalytics';

--- a/src/features/feature-discovery/index.js
+++ b/src/features/feature-discovery/index.js
@@ -3,3 +3,15 @@ export {
   trackFeatureSpotlightDismissed,
   trackFeatureSpotlightImpression,
 } from './model/featureDiscoveryAnalytics';
+export {
+  FEATURE_SPOTLIGHTS,
+  getFeatureSpotlight,
+  isSpotlightActive,
+  isSpotlightInWindow,
+  localYmd,
+  readSpotlightSeen,
+  spotlightStorageKey,
+  writeSpotlightSeen,
+} from './model/featureSpotlights';
+export { useFeatureSpotlight } from './model/useFeatureSpotlight';
+export { default as FeatureNewBadge } from './ui/FeatureNewBadge';

--- a/src/features/feature-discovery/model/featureDiscoveryAnalytics.js
+++ b/src/features/feature-discovery/model/featureDiscoveryAnalytics.js
@@ -1,0 +1,34 @@
+/**
+ * Feature spotlight / “New” marker engagement (#638 contract, UI in #639).
+ *
+ * Wire these from `features/feature-discovery` when markers ship.
+ */
+
+import { ga4Event } from '../../../shared/lib/ga4';
+
+/**
+ * @param {{ feature_id?: string }} [payload]
+ */
+export function trackFeatureSpotlightImpression({ feature_id } = {}) {
+  ga4Event('feature_spotlight_impression', {
+    feature_id: feature_id ?? '',
+  });
+}
+
+/**
+ * @param {{ feature_id?: string }} [payload]
+ */
+export function trackFeatureSpotlightClick({ feature_id } = {}) {
+  ga4Event('feature_spotlight_click', {
+    feature_id: feature_id ?? '',
+  });
+}
+
+/**
+ * @param {{ feature_id?: string }} [payload]
+ */
+export function trackFeatureSpotlightDismissed({ feature_id } = {}) {
+  ga4Event('feature_spotlight_dismissed', {
+    feature_id: feature_id ?? '',
+  });
+}

--- a/src/features/feature-discovery/model/featureDiscoveryAnalytics.test.js
+++ b/src/features/feature-discovery/model/featureDiscoveryAnalytics.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../shared/lib/ga4', () => ({
+  ga4Event: vi.fn(),
+}));
+
+import { ga4Event } from '../../../shared/lib/ga4';
+import {
+  trackFeatureSpotlightClick,
+  trackFeatureSpotlightDismissed,
+  trackFeatureSpotlightImpression,
+} from './featureDiscoveryAnalytics.js';
+
+describe('featureDiscoveryAnalytics', () => {
+  beforeEach(() => {
+    ga4Event.mockClear();
+  });
+
+  it('emits impression / click / dismissed with feature_id', () => {
+    trackFeatureSpotlightImpression({ feature_id: 'tour-stats' });
+    trackFeatureSpotlightClick({ feature_id: 'tour-stats' });
+    trackFeatureSpotlightDismissed({ feature_id: 'live-setlist' });
+
+    expect(ga4Event).toHaveBeenNthCalledWith(1, 'feature_spotlight_impression', {
+      feature_id: 'tour-stats',
+    });
+    expect(ga4Event).toHaveBeenNthCalledWith(2, 'feature_spotlight_click', {
+      feature_id: 'tour-stats',
+    });
+    expect(ga4Event).toHaveBeenNthCalledWith(3, 'feature_spotlight_dismissed', {
+      feature_id: 'live-setlist',
+    });
+  });
+});

--- a/src/features/feature-discovery/model/featureSpotlights.js
+++ b/src/features/feature-discovery/model/featureSpotlights.js
@@ -1,0 +1,118 @@
+/**
+ * Client-side feature spotlight catalog (#639).
+ * Soft “New” markers; dismissals persist in localStorage (per uid).
+ */
+
+/**
+ * @typedef {{
+ *   id: string,
+ *   since: string,
+ *   until: string,
+ *   surfaces: string[],
+ *   path: string,
+ * }} FeatureSpotlight
+ */
+
+/** @type {readonly FeatureSpotlight[]} */
+export const FEATURE_SPOTLIGHTS = Object.freeze([
+  {
+    id: 'tour-stats',
+    since: '2026-06-01',
+    until: '2026-08-31',
+    surfaces: ['standings-stats-tab'],
+    path: '/dashboard/tour-stats',
+  },
+  {
+    id: 'live-setlist',
+    since: '2026-06-01',
+    until: '2026-08-31',
+    surfaces: ['standings-setlist-card'],
+    path: '/dashboard/standings',
+  },
+  {
+    id: 'profile-identity',
+    since: '2026-06-01',
+    until: '2026-08-31',
+    surfaces: ['profile-avatar', 'profile-badges'],
+    path: '/dashboard/profile',
+  },
+]);
+
+const BY_ID = new Map(FEATURE_SPOTLIGHTS.map((s) => [s.id, s]));
+
+/**
+ * @param {string} featureId
+ * @returns {FeatureSpotlight | null}
+ */
+export function getFeatureSpotlight(featureId) {
+  return BY_ID.get(featureId) || null;
+}
+
+/**
+ * Calendar date YYYY-MM-DD in local time (for since/until window).
+ * @param {Date} [now]
+ * @returns {string}
+ */
+export function localYmd(now = new Date()) {
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * True when today is within [since, until] inclusive.
+ * @param {FeatureSpotlight} spot
+ * @param {string} [todayYmd]
+ */
+export function isSpotlightInWindow(spot, todayYmd = localYmd()) {
+  if (!spot?.since || !spot?.until) return false;
+  return todayYmd >= spot.since && todayYmd <= spot.until;
+}
+
+/**
+ * @param {string} uid
+ * @param {string} featureId
+ */
+export function spotlightStorageKey(uid, featureId) {
+  return `set-picks-feature-spotlight:${uid}:${featureId}`;
+}
+
+/**
+ * @param {string | null | undefined} uid
+ * @param {string} featureId
+ */
+export function readSpotlightSeen(uid, featureId) {
+  if (!uid || typeof window === 'undefined') return true;
+  try {
+    return window.localStorage.getItem(spotlightStorageKey(uid, featureId)) === '1';
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * @param {string | null | undefined} uid
+ * @param {string} featureId
+ */
+export function writeSpotlightSeen(uid, featureId) {
+  if (!uid || typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(spotlightStorageKey(uid, featureId), '1');
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+/**
+ * Whether the spotlight should show (in window, not seen, signed-in).
+ * @param {string} featureId
+ * @param {{ uid?: string | null, todayYmd?: string }} [opts]
+ */
+export function isSpotlightActive(featureId, opts = {}) {
+  const { uid = null, todayYmd = localYmd() } = opts;
+  if (!uid) return false;
+  const spot = getFeatureSpotlight(featureId);
+  if (!spot || !isSpotlightInWindow(spot, todayYmd)) return false;
+  return !readSpotlightSeen(uid, featureId);
+}

--- a/src/features/feature-discovery/model/featureSpotlights.test.js
+++ b/src/features/feature-discovery/model/featureSpotlights.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import {
+  FEATURE_SPOTLIGHTS,
+  getFeatureSpotlight,
+  isSpotlightActive,
+  isSpotlightInWindow,
+  localYmd,
+  readSpotlightSeen,
+  spotlightStorageKey,
+  writeSpotlightSeen,
+} from './featureSpotlights.js';
+
+function installMemoryLocalStorage() {
+  /** @type {Map<string, string>} */
+  const store = new Map();
+  const memory = {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => {
+      store.set(String(key), String(value));
+    },
+    removeItem: (key) => {
+      store.delete(String(key));
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+  globalThis.localStorage = memory;
+  globalThis.window = { localStorage: memory };
+}
+
+describe('featureSpotlights', () => {
+  const uid = 'user-abc';
+
+  beforeEach(() => {
+    installMemoryLocalStorage();
+  });
+
+  afterEach(() => {
+    delete globalThis.localStorage;
+    delete globalThis.window;
+  });
+
+  it('includes the three summer discovery features', () => {
+    expect(FEATURE_SPOTLIGHTS.map((s) => s.id).sort()).toEqual([
+      'live-setlist',
+      'profile-identity',
+      'tour-stats',
+    ]);
+  });
+
+  it('isSpotlightInWindow is inclusive on since/until', () => {
+    const spot = getFeatureSpotlight('tour-stats');
+    expect(isSpotlightInWindow(spot, '2026-06-01')).toBe(true);
+    expect(isSpotlightInWindow(spot, '2026-08-31')).toBe(true);
+    expect(isSpotlightInWindow(spot, '2026-05-31')).toBe(false);
+    expect(isSpotlightInWindow(spot, '2026-09-01')).toBe(false);
+  });
+
+  it('localYmd formats local calendar date', () => {
+    expect(localYmd(new Date(2026, 6, 17))).toBe('2026-07-17');
+  });
+
+  it('isSpotlightActive requires uid, window, and unseen', () => {
+    expect(
+      isSpotlightActive('tour-stats', { uid: null, todayYmd: '2026-07-17' }),
+    ).toBe(false);
+    expect(
+      isSpotlightActive('tour-stats', { uid, todayYmd: '2026-07-17' }),
+    ).toBe(true);
+
+    writeSpotlightSeen(uid, 'tour-stats');
+    expect(readSpotlightSeen(uid, 'tour-stats')).toBe(true);
+    expect(
+      isSpotlightActive('tour-stats', { uid, todayYmd: '2026-07-17' }),
+    ).toBe(false);
+    expect(localStorage.getItem(spotlightStorageKey(uid, 'tour-stats'))).toBe(
+      '1',
+    );
+  });
+
+  it('expires after until even if unseen', () => {
+    expect(
+      isSpotlightActive('live-setlist', { uid, todayYmd: '2026-09-15' }),
+    ).toBe(false);
+  });
+});

--- a/src/features/feature-discovery/model/useFeatureSpotlight.js
+++ b/src/features/feature-discovery/model/useFeatureSpotlight.js
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useAuth } from '../../auth';
+import {
+  trackFeatureSpotlightClick,
+  trackFeatureSpotlightDismissed,
+  trackFeatureSpotlightImpression,
+} from './featureDiscoveryAnalytics';
+import {
+  getFeatureSpotlight,
+  isSpotlightActive,
+  writeSpotlightSeen,
+} from './featureSpotlights';
+
+/**
+ * Soft “New” spotlight for one catalog feature (#639).
+ *
+ * @param {string} featureId
+ * @param {{ trackImpression?: boolean }} [options]
+ */
+export function useFeatureSpotlight(featureId, options = {}) {
+  const { trackImpression = true } = options;
+  const { user } = useAuth();
+  const uid = user?.uid || null;
+  const [tick, setTick] = useState(0);
+  const impressedRef = useRef(false);
+
+  const spot = useMemo(() => getFeatureSpotlight(featureId), [featureId]);
+
+  const active = useMemo(() => {
+    void tick;
+    return isSpotlightActive(featureId, { uid });
+  }, [featureId, uid, tick]);
+
+  useEffect(() => {
+    if (!trackImpression || !active || !featureId) return;
+    if (impressedRef.current) return;
+    impressedRef.current = true;
+    trackFeatureSpotlightImpression({ feature_id: featureId });
+  }, [active, featureId, trackImpression]);
+
+  const markSeen = useCallback(() => {
+    if (!uid || !featureId) return;
+    if (!isSpotlightActive(featureId, { uid })) return;
+    writeSpotlightSeen(uid, featureId);
+    trackFeatureSpotlightDismissed({ feature_id: featureId });
+    setTick((t) => t + 1);
+  }, [uid, featureId]);
+
+  const trackClick = useCallback(() => {
+    if (!featureId) return;
+    trackFeatureSpotlightClick({ feature_id: featureId });
+  }, [featureId]);
+
+  return {
+    featureId,
+    path: spot?.path || '',
+    active,
+    markSeen,
+    trackClick,
+  };
+}

--- a/src/features/feature-discovery/ui/FeatureNewBadge.jsx
+++ b/src/features/feature-discovery/ui/FeatureNewBadge.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+/**
+ * Soft discovery chrome (#639).
+ * - `label` — “New” micro-pill (section headings, roomy chrome)
+ * - `dot` — corner accent for tight controls (e.g. Standings Stats tab)
+ *
+ * @param {{
+ *   className?: string,
+ *   title?: string,
+ *   variant?: 'label' | 'dot',
+ * }} [props]
+ */
+export default function FeatureNewBadge({
+  className = '',
+  title = 'New feature',
+  variant = 'label',
+}) {
+  if (variant === 'dot') {
+    return (
+      <span
+        title={title}
+        className={[
+          'pointer-events-none absolute right-1 top-1 inline-flex items-center justify-center',
+          className,
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        <span className="sr-only">{title}</span>
+        <span
+          className="h-1.5 w-1.5 shrink-0 rounded-full bg-brand-primary shadow-[0_0_0_1px_rgba(0,0,0,0.35)]"
+          aria-hidden
+        />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      title={title}
+      className={[
+        'inline-block shrink-0 rounded-md border border-brand-primary/35 bg-brand-primary/15 px-1 py-0.5 text-[9px] font-black uppercase tracking-wider text-brand-primary',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      New
+    </span>
+  );
+}

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
@@ -169,8 +169,8 @@ export const COMMS_TEMPLATE_REGISTRY = {
           `${handleOf(p)}, the run kicks off ${dayLabel}.`,
           venueLine(p, { dateKey: 'first_show_date', venueKey: 'first_show_venue', cityKey: 'first_show_city' })
             ? `First show: ${venueLine(p, { dateKey: 'first_show_date', venueKey: 'first_show_venue', cityKey: 'first_show_city' })}.`
-            : 'Get your picks ready before the first downbeat.',
-          `Picks lock at ${p.lock_time_local || '7:55 PM'} local on show night — don't get shut out.`,
+            : 'The first show is coming up.',
+          'Get your picks ready before the first downbeat.',
         ],
         cta: tourCountdownInAppCta(p),
       };
@@ -185,7 +185,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           first_show_date: 'Jul 18',
           first_show_venue: 'MSG',
           first_show_city: 'New York, NY',
-          lock_time_local: '7:55 PM',
+          lock_time_local: '7:30 PM',
         },
       },
       {
@@ -197,7 +197,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           first_show_date: 'Jul 18',
           first_show_venue: 'MSG',
           first_show_city: 'New York, NY',
-          lock_time_local: '7:55 PM',
+          lock_time_local: '7:30 PM',
         },
       },
       {
@@ -209,7 +209,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           first_show_date: 'Jul 7',
           first_show_venue: 'Kohl Center',
           first_show_city: 'Madison, WI',
-          lock_time_local: '7:55 PM',
+          lock_time_local: '7:30 PM',
         },
       },
       {
@@ -232,7 +232,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           first_show_date: 'Jul 7',
           first_show_venue: 'Kohl Center',
           first_show_city: 'Madison, WI',
-          lock_time_local: '7:55 PM',
+          lock_time_local: '7:30 PM',
           picks_secured: true,
         },
       },
@@ -605,23 +605,24 @@ export const COMMS_TEMPLATE_REGISTRY = {
   'picks-lock-reminder': {
     triggerId: 'picks_lock_reminder',
     displayName: 'Lock reminder',
-    build: (p) => ({
-      icon: AlarmClock,
-      accentClassName: 'text-rose-300',
-      eyebrow: 'Picks lock soon',
-      title: 'Lock in your picks',
-      paragraphs: [
-        `${handleOf(p)}, ${venueLine(p) || "tonight's show"} locks at ${p.lock_time_local || '7:55 PM'} local${
-          p.time_to_lock ? ` — about ${p.time_to_lock} away` : ''
-        }.`,
-        isPicksSecured(p)
-          ? 'Your picks are on the board — open them any time before lock to tweak.'
-          : "You haven't locked picks yet. Don't get shut out of the night.",
-      ],
-      cta: isPicksSecured(p)
-        ? { ...VIEW_EDIT_PICKS_CTA }
-        : { label: 'Make your picks', href: PICKS_HREF },
-    }),
+    build: (p) => {
+      const timeToLock = p.time_to_lock || 'A few hours';
+      return {
+        icon: AlarmClock,
+        accentClassName: 'text-rose-300',
+        eyebrow: 'Picks lock soon',
+        title: `${timeToLock} until picks lock`,
+        paragraphs: [
+          `${handleOf(p)}, lock in your picks${venueLine(p) ? ` for ${venueLine(p)}` : ''}.`,
+          isPicksSecured(p)
+            ? 'Your picks are on the board — open them any time before lock to tweak.'
+            : "You haven't locked picks yet. Don't get shut out of the night.",
+        ],
+        cta: isPicksSecured(p)
+          ? { ...VIEW_EDIT_PICKS_CTA }
+          : { label: 'Make your picks', href: PICKS_HREF },
+      };
+    },
     samples: [
       {
         name: 'Lock reminder',
@@ -631,7 +632,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           venue_name: 'MSG',
           venue_city: 'New York, NY',
           time_to_lock: '3 hours',
-          lock_time_local: '7:55 PM',
+          lock_time_local: '7:30 PM',
         },
       },
       {
@@ -642,7 +643,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           venue_name: 'MSG',
           venue_city: 'New York, NY',
           time_to_lock: '3 hours',
-          lock_time_local: '7:55 PM',
+          lock_time_local: '7:30 PM',
           picks_secured: true,
         },
       },

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.test.js
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.test.js
@@ -91,6 +91,32 @@ describe('comms template registry', () => {
     );
   });
 
+  it('picks lock reminder uses relative cutoff only (#522)', () => {
+    const entry = getCommsTemplateEntry('picks-lock-reminder');
+    const result = entry.build({
+      handle: 'HotDogBilly',
+      venue_name: 'MSG',
+      venue_city: 'New York, NY',
+      time_to_lock: '2h 15m',
+      lock_time_local: '7:30 PM',
+    });
+    const text = [result.title, ...result.paragraphs].join(' ');
+    expect(text).toContain('2h 15m until picks lock');
+    expect(text).not.toContain('7:30 PM');
+  });
+
+  it('tour countdown omits an absolute picks cutoff (#522)', () => {
+    const entry = getCommsTemplateEntry('tour-countdown');
+    const result = entry.build({
+      handle: 'HotDogBilly',
+      days_remaining: 1,
+      lock_time_local: '7:30 PM',
+    });
+    const text = [result.title, ...result.paragraphs].join(' ');
+    expect(text).not.toContain('7:30 PM');
+    expect(text).not.toMatch(/picks lock/i);
+  });
+
   it('tour engagement reminder uses in-app picks CTA (not "Open the app")', () => {
     const entry = getCommsTemplateEntry('tour-engagement-reminder');
     expect(entry.build({}).cta).toEqual({

--- a/src/features/picks/index.js
+++ b/src/features/picks/index.js
@@ -4,6 +4,7 @@ export { default as PastShowLockBanner } from './ui/PastShowLockBanner';
 export { default as TooEarlyBanner } from './ui/TooEarlyBanner';
 export { default as PicksFieldsForm } from './ui/PicksFieldsForm';
 export { default as PicksMobileFixedChrome } from './ui/PicksMobileFixedChrome';
+export { default as PicksLockTimingBanner } from './ui/PicksLockTimingBanner';
 export { default as PicksSubmitButton } from './ui/PicksSubmitButton';
 export { default as PicksSelfRecapSection } from './ui/PicksSelfRecapSection';
 export { default as usePicksForm } from './model/usePicksForm';

--- a/src/features/picks/model/useSetlistLockToast.js
+++ b/src/features/picks/model/useSetlistLockToast.js
@@ -8,7 +8,7 @@ import { showSuccessToast } from '../../../shared/ui/toast';
  *
  * Handles the common case where the user has the dashboard open around show
  * time: without a page reload, the status changes live and the toast fires
- * when 7:55 pm local arrives.  A hard reload after lock (initial status
+ * when the resolved venue-local lock arrives. A hard reload after lock (initial status
  * already 'LIVE') does not re-fire the toast.
  *
  * @param {string|null} showStatus - Result of getShowStatus() for the active
@@ -22,7 +22,7 @@ export function useSetlistLockToast(showStatus) {
     prevStatusRef.current = showStatus;
 
     if (prev === 'NEXT' && showStatus === 'LIVE') {
-      showSuccessToast("Picks are locked — show time! 🎸");
+      showSuccessToast('Picks locked, almost showtime!');
     }
   }, [showStatus]);
 }

--- a/src/features/picks/ui/PicksLockTimingBanner.jsx
+++ b/src/features/picks/ui/PicksLockTimingBanner.jsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import { Clock3, X } from 'lucide-react';
+
+import {
+  PICKS_LOCK_SAFETY_MIN,
+  TOUR_AVG_DOORS_TO_START_MIN,
+  formatLockTimeLocalLabel,
+  parseLocalHm,
+  resolvePicksLockHm,
+} from '../../../shared/utils/picksLockTime';
+
+function durationWords(minutes) {
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  const parts = [];
+  if (hours > 0) parts.push(`${hours} hour${hours === 1 ? '' : 's'}`);
+  if (mins > 0) parts.push(`${mins} minute${mins === 1 ? '' : 's'}`);
+  return parts.join(' ');
+}
+
+/**
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string, picksLockSource?: string } | null | undefined} show
+ */
+export function buildPicksLockTimingMessage(show) {
+  const lock = resolvePicksLockHm(show);
+  const lockLabel = formatLockTimeLocalLabel(lock);
+  const doors = parseLocalHm(lock.doorsLocal);
+  const isDoorsBased =
+    lock.source === 'doors' || show?.picksLockSource === 'doors';
+
+  if (doors && isDoorsBased) {
+    const offsetMinutes =
+      TOUR_AVG_DOORS_TO_START_MIN - PICKS_LOCK_SAFETY_MIN;
+    return `Picks lock at ${lockLabel} — ${durationWords(
+      offsetMinutes
+    )} after tonight’s published doors time (${formatLockTimeLocalLabel(doors)}).`;
+  }
+
+  return `Picks lock at ${lockLabel} venue-local.`;
+}
+
+function dismissalKey(showDate) {
+  return `picks-lock-timing-dismissed:${showDate}`;
+}
+
+function wasDismissed(showDate) {
+  if (!showDate || typeof window === 'undefined') return false;
+  try {
+    return window.sessionStorage.getItem(dismissalKey(showDate)) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function rememberDismissal(showDate) {
+  if (!showDate || typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(dismissalKey(showDate), '1');
+  } catch {
+    // Storage can be disabled; local state still dismisses for this mount.
+  }
+}
+
+/**
+ * Small pre-lock timing notice shared by Picks and Standings.
+ *
+ * @param {{
+ *   show: { date?: string, doorsLocal?: string, picksLockLocal?: string, picksLockSource?: string } | null | undefined,
+ *   showStatus: string | null | undefined
+ * }} props
+ */
+export default function PicksLockTimingBanner({ show, showStatus }) {
+  const showDate = typeof show?.date === 'string' ? show.date : '';
+  const [dismissed, setDismissed] = useState(() => wasDismissed(showDate));
+
+  if (!show || showStatus !== 'NEXT' || dismissed) return null;
+
+  const dismiss = () => {
+    setDismissed(true);
+    rememberDismissal(showDate);
+  };
+
+  return (
+    <div
+      className="mb-4 flex items-start gap-2.5 rounded-md border border-sky-400/30 bg-sky-400/10 p-3 text-sm text-sky-100/90"
+      role="status"
+    >
+      <Clock3 className="mt-0.5 h-5 w-5 shrink-0 text-sky-300" aria-hidden />
+      <span className="min-w-0 flex-1">{buildPicksLockTimingMessage(show)}</span>
+      <button
+        type="button"
+        onClick={dismiss}
+        className="-mr-1 -mt-1 rounded-md p-1 text-sky-200/70 transition hover:bg-sky-300/10 hover:text-sky-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300/70"
+        aria-label="Dismiss picks lock timing"
+      >
+        <X className="h-4 w-4" aria-hidden />
+      </button>
+    </div>
+  );
+}

--- a/src/features/picks/ui/PicksLockTimingBanner.test.js
+++ b/src/features/picks/ui/PicksLockTimingBanner.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildPicksLockTimingMessage } from './PicksLockTimingBanner';
+
+describe('buildPicksLockTimingMessage', () => {
+  it('explains the doors-based lock for tonight', () => {
+    expect(
+      buildPicksLockTimingMessage({
+        date: '2026-07-18',
+        doorsLocal: '17:30',
+        picksLockLocal: '19:10',
+        picksLockSource: 'doors',
+      })
+    ).toBe(
+      'Picks lock at 7:10 PM — 1 hour 40 minutes after tonight’s published doors time (5:30 PM).'
+    );
+  });
+
+  it('shows only the venue-local fallback when doors are unknown', () => {
+    expect(buildPicksLockTimingMessage({ date: '2099-01-01' })).toBe(
+      'Picks lock at 7:30 PM venue-local.'
+    );
+  });
+});

--- a/src/features/profile/api/profileSeasonStats.js
+++ b/src/features/profile/api/profileSeasonStats.js
@@ -1,6 +1,7 @@
 import { doc, getDoc } from 'firebase/firestore';
 
 import { db } from '../../../shared/lib/firebase';
+import { todayYmd } from '../../../shared/utils/dateUtils';
 import { pickCountsTowardSeason } from '../../../shared/utils/showAggregation';
 import { fetchGlobalMaxScoreForShow } from '../../scoring';
 
@@ -65,6 +66,8 @@ export const EMPTY_USER_SEASON_STATS_TELEMETRY = Object.freeze({
  *   - `totalPoints` / `shows` — sum of the user's own graded picks.
  *   - `wins` — shows won overall (global high score across every graded,
  *     non-empty pick for that show), not pool-scoped wins. Ties share.
+ *   - `careerCorrectSlots` — preserved from the user doc when present
+ *     (#635 Slice 0); live path does not recompute slot correctness.
  *
  * Also reports per-invocation read-cost counters via the optional
  * `onTelemetry` callback so `useUserSeasonStats` can ship the #220
@@ -177,7 +180,61 @@ export async function computeUserSeasonStats(uid, showDates, options = {}) {
   }
 
   emit();
-  return { totalPoints, shows, wins };
+  // #635 Slice 0: live path only recomputes points/shows/wins. Preserve
+  // rollup/backfill `careerCorrectSlots` so avg correct still renders when
+  // freshness short-circuit fails (ungraded calendar dates, etc.).
+  return withCareerCorrectSlots({ totalPoints, shows, wins }, userData);
+}
+
+/**
+ * Heuristic for "the most recent finalized show the client is aware of" —
+ * the max calendar date **strictly before today**. Used by
+ * `computeUserSeasonStats` (#244) to decide whether the `users/{uid}`
+ * materialized snapshot is fresh enough to short-circuit the
+ * live-compute fallback.
+ *
+ * Today's show is excluded (#635 Slice 0): finalize is still manual, so
+ * treating an ungraded show-day calendar entry as finalized falsely marks
+ * rollups through yesterday as stale. Multi-day calendar gaps still need
+ * the rollup watermark (Slices 1–2 on #635).
+ *
+ * @param {Array<{ date: string }>} showDates
+ * @param {string} [today] YYYY-MM-DD override for unit tests
+ * @returns {string | null}
+ */
+export function deriveLatestFinalizedShow(showDates, today = todayYmd()) {
+  if (!Array.isArray(showDates) || showDates.length === 0) return null;
+  const todayYmdValue =
+    typeof today === 'string' && today ? today : todayYmd();
+  let latest = null;
+  for (const s of showDates) {
+    const d = s && typeof s.date === 'string' ? s.date : '';
+    // Exclude today and future — only prior calendar nights are treated
+    // as potentially finalized.
+    if (!d || d >= todayYmdValue) continue;
+    if (!latest || d > latest) latest = d;
+  }
+  return latest;
+}
+
+/**
+ * Attach `careerCorrectSlots` from a `users/{uid}` snapshot when present.
+ * Used by both the materialized short-circuit and the live fallback so avg
+ * correct (#554 / #635) does not depend on freshness succeeding.
+ *
+ * @param {UserSeasonStats} stats
+ * @param {Record<string, unknown> | null | undefined} userData
+ * @returns {UserSeasonStats}
+ */
+export function withCareerCorrectSlots(stats, userData) {
+  const out = { ...stats };
+  if (
+    typeof userData?.careerCorrectSlots === 'number' &&
+    Number.isFinite(userData.careerCorrectSlots)
+  ) {
+    out.careerCorrectSlots = userData.careerCorrectSlots;
+  }
+  return out;
 }
 
 /**
@@ -214,12 +271,5 @@ export function readMaterializedSeasonStats(userData, latestFinalizedShow) {
       ? userData.seasonStatsThroughShow
       : '';
   if (!through || through < latestFinalizedShow) return null;
-  const out = { totalPoints, shows, wins };
-  if (
-    typeof userData.careerCorrectSlots === 'number' &&
-    Number.isFinite(userData.careerCorrectSlots)
-  ) {
-    out.careerCorrectSlots = userData.careerCorrectSlots;
-  }
-  return out;
+  return withCareerCorrectSlots({ totalPoints, shows, wins }, userData);
 }

--- a/src/features/profile/api/profileSeasonStats.test.js
+++ b/src/features/profile/api/profileSeasonStats.test.js
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { readMaterializedSeasonStats } from './profileSeasonStats';
+import {
+  deriveLatestFinalizedShow,
+  readMaterializedSeasonStats,
+  withCareerCorrectSlots,
+} from './profileSeasonStats';
 
 /**
  * #244 short-circuit decision logic. Kept as a pure predicate so the
@@ -100,5 +104,87 @@ describe('readMaterializedSeasonStats', () => {
         '2026-04-23'
       )
     ).toEqual({ totalPoints: 0, shows: 0, wins: 0 });
+  });
+});
+
+/**
+ * #635 Slice 0: live fallback must keep rollup/backfill careerCorrectSlots
+ * so avg correct still renders when freshness short-circuit fails.
+ */
+describe('withCareerCorrectSlots', () => {
+  const BASE = { totalPoints: 42, shows: 5, wins: 2 };
+
+  it('attaches a finite careerCorrectSlots from the user doc', () => {
+    expect(
+      withCareerCorrectSlots(BASE, { careerCorrectSlots: 18 })
+    ).toEqual({ ...BASE, careerCorrectSlots: 18 });
+  });
+
+  it('preserves zero careerCorrectSlots', () => {
+    expect(
+      withCareerCorrectSlots(BASE, { careerCorrectSlots: 0 })
+    ).toEqual({ ...BASE, careerCorrectSlots: 0 });
+  });
+
+  it('leaves stats unchanged when careerCorrectSlots is missing or invalid', () => {
+    expect(withCareerCorrectSlots(BASE, null)).toEqual(BASE);
+    expect(withCareerCorrectSlots(BASE, {})).toEqual(BASE);
+    expect(
+      withCareerCorrectSlots(BASE, { careerCorrectSlots: '18' })
+    ).toEqual(BASE);
+    expect(
+      withCareerCorrectSlots(BASE, { careerCorrectSlots: Number.NaN })
+    ).toEqual(BASE);
+  });
+
+  it('does not mutate the input stats object', () => {
+    const input = { ...BASE };
+    withCareerCorrectSlots(input, { careerCorrectSlots: 9 });
+    expect(input).toEqual(BASE);
+  });
+});
+
+/**
+ * #635 Slice 0: exclude today so an ungraded show-day calendar entry does
+ * not falsely stale rollups through yesterday.
+ */
+describe('deriveLatestFinalizedShow', () => {
+  it('returns the max calendar date strictly before today', () => {
+    expect(
+      deriveLatestFinalizedShow(
+        [
+          { date: '2026-07-15' },
+          { date: '2026-07-16' },
+          { date: '2026-07-17' },
+        ],
+        '2026-07-17'
+      )
+    ).toBe('2026-07-16');
+  });
+
+  it('skips today even when it is the only calendar date', () => {
+    expect(
+      deriveLatestFinalizedShow([{ date: '2026-07-17' }], '2026-07-17')
+    ).toBeNull();
+  });
+
+  it('skips future dates and empty/invalid entries', () => {
+    expect(
+      deriveLatestFinalizedShow(
+        [
+          { date: '2026-07-14' },
+          { date: '' },
+          null,
+          { date: '2026-07-20' },
+          { date: '2026-07-15' },
+        ],
+        '2026-07-17'
+      )
+    ).toBe('2026-07-15');
+  });
+
+  it('returns null for an empty calendar', () => {
+    expect(deriveLatestFinalizedShow([], '2026-07-17')).toBeNull();
+    expect(deriveLatestFinalizedShow(null, '2026-07-17')).toBeNull();
   });
 });

--- a/src/features/profile/model/profileEngagementAnalytics.js
+++ b/src/features/profile/model/profileEngagementAnalytics.js
@@ -1,0 +1,37 @@
+import { ga4Event } from '../../../shared/lib/ga4';
+
+/**
+ * User successfully saved a different curated avatar (#638).
+ *
+ * @param {{ avatar_id?: string }} [payload]
+ */
+export function trackAvatarChanged({ avatar_id } = {}) {
+  ga4Event('avatar_changed', {
+    avatar_id: avatar_id ?? '',
+  });
+}
+
+/**
+ * Badge shelf section is visible on profile or public profile (#638).
+ *
+ * @param {{ surface?: 'profile' | 'public_profile', badge_count?: number }} [payload]
+ */
+export function trackBadgeShelfView({ surface, badge_count } = {}) {
+  ga4Event('badge_shelf_view', {
+    surface: surface === 'public_profile' ? 'public_profile' : 'profile',
+    badge_count: Math.max(0, Number(badge_count) || 0),
+  });
+}
+
+/**
+ * User pins/unpins a badge for standings display (#638).
+ * Exported for the future pin UX — no client UI wires this yet.
+ *
+ * @param {{ badge_id?: string, action?: 'pin' | 'unpin' }} [payload]
+ */
+export function trackBadgePinChanged({ badge_id, action } = {}) {
+  ga4Event('badge_pin_changed', {
+    badge_id: badge_id ?? '',
+    action: action === 'unpin' ? 'unpin' : 'pin',
+  });
+}

--- a/src/features/profile/model/profileEngagementAnalytics.test.js
+++ b/src/features/profile/model/profileEngagementAnalytics.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../shared/lib/ga4', () => ({
+  ga4Event: vi.fn(),
+}));
+
+import { ga4Event } from '../../../shared/lib/ga4';
+import {
+  trackAvatarChanged,
+  trackBadgePinChanged,
+  trackBadgeShelfView,
+} from './profileEngagementAnalytics.js';
+
+describe('profileEngagementAnalytics', () => {
+  beforeEach(() => {
+    ga4Event.mockClear();
+  });
+
+  it('trackAvatarChanged emits avatar_id', () => {
+    trackAvatarChanged({ avatar_id: 'disc' });
+    expect(ga4Event).toHaveBeenCalledWith('avatar_changed', {
+      avatar_id: 'disc',
+    });
+  });
+
+  it('trackBadgeShelfView normalizes surface and count', () => {
+    trackBadgeShelfView({ surface: 'public_profile', badge_count: 3 });
+    expect(ga4Event).toHaveBeenCalledWith('badge_shelf_view', {
+      surface: 'public_profile',
+      badge_count: 3,
+    });
+
+    trackBadgeShelfView({ surface: 'other', badge_count: -1 });
+    expect(ga4Event).toHaveBeenLastCalledWith('badge_shelf_view', {
+      surface: 'profile',
+      badge_count: 0,
+    });
+  });
+
+  it('trackBadgePinChanged defaults action to pin', () => {
+    trackBadgePinChanged({ badge_id: 'win_1', action: 'unpin' });
+    expect(ga4Event).toHaveBeenCalledWith('badge_pin_changed', {
+      badge_id: 'win_1',
+      action: 'unpin',
+    });
+
+    trackBadgePinChanged({ badge_id: 'shows_played_1' });
+    expect(ga4Event).toHaveBeenLastCalledWith('badge_pin_changed', {
+      badge_id: 'shows_played_1',
+      action: 'pin',
+    });
+  });
+});

--- a/src/features/profile/model/useUserProfile.js
+++ b/src/features/profile/model/useUserProfile.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useAuth } from '../../auth';
 import { formatMonthYear } from '../../../shared';
@@ -8,6 +8,7 @@ import {
 } from '../api/profileApi';
 import { showSuccessToast } from '../../../shared/ui/toast';
 import { DEFAULT_AVATAR_ID, normalizeAvatarId } from './avatarCatalog';
+import { trackAvatarChanged } from './profileEngagementAnalytics';
 
 /**
  * Loads the signed-in user's profile, holds edit form state, and persists updates.
@@ -25,6 +26,8 @@ export function useUserProfile(user) {
   const [isLoading, setIsLoading] = useState(!!uid);
   const [isSaving, setIsSaving] = useState(false);
   const [message, setMessage] = useState({ text: '', type: '' });
+  /** Last persisted avatar — used to detect real changes on save (#638). */
+  const persistedAvatarIdRef = useRef(DEFAULT_AVATAR_ID);
 
   useEffect(() => {
     if (!uid) {
@@ -34,6 +37,7 @@ export function useUserProfile(user) {
       setAvatarId(DEFAULT_AVATAR_ID);
       setBadges(null);
       setJoinDate('');
+      persistedAvatarIdRef.current = DEFAULT_AVATAR_ID;
       return;
     }
 
@@ -45,7 +49,9 @@ export function useUserProfile(user) {
       if (data) {
         setHandle(data.handle || '');
         setFavoriteSong(data.favoriteSong || '');
-        setAvatarId(normalizeAvatarId(data.avatarId));
+        const nextAvatar = normalizeAvatarId(data.avatarId);
+        setAvatarId(nextAvatar);
+        persistedAvatarIdRef.current = nextAvatar;
         setBadges(
           data.badges && typeof data.badges === 'object' && !Array.isArray(data.badges)
             ? data.badges
@@ -55,6 +61,7 @@ export function useUserProfile(user) {
         setHandle('');
         setFavoriteSong('');
         setAvatarId(DEFAULT_AVATAR_ID);
+        persistedAvatarIdRef.current = DEFAULT_AVATAR_ID;
         setBadges(null);
       }
     };
@@ -112,12 +119,17 @@ export function useUserProfile(user) {
 
       try {
         const nextAvatarId = normalizeAvatarId(avatarId);
+        const avatarChanged = nextAvatarId !== persistedAvatarIdRef.current;
         await updateUserProfileWithPickHandles(uid, {
           handle: trimmedHandle,
           favoriteSong,
           avatarId: nextAvatarId,
         });
         setAvatarId(nextAvatarId);
+        persistedAvatarIdRef.current = nextAvatarId;
+        if (avatarChanged) {
+          trackAvatarChanged({ avatar_id: nextAvatarId });
+        }
         setMessage({ text: 'Profile updated successfully! 🎸', type: 'success' });
         showSuccessToast('Profile updated! 🎸');
         return true;

--- a/src/features/profile/model/useUserSeasonStats.js
+++ b/src/features/profile/model/useUserSeasonStats.js
@@ -1,12 +1,12 @@
 import { useEffect, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
-import { todayYmd } from '../../../shared/utils/dateUtils';
 import { useAuth } from '../../auth';
 import { useShowCalendar } from '../../show-calendar';
 import {
   EMPTY_USER_SEASON_STATS,
   computeUserSeasonStats,
+  deriveLatestFinalizedShow,
 } from '../api/profileSeasonStats';
 import { emitProfileSeasonStatsTelemetry } from './profileStatsTelemetry';
 
@@ -20,34 +20,6 @@ function deriveShowDatesKey(showDates) {
     .map((s) => (s && typeof s.date === 'string' ? s.date : ''))
     .filter(Boolean)
     .join('|');
-}
-
-/**
- * Heuristic for "the most recent finalized show the client is aware of" —
- * the max calendar date on or before today. Used by
- * `computeUserSeasonStats` (#244) to decide whether the `users/{uid}`
- * materialized snapshot is fresh enough to short-circuit the
- * live-compute fallback.
- *
- * Today's show may not have been rolled up yet (finalize is still manual);
- * if that's the case for the most-recent-show user, the snapshot will be
- * stale and they'll fall back to live-compute for one profile view until
- * the next rollup catches up. Acceptable trade-off vs. a second Firestore
- * read to load a global "last rolled up show" marker.
- *
- * @param {Array<{ date: string }>} showDates
- * @returns {string | null}
- */
-function deriveLatestFinalizedShow(showDates) {
-  if (!Array.isArray(showDates) || showDates.length === 0) return null;
-  const today = todayYmd();
-  let latest = null;
-  for (const s of showDates) {
-    const d = s && typeof s.date === 'string' ? s.date : '';
-    if (!d || d > today) continue;
-    if (!latest || d > latest) latest = d;
-  }
-  return latest;
 }
 
 /**

--- a/src/features/profile/ui/AvatarPicker.jsx
+++ b/src/features/profile/ui/AvatarPicker.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { FeatureNewBadge } from '../../feature-discovery';
 import { PROFILE_AVATARS } from '../model/avatarCatalog';
 import ProfileAvatar from './ProfileAvatar';
 
@@ -10,13 +11,20 @@ import ProfileAvatar from './ProfileAvatar';
  *   value: string,
  *   onChange: (avatarId: string) => void,
  *   disabled?: boolean,
+ *   showNewBadge?: boolean,
  * }} props
  */
-export default function AvatarPicker({ value, onChange, disabled = false }) {
+export default function AvatarPicker({
+  value,
+  onChange,
+  disabled = false,
+  showNewBadge = false,
+}) {
   return (
     <fieldset disabled={disabled} className="min-w-0">
-      <legend className="mb-2 ml-1 text-xs font-bold uppercase tracking-widest text-slate-400">
+      <legend className="mb-2 ml-1 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-slate-400">
         Avatar
+        {showNewBadge ? <FeatureNewBadge title="New: profile avatars" /> : null}
       </legend>
       <div className="mb-3 flex items-center gap-3">
         <ProfileAvatar avatarId={value} size="lg" />

--- a/src/features/profile/ui/BadgeShelf.jsx
+++ b/src/features/profile/ui/BadgeShelf.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 
+import { FeatureNewBadge } from '../../feature-discovery';
 import { resolveEarnedBadges } from '../model/badgeCatalog';
 import { trackBadgeShelfView } from '../model/profileEngagementAnalytics';
 
@@ -10,12 +11,14 @@ import { trackBadgeShelfView } from '../model/profileEngagementAnalytics';
  *   badges?: Record<string, unknown> | null,
  *   emptyLabel?: string,
  *   surface?: 'profile' | 'public_profile',
+ *   showNewBadge?: boolean,
  * }} props
  */
 export default function BadgeShelf({
   badges = null,
   emptyLabel = 'No badges yet — play a scored show to start earning.',
   surface = 'profile',
+  showNewBadge = false,
 }) {
   const earned = resolveEarnedBadges(badges);
   const viewLoggedRef = useRef(false);
@@ -31,8 +34,9 @@ export default function BadgeShelf({
 
   return (
     <section className="mt-6 rounded-3xl border border-border-subtle bg-surface-panel p-6 shadow-inset-glass">
-      <h2 className="mb-3 text-xs font-black uppercase tracking-widest text-content-secondary">
+      <h2 className="mb-3 flex items-center gap-2 text-xs font-black uppercase tracking-widest text-content-secondary">
         Badges
+        {showNewBadge ? <FeatureNewBadge title="New: milestone badges" /> : null}
       </h2>
       {earned.length === 0 ? (
         <p className="text-sm font-bold text-content-secondary">{emptyLabel}</p>

--- a/src/features/profile/ui/BadgeShelf.jsx
+++ b/src/features/profile/ui/BadgeShelf.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import { resolveEarnedBadges } from '../model/badgeCatalog';
+import { trackBadgeShelfView } from '../model/profileEngagementAnalytics';
 
 /**
  * Earned milestone badges shelf (#568).
@@ -8,13 +9,25 @@ import { resolveEarnedBadges } from '../model/badgeCatalog';
  * @param {{
  *   badges?: Record<string, unknown> | null,
  *   emptyLabel?: string,
+ *   surface?: 'profile' | 'public_profile',
  * }} props
  */
 export default function BadgeShelf({
   badges = null,
   emptyLabel = 'No badges yet — play a scored show to start earning.',
+  surface = 'profile',
 }) {
   const earned = resolveEarnedBadges(badges);
+  const viewLoggedRef = useRef(false);
+
+  useEffect(() => {
+    if (viewLoggedRef.current) return;
+    viewLoggedRef.current = true;
+    trackBadgeShelfView({
+      surface,
+      badge_count: earned.length,
+    });
+  }, [surface, earned.length]);
 
   return (
     <section className="mt-6 rounded-3xl border border-border-subtle bg-surface-panel p-6 shadow-inset-glass">

--- a/src/features/profile/ui/ProfileEditForm.jsx
+++ b/src/features/profile/ui/ProfileEditForm.jsx
@@ -6,6 +6,20 @@ import AvatarPicker from './AvatarPicker';
 
 /**
  * Editable profile fields (avatar, handle, favorite song) for the signed-in user.
+ *
+ * @param {{
+ *   handle: string,
+ *   favoriteSong: string,
+ *   avatarId: string,
+ *   onHandleChange: (v: string) => void,
+ *   onFavoriteSongChange: (v: string) => void,
+ *   onAvatarChange: (avatarId: string) => void,
+ *   onSave: (e: React.FormEvent) => void,
+ *   isSaving: boolean,
+ *   isLoading?: boolean,
+ *   message: { text: string, type: string },
+ *   showAvatarNewBadge?: boolean,
+ * }} props
  */
 export default function ProfileEditForm({
   handle,
@@ -18,6 +32,7 @@ export default function ProfileEditForm({
   isSaving,
   isLoading = false,
   message,
+  showAvatarNewBadge = false,
 }) {
   return (
     <form
@@ -28,6 +43,7 @@ export default function ProfileEditForm({
         value={avatarId}
         onChange={onAvatarChange}
         disabled={isLoading || isSaving}
+        showNewBadge={showAvatarNewBadge}
       />
 
       <div className="flex flex-col">

--- a/src/features/profile/ui/ProfileSelfStatsPanel.jsx
+++ b/src/features/profile/ui/ProfileSelfStatsPanel.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 
+import InfoTooltip, {
+  InfoTooltipProvider,
+} from '../../../shared/ui/InfoTooltip';
 import { useSongCatalog } from '../../song-catalog';
 import {
   buildDebutYearBySongName,
@@ -34,26 +37,36 @@ export default function ProfileSelfStatsPanel({ uid }) {
   );
   const avgVintage = formatAvgSongVintage(vintage.avgYear);
 
+  const vintageDefinition =
+    vintage.datedCount > 0
+      ? `Mean debut year of songs in your recent top-picks window (${vintage.datedCount} of ${vintage.uniqueCount} dated).`
+      : 'Mean debut year of songs in your recent top-picks window.';
+
   const columns = [
     {
       key: 'avgPts',
       label: 'Avg pts / show',
       value: avgPoints,
+      definition: 'Mean points per graded show across your career.',
     },
     {
       key: 'avgCorrect',
       label: 'Avg correct / show',
       value: avgCorrect,
+      definition:
+        'Mean correct pick slots per graded show. Shows — until your account has been rolled up after a finalize.',
     },
     {
       key: 'vintage',
       label: 'Avg vintage',
       value: avgVintage,
+      definition: vintageDefinition,
     },
     {
       key: 'shows',
       label: 'Shows',
       value: typeof stats?.shows === 'number' ? stats.shows : 0,
+      definition: 'Number of finalized shows you have graded picks for.',
     },
   ];
 
@@ -65,29 +78,25 @@ export default function ProfileSelfStatsPanel({ uid }) {
         <h2 className="mb-4 text-xs font-black uppercase tracking-widest text-content-secondary">
           Your stats
         </h2>
-        <div className="grid grid-cols-2 gap-3 text-center sm:grid-cols-4">
-          {columns.map(({ key, label, value }) => (
-            <div key={key} className="flex flex-col gap-1.5">
-              <p className="flex flex-1 items-end justify-center px-0.5 text-[10px] font-black uppercase leading-snug tracking-wider text-content-secondary">
-                {label}
-              </p>
-              <div className="flex min-h-[3.25rem] items-center justify-center rounded-2xl border border-border-subtle bg-surface-field px-2 py-3">
-                <span className="text-2xl font-black tabular-nums leading-none tracking-tight text-brand-primary">
-                  {statsLoading && key !== 'vintage' ? '…' : value}
-                </span>
+        <InfoTooltipProvider>
+          <div className="grid grid-cols-2 gap-3 text-center sm:grid-cols-4">
+            {columns.map(({ key, label, value, definition }) => (
+              <div key={key} className="flex flex-col gap-1.5">
+                <div className="flex flex-1 items-end justify-center gap-1 px-0.5">
+                  <p className="text-[10px] font-black uppercase leading-snug tracking-wider text-content-secondary">
+                    {label}
+                  </p>
+                  <InfoTooltip label={label} definition={definition} />
+                </div>
+                <div className="flex min-h-[3.25rem] items-center justify-center rounded-2xl border border-border-subtle bg-surface-field px-2 py-3">
+                  <span className="text-2xl font-black tabular-nums leading-none tracking-tight text-brand-primary">
+                    {statsLoading && key !== 'vintage' ? '…' : value}
+                  </span>
+                </div>
               </div>
-            </div>
-          ))}
-        </div>
-        <p className="mt-3 text-[11px] font-medium leading-relaxed text-content-secondary">
-          Career averages across graded nights. Avg correct needs the
-          finalize rollup field (shows — until backfilled). Vintage is the
-          mean debut year of songs in your recent top-picks window
-          {vintage.datedCount > 0
-            ? ` (${vintage.datedCount} of ${vintage.uniqueCount} dated)`
-            : ''}
-          .
-        </p>
+            ))}
+          </div>
+        </InfoTooltipProvider>
       </section>
 
       <TopPicksFrequencyStrip

--- a/src/features/profile/ui/PublicProfileView.jsx
+++ b/src/features/profile/ui/PublicProfileView.jsx
@@ -154,6 +154,7 @@ export default function PublicProfileView({
         <BadgeShelf
           badges={profile.badges}
           emptyLabel="No badges earned yet."
+          surface="public_profile"
         />
       </div>
     </div>

--- a/src/features/scoring/model/standingsAnalytics.js
+++ b/src/features/scoring/model/standingsAnalytics.js
@@ -1,0 +1,25 @@
+import { ga4Event } from '../../../shared/lib/ga4';
+
+/**
+ * Map Standings show status → live setlist engagement status (#638).
+ *
+ * @param {string} [showStatus]
+ * @returns {'live' | 'final' | 'waiting'}
+ */
+export function resolveLiveSetlistStatus(showStatus) {
+  if (showStatus === 'LIVE') return 'live';
+  if (showStatus === 'PAST') return 'final';
+  return 'waiting';
+}
+
+/**
+ * Official / live setlist card is shown on Standings (#638).
+ *
+ * @param {{ show_date?: string, setlist_status?: string }} [payload]
+ */
+export function trackLiveSetlistView({ show_date, setlist_status } = {}) {
+  ga4Event('live_setlist_view', {
+    show_date: show_date ?? '',
+    setlist_status: setlist_status ?? 'waiting',
+  });
+}

--- a/src/features/scoring/model/standingsAnalytics.test.js
+++ b/src/features/scoring/model/standingsAnalytics.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../shared/lib/ga4', () => ({
+  ga4Event: vi.fn(),
+}));
+
+import { ga4Event } from '../../../shared/lib/ga4';
+import {
+  resolveLiveSetlistStatus,
+  trackLiveSetlistView,
+} from './standingsAnalytics.js';
+
+describe('resolveLiveSetlistStatus', () => {
+  it('maps LIVE / PAST / other', () => {
+    expect(resolveLiveSetlistStatus('LIVE')).toBe('live');
+    expect(resolveLiveSetlistStatus('PAST')).toBe('final');
+    expect(resolveLiveSetlistStatus('NEXT')).toBe('waiting');
+    expect(resolveLiveSetlistStatus('')).toBe('waiting');
+  });
+});
+
+describe('trackLiveSetlistView', () => {
+  beforeEach(() => {
+    ga4Event.mockClear();
+  });
+
+  it('emits live_setlist_view with show_date and setlist_status', () => {
+    trackLiveSetlistView({
+      show_date: '2026-07-15',
+      setlist_status: 'live',
+    });
+    expect(ga4Event).toHaveBeenCalledWith('live_setlist_view', {
+      show_date: '2026-07-15',
+      setlist_status: 'live',
+    });
+  });
+
+  it('defaults empty date and waiting status', () => {
+    trackLiveSetlistView();
+    expect(ga4Event).toHaveBeenCalledWith('live_setlist_view', {
+      show_date: '',
+      setlist_status: 'waiting',
+    });
+  });
+});

--- a/src/features/scoring/model/useStandingsScreen.js
+++ b/src/features/scoring/model/useStandingsScreen.js
@@ -183,10 +183,13 @@ export function useStandingsScreen(selectedDate, options = {}) {
 
   // Card / banner surfaces have room for the full city/venue token —
   // do not use the 40-char compact picker truncate here (#609 follow-up).
-  const showLabel = useMemo(() => {
-    const show = showDates.find((s) => s.date === selectedDate);
-    return show ? showOptionLabelDesktop(show) : selectedDate;
-  }, [selectedDate, showDates]);
+  const selectedShow = useMemo(
+    () => showDates.find((show) => show.date === selectedDate) ?? null,
+    [selectedDate, showDates]
+  );
+  const showLabel = selectedShow
+    ? showOptionLabelDesktop(selectedShow)
+    : selectedDate;
 
   const activePoolName = useMemo(() => {
     if (view !== 'pools' || !poolId) return null;
@@ -262,6 +265,7 @@ export function useStandingsScreen(selectedDate, options = {}) {
     loading,
     showStatus,
     showLabel,
+    selectedShow,
     selectedDate,
     isShowToday,
     picks,

--- a/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
+++ b/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useRef } from 'react';
 import { ChevronDown, ExternalLink, ListMusic } from 'lucide-react';
 
+import {
+  FeatureNewBadge,
+  useFeatureSpotlight,
+} from '../../feature-discovery';
 import Card from '../../../shared/ui/Card';
 import { SCORING_RULES } from '../../../shared/utils/scoring';
 import { buildPhishNetSetlistUrl } from '../model/buildPhishNetSetlistUrl';
@@ -115,10 +119,12 @@ export default function StandingsOfficialSetlistCard({
   const bustoutTitleSet = buildBustoutTitleSet(actualSetlist);
   const gapMap = buildSongGapMap(actualSetlist);
   const viewLoggedRef = useRef('');
+  const setlistSpotlight = useFeatureSpotlight('live-setlist');
 
   const hasContent =
     Boolean(actualSetlist) &&
     (grouped.hasSongs || grouped.hasOfficialSlots);
+  const isLive = showStatus === 'LIVE';
 
   useEffect(() => {
     if (!hasContent) return;
@@ -136,9 +142,14 @@ export default function StandingsOfficialSetlistCard({
     return null;
   }
 
-  const isLive = showStatus === 'LIVE';
   const statusLabel = isLive ? 'Live' : showStatus === 'PAST' ? 'Final' : 'Official';
   const phishNetHref = buildPhishNetSetlistUrl(showDate);
+
+  const onDetailsToggle = () => {
+    if (setlistSpotlight.active) {
+      setlistSpotlight.markSeen();
+    }
+  };
 
   return (
     <Card
@@ -147,7 +158,11 @@ export default function StandingsOfficialSetlistCard({
       padding="none"
       className={`mb-3 ${STANDINGS_CARD_SHELL} ${className}`.trim()}
     >
-      <details className="group" defaultOpen={isLive}>
+      <details
+        className="group"
+        defaultOpen={isLive}
+        onToggle={onDetailsToggle}
+      >
         <summary className="flex cursor-pointer list-none items-start justify-between gap-3 [&::-webkit-details-marker]:hidden">
           <div className="min-w-0 space-y-1">
             <div className="flex flex-wrap items-center gap-2">
@@ -167,6 +182,9 @@ export default function StandingsOfficialSetlistCard({
               >
                 {statusLabel}
               </span>
+              {setlistSpotlight.active ? (
+                <FeatureNewBadge title="New: live official setlist" />
+              ) : null}
             </div>
             {showLabel ? (
               <p className={`truncate ${STANDINGS_BOX_TITLE}`}>{showLabel}</p>

--- a/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
+++ b/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { ChevronDown, ExternalLink, ListMusic } from 'lucide-react';
 
 import Card from '../../../shared/ui/Card';
@@ -11,6 +11,10 @@ import {
   groupOfficialSetlistBySet,
   isOfficialSetlistBustout,
 } from '../model/groupOfficialSetlistBySet';
+import {
+  resolveLiveSetlistStatus,
+  trackLiveSetlistView,
+} from '../model/standingsAnalytics';
 import OfficialPickSlotsGrid from './OfficialPickSlotsGrid';
 import {
   STANDINGS_BOX_BODY,
@@ -110,8 +114,25 @@ export default function StandingsOfficialSetlistCard({
   const grouped = groupOfficialSetlistBySet(actualSetlist);
   const bustoutTitleSet = buildBustoutTitleSet(actualSetlist);
   const gapMap = buildSongGapMap(actualSetlist);
+  const viewLoggedRef = useRef('');
 
-  if (!actualSetlist || (!grouped.hasSongs && !grouped.hasOfficialSlots)) {
+  const hasContent =
+    Boolean(actualSetlist) &&
+    (grouped.hasSongs || grouped.hasOfficialSlots);
+
+  useEffect(() => {
+    if (!hasContent) return;
+    const setlistStatus = resolveLiveSetlistStatus(showStatus);
+    const sig = `${showDate}|${setlistStatus}`;
+    if (viewLoggedRef.current === sig) return;
+    viewLoggedRef.current = sig;
+    trackLiveSetlistView({
+      show_date: showDate || '',
+      setlist_status: setlistStatus,
+    });
+  }, [hasContent, showDate, showStatus]);
+
+  if (!hasContent) {
     return null;
   }
 

--- a/src/features/scoring/ui/StandingsShowOrPoolView.jsx
+++ b/src/features/scoring/ui/StandingsShowOrPoolView.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Inbox, Loader2, Music } from 'lucide-react';
 
+import { PicksLockTimingBanner } from '../../picks';
 import Card from '../../../shared/ui/Card';
 import PageTitle from '../../../shared/ui/PageTitle';
 import StandingsSelfRecapCard from './StandingsSelfRecapCard';
@@ -34,6 +35,7 @@ export default function StandingsShowOrPoolView({ screen }) {
     loading,
     showStatus,
     showLabel,
+    selectedShow,
     selectedDate,
     isShowToday,
     picks,
@@ -100,6 +102,11 @@ export default function StandingsShowOrPoolView({ screen }) {
   if (isShowView && showStatus === 'NEXT') {
     return (
       <>
+        <PicksLockTimingBanner
+          key={selectedDate}
+          show={selectedShow}
+          showStatus={showStatus}
+        />
         {showLastShowWinnerBanner ? (
           <StandingsWinnerOfTheNightBanner
             variant="lastShow"

--- a/src/features/scoring/ui/StandingsViewToggle.jsx
+++ b/src/features/scoring/ui/StandingsViewToggle.jsx
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { BarChart3, CalendarDays, ListOrdered, Users } from 'lucide-react';
 
+import {
+  FeatureNewBadge,
+  useFeatureSpotlight,
+} from '../../feature-discovery';
 import ChromeSegmentedControl from '../../../shared/ui/ChromeSegmentedControl';
 
 const OPTIONS = [
@@ -11,7 +15,7 @@ const OPTIONS = [
 ];
 
 const baseClass =
-  'shrink-0 inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-semibold tracking-tight transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg';
+  'relative shrink-0 inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-semibold tracking-tight transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg';
 
 /**
  * Active state mirrors `Button variant="primary"` (teal fill, dark text,
@@ -44,13 +48,31 @@ const unselectedClass =
  * }} props
  */
 export default function StandingsViewToggle({ view, onChange, className = '' }) {
+  const tourStatsSpotlight = useFeatureSpotlight('tour-stats');
+
+  const handleChange = (next) => {
+    if (next === 'stats' && tourStatsSpotlight.active) {
+      tourStatsSpotlight.trackClick();
+    }
+    onChange(next);
+  };
+
+  const items = useMemo(() => {
+    const badge = tourStatsSpotlight.active ? (
+      <FeatureNewBadge variant="dot" title="New: Tour Stats" />
+    ) : null;
+    return OPTIONS.map((opt) =>
+      opt.id === 'stats' ? { ...opt, badge } : opt,
+    );
+  }, [tourStatsSpotlight.active]);
+
   return (
     <>
       <ChromeSegmentedControl
         ariaLabel="Standings view"
         value={view}
-        onChange={onChange}
-        items={OPTIONS}
+        onChange={handleChange}
+        items={items}
         className={['md:hidden', className].filter(Boolean).join(' ')}
       />
 
@@ -64,7 +86,7 @@ export default function StandingsViewToggle({ view, onChange, className = '' }) 
           .filter(Boolean)
           .join(' ')}
       >
-        {OPTIONS.map(({ id, label, icon: Icon }) => {
+        {items.map(({ id, label, icon: Icon, badge }) => {
           const selected = view === id;
           return (
             <button
@@ -72,7 +94,7 @@ export default function StandingsViewToggle({ view, onChange, className = '' }) 
               type="button"
               role="tab"
               aria-selected={selected}
-              onClick={() => onChange(id)}
+              onClick={() => handleChange(id)}
               className={[
                 baseClass,
                 selected ? selectedClass : unselectedClass,
@@ -81,6 +103,7 @@ export default function StandingsViewToggle({ view, onChange, className = '' }) 
             >
               <Icon className="h-4 w-4 shrink-0" aria-hidden />
               {label}
+              {badge}
             </button>
           );
         })}

--- a/src/features/show-calendar/model/normalizeShowCalendarDoc.js
+++ b/src/features/show-calendar/model/normalizeShowCalendarDoc.js
@@ -1,9 +1,37 @@
+import { enrichShowWithPicksLock } from '../../../shared/utils/picksLockTime';
 import { resolveShowTimeZone } from '../../../shared/utils/showTimeZone';
 
 /**
+ * @param {Record<string, unknown>} s
+ * @returns {{ date: string, venue: string, timeZone: string, doorsLocal?: string, picksLockLocal?: string, picksLockSource?: string } | null}
+ */
+function normalizeShowRow(s) {
+  if (!s || typeof s !== 'object') return null;
+  const date = typeof s.date === 'string' ? s.date.trim() : '';
+  const venue = typeof s.venue === 'string' ? s.venue.trim() : '';
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || !venue) return null;
+  /** @type {{ date: string, venue: string, timeZone: string, doorsLocal?: string, picksLockLocal?: string }} */
+  const base = {
+    date,
+    venue,
+    timeZone: resolveShowTimeZone(
+      /** @type {{ timeZone?: string, timezone?: string, venue: string }} */ (s)
+    ),
+  };
+  if (typeof s.doorsLocal === 'string' && s.doorsLocal.trim()) {
+    base.doorsLocal = s.doorsLocal.trim();
+  }
+  if (typeof s.picksLockLocal === 'string' && s.picksLockLocal.trim()) {
+    base.picksLockLocal = s.picksLockLocal.trim();
+  }
+  return enrichShowWithPicksLock(base);
+}
+
+/**
  * Validates Firestore `show_calendar/snapshot` written by Cloud Functions (issue #160).
+ * Enriches each show with `doorsLocal` / `picksLockLocal` (#522 doors-based lock).
  * @param {import('firebase/firestore').DocumentData | null | undefined} data
- * @returns {{ showDatesByTour: { tour: string, shows: { date: string, venue: string, timeZone: string }[] }[], showDates: { date: string, venue: string, timeZone: string }[], syncError?: string | null } | null}
+ * @returns {{ showDatesByTour: { tour: string, shows: { date: string, venue: string, timeZone: string, doorsLocal?: string, picksLockLocal?: string }[] }[], showDates: { date: string, venue: string, timeZone: string, doorsLocal?: string, picksLockLocal?: string }[], syncError?: string | null } | null}
  */
 export function normalizeShowCalendarDoc(data) {
   if (!data || typeof data !== 'object') return null;
@@ -23,17 +51,9 @@ export function normalizeShowCalendarDoc(data) {
       if (!tour || !Array.isArray(shows) || shows.length === 0) return null;
       const normShows = [];
       for (const s of shows) {
-        if (!s || typeof s !== 'object') return null;
-        const date = typeof s.date === 'string' ? s.date.trim() : '';
-        const venue = typeof s.venue === 'string' ? s.venue.trim() : '';
-        if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || !venue) return null;
-        normShows.push({
-          date,
-          venue,
-          timeZone: resolveShowTimeZone(
-            /** @type {{ timeZone?: string, timezone?: string, venue: string }} */ (s)
-          ),
-        });
+        const row = normalizeShowRow(/** @type {Record<string, unknown>} */ (s));
+        if (!row) return null;
+        normShows.push(row);
       }
       groups.push({ tour, shows: normShows });
     }
@@ -45,17 +65,9 @@ export function normalizeShowCalendarDoc(data) {
   if (Array.isArray(flatOnly) && flatOnly.length > 0) {
     const flat = [];
     for (const s of flatOnly) {
-      if (!s || typeof s !== 'object') return null;
-      const date = typeof s.date === 'string' ? s.date.trim() : '';
-      const venue = typeof s.venue === 'string' ? s.venue.trim() : '';
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || !venue) return null;
-      flat.push({
-        date,
-        venue,
-        timeZone: resolveShowTimeZone(
-          /** @type {{ timeZone?: string, timezone?: string, venue: string }} */ (s)
-        ),
-      });
+      const row = normalizeShowRow(/** @type {Record<string, unknown>} */ (s));
+      if (!row) return null;
+      flat.push(row);
     }
     return {
       showDatesByTour: [{ tour: 'Scheduled shows', shows: flat }],

--- a/src/features/tour-stats/model/tourStatsAnalytics.js
+++ b/src/features/tour-stats/model/tourStatsAnalytics.js
@@ -1,0 +1,12 @@
+import { ga4Event } from '../../../shared/lib/ga4';
+
+/**
+ * Tour Stats explorer content is ready for the selected tour (#638).
+ *
+ * @param {{ tour?: string }} [payload]
+ */
+export function trackTourStatsView({ tour } = {}) {
+  ga4Event('tour_stats_view', {
+    tour: tour ?? '',
+  });
+}

--- a/src/features/tour-stats/model/tourStatsAnalytics.test.js
+++ b/src/features/tour-stats/model/tourStatsAnalytics.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../shared/lib/ga4', () => ({
+  ga4Event: vi.fn(),
+}));
+
+import { ga4Event } from '../../../shared/lib/ga4';
+import { trackTourStatsView } from './tourStatsAnalytics.js';
+
+describe('trackTourStatsView', () => {
+  beforeEach(() => {
+    ga4Event.mockClear();
+  });
+
+  it('emits tour_stats_view with tour scope', () => {
+    trackTourStatsView({ tour: 'Summer Tour 2026' });
+    expect(ga4Event).toHaveBeenCalledWith('tour_stats_view', {
+      tour: 'Summer Tour 2026',
+    });
+  });
+
+  it('defaults empty tour', () => {
+    trackTourStatsView();
+    expect(ga4Event).toHaveBeenCalledWith('tour_stats_view', { tour: '' });
+  });
+});

--- a/src/features/tour-stats/model/useTourStatsScreen.js
+++ b/src/features/tour-stats/model/useTourStatsScreen.js
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { useAuth } from '../../auth';
@@ -6,6 +6,7 @@ import { useSongCatalog } from '../../song-catalog';
 import { computeTourStatsSelfOverlay } from '../api/computeTourStatsSelfOverlay';
 import { fetchTourOfficialSetlists } from '../api/fetchTourOfficialSetlists';
 import { aggregateTourSetlistStats } from './aggregateTourSetlistStats';
+import { trackTourStatsView } from './tourStatsAnalytics';
 
 /**
  * Normalized (lowercased/trimmed) title → lifetime times-played, from the song
@@ -94,6 +95,23 @@ export function useTourStatsScreen(options = {}) {
         topSongTitles: stats.topSongs.map((r) => r.title),
       }),
   });
+
+  const tourViewLoggedRef = useRef('');
+  useEffect(() => {
+    if (calendarLoading || !selectedTour || !tourName) return;
+    if (setlistQuery.isLoading || setlistQuery.isError) return;
+    if (!setlistQuery.isSuccess) return;
+    if (tourViewLoggedRef.current === tourName) return;
+    tourViewLoggedRef.current = tourName;
+    trackTourStatsView({ tour: tourName });
+  }, [
+    calendarLoading,
+    selectedTour,
+    tourName,
+    setlistQuery.isLoading,
+    setlistQuery.isError,
+    setlistQuery.isSuccess,
+  ]);
 
   return {
     calendarLoading,

--- a/src/features/tour-stats/ui/TourStatsView.jsx
+++ b/src/features/tour-stats/ui/TourStatsView.jsx
@@ -1,17 +1,10 @@
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useId,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
-import { createPortal } from 'react-dom';
-import { Info, Loader2 } from 'lucide-react';
+import React from 'react';
+import { Loader2 } from 'lucide-react';
 
 import Card from '../../../shared/ui/Card';
+import InfoTooltip, {
+  InfoTooltipProvider,
+} from '../../../shared/ui/InfoTooltip';
 import { SCORING_RULES } from '../../../shared/utils/scoring';
 import { TOUR_STATS_GAP_HIGHLIGHT_MIN } from '../model/aggregateTourSetlistStats';
 
@@ -31,10 +24,6 @@ const GAP_ROW_GRID =
 
 const COL_HEADER =
   'mb-0.5 border-b border-brand-primary/20 pb-1 text-[10px] font-black uppercase tracking-wider text-slate-300';
-
-const TOOLTIP_VIEWPORT_PAD = 8;
-const TOOLTIP_MAX_WIDTH = 256;
-const TOOLTIP_GAP = 6;
 
 const MOST_PLAYED_DEF =
   'Ranked by frequency; songs with the same number of plays this tour are sorted by total # of times played all-time.';
@@ -59,12 +48,6 @@ const TILE_DEFS = {
     long: `Songs with a pre-show gap ≥ ${BUSTOUT_MIN_GAP} (Bustout Boost eligible).`,
   },
 };
-
-/** @type {React.Context<{ openId: string | null, setOpenId: (id: string | null) => void }>} */
-const TourStatsTooltipContext = createContext({
-  openId: null,
-  setOpenId: () => {},
-});
 
 /**
  * @param {{
@@ -97,8 +80,6 @@ export default function TourStatsView({
   overlayLoading,
   onOpenScoringRules,
 }) {
-  const [openTooltipId, setOpenTooltipId] = useState(/** @type {string | null} */ (null));
-
   if (calendarLoading || setlistLoading) {
     return (
       <div className="flex justify-center py-16">
@@ -129,9 +110,7 @@ export default function TourStatsView({
   }
 
   return (
-    <TourStatsTooltipContext.Provider
-      value={{ openId: openTooltipId, setOpenId: setOpenTooltipId }}
-    >
+    <InfoTooltipProvider>
       <div className="space-y-4">
         <p className="rounded-xl border border-border-subtle/50 bg-surface-panel-strong/60 px-3.5 py-2 text-sm font-bold text-white shadow-inset-glass">
           {tourName ? (
@@ -311,7 +290,7 @@ export default function TourStatsView({
           </TourStatsSectionCard>
         ) : null}
       </div>
-    </TourStatsTooltipContext.Provider>
+    </InfoTooltipProvider>
   );
 }
 
@@ -370,171 +349,6 @@ function TourStatsSectionCard({
       </div>
       {children}
     </Card>
-  );
-}
-
-/**
- * Clamp a fixed-position tooltip so it stays inside the viewport on mobile.
- * @param {DOMRect} triggerRect
- * @param {number} tooltipWidth
- * @param {number} tooltipHeight
- * @returns {{ top: number, left: number, width: number }}
- */
-function clampTooltipPosition(triggerRect, tooltipWidth, tooltipHeight) {
-  const vw = typeof window !== 'undefined' ? window.innerWidth : 360;
-  const vh = typeof window !== 'undefined' ? window.innerHeight : 640;
-  const width = Math.min(
-    tooltipWidth,
-    TOOLTIP_MAX_WIDTH,
-    Math.max(120, vw - TOOLTIP_VIEWPORT_PAD * 2),
-  );
-
-  let left = triggerRect.left + triggerRect.width / 2 - width / 2;
-  left = Math.max(
-    TOOLTIP_VIEWPORT_PAD,
-    Math.min(left, vw - width - TOOLTIP_VIEWPORT_PAD),
-  );
-
-  let top = triggerRect.bottom + TOOLTIP_GAP;
-  if (top + tooltipHeight > vh - TOOLTIP_VIEWPORT_PAD) {
-    top = Math.max(
-      TOOLTIP_VIEWPORT_PAD,
-      triggerRect.top - tooltipHeight - TOOLTIP_GAP,
-    );
-  }
-
-  return { top, left, width };
-}
-
-/**
- * Exclusive, viewport-clamped Info tooltip (one open at a time on this surface).
- *
- * @param {{
- *   label: string,
- *   definition: string,
- * }} props
- */
-function InfoTooltip({ label, definition }) {
-  const reactId = useId();
-  const tooltipId = `tour-stats-tip-${reactId}`;
-  const { openId, setOpenId } = useContext(TourStatsTooltipContext);
-  const open = openId === tooltipId;
-  const triggerRef = useRef(/** @type {HTMLButtonElement | null} */ (null));
-  const panelRef = useRef(/** @type {HTMLDivElement | null} */ (null));
-  const [coords, setCoords] = useState(
-    /** @type {{ top: number, left: number, width: number } | null} */ (null),
-  );
-
-  const close = useCallback(() => {
-    setOpenId((current) => (current === tooltipId ? null : current));
-  }, [setOpenId, tooltipId]);
-
-  const toggle = useCallback(() => {
-    setOpenId((current) => (current === tooltipId ? null : tooltipId));
-  }, [setOpenId, tooltipId]);
-
-  useLayoutEffect(() => {
-    if (!open || !triggerRef.current) {
-      setCoords(null);
-      return undefined;
-    }
-
-    const update = () => {
-      const triggerRect = triggerRef.current?.getBoundingClientRect();
-      if (!triggerRect) return;
-      const panelRect = panelRef.current?.getBoundingClientRect();
-      const height = panelRect?.height || 72;
-      const width = Math.min(
-        TOOLTIP_MAX_WIDTH,
-        Math.max(120, window.innerWidth - TOOLTIP_VIEWPORT_PAD * 2),
-      );
-      setCoords(clampTooltipPosition(triggerRect, width, height));
-    };
-
-    update();
-    // Re-measure after paint so height is accurate for flip-above.
-    const raf = requestAnimationFrame(update);
-    window.addEventListener('resize', update);
-    window.addEventListener('scroll', update, true);
-    return () => {
-      cancelAnimationFrame(raf);
-      window.removeEventListener('resize', update);
-      window.removeEventListener('scroll', update, true);
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return undefined;
-
-    const onPointerDown = (event) => {
-      const target = event.target;
-      if (!(target instanceof Node)) return;
-      if (triggerRef.current?.contains(target)) return;
-      if (panelRef.current?.contains(target)) return;
-      close();
-    };
-    const onKeyDown = (event) => {
-      if (event.key === 'Escape') close();
-    };
-
-    document.addEventListener('pointerdown', onPointerDown);
-    document.addEventListener('keydown', onKeyDown);
-    return () => {
-      document.removeEventListener('pointerdown', onPointerDown);
-      document.removeEventListener('keydown', onKeyDown);
-    };
-  }, [open, close]);
-
-  return (
-    <>
-      <button
-        ref={triggerRef}
-        type="button"
-        className="shrink-0 rounded p-0.5 text-brand-primary/85 transition-colors hover:text-brand-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
-        aria-label={`About ${label}`}
-        aria-expanded={open}
-        aria-controls={tooltipId}
-        onClick={toggle}
-      >
-        <Info className="h-3 w-3" strokeWidth={2} aria-hidden />
-      </button>
-      {open && typeof document !== 'undefined'
-        ? createPortal(
-            <div
-              ref={panelRef}
-              id={tooltipId}
-              role="tooltip"
-              style={
-                coords
-                  ? {
-                      position: 'fixed',
-                      top: coords.top,
-                      left: coords.left,
-                      width: coords.width,
-                      zIndex: 80,
-                    }
-                  : {
-                      position: 'fixed',
-                      top: -9999,
-                      left: -9999,
-                      width: Math.min(
-                        TOOLTIP_MAX_WIDTH,
-                        typeof window !== 'undefined'
-                          ? window.innerWidth - TOOLTIP_VIEWPORT_PAD * 2
-                          : TOOLTIP_MAX_WIDTH,
-                      ),
-                      zIndex: 80,
-                      visibility: 'hidden',
-                    }
-              }
-              className="rounded-lg border border-border-muted bg-[rgb(var(--surface-panel-strong))] px-3 py-2 text-left text-xs font-medium leading-snug text-slate-100 shadow-lg"
-            >
-              {definition}
-            </div>,
-            document.body,
-          )
-        : null}
-    </>
   );
 }
 

--- a/src/pages/picks/PicksPage.jsx
+++ b/src/pages/picks/PicksPage.jsx
@@ -6,6 +6,7 @@ import { CheckCircle2, Lock, Scale } from 'lucide-react';
 import { logCommsEmailLanded } from '../../features/comms';
 import {
   PicksFieldsForm,
+  PicksLockTimingBanner,
   PicksMobileFixedChrome,
   PicksSelfRecapSection,
   PicksSubmitButton,
@@ -34,6 +35,7 @@ export default function PicksPage({ user, selectedDate }) {
     isLoadingPicks,
     isLocked,
     hasExistingPicks,
+    showStatus,
     saveFeedback,
     pickConstraintMessage,
   } = usePicksForm({ user, selectedDate, showDates, showDatesByTour });
@@ -105,6 +107,11 @@ export default function PicksPage({ user, selectedDate }) {
         </DashboardActionRow>
       </div>
       <div className="relative">
+        <PicksLockTimingBanner
+          key={selectedDate}
+          show={showForShare}
+          showStatus={showStatus}
+        />
         {shouldShowStatus ? (
           <>
             <div id={statusContentId} className={isMobileStatusExpanded ? 'md:block' : 'hidden md:block'}>

--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -61,7 +61,7 @@ export default function ProfilePage({ user: userProp }) {
 
       <ProfileSelfStatsPanel uid={user?.uid} />
 
-      <BadgeShelf badges={badges} />
+      {!isLoading ? <BadgeShelf badges={badges} surface="profile" /> : null}
 
       <div className="mt-6">
         <ProfileEditForm

--- a/src/pages/profile/ProfilePage.jsx
+++ b/src/pages/profile/ProfilePage.jsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Link, useOutletContext } from 'react-router-dom';
 import { ExternalLink } from 'lucide-react';
 
+import { useFeatureSpotlight } from '../../features/feature-discovery';
 import { InstallAppCard } from '../../features/install';
 import {
   BadgeShelf,
@@ -19,6 +20,7 @@ import DashboardRowPill from '../../shared/ui/DashboardRowPill';
 export default function ProfilePage({ user: userProp }) {
   const outlet = useOutletContext();
   const user = userProp ?? outlet?.user;
+  const identitySpotlight = useFeatureSpotlight('profile-identity');
 
   const {
     handle,
@@ -34,6 +36,17 @@ export default function ProfilePage({ user: userProp }) {
     setAvatarId,
     saveProfile,
   } = useUserProfile(user);
+
+  const onAvatarChange = useCallback(
+    (nextId) => {
+      setAvatarId(nextId);
+      if (identitySpotlight.active) {
+        identitySpotlight.trackClick();
+        identitySpotlight.markSeen();
+      }
+    },
+    [setAvatarId, identitySpotlight],
+  );
 
   return (
     <div>
@@ -61,7 +74,13 @@ export default function ProfilePage({ user: userProp }) {
 
       <ProfileSelfStatsPanel uid={user?.uid} />
 
-      {!isLoading ? <BadgeShelf badges={badges} surface="profile" /> : null}
+      {!isLoading ? (
+        <BadgeShelf
+          badges={badges}
+          surface="profile"
+          showNewBadge={identitySpotlight.active}
+        />
+      ) : null}
 
       <div className="mt-6">
         <ProfileEditForm
@@ -70,11 +89,12 @@ export default function ProfilePage({ user: userProp }) {
           avatarId={avatarId}
           onHandleChange={setHandle}
           onFavoriteSongChange={setFavoriteSong}
-          onAvatarChange={setAvatarId}
+          onAvatarChange={onAvatarChange}
           onSave={saveProfile}
           isSaving={isSaving}
           isLoading={isLoading}
           message={message}
+          showAvatarNewBadge={identitySpotlight.active}
         />
       </div>
 

--- a/src/pages/tour-stats/TourStatsPage.jsx
+++ b/src/pages/tour-stats/TourStatsPage.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 
+import { useFeatureSpotlight } from '../../features/feature-discovery';
 import {
   StandingsMobileFixedChrome,
   StandingsStickyChrome,
@@ -28,6 +29,13 @@ export default function TourStatsPage() {
   const setView = useStandingsViewChange({ view: 'stats' });
   const { openScoringRules: openScoringRulesModal } = useScoringRulesModal();
   const mobileChromeRoot = useDashboardMobileChromePortal();
+  const tourStatsSpotlight = useFeatureSpotlight('tour-stats', {
+    trackImpression: false,
+  });
+
+  useEffect(() => {
+    tourStatsSpotlight.markSeen();
+  }, [tourStatsSpotlight.markSeen]);
 
   const openScoringRules = () => {
     ga4Event('scoring_rules_opened', { surface: 'tour-stats' });

--- a/src/shared/ui/ChromeSegmentedControl.jsx
+++ b/src/shared/ui/ChromeSegmentedControl.jsx
@@ -5,7 +5,7 @@ const trayClass =
   'flex w-full min-w-0 gap-1 rounded-xl border border-border-subtle/60 bg-surface-panel-strong p-1 shadow-inset-glass';
 
 const segmentBase =
-  'flex min-w-0 flex-1 items-center justify-center gap-1 rounded-lg px-2 py-2 text-center text-[11px] font-black uppercase tracking-widest transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg';
+  'relative flex min-w-0 flex-1 items-center justify-center gap-1 rounded-lg px-2 py-2 text-center text-[11px] font-black uppercase tracking-widest transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg';
 
 const segmentActive =
   'bg-brand-primary/15 text-brand-primary ring-1 ring-inset ring-brand-primary/35';
@@ -28,6 +28,7 @@ const segmentInactive =
  *     end?: boolean,
  *     label: string,
  *     icon?: React.ComponentType<{ className?: string, 'aria-hidden'?: boolean }>,
+ *     badge?: React.ReactNode,
  *   }>,
  * }} props
  */
@@ -46,7 +47,7 @@ export default function ChromeSegmentedControl({
         className={[trayClass, className].filter(Boolean).join(' ')}
         aria-label={ariaLabel}
       >
-        {items.map(({ to, label, end, icon: Icon }) => (
+        {items.map(({ to, label, end, icon: Icon, badge }) => (
           <NavLink
             key={to}
             to={to}
@@ -57,6 +58,7 @@ export default function ChromeSegmentedControl({
           >
             {Icon ? <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden /> : null}
             <span className="truncate">{label}</span>
+            {badge}
           </NavLink>
         ))}
       </nav>
@@ -69,7 +71,7 @@ export default function ChromeSegmentedControl({
       aria-label={ariaLabel}
       className={[trayClass, className].filter(Boolean).join(' ')}
     >
-      {items.map(({ id, label, icon: Icon }) => {
+      {items.map(({ id, label, icon: Icon, badge }) => {
         const selected = value === id;
         return (
           <button
@@ -82,6 +84,7 @@ export default function ChromeSegmentedControl({
           >
             {Icon ? <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden /> : null}
             <span className="truncate">{label}</span>
+            {badge}
           </button>
         );
       })}

--- a/src/shared/ui/InfoTooltip.jsx
+++ b/src/shared/ui/InfoTooltip.jsx
@@ -1,0 +1,207 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { Info } from 'lucide-react';
+
+const TOOLTIP_VIEWPORT_PAD = 8;
+const TOOLTIP_MAX_WIDTH = 256;
+const TOOLTIP_GAP = 6;
+
+/**
+ * @typedef {{ openId: string | null, setOpenId: React.Dispatch<React.SetStateAction<string | null>> }} InfoTooltipContextValue
+ */
+
+/** @type {React.Context<InfoTooltipContextValue>} */
+const InfoTooltipContext = createContext({
+  openId: null,
+  setOpenId: () => {},
+});
+
+/**
+ * Surface-scoped exclusive tooltip state (one open at a time).
+ * Wrap any cluster of `InfoTooltip` triggers (e.g. stats tiles).
+ *
+ * @param {{ children: React.ReactNode }} props
+ */
+export function InfoTooltipProvider({ children }) {
+  const [openId, setOpenId] = useState(/** @type {string | null} */ (null));
+  return (
+    <InfoTooltipContext.Provider value={{ openId, setOpenId }}>
+      {children}
+    </InfoTooltipContext.Provider>
+  );
+}
+
+/**
+ * Clamp a fixed-position tooltip so it stays inside the viewport on mobile.
+ * @param {DOMRect} triggerRect
+ * @param {number} tooltipWidth
+ * @param {number} tooltipHeight
+ * @returns {{ top: number, left: number, width: number }}
+ */
+function clampTooltipPosition(triggerRect, tooltipWidth, tooltipHeight) {
+  const vw = typeof window !== 'undefined' ? window.innerWidth : 360;
+  const vh = typeof window !== 'undefined' ? window.innerHeight : 640;
+  const width = Math.min(
+    tooltipWidth,
+    TOOLTIP_MAX_WIDTH,
+    Math.max(120, vw - TOOLTIP_VIEWPORT_PAD * 2),
+  );
+
+  let left = triggerRect.left + triggerRect.width / 2 - width / 2;
+  left = Math.max(
+    TOOLTIP_VIEWPORT_PAD,
+    Math.min(left, vw - width - TOOLTIP_VIEWPORT_PAD),
+  );
+
+  let top = triggerRect.bottom + TOOLTIP_GAP;
+  if (top + tooltipHeight > vh - TOOLTIP_VIEWPORT_PAD) {
+    top = Math.max(
+      TOOLTIP_VIEWPORT_PAD,
+      triggerRect.top - tooltipHeight - TOOLTIP_GAP,
+    );
+  }
+
+  return { top, left, width };
+}
+
+/**
+ * Exclusive, viewport-clamped Info tooltip (one open at a time per provider).
+ * Same interaction + chrome as Standings → Stats tiles.
+ *
+ * @param {{
+ *   label: string,
+ *   definition: string,
+ * }} props
+ */
+export default function InfoTooltip({ label, definition }) {
+  const reactId = useId();
+  const tooltipId = `info-tip-${reactId}`;
+  const { openId, setOpenId } = useContext(InfoTooltipContext);
+  const open = openId === tooltipId;
+  const triggerRef = useRef(/** @type {HTMLButtonElement | null} */ (null));
+  const panelRef = useRef(/** @type {HTMLDivElement | null} */ (null));
+  const [coords, setCoords] = useState(
+    /** @type {{ top: number, left: number, width: number } | null} */ (null),
+  );
+
+  const close = useCallback(() => {
+    setOpenId((current) => (current === tooltipId ? null : current));
+  }, [setOpenId, tooltipId]);
+
+  const toggle = useCallback(() => {
+    setOpenId((current) => (current === tooltipId ? null : tooltipId));
+  }, [setOpenId, tooltipId]);
+
+  useLayoutEffect(() => {
+    if (!open || !triggerRef.current) {
+      setCoords(null);
+      return undefined;
+    }
+
+    const update = () => {
+      const triggerRect = triggerRef.current?.getBoundingClientRect();
+      if (!triggerRect) return;
+      const panelRect = panelRef.current?.getBoundingClientRect();
+      const height = panelRect?.height || 72;
+      const width = Math.min(
+        TOOLTIP_MAX_WIDTH,
+        Math.max(120, window.innerWidth - TOOLTIP_VIEWPORT_PAD * 2),
+      );
+      setCoords(clampTooltipPosition(triggerRect, width, height));
+    };
+
+    update();
+    // Re-measure after paint so height is accurate for flip-above.
+    const raf = requestAnimationFrame(update);
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update, true);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const onPointerDown = (event) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (triggerRef.current?.contains(target)) return;
+      if (panelRef.current?.contains(target)) return;
+      close();
+    };
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') close();
+    };
+
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open, close]);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="shrink-0 rounded p-0.5 text-brand-primary/85 transition-colors hover:text-brand-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
+        aria-label={`About ${label}`}
+        aria-expanded={open}
+        aria-controls={tooltipId}
+        onClick={toggle}
+      >
+        <Info className="h-3 w-3" strokeWidth={2} aria-hidden />
+      </button>
+      {open && typeof document !== 'undefined'
+        ? createPortal(
+            <div
+              ref={panelRef}
+              id={tooltipId}
+              role="tooltip"
+              style={
+                coords
+                  ? {
+                      position: 'fixed',
+                      top: coords.top,
+                      left: coords.left,
+                      width: coords.width,
+                      zIndex: 80,
+                    }
+                  : {
+                      position: 'fixed',
+                      top: -9999,
+                      left: -9999,
+                      width: Math.min(
+                        TOOLTIP_MAX_WIDTH,
+                        typeof window !== 'undefined'
+                          ? window.innerWidth - TOOLTIP_VIEWPORT_PAD * 2
+                          : TOOLTIP_MAX_WIDTH,
+                      ),
+                      zIndex: 80,
+                      visibility: 'hidden',
+                    }
+              }
+              className="rounded-lg border border-border-muted bg-[rgb(var(--surface-panel-strong))] px-3 py-2 text-left text-xs font-medium leading-snug text-slate-100 shadow-lg"
+            >
+              {definition}
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}

--- a/src/shared/ui/index.js
+++ b/src/shared/ui/index.js
@@ -9,6 +9,7 @@ export { default as DashboardMobileChromeBar } from './DashboardMobileChromeBar'
 export { default as DashboardRowPill } from './DashboardRowPill';
 export { default as FilterPill } from './FilterPill';
 export { default as GhostPill } from './GhostPill';
+export { default as InfoTooltip, InfoTooltipProvider } from './InfoTooltip';
 export { default as Input } from './Input';
 export { default as MetaChip } from './MetaChip';
 export { default as PageTitle } from './PageTitle';

--- a/src/shared/utils/picksLockTime.js
+++ b/src/shared/utils/picksLockTime.js
@@ -1,0 +1,199 @@
+/**
+ * Per-show picks wall-clock lock (#522).
+ *
+ * When doors are known: lock = doors + (tourAvgDoorsToStart − safety).
+ * Summer Tour 2026 setlist.fm avg doors→start is 1h59m (119); safety 19 → doors+100.
+ * Fallback when doors unknown: 19:30 venue-local.
+ */
+
+/** @type {{ hour: number, minute: number }} */
+export const DEFAULT_PICKS_LOCK_HM = Object.freeze({ hour: 19, minute: 30 });
+
+/** Back-compat aliases for callers that still import fixed hour/minute. */
+export const SHOW_PICKS_LOCK_HOUR_LOCAL = DEFAULT_PICKS_LOCK_HM.hour;
+export const SHOW_PICKS_LOCK_MINUTE_LOCAL = DEFAULT_PICKS_LOCK_HM.minute;
+
+/** setlist.fm Summer Tour 2026 “Avg start time after doors”. */
+export const TOUR_AVG_DOORS_TO_START_MIN = 119;
+
+/** Minutes before average start to lock picks (doors+100 when avg is 119). */
+export const PICKS_LOCK_SAFETY_MIN = 19;
+
+/**
+ * Known doors times (venue-local 24h `HH:mm`) from setlist.fm / tickets.
+ * Ops: extend as future dates publish. Calendar fields `doorsLocal` /
+ * `picksLockLocal` override this seed when present.
+ *
+ * @type {Readonly<Record<string, string>>}
+ */
+export const SHOW_DOORS_LOCAL_BY_DATE = Object.freeze({
+  '2026-07-18': '17:30', // Merriweather
+  '2026-07-19': '17:30',
+  '2026-07-21': '17:30', // Syracuse
+  '2026-07-22': '18:30', // MSG
+  '2026-07-24': '18:30',
+  '2026-07-25': '18:30',
+  '2026-07-27': '18:30',
+  '2026-07-29': '18:30',
+  '2026-07-31': '17:00', // Fenway
+  '2026-08-01': '17:00',
+  '2026-09-04': '18:00', // Dick's
+  '2026-09-05': '18:00',
+  '2026-09-06': '18:00',
+});
+
+/**
+ * @param {string | null | undefined} value
+ * @returns {{ hour: number, minute: number } | null}
+ */
+export function parseLocalHm(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const h24 = trimmed.match(/^(\d{1,2}):(\d{2})$/);
+  if (h24) {
+    const hour = Number(h24[1]);
+    const minute = Number(h24[2]);
+    if (
+      Number.isInteger(hour) &&
+      Number.isInteger(minute) &&
+      hour >= 0 &&
+      hour <= 23 &&
+      minute >= 0 &&
+      minute <= 59
+    ) {
+      return { hour, minute };
+    }
+    return null;
+  }
+
+  const h12 = trimmed.match(/^(\d{1,2}):(\d{2})\s*([AaPp][Mm])$/);
+  if (!h12) return null;
+  let hour = Number(h12[1]);
+  const minute = Number(h12[2]);
+  const ap = h12[3].toUpperCase();
+  if (
+    !Number.isInteger(hour) ||
+    !Number.isInteger(minute) ||
+    hour < 1 ||
+    hour > 12 ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return null;
+  }
+  if (ap === 'AM') {
+    if (hour === 12) hour = 0;
+  } else if (hour !== 12) {
+    hour += 12;
+  }
+  return { hour, minute };
+}
+
+/**
+ * @param {{ hour: number, minute: number }} hm
+ * @returns {string} `HH:mm` 24h
+ */
+export function formatLocalHm24(hm) {
+  return `${String(hm.hour).padStart(2, '0')}:${String(hm.minute).padStart(2, '0')}`;
+}
+
+/**
+ * @param {{ hour: number, minute: number }} hm
+ * @returns {string} e.g. `7:10 PM`
+ */
+export function formatLockTimeLocalLabel(hm) {
+  const hour12 = ((hm.hour + 11) % 12) + 1;
+  const suffix = hm.hour >= 12 ? 'PM' : 'AM';
+  return `${hour12}:${String(hm.minute).padStart(2, '0')} ${suffix}`;
+}
+
+/**
+ * @param {{ hour: number, minute: number }} doors
+ * @param {{ tourAvgDoorsToStartMin?: number, safetyMin?: number }} [opts]
+ * @returns {{ hour: number, minute: number }}
+ */
+export function lockHmFromDoors(
+  doors,
+  {
+    tourAvgDoorsToStartMin = TOUR_AVG_DOORS_TO_START_MIN,
+    safetyMin = PICKS_LOCK_SAFETY_MIN,
+  } = {}
+) {
+  const offset = Math.max(0, tourAvgDoorsToStartMin - safetyMin);
+  const total = doors.hour * 60 + doors.minute + offset;
+  const wrapped = ((total % (24 * 60)) + 24 * 60) % (24 * 60);
+  return { hour: Math.floor(wrapped / 60), minute: wrapped % 60 };
+}
+
+/**
+ * Resolve venue-local picks lock for a show.
+ *
+ * Priority:
+ * 1. `show.picksLockLocal` (materialized / override)
+ * 2. `show.doorsLocal` or seeded doors for `show.date` → doors + (avg − safety)
+ * 3. Default 19:30
+ *
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null | undefined} show
+ * @param {{
+ *   doorsByDate?: Record<string, string>,
+ *   tourAvgDoorsToStartMin?: number,
+ *   safetyMin?: number,
+ *   fallback?: { hour: number, minute: number },
+ * }} [opts]
+ * @returns {{ hour: number, minute: number, source: 'picksLockLocal' | 'doors' | 'fallback', doorsLocal: string | null }}
+ */
+export function resolvePicksLockHm(show, opts = {}) {
+  const fallback = opts.fallback ?? DEFAULT_PICKS_LOCK_HM;
+  const doorsByDate = opts.doorsByDate ?? SHOW_DOORS_LOCAL_BY_DATE;
+
+  const explicitLock = parseLocalHm(show?.picksLockLocal);
+  if (explicitLock) {
+    return {
+      ...explicitLock,
+      source: 'picksLockLocal',
+      doorsLocal: typeof show?.doorsLocal === 'string' ? show.doorsLocal.trim() || null : null,
+    };
+  }
+
+  const date = typeof show?.date === 'string' ? show.date.trim() : '';
+  const doorsRaw =
+    (typeof show?.doorsLocal === 'string' && show.doorsLocal.trim()) ||
+    (date && doorsByDate[date]) ||
+    null;
+  const doors = parseLocalHm(doorsRaw);
+  if (doors) {
+    const lock = lockHmFromDoors(doors, opts);
+    return {
+      ...lock,
+      source: 'doors',
+      doorsLocal: formatLocalHm24(doors),
+    };
+  }
+
+  return {
+    ...fallback,
+    source: 'fallback',
+    doorsLocal: null,
+  };
+}
+
+/**
+ * Enrich a show row with resolved lock fields (idempotent).
+ * @param {{ date: string, venue?: string, timeZone?: string, doorsLocal?: string, picksLockLocal?: string }} show
+ */
+export function enrichShowWithPicksLock(show) {
+  if (!show || typeof show !== 'object') return show;
+  const resolved = resolvePicksLockHm(show);
+  if (resolved.source === 'fallback') return { ...show };
+
+  const enriched = {
+    ...show,
+    picksLockLocal: show.picksLockLocal || formatLocalHm24(resolved),
+    picksLockSource: resolved.source,
+  };
+  const doorsLocal = show.doorsLocal || resolved.doorsLocal;
+  if (doorsLocal) enriched.doorsLocal = doorsLocal;
+  return enriched;
+}

--- a/src/shared/utils/picksLockTime.test.js
+++ b/src/shared/utils/picksLockTime.test.js
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_PICKS_LOCK_HM,
+  formatLockTimeLocalLabel,
+  formatLocalHm24,
+  lockHmFromDoors,
+  parseLocalHm,
+  resolvePicksLockHm,
+} from './picksLockTime';
+
+describe('parseLocalHm', () => {
+  it('parses 24h and 12h strings', () => {
+    expect(parseLocalHm('17:30')).toEqual({ hour: 17, minute: 30 });
+    expect(parseLocalHm('7:10 PM')).toEqual({ hour: 19, minute: 10 });
+    expect(parseLocalHm('12:05 AM')).toEqual({ hour: 0, minute: 5 });
+    expect(parseLocalHm('bad')).toBeNull();
+  });
+});
+
+describe('lockHmFromDoors', () => {
+  it('locks doors+100 when avg=119 and safety=19', () => {
+    expect(lockHmFromDoors({ hour: 17, minute: 30 })).toEqual({ hour: 19, minute: 10 });
+    expect(lockHmFromDoors({ hour: 18, minute: 30 })).toEqual({ hour: 20, minute: 10 });
+    expect(lockHmFromDoors({ hour: 17, minute: 0 })).toEqual({ hour: 18, minute: 40 });
+  });
+});
+
+describe('resolvePicksLockHm (#522)', () => {
+  it('uses seeded doors for Merriweather / MSG / Fenway', () => {
+    expect(resolvePicksLockHm({ date: '2026-07-18' })).toMatchObject({
+      hour: 19,
+      minute: 10,
+      source: 'doors',
+      doorsLocal: '17:30',
+    });
+    expect(resolvePicksLockHm({ date: '2026-07-22' })).toMatchObject({
+      hour: 20,
+      minute: 10,
+      source: 'doors',
+    });
+    expect(resolvePicksLockHm({ date: '2026-07-31' })).toMatchObject({
+      hour: 18,
+      minute: 40,
+      source: 'doors',
+    });
+  });
+
+  it('falls back to 19:30 when doors unknown', () => {
+    expect(resolvePicksLockHm({ date: '2099-01-01' })).toEqual({
+      ...DEFAULT_PICKS_LOCK_HM,
+      source: 'fallback',
+      doorsLocal: null,
+    });
+  });
+
+  it('prefers picksLockLocal then doorsLocal on the show', () => {
+    expect(
+      resolvePicksLockHm({
+        date: '2026-07-18',
+        picksLockLocal: '19:40',
+        doorsLocal: '17:30',
+      })
+    ).toMatchObject({ hour: 19, minute: 40, source: 'picksLockLocal' });
+
+    expect(
+      resolvePicksLockHm({
+        date: '2099-01-01',
+        doorsLocal: '18:00',
+      })
+    ).toMatchObject({ hour: 19, minute: 40, source: 'doors', doorsLocal: '18:00' });
+  });
+
+  it('formats labels', () => {
+    expect(formatLocalHm24({ hour: 19, minute: 10 })).toBe('19:10');
+    expect(formatLockTimeLocalLabel({ hour: 19, minute: 10 })).toBe('7:10 PM');
+  });
+});

--- a/src/shared/utils/timeLogic.js
+++ b/src/shared/utils/timeLogic.js
@@ -1,17 +1,25 @@
 // src/shared/utils/timeLogic.js
 import { ymdInTimeZone } from './dateUtils';
+import {
+  DEFAULT_PICKS_LOCK_HM,
+  formatLockTimeLocalLabel,
+  resolvePicksLockHm,
+  SHOW_PICKS_LOCK_HOUR_LOCAL,
+  SHOW_PICKS_LOCK_MINUTE_LOCAL,
+} from './picksLockTime';
 import { DEFAULT_SHOW_TIME_ZONE, resolveShowTimeZone } from './showTimeZone';
 
 /** Fallback when a show does not carry an explicit `timeZone` field. */
 export const SHOW_SCHEDULE_TIMEZONE = DEFAULT_SHOW_TIME_ZONE;
 
-/**
- * Picks lock at this local time on the show's calendar date in the show's local timezone.
- * Temporary: 7:55pm venue-local (was 7:30). Revert / replace with first-song /
- * admin-configurable lock when that lands.
- */
-export const SHOW_PICKS_LOCK_HOUR_LOCAL = 19;
-export const SHOW_PICKS_LOCK_MINUTE_LOCAL = 55;
+// Re-export lock constants / resolver for existing imports.
+export {
+  DEFAULT_PICKS_LOCK_HM,
+  formatLockTimeLocalLabel,
+  resolvePicksLockHm,
+  SHOW_PICKS_LOCK_HOUR_LOCAL,
+  SHOW_PICKS_LOCK_MINUTE_LOCAL,
+};
 // Back-compat aliases for existing imports.
 export const SHOW_PICKS_LOCK_HOUR_PT = SHOW_PICKS_LOCK_HOUR_LOCAL;
 export const SHOW_PICKS_LOCK_MINUTE_PT = SHOW_PICKS_LOCK_MINUTE_LOCAL;
@@ -46,15 +54,51 @@ function showClockOnShowYmd(showYmd, showTimeZone, now = new Date()) {
  * DST fall-back ambiguity is handled by deriving wall-clock parts from a real
  * instant (`now`) in the show's timezone; both repeated local hours map to the
  * same show date boundary and compare consistently against lock hh:mm.
+ *
+ * @param {string} showYmd
+ * @param {string} [showTimeZone]
+ * @param {Date} [now]
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | { hour: number, minute: number } | null} [showOrLockHm]
+ *   Show row (preferred) or explicit `{ hour, minute }` lock. Defaults to 19:30.
  */
-export function isPastPicksLock(showYmd, showTimeZone = SHOW_SCHEDULE_TIMEZONE, now = new Date()) {
+export function isPastPicksLock(
+  showYmd,
+  showTimeZone = SHOW_SCHEDULE_TIMEZONE,
+  now = new Date(),
+  showOrLockHm = null
+) {
   const clock = showClockOnShowYmd(showYmd, showTimeZone, now);
   if (!clock) return false;
+
+  const lockHm = coercePicksLockHm(showYmd, showOrLockHm);
   const { hour, minute } = clock;
-  return (
-    hour > SHOW_PICKS_LOCK_HOUR_LOCAL ||
-    (hour === SHOW_PICKS_LOCK_HOUR_LOCAL && minute >= SHOW_PICKS_LOCK_MINUTE_LOCAL)
-  );
+  return hour > lockHm.hour || (hour === lockHm.hour && minute >= lockHm.minute);
+}
+
+/**
+ * @param {string} showYmd
+ * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | { hour: number, minute: number } | null | undefined} showOrLockHm
+ */
+function coercePicksLockHm(showYmd, showOrLockHm) {
+  if (
+    showOrLockHm &&
+    typeof showOrLockHm === 'object' &&
+    Number.isInteger(showOrLockHm.hour) &&
+    Number.isInteger(showOrLockHm.minute) &&
+    showOrLockHm.date === undefined &&
+    showOrLockHm.doorsLocal === undefined &&
+    showOrLockHm.picksLockLocal === undefined
+  ) {
+    return { hour: showOrLockHm.hour, minute: showOrLockHm.minute };
+  }
+  if (showOrLockHm && typeof showOrLockHm === 'object') {
+    return resolvePicksLockHm({
+      date: typeof showOrLockHm.date === 'string' ? showOrLockHm.date : showYmd,
+      doorsLocal: showOrLockHm.doorsLocal,
+      picksLockLocal: showOrLockHm.picksLockLocal,
+    });
+  }
+  return resolvePicksLockHm({ date: showYmd });
 }
 // Back-compat alias.
 export const isPastPicksLockPacific = isPastPicksLock;
@@ -78,7 +122,7 @@ export function getNextShow(showDates) {
 
 /**
  * NEXT — only date users can enter picks (the upcoming show from each show's local "today", before lock).
- * LIVE — selected show date in local timezone and wall time there is at/after picks lock ({@link SHOW_PICKS_LOCK_HOUR_LOCAL}:{@link SHOW_PICKS_LOCK_MINUTE_LOCAL} local): picks locked, live standings UX.
+ * LIVE — selected show date in local timezone and wall time there is at/after picks lock: picks locked, live standings UX.
  * PAST — calendar date before local "today" in the selected show timezone (show already happened there).
  * FUTURE — any other listed date (e.g. later tour nights): too early until that show becomes "next".
  */
@@ -97,7 +141,7 @@ export function getShowBeforeDate(ymd, showDates) {
 
 /**
  * @param {string} selectedDate — YYYY-MM-DD
- * @param {{ date: string }[]} showDates
+ * @param {{ date: string, doorsLocal?: string, picksLockLocal?: string }[]} showDates
  */
 export const getShowStatus = (selectedDate, showDates) => {
   const nextShow = getNextShow(showDates);
@@ -108,7 +152,16 @@ export const getShowStatus = (selectedDate, showDates) => {
   if (selectedDate < today) return 'PAST';
   if (selectedDate === nextShow.date) {
     if (selectedDate === today) {
-      if (isPastPicksLock(selectedDate, selectedTimeZone)) return 'LIVE';
+      if (
+        isPastPicksLock(
+          selectedDate,
+          selectedTimeZone,
+          new Date(),
+          selectedShow || { date: selectedDate }
+        )
+      ) {
+        return 'LIVE';
+      }
     }
     return 'NEXT';
   }

--- a/src/shared/utils/timeLogic.test.js
+++ b/src/shared/utils/timeLogic.test.js
@@ -56,15 +56,46 @@ describe('venue-local lock + status (#278)', () => {
     expect(getNextShow(shows)).toEqual(shows[1]);
   });
 
-  it('marks a show LIVE at 7:55 in the venue timezone on show date', () => {
+  it('marks a show LIVE at fallback 7:30 in the venue timezone on show date', () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-07-11T00:56:00.000Z'));
+    vi.setSystemTime(new Date('2099-06-16T00:31:00.000Z'));
 
     const shows = [
-      { date: '2026-07-10', venue: 'Kohl Center, Madison, WI', timeZone: 'America/Chicago' },
+      { date: '2099-06-15', venue: 'Kohl Center, Madison, WI', timeZone: 'America/Chicago' },
     ];
 
-    expect(getShowStatus('2026-07-10', shows)).toBe('LIVE');
+    expect(getShowStatus('2099-06-15', shows)).toBe('LIVE');
+  });
+
+  it('locks Merriweather at doors+100 (7:10 PM ET) before fallback 7:30', () => {
+    vi.useFakeTimers();
+    // 2026-07-18 23:15Z = 7:15 PM ET → past 7:10 lock, before 7:30 fallback.
+    vi.setSystemTime(new Date('2026-07-18T23:15:00.000Z'));
+
+    const shows = [
+      {
+        date: '2026-07-18',
+        venue: 'Merriweather Post Pavilion, Columbia, MD',
+        timeZone: 'America/New_York',
+      },
+    ];
+
+    expect(getShowStatus('2026-07-18', shows)).toBe('LIVE');
+  });
+
+  it('keeps Merriweather NEXT at 7:00 PM ET (before doors+100 lock)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-18T23:00:00.000Z'));
+
+    const shows = [
+      {
+        date: '2026-07-18',
+        venue: 'Merriweather Post Pavilion, Columbia, MD',
+        timeZone: 'America/New_York',
+      },
+    ];
+
+    expect(getShowStatus('2026-07-18', shows)).toBe('NEXT');
   });
 
   it('keeps fallback venue parsing for old docs without explicit timeZone', () => {


### PR DESCRIPTION
## Summary
- Promotes the **1.31.0** train from `staging` → `main`.
- **Doors-based picks lock (#522)** — wall clock = doors+1:40 (or 19:30 fallback); Phish.com schedule enrichment; daily calendar sync; Picks/Standings timing banner.
- **Feature discovery (#639) + engagement GA4 (#638)** — soft New markers + client analytics for recent surfaces.
- **Profile season-stats freshness Slice 0 (#635)** — avg correct on show day + Your stats Info tooltips.
- **Docs** — `docs/scoring-analysis/` canvas research archive.

**Held on staging (not in this promote):** Dependabot PRs #517–#519, #521, #624 (red/unknown functions checks).

## Test plan
- [x] `npm run lint`
- [x] `npm test` — 69 files / 414 tests
- [x] `npm run verify:dashboard-meta`
- [x] `npm run verify:dashboard-ui`
- [x] `npm run release:gate`
- [ ] Promote PR CI / Vercel production READY
- [ ] After merge: `npm run release:publish -- --confirm` → tag `v1.31.0`
- [ ] Deploy Functions (calendar sync + lock resolver) when ready for live doors enrichment


Made with [Cursor](https://cursor.com)