### PR TITLE
docs(seo): record GSC week-1 baseline in playbook

### DIFF
--- a/docs/SEO_GEO_PLAYBOOK.md
+++ b/docs/SEO_GEO_PLAYBOOK.md
@@ -101,7 +101,7 @@ Fill one row per week (Sunday or Monday). Source: Search Console Performance (28
 
 | Week starting | Impressions (site) | Clicks | Top query (non-brand) | Best position (C1–C4) | Favicon on `site:setlistpickem.com`? | AI Overview / generative citation? | Notes |
 |---------------|--------------------:|-------:|------------------------|------------------------:|--------------------------------------|------------------------------------|-------|
-| 2026-07-19 | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _check_ | _check_ | Child A live; www reindex requested; playbook (#664) |
+| 2026-07-19 | 76 | 24 | _TBD_ | 5.7 (site avg) | _check_ | _check_ | GSC Performance **last 3 months** (Web; through ~2026-07-17): CTR 31.6%, avg position 5.7. Child A live; www reindex requested; playbook (#664). Prefer last-7-days for later weekly rows. |
 | 2026-07-26 | | | | | | | |
 | 2026-08-02 | | | | | | | |
 | 2026-08-09 | | | | | | | |


### PR DESCRIPTION
## Summary
- Fill `docs/SEO_GEO_PLAYBOOK.md` §4 week-1 row with GSC Performance (last 3 months): 76 impressions, 24 clicks, 31.6% CTR, avg position 5.7

## Test plan
- [x] Docs-only (`skip-version-bump`)


Made with [Cursor](https://cursor.com)