### PR TITLE
fix(seo): stop serving empty-body OG HTML to Googlebot (#658)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.31.1] — 2026-07-19
+
+### Fixed
+- **Googlebot empty-body OG (#658)** — homepage edge middleware no longer serves the minimal empty-body OG shell to `Googlebot` / `bingbot` / `Applebot` / `ia_archiver`. Those bots get the normal SPA `index.html`. Social scrapers still get the OG shell, which now also includes favicon `<link>`s.
+
+---
+
 ## [1.31.0] — 2026-07-18
 
 ### Added

--- a/docs/GITHUB_AUTOMATION_CONTEXT.md
+++ b/docs/GITHUB_AUTOMATION_CONTEXT.md
@@ -20,7 +20,7 @@
 
 - **Frontend:** React (Vite), Tailwind, React Router.
 - **PWA / home screen performance (spike):** `docs/PWA_HOME_SCREEN_PERFORMANCE.md` — precache vs FCM service worker, measurement, deploy freshness.
-- **Public landing SEO:** `src/shared/config/seo.js`, `og-home-html.mjs` + `middleware.js` (Meta crawlers on `/`), `src/features/landing/ui/LandingSeo.jsx` (Helmet + JSON-LD), `public/llms.txt`, `public/branding/og-card-1200x630.jpg` (regenerate via `npm run generate:og-card` after changing splash SVGs; bump `OG_IMAGE_VERSION` in `seo.js` / `og-home-html.mjs`).
+- **Public landing SEO:** `src/shared/config/seo.js`, `og-home-html.mjs` + `middleware.js` (social scrapers only on `/` — not Googlebot/bingbot), `src/features/landing/ui/LandingSeo.jsx` (Helmet + JSON-LD), `public/llms.txt`, `public/branding/og-card-1200x630.jpg` (regenerate via `npm run generate:og-card` after changing splash SVGs; bump `OG_IMAGE_VERSION` in `seo.js` / `og-home-html.mjs`).
 - **Backend / data:** Firebase Auth, Firestore, App Check; **Firebase Cloud Functions** live under repo root **`functions/`** (e.g. `functions/index.js`), not `firebase/functions/`.
 - **Official setlists (Firestore):** `official_setlists/{showDate}` field semantics, scoring, save vs finalize — **`docs/OFFICIAL_SETLISTS_SCHEMA.md`**.
 - **Pool admin callables:** `deletePoolWithCleanup` (issue #138) handles server-side pool delete + member cleanup via Admin SDK — **`docs/POOL_DELETE_RUNBOOK.md`**. Owner-auth + activity check mirror `src/features/pools/api/poolFirestore.js`.

--- a/middleware.js
+++ b/middleware.js
@@ -5,6 +5,9 @@
  * `index.html` are usually enough; this guarantees OG meta is the first bytes
  * after charset and busts stale Meta cache issues when paired with a versioned
  * `og:image` URL.
+ *
+ * Search bots (Googlebot, bingbot, …) must fall through to the SPA `index.html`
+ * — they need body content / JSON-LD / favicons, not the empty-body OG shell.
  */
 import { buildHomeOgHtml, SOCIAL_CRAWLER_RE } from './og-home-html.mjs';
 

--- a/og-home-html.mjs
+++ b/og-home-html.mjs
@@ -65,6 +65,11 @@ export function buildHomeOgHtml({
   <meta name="twitter:title" content="${escapeHtml(title)}" />
   <meta name="twitter:description" content="${escapeHtml(description)}" />
   <meta name="twitter:image" content="${escapeHtml(imageUrl)}" />
+  <link rel="icon" type="image/png" href="/favicon/favicon-96x96.png?v=20260715" sizes="96x96" />
+  <link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg?v=20260715" />
+  <link rel="shortcut icon" href="/favicon/favicon.ico?v=20260715" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png?v=20260715" />
+  <link rel="manifest" href="/favicon/site.webmanifest?v=20260715" />
   <link rel="canonical" href="${escapeHtml(url)}" />
   <title>${escapeHtml(title)}</title>
 </head>
@@ -72,6 +77,10 @@ export function buildHomeOgHtml({
 </html>`;
 }
 
-/** Scraper bots only — do NOT match the Instagram in-app browser (contains "Instagram"). */
+/**
+ * Social scrapers only — empty-body OG HTML is for Meta/X/Slack/etc. (no JS).
+ * Do NOT match search/archive bots (Googlebot, bingbot, Applebot, ia_archiver)
+ * or the Instagram in-app browser (UA contains "Instagram").
+ */
 export const SOCIAL_CRAWLER_RE =
-  /facebookexternalhit|Facebot|Twitterbot|WhatsApp|Slackbot|LinkedInBot|TelegramBot|Discordbot|redditbot|bingbot|Applebot|Googlebot|ia_archiver/i;
+  /facebookexternalhit|Facebot|Twitterbot|WhatsApp|Slackbot|LinkedInBot|TelegramBot|Discordbot|redditbot/i;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setlistpickem",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setlistpickem",
-      "version": "1.31.0",
+      "version": "1.31.1",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "firebase": "10.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-"version": "1.31.0",
+"version": "1.31.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/verify-og-home.mjs
+++ b/scripts/verify-og-home.mjs
@@ -1,6 +1,8 @@
 /**
  * CI guard: homepage Open Graph tags must be present for Meta crawlers within
  * the first 60 KB of HTML (Instagram/Facebook do not execute JS).
+ *
+ * Also guards that search bots are excluded from the empty-body OG shell.
  */
 import { buildHomeOgHtml, SOCIAL_CRAWLER_RE, ogHomeImageUrl } from '../og-home-html.mjs';
 
@@ -25,14 +27,42 @@ assert(html.includes(ogHomeImageUrl()), 'missing versioned og:image URL');
 assert(html.includes('og:image:type'), 'missing og:image:type');
 assert(html.includes('og:image:width'), 'missing og:image:width');
 assert(html.includes('og:image:height'), 'missing og:image:height');
+assert(html.includes('rel="icon"'), 'OG shell must include favicon link(s)');
+assert(html.includes('/favicon/favicon.ico'), 'OG shell must include shortcut favicon');
 
 assert(
   SOCIAL_CRAWLER_RE.test('facebookexternalhit/1.1'),
   'SOCIAL_CRAWLER_RE must match facebookexternalhit',
 );
 assert(
+  SOCIAL_CRAWLER_RE.test('Twitterbot/1.0'),
+  'SOCIAL_CRAWLER_RE must match Twitterbot',
+);
+assert(
+  SOCIAL_CRAWLER_RE.test('Slackbot-LinkExpanding 1.0'),
+  'SOCIAL_CRAWLER_RE must match Slackbot',
+);
+assert(
   !SOCIAL_CRAWLER_RE.test('Instagram 219.0.0.12.117 Android'),
   'SOCIAL_CRAWLER_RE must not match Instagram in-app browser',
+);
+assert(
+  !SOCIAL_CRAWLER_RE.test(
+    'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+  ),
+  'SOCIAL_CRAWLER_RE must not match Googlebot',
+);
+assert(
+  !SOCIAL_CRAWLER_RE.test('Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)'),
+  'SOCIAL_CRAWLER_RE must not match bingbot',
+);
+assert(
+  !SOCIAL_CRAWLER_RE.test('Mozilla/5.0 (compatible; Applebot/0.1)'),
+  'SOCIAL_CRAWLER_RE must not match Applebot',
+);
+assert(
+  !SOCIAL_CRAWLER_RE.test('ia_archiver'),
+  'SOCIAL_CRAWLER_RE must not match ia_archiver',
 );
 
 console.log('verify:og-home OK');


### PR DESCRIPTION
Closes #658

## Summary
- Narrow `SOCIAL_CRAWLER_RE` so `Googlebot` / `bingbot` / `Applebot` / `ia_archiver` fall through to the SPA `index.html` instead of the empty-body OG shell
- Keep social scrapers on the minimal OG HTML; add favicon `<link>`s to that shell
- Extend `verify:og-home` assertions for search-bot exclusion + favicons
- PATCH `1.31.1`

## Test plan
- [x] `npm run verify:og-home` passes locally
- [ ] Vercel preview: `curl -A Googlebot <preview>/` returns SPA shell (non-empty body / favicon links from `index.html`)
- [ ] Vercel preview: `curl -A facebookexternalhit <preview>/` still returns minimal OG HTML
- [ ] After staging → main promote: request reindex of `/` in Search Console (#664 / Child G)


Made with [Cursor](https://cursor.com)