### PR TITLE
fix(seo): App Check race on public tour-stats (#665)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.34.3] — 2026-07-19
+
+### Fixed
+- **Public tour-stats App Check race (#665)** — await `whenFirebaseReady()` before `public_tour_stats` reads; kick App Check on page mount so localhost/prod enforcement does not 403 the first fetch.
+
+---
+
 ## [1.34.2] — 2026-07-19
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.34.2",
+  "version": "1.34.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/tour-stats/api/fetchPublicTourStats.js
+++ b/src/features/tour-stats/api/fetchPublicTourStats.js
@@ -1,6 +1,7 @@
 import { collection, doc, getDoc, getDocs, query, where } from 'firebase/firestore';
 
 import { db } from '../../../shared/lib/firebase';
+import { whenFirebaseReady } from '../../../shared/lib/firebaseAppCheck';
 
 /**
  * @typedef {{
@@ -19,6 +20,7 @@ import { db } from '../../../shared/lib/firebase';
  * }>}
  */
 export async function fetchPublicTourStatsIndex() {
+  await whenFirebaseReady();
   const snap = await getDoc(doc(db, 'public_tour_stats', '_index'));
   if (!snap.exists()) {
     return { tours: [], defaultTourSlug: '2026-sphere' };
@@ -39,6 +41,7 @@ export async function fetchPublicTourStatsIndex() {
 export async function fetchPublicTourStatsDoc(tourSlug) {
   const slug = String(tourSlug ?? '').trim();
   if (!slug || slug.startsWith('_')) return null;
+  await whenFirebaseReady();
   const snap = await getDoc(doc(db, 'public_tour_stats', slug));
   if (!snap.exists()) return null;
   return { id: snap.id, ...snap.data() };
@@ -49,6 +52,7 @@ export async function fetchPublicTourStatsDoc(tourSlug) {
  * @returns {Promise<PublicTourIndexEntry[]>}
  */
 export async function listPublicTourStatsDocs() {
+  await whenFirebaseReady();
   const q = query(collection(db, 'public_tour_stats'), where('schemaVersion', '==', 1));
   const snap = await getDocs(q);
   return snap.docs

--- a/src/pages/marketing/PublicTourStatsPage.jsx
+++ b/src/pages/marketing/PublicTourStatsPage.jsx
@@ -9,8 +9,14 @@ import {
 } from '../../features/tour-stats';
 import { SEO_CONFIG } from '../../shared/config/seo';
 import { getPrerenderRoute } from '../../shared/config/seoRoutes';
+import { ensureAppCheckNow } from '../../shared/lib/firebaseAppCheck';
 
 export default function PublicTourStatsPage() {
+  // Public Firestore reads need App Check before first getDoc (#665 localhost race).
+  useEffect(() => {
+    ensureAppCheckNow();
+  }, []);
+
   const screen = usePublicTourStatsScreen();
   const route = screen.routeHasSlug
     ? getPrerenderRoute(`/tour-stats/${screen.activeSlug}`) ||


### PR DESCRIPTION
## Summary
- Await `whenFirebaseReady()` in `fetchPublicTourStats*` before Firestore reads
- `ensureAppCheckNow()` on `/tour-stats` mount (same pattern as dashboard deep links)
- SemVer **1.34.3**

## Test plan
- [ ] `npm run dev` → `/tour-stats` loads Sphere aggregates (no red error banner)
- [ ] DevTools Network: Firestore reads succeed after App Check token


Made with [Cursor](https://cursor.com)