### PR TITLE
fix(firebase): whenFirebaseReady always starts App Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.34.4] — 2026-07-19
+
+### Fixed
+- **`whenFirebaseReady` no-op race** — always kick App Check init instead of resolving immediately when deferred init has not started yet.
+
+---
+
 ## [1.34.3] — 2026-07-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.34.3",
+  "version": "1.34.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/shared/lib/firebaseAppCheck.js
+++ b/src/shared/lib/firebaseAppCheck.js
@@ -84,11 +84,10 @@ export function ensureAppCheckNow() {
 }
 
 /**
- * Resolves once App Check init has completed (or immediately if init was
- * never kicked off, e.g. in SSR / test environments). Earliest-path
- * Firestore callers should `await whenFirebaseReady()` before their first
- * read to avoid racing App Check Enforcement in prod.
+ * Resolves once App Check init has completed. Always kicks deferred init if
+ * nothing has started yet — never resolve early with a no-op promise, or
+ * earliest Firestore reads race App Check enforcement.
  */
 export function whenFirebaseReady() {
-  return readyPromise ?? Promise.resolve();
+  return initializeAppCheckDeferred();
 }


### PR DESCRIPTION
## Summary
- `whenFirebaseReady()` now always calls `initializeAppCheckDeferred()` instead of `Promise.resolve()` when init has not started
- SemVer **1.34.4**

**Ops note:** Firestore rules for `public_tour_stats` were also confirmed deployed (root cause of localhost permission errors).

## Test plan
- [ ] `/tour-stats` on localhost loads without the red error banner


Made with [Cursor](https://cursor.com)