### PR TITLE
fix(seo): align public tour-stats default slug with 2026 Sphere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.34.1] — 2026-07-19
+
+### Fixed
+- **Public tour-stats default slug (#665)** — align default/prerender with live calendar label **2026 Sphere** → `2026-sphere` (was hardcoded `sphere-run-2026`). Index writer prefers any Sphere tour when present.
+
+---
+
 ## [1.34.0] — 2026-07-19
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -156,7 +156,7 @@ Per-show official results. Document ID is the show date (`YYYY-MM-DD`). Full sch
 
 Public, aggregate-only tour song stats for SEO marketing routes. Written by Cloud Functions Admin SDK (`refreshPublicTourStats` / nightly schedule). **Never** contains full per-show `officialSetlist` arrays. Clients may read; client writes denied.
 
-Document ID is a kebab-case slug from the calendar tour label (`Sphere Run 2026` → `sphere-run-2026`). Special doc `_index` lists tours for the public filter.
+Document ID is a kebab-case slug from the calendar tour label (`2026 Sphere` → `2026-sphere`). Special doc `_index` lists tours for the public filter.
 
 | Field | Type | Notes |
 |-------|------|-------|
@@ -172,7 +172,7 @@ Document ID is a kebab-case slug from the calendar tour label (`Sphere Run 2026`
 | `writtenAt` | string | ISO timestamp |
 | `schemaVersion` | number | `1` |
 
-`_index` fields: `tours[]` (`tourSlug`, `tourLabel`, `firstShowDate`, `lastShowDate`, `showCount`), `defaultTourSlug` (`sphere-run-2026`), `writtenAt`, `schemaVersion`.
+`_index` fields: `tours[]` (`tourSlug`, `tourLabel`, `firstShowDate`, `lastShowDate`, `showCount`), `defaultTourSlug` (prefers Sphere when present, e.g. `2026-sphere`), `writtenAt`, `schemaVersion`.
 
 Tour labels are ingested via **`scheduledPhishnetShowCalendar`** (daily 06:00 ET) from Phish.net as new dates publish; public stats rebuild after calendar sync and again at **07:30 ET** (`scheduledPublicTourStatsRefresh`).
 
@@ -356,7 +356,7 @@ These routes are part of the public surface. Renaming or removing them is a MAJO
 | `/how-it-works` | None | How to play marketing page. **v1.32.0+ (#659):** served as prerendered `dist/how-it-works/index.html` when present. |
 | `/how-scoring-works` | None | Scoring rules marketing page. **v1.32.0+ (#659):** served as prerendered `dist/how-scoring-works/index.html` when present. |
 | `/tour-stats` | None | **v1.33.0 (#665):** public aggregate tour song stats (filter + default Sphere). Prerendered shell; live data from `public_tour_stats`. Never full nightly setlists. |
-| `/tour-stats/:tourSlug` | None | **v1.33.0 (#665):** same surface for a kebab-case tour slug (e.g. `sphere-run-2026`). Default Sphere slug is also prerendered. |
+| `/tour-stats/:tourSlug` | None | **v1.33.0 (#665):** same surface for a kebab-case tour slug (e.g. `2026-sphere`). Default Sphere slug is also prerendered. |
 | `/phish-setlist-prediction-game` | None | **v1.34.0 (#660):** keyword-intent educational page for Phish setlist prediction game queries; prerendered HTML + FAQ JSON-LD. |
 | `/join/:code` | None | Pool invite deep link; optional `?from={handle}` for inviter personalization; VIP landing stores code and prompts auth (#580); personalized OG (#582) |
 | `/invite/:handle` | None | Site VIP invite deep link; personalized landing when handle resolves; no pool join side effects (#580); personalized OG (#582) |

--- a/docs/DASHBOARD_IA.md
+++ b/docs/DASHBOARD_IA.md
@@ -19,7 +19,7 @@ Single reference for **support**, **product**, and **engineering** when adding r
 |-------|------|-------|
 | **Stats** (Standings peer tab) | `/dashboard/tour-stats` | Private explorer: unique songs, frequency, bustouts, self pick overlay. Discovered via Standings chrome **Show \| Tour \| Stats \| Pools** (not a 5th primary nav tab). Standings tab stays active. Shares the chrome **tour scope** picker with Tour view (`?tour=`). No global date picker. |
 
-**Public marketing counterpart (#665):** `/tour-stats` and `/tour-stats/:tourSlug` — aggregate song datasets only (most played, bustouts, gaps); default tour is Sphere (`sphere-run-2026`). Not a dashboard route; `robots.txt` still Disallows `/dashboard/*`. Do not unlock private Stats or self-overlay for anonymous users.
+**Public marketing counterpart (#665):** `/tour-stats` and `/tour-stats/:tourSlug` — aggregate song datasets only (most played, bustouts, gaps); default tour is Sphere (`2026-sphere` from live calendar label **2026 Sphere**). Not a dashboard route; `robots.txt` still Disallows `/dashboard/*`. Do not unlock private Stats or self-overlay for anonymous users.
 
 ### Feature discovery “New” markers (#639)
 

--- a/docs/SEO_GEO_PLAYBOOK.md
+++ b/docs/SEO_GEO_PLAYBOOK.md
@@ -93,7 +93,7 @@ Track these weekly in Search Console (Performance → Queries) and spot-check SE
 | S2 | `phish song frequency [tour year]` (e.g. summer 2026) |
 | S3 | `phish bustouts [tour]` |
 
-Public surface: `/tour-stats` + `/tour-stats/:tourSlug` (kebab-case labels from Phish.net calendar ingest). **Aggregates only** — most played, bustouts, gap highlights; never full night setlists. Default tour: Sphere (`sphere-run-2026`). Prerender hub + Sphere shell; other tours hydrate client-side from `public_tour_stats`.
+Public surface: `/tour-stats` + `/tour-stats/:tourSlug` (kebab-case labels from Phish.net calendar ingest). **Aggregates only** — most played, bustouts, gap highlights; never full night setlists. Default tour: Sphere (`2026-sphere`). Prerender hub + Sphere shell; other tours hydrate client-side from `public_tour_stats`.
 
 Add/remove rows as pages ship; keep IDs stable once used in the log.
 

--- a/docs/SHOW_CALENDAR_TOUR_LABELS.md
+++ b/docs/SHOW_CALENDAR_TOUR_LABELS.md
@@ -19,4 +19,4 @@ Each successful sync also writes **`reviewQueue`** on `snapshot` (empty on **fir
 
 **Related:** [PHISHNET_CALLABLE_RUNBOOK.md](./PHISHNET_CALLABLE_RUNBOOK.md) §8.
 
-**Public tour-stats SEO (#665):** kebab-case slugs from these labels feed `public_tour_stats/{tourSlug}` (e.g. `Sphere Run 2026` → `sphere-run-2026`). Calendar sync and `scheduledPublicTourStatsRefresh` keep aggregates current; see `docs/API.md` §1.13.
+**Public tour-stats SEO (#665):** kebab-case slugs from these labels feed `public_tour_stats/{tourSlug}` (e.g. `2026 Sphere` → `2026-sphere`). Calendar sync and `scheduledPublicTourStatsRefresh` keep aggregates current; see `docs/API.md` §1.13.

--- a/functions/aggregateTourSetlistStats.test.js
+++ b/functions/aggregateTourSetlistStats.test.js
@@ -10,8 +10,8 @@ const {
 } = require("./aggregateTourSetlistStats.cjs");
 
 describe("tourLabelToSlug", () => {
-  it("kebab-cases Sphere Run 2026", () => {
-    assert.equal(tourLabelToSlug("Sphere Run 2026"), "sphere-run-2026");
+  it("kebab-cases 2026 Sphere", () => {
+    assert.equal(tourLabelToSlug("2026 Sphere"), "2026-sphere");
   });
   it("kebab-cases Summer Tour 2026", () => {
     assert.equal(tourLabelToSlug("Summer Tour 2026"), "summer-tour-2026");

--- a/functions/publicTourStats.js
+++ b/functions/publicTourStats.js
@@ -129,20 +129,47 @@ async function refreshPublicTourStats(db, opts = {}) {
       return a.tourLabel.localeCompare(b.tourLabel);
     });
 
+  const defaultTourSlug = pickDefaultPublicTourSlug(indexTours);
+
   await db.collection("public_tour_stats").doc("_index").set(
     {
       tours: indexTours,
-      defaultTourSlug: "sphere-run-2026",
+      defaultTourSlug,
       writtenAt,
       schemaVersion: 1,
     },
     { merge: false }
   );
 
-  return { toursWritten, today, indexCount: indexTours.length };
+  return { toursWritten, today, indexCount: indexTours.length, defaultTourSlug };
+}
+
+/**
+ * Prefer Sphere (game launch) when present; else first indexed tour.
+ * @param {Array<{ tourSlug: string, tourLabel: string }>} indexTours
+ * @returns {string}
+ */
+function pickDefaultPublicTourSlug(indexTours) {
+  const preferredSlugs = [
+    "2026-sphere",
+    "sphere-run-2026",
+    "sphere-2026",
+    "sphere",
+  ];
+  for (const slug of preferredSlugs) {
+    if (indexTours.some((t) => t.tourSlug === slug)) return slug;
+  }
+  const sphere = indexTours.find(
+    (t) =>
+      /sphere/i.test(String(t.tourLabel || "")) ||
+      /sphere/i.test(String(t.tourSlug || ""))
+  );
+  if (sphere) return sphere.tourSlug;
+  return indexTours[0]?.tourSlug || "2026-sphere";
 }
 
 module.exports = {
   refreshPublicTourStats,
+  pickDefaultPublicTourSlug,
   GAME_LAUNCH_SHOW_DATE,
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.34.0",
+  "version": "1.34.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -22,6 +22,6 @@
 - How It Works: https://www.setlistpickem.com/how-it-works
 - How Scoring Works: https://www.setlistpickem.com/how-scoring-works
 - Tour Stats: https://www.setlistpickem.com/tour-stats
-- Sphere Run 2026 Stats: https://www.setlistpickem.com/tour-stats/sphere-run-2026
+- Sphere Run 2026 Stats: https://www.setlistpickem.com/tour-stats/2026-sphere
 - Phish Setlist Prediction Game: https://www.setlistpickem.com/phish-setlist-prediction-game
 - Setlist data: https://phish.net (The Mockingbird Foundation)

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -21,7 +21,7 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.setlistpickem.com/tour-stats/sphere-run-2026</loc>
+    <loc>https://www.setlistpickem.com/tour-stats/2026-sphere</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/scripts/verify-seo-prerender.mjs
+++ b/scripts/verify-seo-prerender.mjs
@@ -45,7 +45,7 @@ assert(
   'expected /tour-stats prerender entry',
 );
 assert(
-  PRERENDER_ROUTES.some((r) => r.path === '/tour-stats/sphere-run-2026'),
+  PRERENDER_ROUTES.some((r) => r.path === '/tour-stats/2026-sphere'),
   'expected Sphere tour-stats prerender entry',
 );
 assert(

--- a/src/features/tour-stats/api/fetchPublicTourStats.js
+++ b/src/features/tour-stats/api/fetchPublicTourStats.js
@@ -21,14 +21,14 @@ import { db } from '../../../shared/lib/firebase';
 export async function fetchPublicTourStatsIndex() {
   const snap = await getDoc(doc(db, 'public_tour_stats', '_index'));
   if (!snap.exists()) {
-    return { tours: [], defaultTourSlug: 'sphere-run-2026' };
+    return { tours: [], defaultTourSlug: '2026-sphere' };
   }
   const data = snap.data() || {};
   const tours = Array.isArray(data.tours) ? data.tours : [];
   const defaultTourSlug =
     typeof data.defaultTourSlug === 'string' && data.defaultTourSlug
       ? data.defaultTourSlug
-      : 'sphere-run-2026';
+      : '2026-sphere';
   return { tours, defaultTourSlug };
 }
 

--- a/src/shared/config/seoRoutes.js
+++ b/src/shared/config/seoRoutes.js
@@ -178,10 +178,10 @@ const TOUR_STATS_HUB_DESCRIPTION =
   "Aggregate Phish tour setlist stats — most-played songs, bustouts, and gap highlights. Starts with the Sphere run (when Setlist Pick 'Em launched); tours update as Phish.net publishes new dates.";
 const TOUR_STATS_HUB_URL = `${SEO_CONFIG.siteUrl}/tour-stats`;
 
-const TOUR_STATS_SPHERE_TITLE = "Sphere Run 2026 Tour Stats | Setlist Pick'Em";
+const TOUR_STATS_SPHERE_TITLE = "2026 Sphere Tour Stats | Setlist Pick'Em";
 const TOUR_STATS_SPHERE_DESCRIPTION =
-  "Sphere Run 2026 setlist stats for Setlist Pick 'Em — most-played songs, bustouts, and gap highlights from the inaugural Pick'em tour. Aggregate song data only; not full nightly setlists.";
-const TOUR_STATS_SPHERE_URL = `${SEO_CONFIG.siteUrl}/tour-stats/sphere-run-2026`;
+  "2026 Sphere setlist stats for Setlist Pick 'Em — most-played songs, bustouts, and gap highlights from the inaugural Pick'em tour. Aggregate song data only; not full nightly setlists.";
+const TOUR_STATS_SPHERE_URL = `${SEO_CONFIG.siteUrl}/tour-stats/2026-sphere`;
 
 function buildTourStatsHubJsonLd() {
   return {
@@ -246,7 +246,7 @@ function buildTourStatsSphereJsonLd() {
           {
             '@type': 'ListItem',
             position: 3,
-            name: 'Sphere Run 2026',
+            name: '2026 Sphere',
             item: TOUR_STATS_SPHERE_URL,
           },
         ],
@@ -452,13 +452,13 @@ export const PRERENDER_ROUTES = [
     buildJsonLd: buildTourStatsHubJsonLd,
   },
   {
-    path: '/tour-stats/sphere-run-2026',
+    path: '/tour-stats/2026-sphere',
     title: TOUR_STATS_SPHERE_TITLE,
     description: TOUR_STATS_SPHERE_DESCRIPTION,
     canonicalUrl: TOUR_STATS_SPHERE_URL,
-    h1: 'Sphere Run 2026 tour stats',
+    h1: '2026 Sphere tour stats',
     paragraphs: [
-      'Most-played songs, bustouts, and gap highlights from the Sphere run — the inaugural Setlist Pick \'Em tour.',
+      'Most-played songs, bustouts, and gap highlights from the 2026 Sphere run — the inaugural Setlist Pick \'Em tour.',
       'Tour names and dates sync from Phish.net as new shows publish so stats stay current while you make picks for every show.',
       'Aggregate song data only — not night-by-night full setlists.',
     ],

--- a/src/shared/lib/tourSlug.js
+++ b/src/shared/lib/tourSlug.js
@@ -1,6 +1,6 @@
 /**
  * Stable URL slug from a Phish.net / calendar tour display label.
- * "Sphere Run 2026" → "sphere-run-2026"
+ * "2026 Sphere" → "2026-sphere"
  *
  * @param {string} tourLabel
  * @returns {string}
@@ -17,14 +17,16 @@ export function tourLabelToSlug(tourLabel) {
 }
 
 /**
- * Default public tour-stats slug — Sphere run (game launch / inaugural Pick'em).
- * Calendar label is typically "Sphere Run 2026" (see show_calendar + overrides).
+ * Default public tour-stats slug — Sphere (game launch / inaugural Pick'em).
+ * Live `show_calendar` label is currently **"2026 Sphere"** → `2026-sphere`.
  */
-export const DEFAULT_PUBLIC_TOUR_SLUG = 'sphere-run-2026';
+export const DEFAULT_PUBLIC_TOUR_SLUG = '2026-sphere';
 
-/** Preferred calendar labels that map to {@link DEFAULT_PUBLIC_TOUR_SLUG}. */
+/** Preferred calendar labels that map to the Sphere default slug family. */
 export const DEFAULT_PUBLIC_TOUR_LABEL_CANDIDATES = [
+  '2026 Sphere',
   'Sphere Run 2026',
   'Sphere 2026',
+  'Sphere Run',
   'Sphere',
 ];

--- a/src/shared/lib/tourSlug.test.js
+++ b/src/shared/lib/tourSlug.test.js
@@ -7,9 +7,9 @@ import {
 } from './tourSlug';
 
 describe('tourLabelToSlug', () => {
-  it('kebab-cases Sphere Run 2026 to the default public slug', () => {
-    expect(tourLabelToSlug('Sphere Run 2026')).toBe(DEFAULT_PUBLIC_TOUR_SLUG);
-    expect(DEFAULT_PUBLIC_TOUR_SLUG).toBe('sphere-run-2026');
+  it('kebab-cases live Sphere calendar label to the default public slug', () => {
+    expect(tourLabelToSlug('2026 Sphere')).toBe(DEFAULT_PUBLIC_TOUR_SLUG);
+    expect(DEFAULT_PUBLIC_TOUR_SLUG).toBe('2026-sphere');
   });
 
   it('normalizes punctuation and accents', () => {
@@ -17,10 +17,10 @@ describe('tourLabelToSlug', () => {
     expect(tourLabelToSlug('  Fall Tour 2026  ')).toBe('fall-tour-2026');
   });
 
-  it('maps preferred Sphere label candidates to the same slug family', () => {
+  it('maps preferred Sphere label candidates to a sphere* slug', () => {
     for (const label of DEFAULT_PUBLIC_TOUR_LABEL_CANDIDATES) {
-      expect(tourLabelToSlug(label).startsWith('sphere')).toBe(true);
+      expect(tourLabelToSlug(label)).toMatch(/sphere/);
     }
-    expect(tourLabelToSlug('Sphere Run 2026')).toBe('sphere-run-2026');
+    expect(tourLabelToSlug('2026 Sphere')).toBe('2026-sphere');
   });
 });


### PR DESCRIPTION
## Summary
- Live `show_calendar` uses **2026 Sphere** → slug `2026-sphere` (not `sphere-run-2026`)
- Index writer prefers any Sphere tour; prerender/sitemap/client defaults updated
- SemVer **1.34.1** (PATCH)

## Test plan
- [x] Admin refresh wrote `defaultTourSlug: 2026-sphere` with 2 tours
- [ ] CI verify green
- [ ] `/tour-stats` loads Sphere aggregates after staging deploy


Made with [Cursor](https://cursor.com)