### PR TITLE
feat(seo): keyword-intent Phish setlist prediction page (#660)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.34.0] — 2026-07-19
+
+### Added
+- **Keyword-intent page (#660)** — public `/phish-setlist-prediction-game` educational landing (what a Phish setlist prediction game is, vs archives/trackers, how to play). Prerender + FAQ JSON-LD; sitemap/`llms.txt` + marketing footer links.
+
+---
+
 ## [1.33.0] — 2026-07-19
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -357,6 +357,7 @@ These routes are part of the public surface. Renaming or removing them is a MAJO
 | `/how-scoring-works` | None | Scoring rules marketing page. **v1.32.0+ (#659):** served as prerendered `dist/how-scoring-works/index.html` when present. |
 | `/tour-stats` | None | **v1.33.0 (#665):** public aggregate tour song stats (filter + default Sphere). Prerendered shell; live data from `public_tour_stats`. Never full nightly setlists. |
 | `/tour-stats/:tourSlug` | None | **v1.33.0 (#665):** same surface for a kebab-case tour slug (e.g. `sphere-run-2026`). Default Sphere slug is also prerendered. |
+| `/phish-setlist-prediction-game` | None | **v1.34.0 (#660):** keyword-intent educational page for Phish setlist prediction game queries; prerendered HTML + FAQ JSON-LD. |
 | `/join/:code` | None | Pool invite deep link; optional `?from={handle}` for inviter personalization; VIP landing stores code and prompts auth (#580); personalized OG (#582) |
 | `/invite/:handle` | None | Site VIP invite deep link; personalized landing when handle resolves; no pool join side effects (#580); personalized OG (#582) |
 | `/user/:userId` | None | Public player profile |

--- a/docs/SEO_GEO_PLAYBOOK.md
+++ b/docs/SEO_GEO_PLAYBOOK.md
@@ -83,6 +83,8 @@ Track these weekly in Search Console (Performance → Queries) and spot-check SE
 | C3 | `phish pick em` / `phish pick'em` |
 | C4 | `live setlist prediction` |
 
+**Keyword landing (#660):** `/phish-setlist-prediction-game` — definitional page targeting C1–C3; disambiguates prediction game vs setlist archives.
+
 ### Stats-intent (after #665 public `/tour-stats`)
 
 | ID | Query |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.33.0",
+  "version": "1.34.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -23,4 +23,5 @@
 - How Scoring Works: https://www.setlistpickem.com/how-scoring-works
 - Tour Stats: https://www.setlistpickem.com/tour-stats
 - Sphere Run 2026 Stats: https://www.setlistpickem.com/tour-stats/sphere-run-2026
+- Phish Setlist Prediction Game: https://www.setlistpickem.com/phish-setlist-prediction-game
 - Setlist data: https://phish.net (The Mockingbird Foundation)

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -25,4 +25,9 @@
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc>https://www.setlistpickem.com/phish-setlist-prediction-game</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.85</priority>
+  </url>
 </urlset>

--- a/scripts/verify-seo-prerender.mjs
+++ b/scripts/verify-seo-prerender.mjs
@@ -39,7 +39,7 @@ function assertRouteHtml(html, route, label) {
   }
 }
 
-assert(PRERENDER_ROUTES.length >= 5, 'expected home + how-it-works + how-scoring-works + tour-stats hub + sphere');
+assert(PRERENDER_ROUTES.length >= 6, 'expected marketing + tour-stats + keyword-intent routes');
 assert(
   PRERENDER_ROUTES.some((r) => r.path === '/tour-stats'),
   'expected /tour-stats prerender entry',
@@ -47,6 +47,10 @@ assert(
 assert(
   PRERENDER_ROUTES.some((r) => r.path === '/tour-stats/sphere-run-2026'),
   'expected Sphere tour-stats prerender entry',
+);
+assert(
+  PRERENDER_ROUTES.some((r) => r.path === '/phish-setlist-prediction-game'),
+  'expected keyword-intent prerender entry',
 );
 assert(
   PRERENDER_ROUTES.every((r) => !r.path.startsWith('/dashboard')),

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -21,6 +21,9 @@ const InviteLandingPage = lazy(() => import('../pages/invite/InviteLandingPage')
 const HowItWorksPage = lazy(() => import('../pages/marketing/HowItWorksPage'));
 const HowScoringWorksPage = lazy(() => import('../pages/marketing/HowScoringWorksPage'));
 const PublicTourStatsPage = lazy(() => import('../pages/marketing/PublicTourStatsPage'));
+const PhishSetlistPredictionGamePage = lazy(
+  () => import('../pages/marketing/PhishSetlistPredictionGamePage'),
+);
 const PrivacyPolicyPage = lazy(() => import('../pages/legal/PrivacyPolicyPage'));
 const TermsOfServicePage = lazy(() => import('../pages/legal/TermsOfServicePage'));
 const SetupRoute = lazy(() => import('./routes/SetupRoute'));
@@ -43,6 +46,10 @@ function App() {
         <Route path="/how-scoring-works" element={<HowScoringWorksPage />} />
         <Route path="/tour-stats" element={<PublicTourStatsPage />} />
         <Route path="/tour-stats/:tourSlug" element={<PublicTourStatsPage />} />
+        <Route
+          path="/phish-setlist-prediction-game"
+          element={<PhishSetlistPredictionGamePage />}
+        />
 
         {/* Legal pages — public, no auth (required for GCP OAuth consent screen) */}
         <Route path="/privacy" element={<PrivacyPolicyPage />} />

--- a/src/features/landing/index.js
+++ b/src/features/landing/index.js
@@ -1,6 +1,7 @@
 export { default as HowItWorksPageContent } from './ui/HowItWorksPageContent';
 export { default as LandingSeo } from './ui/LandingSeo';
 export { default as MarketingPageShell } from './ui/MarketingPageShell';
+export { default as PhishSetlistPredictionGamePageContent } from './ui/PhishSetlistPredictionGamePageContent';
 export { default as SplashAboutSection } from './ui/SplashAboutSection';
 export { default as SplashAuthModals } from './ui/SplashAuthModals';
 export { default as SplashGetStartedSection } from './ui/SplashGetStartedSection';

--- a/src/features/landing/ui/MarketingPageShell.jsx
+++ b/src/features/landing/ui/MarketingPageShell.jsx
@@ -9,7 +9,7 @@ import {
 
 /**
  * Minimal shell for standalone marketing / educational pages
- * (`/how-it-works`, `/how-scoring-works`, `/tour-stats`). Provides a sticky header with home
+ * (`/how-it-works`, `/how-scoring-works`, `/tour-stats`, `/phish-setlist-prediction-game`). Provides a sticky header with home
  * link and a simple footer — no auth logic, no scroll machinery.
  */
 export default function MarketingPageShell({ children }) {
@@ -62,6 +62,7 @@ export default function MarketingPageShell({ children }) {
           <Link to="/how-it-works" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400">How It Works</Link>
           <Link to="/how-scoring-works" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400">How Scoring Works</Link>
           <Link to="/tour-stats" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400">Tour Stats</Link>
+          <Link to="/phish-setlist-prediction-game" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400">Phish Setlist Game</Link>
           <Link to="/privacy" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400">Privacy Policy</Link>
           <Link to="/terms" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400">Terms of Service</Link>
         </p>

--- a/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
+++ b/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowRight } from 'lucide-react';
+
+/**
+ * Keyword-intent educational page for `/phish-setlist-prediction-game` (#660).
+ * Entity-dense copy for category queries — not a thin doorway.
+ */
+export default function PhishSetlistPredictionGamePageContent() {
+  return (
+    <article className="relative z-10 w-full bg-slate-50 py-16 md:py-24">
+      <div className="mx-auto w-full max-w-3xl px-4 sm:px-6 lg:px-8">
+        <p className="mb-3 text-center text-[10px] font-black uppercase tracking-widest text-emerald-700">
+          Setlist Pick&apos;Em
+        </p>
+        <h1 className="mb-5 text-center font-display text-3xl font-bold text-slate-900 sm:text-4xl md:text-5xl">
+          The free Phish setlist prediction game
+        </h1>
+        <p className="mb-10 text-center text-lg leading-relaxed text-slate-600">
+          Setlist Pick&apos;Em (also called Setlist Pickem / Set Picks) is a live{' '}
+          <strong className="font-semibold text-slate-800">setlist prediction game</strong> for
+          Phish fans: lock openers, closers, encore, and a wildcard before showtime, then score as
+          the setlist unfolds.
+        </p>
+
+        <section className="mb-12 space-y-4 text-base leading-relaxed text-slate-700">
+          <h2 className="font-display text-2xl font-bold text-slate-900">
+            What is a Phish setlist game?
+          </h2>
+          <p>
+            A Phish setlist game asks you to predict songs and slots for tonight&apos;s show—not to
+            archive what already happened. You compete against friends in private pools and against
+            everyone on the global board. Scores update live as songs are played.
+          </p>
+          <p>
+            Setlist Pick&apos;Em started covering the Sphere run in 2026 and follows each tour as
+            Phish.net publishes new dates. Tour-level song frequency, bustouts, and gap highlights
+            are available on our public{' '}
+            <Link
+              to="/tour-stats"
+              className="font-semibold text-emerald-700 underline decoration-emerald-300 underline-offset-2 hover:decoration-emerald-500"
+            >
+              tour stats
+            </Link>{' '}
+            pages so you can research picks without an account.
+          </p>
+        </section>
+
+        <section className="mb-12 space-y-4 text-base leading-relaxed text-slate-700">
+          <h2 className="font-display text-2xl font-bold text-slate-900">
+            Prediction game vs setlist trackers
+          </h2>
+          <p>
+            Sites like Phish.net and setlist.fm are outstanding archives and reference libraries—
+            they document what was played. Setlist Pick&apos;Em is a{' '}
+            <strong className="font-semibold text-slate-800">game layer on top of that world</strong>
+            : you make picks before the lights go down, earn points for correct slots and wildcards,
+            and chase Bustout Boosts on longshot calls.
+          </p>
+          <ul className="list-disc space-y-2 pl-5">
+            <li>
+              <strong className="text-slate-900">Before the show:</strong> lock picks; they freeze
+              near doors / showtime.
+            </li>
+            <li>
+              <strong className="text-slate-900">During the show:</strong> live scoring and
+              standings as the setlist updates.
+            </li>
+            <li>
+              <strong className="text-slate-900">After the show:</strong> final grades, tour
+              standings, and aggregate song stats—not a replacement for the official archive.
+            </li>
+          </ul>
+          <p>
+            Song and setlist data for scoring and public stats are provided by{' '}
+            <a
+              href="https://phish.net"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold text-emerald-700 underline decoration-emerald-300 underline-offset-2 hover:decoration-emerald-500"
+            >
+              The Mockingbird Foundation / Phish.Net
+            </a>
+            .
+          </p>
+        </section>
+
+        <section className="mb-12 space-y-4 text-base leading-relaxed text-slate-700">
+          <h2 className="font-display text-2xl font-bold text-slate-900">How to play</h2>
+          <ol className="list-decimal space-y-3 pl-5">
+            <li>
+              Create a free account and open tonight&apos;s show on the dashboard.
+            </li>
+            <li>
+              Pick Set 1 opener/closer, Set 2 opener/closer, encore, and a wildcard.
+            </li>
+            <li>
+              Watch scores update live; climb show and tour standings or invite friends to a pool.
+            </li>
+          </ol>
+          <p className="flex flex-wrap gap-x-4 gap-y-2">
+            <Link
+              to="/how-it-works"
+              className="inline-flex items-center gap-1 font-semibold text-emerald-700 underline decoration-emerald-300 underline-offset-2 hover:decoration-emerald-500"
+            >
+              How it works
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Link>
+            <Link
+              to="/how-scoring-works"
+              className="inline-flex items-center gap-1 font-semibold text-emerald-700 underline decoration-emerald-300 underline-offset-2 hover:decoration-emerald-500"
+            >
+              How scoring works
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Link>
+          </p>
+        </section>
+
+        <div className="flex justify-center border-t border-slate-200 pt-10">
+          <Link
+            to="/"
+            className="inline-flex items-center gap-2 rounded-xl bg-brand-primary px-10 py-3.5 text-base font-bold text-white shadow-[0_10px_20px_-10px_rgba(16,185,129,0.5)] transition-all hover:bg-brand-primary-hover hover:shadow-[0_15px_30px_-15px_rgba(16,185,129,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue"
+          >
+            Play the Phish setlist prediction game
+          </Link>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/features/landing/ui/SplashPageShell.jsx
+++ b/src/features/landing/ui/SplashPageShell.jsx
@@ -92,6 +92,12 @@ export default function SplashPageShell({
               Tour Stats
             </Link>
             <Link
+              to="/phish-setlist-prediction-game"
+              className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400"
+            >
+              Phish Setlist Game
+            </Link>
+            <Link
               to="/privacy"
               className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400"
             >

--- a/src/pages/marketing/PhishSetlistPredictionGamePage.jsx
+++ b/src/pages/marketing/PhishSetlistPredictionGamePage.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+
+import {
+  MarketingPageShell,
+  PhishSetlistPredictionGamePageContent,
+} from '../../features/landing';
+import { SEO_CONFIG } from '../../shared/config/seo';
+import { getPrerenderRoute } from '../../shared/config/seoRoutes';
+
+const route = getPrerenderRoute('/phish-setlist-prediction-game');
+
+export default function PhishSetlistPredictionGamePage() {
+  const jsonLd = route.buildJsonLd();
+  return (
+    <>
+      <Helmet>
+        <title>{route.title}</title>
+        <meta name="description" content={route.description} />
+        <meta name="author" content={SEO_CONFIG.publisherName} />
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={route.title} />
+        <meta property="og:description" content={route.description} />
+        <meta property="og:url" content={route.canonicalUrl} />
+        <meta property="og:image" content={SEO_CONFIG.ogImageUrl} />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta
+          property="og:image:alt"
+          content="Setlist Pick 'Em — Phish setlist prediction game"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={route.title} />
+        <meta name="twitter:description" content={route.description} />
+        <meta name="twitter:image" content={SEO_CONFIG.ogImageUrl} />
+        <link rel="canonical" href={route.canonicalUrl} />
+        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+      </Helmet>
+      <MarketingPageShell>
+        <PhishSetlistPredictionGamePageContent />
+      </MarketingPageShell>
+    </>
+  );
+}

--- a/src/shared/config/seoRoutes.js
+++ b/src/shared/config/seoRoutes.js
@@ -255,6 +255,75 @@ function buildTourStatsSphereJsonLd() {
   };
 }
 
+const KEYWORD_PAGE_PATH = '/phish-setlist-prediction-game';
+const KEYWORD_PAGE_TITLE =
+  "Phish Setlist Prediction Game | Setlist Pick'Em";
+const KEYWORD_PAGE_DESCRIPTION =
+  "Setlist Pick'Em is the free Phish setlist prediction game: lock openers, closers, encore, and a wildcard before showtime, score live as songs are played, and compete with friends. Not a setlist archive — a game.";
+const KEYWORD_PAGE_URL = `${SEO_CONFIG.siteUrl}${KEYWORD_PAGE_PATH}`;
+
+function buildKeywordIntentPageJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebPage',
+        '@id': KEYWORD_PAGE_URL,
+        url: KEYWORD_PAGE_URL,
+        name: KEYWORD_PAGE_TITLE,
+        description: KEYWORD_PAGE_DESCRIPTION,
+        isPartOf: { '@id': `${SEO_CONFIG.siteUrl}/#website` },
+      },
+      {
+        '@type': 'FAQPage',
+        mainEntity: [
+          {
+            '@type': 'Question',
+            name: 'What is a Phish setlist prediction game?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: "A Phish setlist prediction game asks fans to predict songs and slots before the show. Setlist Pick'Em scores picks live as the setlist unfolds and ranks players in private pools and global standings.",
+            },
+          },
+          {
+            '@type': 'Question',
+            name: 'How is Setlist Pick\'Em different from Phish.net or setlist.fm?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'Phish.net and setlist.fm are setlist archives and references. Setlist Pick\'Em is a free live prediction game that uses official setlist data for scoring — you compete before and during the show rather than only browsing what was played.',
+            },
+          },
+          {
+            '@type': 'Question',
+            name: 'Is Setlist Pick\'Em free?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'Yes. There is no charge to sign up and play.',
+            },
+          },
+        ],
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'Home',
+            item: `${SEO_CONFIG.siteUrl}/`,
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'Phish setlist prediction game',
+            item: KEYWORD_PAGE_URL,
+          },
+        ],
+      },
+    ],
+  };
+}
+
 function buildHowScoringJsonLd() {
   return {
     '@context': 'https://schema.org',
@@ -394,6 +463,19 @@ export const PRERENDER_ROUTES = [
       'Aggregate song data only — not night-by-night full setlists.',
     ],
     buildJsonLd: buildTourStatsSphereJsonLd,
+  },
+  {
+    path: KEYWORD_PAGE_PATH,
+    title: KEYWORD_PAGE_TITLE,
+    description: KEYWORD_PAGE_DESCRIPTION,
+    canonicalUrl: KEYWORD_PAGE_URL,
+    h1: 'The free Phish setlist prediction game',
+    paragraphs: [
+      "Setlist Pick'Em (also called Setlist Pickem / Set Picks) is a live setlist prediction game for Phish fans: lock openers, closers, encore, and a wildcard before showtime, then score as the setlist unfolds.",
+      'A Phish setlist game asks you to predict songs and slots for tonight\'s show—not to archive what already happened. You compete against friends in private pools and against everyone on the global board.',
+      'Sites like Phish.net and setlist.fm are outstanding archives. Setlist Pick\'Em is a game layer: you make picks before the lights go down and earn points as songs are played.',
+    ],
+    buildJsonLd: buildKeywordIntentPageJsonLd,
   },
 ];
 

--- a/vercel.json
+++ b/vercel.json
@@ -226,6 +226,15 @@
       ]
     },
     {
+      "source": "/phish-setlist-prediction-game",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        }
+      ]
+    },
+    {
       "source": "/privacy",
       "headers": [
         {


### PR DESCRIPTION
Closes #660

## Summary
- Public `/phish-setlist-prediction-game` — entity-dense educational page for category queries (`phish setlist game`, setlist prediction game)
- Helmet + prerender + FAQ JSON-LD; sitemap / `llms.txt` / footer links
- SemVer **1.34.0**

## Test plan
- [ ] `npm run verify:seo-prerender` / `npm run lint` green
- [ ] Preview: page renders; footer link from splash/marketing shell
- [ ] View-source / prerender has unique title, H1, FAQ JSON-LD


Made with [Cursor](https://cursor.com)