### PR TITLE
feat(seo): shared marketing nav for public routes (#663)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.34.2] — 2026-07-19
+
+### Changed
+- **Marketing internal nav (#663)** — shared primary route list drives splash + marketing headers (lg+) and footers; splash hero secondary CTAs are real `<Link>`s to `/how-it-works`, `/tour-stats`, and `/phish-setlist-prediction-game` instead of in-page-only scroll.
+
+---
+
 ## [1.34.1] — 2026-07-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.34.1",
+  "version": "1.34.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/landing/index.js
+++ b/src/features/landing/index.js
@@ -1,6 +1,8 @@
 export { default as HowItWorksPageContent } from './ui/HowItWorksPageContent';
 export { default as LandingSeo } from './ui/LandingSeo';
 export { default as MarketingPageShell } from './ui/MarketingPageShell';
+export { MarketingFooterNav, MarketingHeaderNav } from './ui/MarketingSiteNav';
+export { MARKETING_LEGAL_NAV, MARKETING_PRIMARY_NAV } from './model/marketingNav';
 export { default as PhishSetlistPredictionGamePageContent } from './ui/PhishSetlistPredictionGamePageContent';
 export { default as SplashAboutSection } from './ui/SplashAboutSection';
 export { default as SplashAuthModals } from './ui/SplashAuthModals';

--- a/src/features/landing/model/marketingNav.js
+++ b/src/features/landing/model/marketingNav.js
@@ -1,0 +1,18 @@
+/**
+ * Public marketing routes for header/footer internal linking (#663).
+ * Keep in sync with `App.jsx` public routes + `seoRoutes` prerender list.
+ */
+
+/** Educational / product pages (not legal). */
+export const MARKETING_PRIMARY_NAV = [
+  { to: '/how-it-works', label: 'How it works' },
+  { to: '/how-scoring-works', label: 'Scoring' },
+  { to: '/tour-stats', label: 'Tour stats' },
+  { to: '/phish-setlist-prediction-game', label: 'The game' },
+];
+
+/** Legal links — footer only. */
+export const MARKETING_LEGAL_NAV = [
+  { to: '/privacy', label: 'Privacy Policy' },
+  { to: '/terms', label: 'Terms of Service' },
+];

--- a/src/features/landing/ui/MarketingPageShell.jsx
+++ b/src/features/landing/ui/MarketingPageShell.jsx
@@ -6,44 +6,47 @@ import {
   BRAND_SPLASH_HEADER_VINYL_MARK_SRC,
   brandSplashHeaderVinylMarkImgClassNames,
 } from '../../../shared/config/branding';
+import { MarketingFooterNav, MarketingHeaderNav } from './MarketingSiteNav';
 
 /**
- * Minimal shell for standalone marketing / educational pages
- * (`/how-it-works`, `/how-scoring-works`, `/tour-stats`, `/phish-setlist-prediction-game`). Provides a sticky header with home
- * link and a simple footer — no auth logic, no scroll machinery.
+ * Shell for standalone marketing / educational pages.
+ * Sticky header: home + primary marketing nav (#663); footer shares the same links.
  */
 export default function MarketingPageShell({ children }) {
   return (
     <div className="relative flex min-h-screen w-full flex-col bg-transparent text-white">
       <header className="sticky top-0 z-50 flex h-[5.35rem] items-center border-b border-white/5 bg-brand-bg/80 backdrop-blur-lg sm:h-[5.25rem]">
-        <div className="flex w-full max-w-5xl mx-auto items-center justify-between px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
           <Link
             to="/"
-            aria-label="Setlist Pick \'Em — back to home"
-            className="flex items-center gap-2 outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue rounded-md"
+            aria-label="Setlist Pick 'Em — back to home"
+            className="flex shrink-0 items-center gap-2 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue"
           >
             <img
               src={BRAND_SPLASH_HEADER_VINYL_MARK_SRC}
-              alt="Setlist Pick \'Em"
+              alt="Setlist Pick 'Em"
               width={36}
               height={36}
               decoding="async"
               className={brandSplashHeaderVinylMarkImgClassNames}
             />
-            <span className="hidden sm:block font-display font-bold text-white text-base tracking-tight">
+            <span className="hidden font-display text-base font-bold tracking-tight text-white sm:block">
               Setlist Pick&nbsp;&apos;Em
             </span>
           </Link>
+
+          <MarketingHeaderNav className="hidden md:flex" />
+
           <Link
             to="/"
-            className="inline-flex items-center gap-1 text-sm font-semibold text-slate-400 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue rounded-sm"
+            className="inline-flex shrink-0 items-center gap-1 rounded-sm text-sm font-semibold text-slate-400 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue"
           >
             <ChevronLeft className="h-4 w-4" aria-hidden />
-            Back to Home
+            <span className="hidden sm:inline">Home</span>
           </Link>
         </div>
       </header>
-      <main className="flex-1 w-full">{children}</main>
+      <main className="w-full flex-1">{children}</main>
       <footer className="relative z-10 border-t border-slate-800/60 bg-transparent px-4 py-6 text-center text-xs font-medium leading-relaxed text-slate-500 sm:px-6 lg:px-8">
         <p>&copy; {new Date().getFullYear()} Road2 Media, LLC. All rights reserved.</p>
         <p className="mt-1">
@@ -58,14 +61,7 @@ export default function MarketingPageShell({ children }) {
           </a>
           .
         </p>
-        <p className="mt-2 space-x-3">
-          <Link to="/how-it-works" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400">How It Works</Link>
-          <Link to="/how-scoring-works" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400">How Scoring Works</Link>
-          <Link to="/tour-stats" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400">Tour Stats</Link>
-          <Link to="/phish-setlist-prediction-game" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400">Phish Setlist Game</Link>
-          <Link to="/privacy" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400">Privacy Policy</Link>
-          <Link to="/terms" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400">Terms of Service</Link>
-        </p>
+        <MarketingFooterNav />
       </footer>
     </div>
   );

--- a/src/features/landing/ui/MarketingSiteNav.jsx
+++ b/src/features/landing/ui/MarketingSiteNav.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+
+import {
+  MARKETING_LEGAL_NAV,
+  MARKETING_PRIMARY_NAV,
+} from '../model/marketingNav';
+
+const FOOTER_LINK =
+  'text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400';
+
+const HEADER_LINK =
+  'rounded-sm text-xs font-semibold text-slate-400 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue lg:text-sm';
+
+const HEADER_LINK_ACTIVE = 'text-white';
+
+/**
+ * Compact primary nav for marketing page headers (#663).
+ */
+export function MarketingHeaderNav({ className = 'hidden lg:flex' }) {
+  const { pathname } = useLocation();
+  return (
+    <nav
+      aria-label="Marketing"
+      className={`items-center gap-3 xl:gap-4 ${className}`.trim()}
+    >
+      {MARKETING_PRIMARY_NAV.map(({ to, label }) => {
+        const active = pathname === to || pathname.startsWith(`${to}/`);
+        return (
+          <Link
+            key={to}
+            to={to}
+            className={`${HEADER_LINK} ${active ? HEADER_LINK_ACTIVE : ''}`.trim()}
+            aria-current={active ? 'page' : undefined}
+          >
+            {label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+/**
+ * Footer link row: primary + legal (#663).
+ */
+export function MarketingFooterNav({ className = '' }) {
+  const links = [...MARKETING_PRIMARY_NAV, ...MARKETING_LEGAL_NAV];
+  return (
+    <p className={`mt-2 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 ${className}`.trim()}>
+      {links.map(({ to, label }) => (
+        <Link key={to} to={to} className={FOOTER_LINK}>
+          {label}
+        </Link>
+      ))}
+    </p>
+  );
+}

--- a/src/features/landing/ui/SplashAboutSection.jsx
+++ b/src/features/landing/ui/SplashAboutSection.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+
 import Button from '../../../shared/ui/Button';
 
 export default function SplashAboutSection({
   sectionRef,
   headingRef,
-  onHowItWorksClick,
   onGetStartedClick,
 }) {
   const linkButtonClassName =
@@ -79,13 +80,19 @@ export default function SplashAboutSection({
         </div>
 
         <nav
-          className="mt-16 pt-8 border-t border-slate-800 flex flex-wrap items-center justify-start lg:justify-end gap-x-2 gap-y-2 text-center"
+          className="mt-16 flex flex-wrap items-center justify-start gap-x-2 gap-y-2 border-t border-slate-800 pt-8 text-center lg:justify-end"
           aria-label="Jump to How it works or Get started"
         >
-          <Button variant="link" type="button" onClick={onHowItWorksClick} className={linkButtonClassName}>
+          <Link to="/how-it-works" className={linkButtonClassName}>
             How it works
-          </Button>
-          <span className="mx-2 text-slate-700 select-none" aria-hidden>
+          </Link>
+          <span className="mx-2 select-none text-slate-700" aria-hidden>
+            ·
+          </span>
+          <Link to="/tour-stats" className={linkButtonClassName}>
+            Tour stats
+          </Link>
+          <span className="mx-2 select-none text-slate-700" aria-hidden>
             ·
           </span>
           <Button variant="link" type="button" onClick={onGetStartedClick} className={linkButtonClassName}>

--- a/src/features/landing/ui/SplashHeader.jsx
+++ b/src/features/landing/ui/SplashHeader.jsx
@@ -7,6 +7,7 @@ import {
 } from '../../../shared/config/branding';
 import BrandWordmarkBarRow from '../../../shared/ui/BrandWordmarkBarRow';
 import Button from '../../../shared/ui/Button';
+import { MarketingHeaderNav } from './MarketingSiteNav';
 
 export default function SplashHeader({
   onPlayNowClick,
@@ -32,12 +33,13 @@ export default function SplashHeader({
           />
         </button>
 
-        <div className="flex min-w-0 items-center justify-self-end gap-0.25 sm:justify-self-auto sm:gap-4">
+        <div className="flex min-w-0 items-center justify-self-end gap-3 sm:justify-self-auto sm:gap-4">
+          <MarketingHeaderNav />
           <Button
             variant="text"
             size="none"
             onClick={onSignInClick}
-            className="text-sm sm:text-sm whitespace-nowrap"
+            className="whitespace-nowrap text-sm sm:text-sm"
           >
             Sign In
           </Button>

--- a/src/features/landing/ui/SplashHeroSection.jsx
+++ b/src/features/landing/ui/SplashHeroSection.jsx
@@ -1,9 +1,17 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import Button from '../../../shared/ui/Button';
 import SplashHeroWordmark from './SplashHeroWordmark';
 
-export default function SplashHeroSection({ onHowItWorksClick, onPlayNowClick, onAboutClick }) {
+const secondaryLinkClassName =
+  'underline decoration-slate-600 underline-offset-4 transition-colors hover:text-emerald-400';
+
+/**
+ * Splash hero — primary CTA stays auth/get-started; secondary links are real
+ * marketing routes for crawlable internal linking (#663).
+ */
+export default function SplashHeroSection({ onPlayNowClick }) {
   return (
     <section className="relative flex min-h-[100svh] w-full flex-col bg-transparent pt-[5.35rem] pb-6 sm:min-h-screen sm:pt-[5.25rem] sm:pb-14">
       <div className="relative z-10 mx-auto flex min-h-0 w-full max-w-7xl flex-1 flex-col px-4 pt-1 text-center sm:px-6 sm:pt-0 lg:px-8">
@@ -19,12 +27,12 @@ export default function SplashHeroSection({ onHowItWorksClick, onPlayNowClick, o
 
         <div className="mx-auto mt-6 max-w-2xl shrink-0 sm:-mt-0.5 md:-mt-1">
           <p className="mb-3 text-lg font-bold tracking-wide text-teal-400 drop-shadow-[0_0_12px_rgba(45,212,191,0.5)] sm:mb-2 md:text-xl">
-            Predict the setlist. Win the night. 
+            Predict the setlist. Win the night.
             Now live on Phish Tour.
           </p>
 
           <p className="text-base font-normal leading-relaxed text-slate-300 sm:leading-snug md:text-lg md:leading-relaxed">
-            Make picks for tonight's show, watch scores update as songs are played, and compete with your tour crew for the top spot.
+            Make picks for tonight&apos;s show, watch scores update as songs are played, and compete with your tour crew for the top spot.
           </p>
 
           <p className="mt-4 text-base font-normal leading-relaxed text-slate-300 sm:leading-snug md:text-lg md:leading-relaxed">
@@ -41,26 +49,23 @@ export default function SplashHeroSection({ onHowItWorksClick, onPlayNowClick, o
             type="button"
             onClick={onPlayNowClick}
             aria-label="Play now: go to sign in or create an account"
-            className="w-full sm:w-auto min-w-[12rem]"
+            className="w-full min-w-[12rem] sm:w-auto"
           >
             Make picks now
           </Button>
           <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm font-semibold text-slate-400">
-            <button
-              type="button"
-              className="underline decoration-slate-600 underline-offset-4 transition-colors hover:text-emerald-400"
-              onClick={onHowItWorksClick}
+            <Link to="/how-it-works" className={secondaryLinkClassName}>
+              How it works
+            </Link>
+            <Link to="/tour-stats" className={secondaryLinkClassName}>
+              Tour stats
+            </Link>
+            <Link
+              to="/phish-setlist-prediction-game"
+              className={secondaryLinkClassName}
             >
-              Game format
-            </button>
-            <button
-              type="button"
-              className="underline decoration-slate-600 underline-offset-4 transition-colors hover:text-emerald-400"
-              onClick={onAboutClick}
-              aria-label={"About Setlist Pick 'Em"}
-            >
-              About
-            </button>
+              What is this game?
+            </Link>
           </div>
         </div>
 

--- a/src/features/landing/ui/SplashPageShell.jsx
+++ b/src/features/landing/ui/SplashPageShell.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 
 import useSplashDocumentScrollPadding from '../model/useSplashDocumentScrollPadding';
+import { MarketingFooterNav } from './MarketingSiteNav';
 import SplashAboutSection from './SplashAboutSection';
 import SplashGetStartedSection from './SplashGetStartedSection';
 import SplashHeader from './SplashHeader';
@@ -15,9 +15,7 @@ export default function SplashPageShell({
   getStartedHeadingRef,
   aboutSectionRef,
   aboutHeadingRef,
-  onScrollToHowItWorks,
   onScrollToGetStarted,
-  onScrollToAbout,
   onCreateAccountFromHowItWorks,
   onOpenSignUpModal,
   onOpenSignInModal,
@@ -31,12 +29,8 @@ export default function SplashPageShell({
       <SplashHeader onPlayNowClick={onScrollToGetStarted} onSignInClick={onOpenSignInModal} />
 
       <div className="relative flex min-h-screen w-full flex-col bg-transparent text-white">
-        <main className="flex-1 w-full relative overflow-x-hidden">
-          <SplashHeroSection
-            onHowItWorksClick={onScrollToHowItWorks}
-            onPlayNowClick={onScrollToGetStarted}
-            onAboutClick={onScrollToAbout}
-          />
+        <main className="relative w-full flex-1 overflow-x-hidden">
+          <SplashHeroSection onPlayNowClick={onScrollToGetStarted} />
           <SplashHowItWorksSection
             sectionRef={howItWorksSectionRef}
             headingRef={howItWorksHeadingRef}
@@ -51,7 +45,6 @@ export default function SplashPageShell({
           <SplashAboutSection
             sectionRef={aboutSectionRef}
             headingRef={aboutHeadingRef}
-            onHowItWorksClick={onScrollToHowItWorks}
             onGetStartedClick={onScrollToGetStarted}
           />
         </main>
@@ -72,44 +65,7 @@ export default function SplashPageShell({
             </a>
             .
           </p>
-          <p className="mt-2 space-x-3">
-            <Link
-              to="/how-it-works"
-              className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400"
-            >
-              How It Works
-            </Link>
-            <Link
-              to="/how-scoring-works"
-              className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400"
-            >
-              How Scoring Works
-            </Link>
-            <Link
-              to="/tour-stats"
-              className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400"
-            >
-              Tour Stats
-            </Link>
-            <Link
-              to="/phish-setlist-prediction-game"
-              className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400"
-            >
-              Phish Setlist Game
-            </Link>
-            <Link
-              to="/privacy"
-              className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400"
-            >
-              Privacy Policy
-            </Link>
-            <Link
-              to="/terms"
-              className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400"
-            >
-              Terms of Service
-            </Link>
-          </p>
+          <MarketingFooterNav />
         </footer>
 
         {children}

--- a/src/pages/landing/SplashPage.jsx
+++ b/src/pages/landing/SplashPage.jsx
@@ -36,7 +36,6 @@ export default function Splash() {
     getStartedHeadingRef,
     aboutSectionRef,
     aboutHeadingRef,
-    handleScrollToHowItWorks,
     handleScrollToGetStarted,
     handleScrollToAbout,
     handleCreateAccountFromHowItWorks,
@@ -83,9 +82,7 @@ export default function Splash() {
         getStartedHeadingRef={getStartedHeadingRef}
         aboutSectionRef={aboutSectionRef}
         aboutHeadingRef={aboutHeadingRef}
-        onScrollToHowItWorks={handleScrollToHowItWorks}
         onScrollToGetStarted={handleScrollToGetStarted}
-        onScrollToAbout={handleScrollToAbout}
         onCreateAccountFromHowItWorks={handleCreateAccountFromHowItWorks}
         onOpenSignUpModal={openSignUpModal}
         onOpenSignInModal={openSignInModal}


### PR DESCRIPTION
Refs #663

## Summary
- Shared `MARKETING_PRIMARY_NAV` / footer legal list
- Splash + marketing **header** nav (lg+/md+) so public pages aren’t footer-only
- Splash hero: real `<Link>`s to `/how-it-works`, `/tour-stats`, `/phish-setlist-prediction-game`
- SemVer **1.34.2** (PATCH)

**Still open on #663:** SEO string sync CI + robots hygiene (not in this PR).

## Test plan
- [ ] Splash (desktop): header shows How it works / Scoring / Tour stats / The game
- [ ] Splash hero links navigate (not just scroll)
- [ ] Marketing page header swaps active state; footer still lists all links
- [ ] Mobile: header nav hidden; footer + hero links still work; no splash LCP regression


Made with [Cursor](https://cursor.com)