### PR TITLE
fix(seo): default public tour-stats to current tour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.34.5] — 2026-07-19
+
+### Changed
+- **Public `/tour-stats` default tour (#665)** — default is the current tour (newest `lastShowDate` on `_index`), not a hardcoded Sphere preference.
+
+---
+
 ## [1.34.4] — 2026-07-19
 
 ### Fixed

--- a/docs/API.md
+++ b/docs/API.md
@@ -172,7 +172,7 @@ Document ID is a kebab-case slug from the calendar tour label (`2026 Sphere` →
 | `writtenAt` | string | ISO timestamp |
 | `schemaVersion` | number | `1` |
 
-`_index` fields: `tours[]` (`tourSlug`, `tourLabel`, `firstShowDate`, `lastShowDate`, `showCount`), `defaultTourSlug` (prefers Sphere when present, e.g. `2026-sphere`), `writtenAt`, `schemaVersion`.
+`_index` fields: `tours[]` (`tourSlug`, `tourLabel`, `firstShowDate`, `lastShowDate`, `showCount`), `defaultTourSlug` (current tour = newest `lastShowDate` among indexed tours), `writtenAt`, `schemaVersion`.
 
 Tour labels are ingested via **`scheduledPhishnetShowCalendar`** (daily 06:00 ET) from Phish.net as new dates publish; public stats rebuild after calendar sync and again at **07:30 ET** (`scheduledPublicTourStatsRefresh`).
 

--- a/docs/DASHBOARD_IA.md
+++ b/docs/DASHBOARD_IA.md
@@ -19,7 +19,7 @@ Single reference for **support**, **product**, and **engineering** when adding r
 |-------|------|-------|
 | **Stats** (Standings peer tab) | `/dashboard/tour-stats` | Private explorer: unique songs, frequency, bustouts, self pick overlay. Discovered via Standings chrome **Show \| Tour \| Stats \| Pools** (not a 5th primary nav tab). Standings tab stays active. Shares the chrome **tour scope** picker with Tour view (`?tour=`). No global date picker. |
 
-**Public marketing counterpart (#665):** `/tour-stats` and `/tour-stats/:tourSlug` — aggregate song datasets only (most played, bustouts, gaps); default tour is Sphere (`2026-sphere` from live calendar label **2026 Sphere**). Not a dashboard route; `robots.txt` still Disallows `/dashboard/*`. Do not unlock private Stats or self-overlay for anonymous users.
+**Public marketing counterpart (#665):** `/tour-stats` and `/tour-stats/:tourSlug` — aggregate song datasets only (most played, bustouts, gaps); default tour is the **current** tour (newest `lastShowDate` on `_index`). Not a dashboard route; `robots.txt` still Disallows `/dashboard/*`. Do not unlock private Stats or self-overlay for anonymous users.
 
 ### Feature discovery “New” markers (#639)
 

--- a/docs/SEO_GEO_PLAYBOOK.md
+++ b/docs/SEO_GEO_PLAYBOOK.md
@@ -93,7 +93,7 @@ Track these weekly in Search Console (Performance → Queries) and spot-check SE
 | S2 | `phish song frequency [tour year]` (e.g. summer 2026) |
 | S3 | `phish bustouts [tour]` |
 
-Public surface: `/tour-stats` + `/tour-stats/:tourSlug` (kebab-case labels from Phish.net calendar ingest). **Aggregates only** — most played, bustouts, gap highlights; never full night setlists. Default tour: Sphere (`2026-sphere`). Prerender hub + Sphere shell; other tours hydrate client-side from `public_tour_stats`.
+Public surface: `/tour-stats` + `/tour-stats/:tourSlug` (kebab-case labels from Phish.net calendar ingest). **Aggregates only** — most played, bustouts, gap highlights; never full night setlists. Default tour: **current** (newest `lastShowDate`). Prerender hub + Sphere shell; other tours hydrate client-side from `public_tour_stats`.
 
 Add/remove rows as pages ship; keep IDs stable once used in the log.
 

--- a/functions/comms/emailBranding.cjs
+++ b/functions/comms/emailBranding.cjs
@@ -29,9 +29,6 @@ const EMAIL_WORDMARK_INLINE_CONTENT_ID = 'email-gradient-wordmark';
 const EMAIL_BRAND_PRIMARY = '#2dd4bf';
 const EMAIL_BRAND_PRIMARY_STRONG = '#14b8a6';
 const EMAIL_BRAND_BG_DEEP = '#020617';
-/** Secondary CTA (invite share) — blue to contrast teal primary. */
-const EMAIL_BRAND_SECONDARY = '#2563eb';
-const EMAIL_BRAND_SECONDARY_FG = '#ffffff';
 /** Hint for BIMI / domain-favicon ops — not injected into email HTML. */
 const EMAIL_INBOX_BADGE_FAVICON_PATH = '/favicon/favicon-96x96.png';
 const DEFAULT_SITE_URL = 'https://www.setlistpickem.com';
@@ -127,8 +124,6 @@ module.exports = {
   EMAIL_BRAND_PRIMARY,
   EMAIL_BRAND_PRIMARY_STRONG,
   EMAIL_BRAND_BG_DEEP,
-  EMAIL_BRAND_SECONDARY,
-  EMAIL_BRAND_SECONDARY_FG,
   EMAIL_INBOX_BADGE_FAVICON_PATH,
   buildEmailInBodyLogoUrl,
   buildEmailLogoUrl,

--- a/functions/publicTourStats.js
+++ b/functions/publicTourStats.js
@@ -145,27 +145,12 @@ async function refreshPublicTourStats(db, opts = {}) {
 }
 
 /**
- * Prefer Sphere (game launch) when present; else first indexed tour.
- * @param {Array<{ tourSlug: string, tourLabel: string }>} indexTours
+ * Current tour = newest by `lastShowDate` (index already sorted that way).
+ * @param {Array<{ tourSlug: string, tourLabel?: string, lastShowDate?: string | null }>} indexTours
  * @returns {string}
  */
 function pickDefaultPublicTourSlug(indexTours) {
-  const preferredSlugs = [
-    "2026-sphere",
-    "sphere-run-2026",
-    "sphere-2026",
-    "sphere",
-  ];
-  for (const slug of preferredSlugs) {
-    if (indexTours.some((t) => t.tourSlug === slug)) return slug;
-  }
-  const sphere = indexTours.find(
-    (t) =>
-      /sphere/i.test(String(t.tourLabel || "")) ||
-      /sphere/i.test(String(t.tourSlug || ""))
-  );
-  if (sphere) return sphere.tourSlug;
-  return indexTours[0]?.tourSlug || "2026-sphere";
+  return indexTours[0]?.tourSlug || "";
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.34.4",
+  "version": "1.34.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/tour-stats/api/fetchPublicTourStats.js
+++ b/src/features/tour-stats/api/fetchPublicTourStats.js
@@ -23,14 +23,14 @@ export async function fetchPublicTourStatsIndex() {
   await whenFirebaseReady();
   const snap = await getDoc(doc(db, 'public_tour_stats', '_index'));
   if (!snap.exists()) {
-    return { tours: [], defaultTourSlug: '2026-sphere' };
+    return { tours: [], defaultTourSlug: '' };
   }
   const data = snap.data() || {};
   const tours = Array.isArray(data.tours) ? data.tours : [];
   const defaultTourSlug =
     typeof data.defaultTourSlug === 'string' && data.defaultTourSlug
       ? data.defaultTourSlug
-      : '2026-sphere';
+      : tours[0]?.tourSlug || '';
   return { tours, defaultTourSlug };
 }
 

--- a/src/features/tour-stats/model/usePublicTourStatsScreen.js
+++ b/src/features/tour-stats/model/usePublicTourStatsScreen.js
@@ -2,15 +2,14 @@ import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import {
-  DEFAULT_PUBLIC_TOUR_SLUG,
-} from '../../../shared/lib/tourSlug';
-import {
   fetchPublicTourStatsDoc,
   fetchPublicTourStatsIndex,
 } from '../api/fetchPublicTourStats';
 
 /**
  * Public tour-stats screen (#665) — aggregate docs only; no self overlay.
+ * Default tour = `_index.defaultTourSlug` (current / most recent), not a
+ * hardcoded Sphere or Summer preference.
  */
 export function usePublicTourStatsScreen() {
   const { tourSlug: routeSlug } = useParams();
@@ -18,11 +17,14 @@ export function usePublicTourStatsScreen() {
   const [indexLoading, setIndexLoading] = useState(true);
   const [statsLoading, setStatsLoading] = useState(true);
   const [tours, setTours] = useState([]);
-  const [defaultTourSlug, setDefaultTourSlug] = useState(DEFAULT_PUBLIC_TOUR_SLUG);
+  const [defaultTourSlug, setDefaultTourSlug] = useState('');
   const [doc, setDoc] = useState(null);
   const [error, setError] = useState(null);
 
-  const activeSlug = (routeSlug || '').trim() || defaultTourSlug;
+  const trimmedRoute = (routeSlug || '').trim();
+  // Wait for index before picking a default so we don't flash the wrong tour.
+  const activeSlug =
+    trimmedRoute || (indexLoading ? '' : defaultTourSlug);
 
   useEffect(() => {
     let cancelled = false;
@@ -31,8 +33,13 @@ export function usePublicTourStatsScreen() {
       try {
         const idx = await fetchPublicTourStatsIndex();
         if (cancelled) return;
-        setTours(Array.isArray(idx.tours) ? idx.tours : []);
-        setDefaultTourSlug(idx.defaultTourSlug || DEFAULT_PUBLIC_TOUR_SLUG);
+        const list = Array.isArray(idx.tours) ? idx.tours : [];
+        setTours(list);
+        const fromIndex =
+          (typeof idx.defaultTourSlug === 'string' && idx.defaultTourSlug.trim()) ||
+          list[0]?.tourSlug ||
+          '';
+        setDefaultTourSlug(fromIndex);
       } catch (err) {
         if (!cancelled) setError(err);
       } finally {
@@ -46,6 +53,11 @@ export function usePublicTourStatsScreen() {
 
   useEffect(() => {
     let cancelled = false;
+    if (!activeSlug) {
+      setStatsLoading(indexLoading);
+      if (!indexLoading) setDoc(null);
+      return undefined;
+    }
     (async () => {
       setStatsLoading(true);
       setError(null);
@@ -65,7 +77,7 @@ export function usePublicTourStatsScreen() {
     return () => {
       cancelled = true;
     };
-  }, [activeSlug]);
+  }, [activeSlug, indexLoading]);
 
   const stats = useMemo(() => {
     if (!doc) {
@@ -107,7 +119,7 @@ export function usePublicTourStatsScreen() {
 
   return {
     activeSlug,
-    routeHasSlug: Boolean((routeSlug || '').trim()),
+    routeHasSlug: Boolean(trimmedRoute),
     defaultTourSlug,
     tours,
     tourName,

--- a/src/shared/lib/tourSlug.js
+++ b/src/shared/lib/tourSlug.js
@@ -15,18 +15,3 @@ export function tourLabelToSlug(tourLabel) {
     .replace(/^-+|-+$/g, '');
   return raw || 'tour';
 }
-
-/**
- * Default public tour-stats slug — Sphere (game launch / inaugural Pick'em).
- * Live `show_calendar` label is currently **"2026 Sphere"** → `2026-sphere`.
- */
-export const DEFAULT_PUBLIC_TOUR_SLUG = '2026-sphere';
-
-/** Preferred calendar labels that map to the Sphere default slug family. */
-export const DEFAULT_PUBLIC_TOUR_LABEL_CANDIDATES = [
-  '2026 Sphere',
-  'Sphere Run 2026',
-  'Sphere 2026',
-  'Sphere Run',
-  'Sphere',
-];

--- a/src/shared/lib/tourSlug.test.js
+++ b/src/shared/lib/tourSlug.test.js
@@ -1,26 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  DEFAULT_PUBLIC_TOUR_LABEL_CANDIDATES,
-  DEFAULT_PUBLIC_TOUR_SLUG,
-  tourLabelToSlug,
-} from './tourSlug';
+import { tourLabelToSlug } from './tourSlug';
 
 describe('tourLabelToSlug', () => {
-  it('kebab-cases live Sphere calendar label to the default public slug', () => {
-    expect(tourLabelToSlug('2026 Sphere')).toBe(DEFAULT_PUBLIC_TOUR_SLUG);
-    expect(DEFAULT_PUBLIC_TOUR_SLUG).toBe('2026-sphere');
+  it('kebab-cases live calendar labels', () => {
+    expect(tourLabelToSlug('2026 Sphere')).toBe('2026-sphere');
+    expect(tourLabelToSlug('2026 Summer Tour')).toBe('2026-summer-tour');
   });
 
   it('normalizes punctuation and accents', () => {
     expect(tourLabelToSlug("Summer Tour '26")).toBe('summer-tour-26');
     expect(tourLabelToSlug('  Fall Tour 2026  ')).toBe('fall-tour-2026');
-  });
-
-  it('maps preferred Sphere label candidates to a sphere* slug', () => {
-    for (const label of DEFAULT_PUBLIC_TOUR_LABEL_CANDIDATES) {
-      expect(tourLabelToSlug(label)).toMatch(/sphere/);
-    }
-    expect(tourLabelToSlug('2026 Sphere')).toBe('2026-sphere');
   });
 });


### PR DESCRIPTION
## Summary
- `_index.defaultTourSlug` = newest tour by `lastShowDate` (same idea as dashboard selectable tours)
- Client waits for index before loading stats (no Sphere flash)
- SemVer **1.34.5**; Functions redeployed + index refreshed (`2026-summer-tour` current as of today)

## Test plan
- [ ] `/tour-stats` defaults to current tour (Summer today; Sphere still in filter)
- [ ] Selecting Sphere navigates to `/tour-stats/2026-sphere`


Made with [Cursor](https://cursor.com)