### PR TITLE
fix(seo): fan-facing marketing copy for stats cadence (#657)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ No unreleased changes.
 ## [1.34.6] — 2026-07-20
 
 ### Changed
-- **Marketing SEO copy voice** — public tour stats, how-it-works, keyword page, splash how-it-works, `llms.txt`, and meta/OG mirrors now say stats refresh every night the band plays live (not “when Phish.net publishes”); emphasize personal stats from playing, multi-band destination framing, and fan-facing prose without technical jargon.
+- **Marketing SEO copy voice** — public tour stats, how-it-works, keyword page, splash how-it-works, `llms.txt`, and meta/OG mirrors now say stats refresh every night the band plays live (not “when Phish.net publishes”); emphasize personal stats from playing, multi-band destination framing, and fan-facing prose without technical jargon. Dropped the public “Set Picks” alias in favor of Setlist Pick ’Em / Setlist Pickem only.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ No unreleased changes.
 ### Changed
 - **Marketing SEO copy voice** — public tour stats, how-it-works, keyword page, splash how-it-works, `llms.txt`, and meta/OG mirrors now say stats refresh every night the band plays live (not “when Phish.net publishes”); emphasize personal stats from playing, multi-band destination framing, and fan-facing prose without technical jargon. Dropped the public “Set Picks” alias in favor of Setlist Pick ’Em / Setlist Pickem only.
 - **Marketing internal links** — shared `surfaceLinkStyles` (teal/emerald, underlined) for readable secondary CTAs; contextual in-copy links across splash sections and marketing pages; splash Game Format scoring link is a real `/how-scoring-works` route.
+- **Keyword page adjacent terms** — gracefully weave fantasy setlist, setlist picks game, predicting setlists, calling the set / couch tour vernacular (informed by incumbent lookalikes) without competitor name-drops.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ No unreleased changes.
 
 ### Changed
 - **Marketing SEO copy voice** — public tour stats, how-it-works, keyword page, splash how-it-works, `llms.txt`, and meta/OG mirrors now say stats refresh every night the band plays live (not “when Phish.net publishes”); emphasize personal stats from playing, multi-band destination framing, and fan-facing prose without technical jargon. Dropped the public “Set Picks” alias in favor of Setlist Pick ’Em / Setlist Pickem only.
+- **Marketing internal links** — shared `surfaceLinkStyles` (teal/emerald, underlined) for readable secondary CTAs; contextual in-copy links across splash sections and marketing pages; splash Game Format scoring link is a real `/how-scoring-works` route.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.34.6] — 2026-07-20
+
+### Changed
+- **Marketing SEO copy voice** — public tour stats, how-it-works, keyword page, splash how-it-works, `llms.txt`, and meta/OG mirrors now say stats refresh every night the band plays live (not “when Phish.net publishes”); emphasize personal stats from playing, multi-band destination framing, and fan-facing prose without technical jargon.
+
+---
+
 ## [1.34.5] — 2026-07-19
 
 ### Changed

--- a/api/inviteOgHelpers.mjs
+++ b/api/inviteOgHelpers.mjs
@@ -10,7 +10,7 @@ export const DEFAULT_OG_IMAGE = `${SITE_URL}/branding/og-card-1200x630.jpg?v=${O
 export const DEFAULT_OG_IMAGE_ALT = "Setlist Pick 'Em — live setlist prediction game";
 export const DEFAULT_TITLE = "Setlist Pick'em | The Ultimate Live Music Prediction Game";
 export const DEFAULT_DESCRIPTION =
-  "Setlist Pick 'Em is a free live setlist prediction game for Phish fans. Pick openers, closers, encore, and a wildcard before each show; scores update in real time as songs are played. Compete in a global pool or create private pools with friends.";
+  "Setlist Pick 'Em is a free live setlist prediction game built for Phish fans—and more bands soon. Lock openers, closers, encore, and a wildcard before each show; scores update live as songs are played. Tour insights refresh every night the band plays live. Play to unlock personal stats and compete with friends.";
 
 /** Social-crawler user-agent detection (case-insensitive substring match). */
 export const CRAWLER_RE =

--- a/docs/SEO_GEO_PLAYBOOK.md
+++ b/docs/SEO_GEO_PLAYBOOK.md
@@ -79,11 +79,12 @@ Track these weekly in Search Console (Performance → Queries) and spot-check SE
 | ID | Query |
 |----|--------|
 | C1 | `phish setlist game` |
-| C2 | `setlist prediction game` |
-| C3 | `phish pick em` / `phish pick'em` |
+| C2 | `setlist prediction game` / `predicting setlists` |
+| C3 | `phish pick em` / `phish pick'em` / `setlist picks game` |
 | C4 | `live setlist prediction` |
+| C5 | `fantasy setlist` / `fantasy setlists` / `phish fantasy setlist` |
 
-**Keyword landing (#660):** `/phish-setlist-prediction-game` — definitional page targeting C1–C3; disambiguates prediction game vs setlist archives.
+**Keyword landing (#660):** `/phish-setlist-prediction-game` — definitional page targeting C1–C5; disambiguates prediction / fantasy setlist game vs setlist archives; jam-band framing with Phish as exemplar.
 
 ### Stats-intent (after #665 public `/tour-stats`)
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta property="og:title" content="Setlist Pick'em | The Ultimate Live Music Prediction Game" />
     <meta
       property="og:description"
-      content="Setlist Pick 'Em is a free live setlist prediction game for Phish fans. Pick openers, closers, encore, and a wildcard before each show; scores update in real time as songs are played. Compete in a global pool or create private pools with friends."
+      content="Setlist Pick 'Em is a free live setlist prediction game built for Phish fans—and more bands soon. Lock openers, closers, encore, and a wildcard before each show; scores update live as songs are played. Tour insights refresh every night the band plays live. Play to unlock personal stats and compete with friends."
     />
     <meta property="og:url" content="https://www.setlistpickem.com/" />
     <meta property="og:image" content="https://www.setlistpickem.com/branding/og-card-1200x630.jpg?v=20260711" />
@@ -21,7 +21,7 @@
     <meta name="twitter:title" content="Setlist Pick'em | The Ultimate Live Music Prediction Game" />
     <meta
       name="twitter:description"
-      content="Setlist Pick 'Em is a free live setlist prediction game for Phish fans. Pick openers, closers, encore, and a wildcard before each show; scores update in real time as songs are played. Compete in a global pool or create private pools with friends."
+      content="Setlist Pick 'Em is a free live setlist prediction game built for Phish fans—and more bands soon. Lock openers, closers, encore, and a wildcard before each show; scores update live as songs are played. Tour insights refresh every night the band plays live. Play to unlock personal stats and compete with friends."
     />
     <meta name="twitter:image" content="https://www.setlistpickem.com/branding/og-card-1200x630.jpg?v=20260711" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
@@ -34,7 +34,7 @@
     <link rel="canonical" href="https://www.setlistpickem.com/" />
     <meta
       name="description"
-      content="Setlist Pick 'Em is a free live setlist prediction game for Phish fans. Pick openers, closers, encore, and a wildcard before each show; scores update in real time as songs are played. Compete in a global pool or create private pools with friends."
+      content="Setlist Pick 'Em is a free live setlist prediction game built for Phish fans—and more bands soon. Lock openers, closers, encore, and a wildcard before each show; scores update live as songs are played. Tour insights refresh every night the band plays live. Play to unlock personal stats and compete with friends."
     />
     <meta name="author" content="Road2 Media LLC" />
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/og-home-html.mjs
+++ b/og-home-html.mjs
@@ -15,7 +15,7 @@ export const OG_HOME = {
   imageAlt: "Setlist Pick 'Em — live setlist prediction game",
   title: "Setlist Pick'em | The Ultimate Live Music Prediction Game",
   description:
-    "Setlist Pick 'Em is a free live setlist prediction game for Phish fans. Pick openers, closers, encore, and a wildcard before each show; scores update in real time as songs are played. Compete in a global pool or create private pools with friends.",
+    "Setlist Pick 'Em is a free live setlist prediction game built for Phish fans—and more bands soon. Lock openers, closers, encore, and a wildcard before each show; scores update live as songs are played. Tour insights refresh every night the band plays live. Play to unlock personal stats and compete with friends.",
   publisherName: 'Road2 Media LLC',
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.34.5",
+  "version": "1.34.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,11 +1,11 @@
 # Setlist Pick 'Em
 
-> Free live setlist prediction game for Phish fans (more bands soon). Predict openers, closers, encore, and a wildcard before each show; compete live as songs are played. Tour insights refresh every night the band plays live.
+> Free setlist picks / fantasy setlist game for Phish fans (more bands soon). Predict openers, closers, encore, and a wildcard before each show; compete live as songs are played. Tour insights refresh every night the band plays live.
 
 ## How it works
 
-- Lock picks before showtime
-- Scoring updates live during the show
+- Lock picks before showtime (predicting setlists, not browsing archives)
+- Scoring updates live during the show — at the venue or on couch tour
 - Global and private leaderboards
 - Personal stats unlock when you play
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,12 +1,13 @@
 # Setlist Pick 'Em
 
-> Free live setlist prediction game for Phish fans. Predict openers, closers, encore, and a wildcard before each show; compete live as songs are played.
+> Free live setlist prediction game for Phish fans (more bands soon). Predict openers, closers, encore, and a wildcard before each show; compete live as songs are played. Tour insights refresh every night the band plays live.
 
 ## How it works
 
 - Lock picks before showtime
 - Scoring updates live during the show
 - Global and private leaderboards
+- Personal stats unlock when you play
 
 ## Scoring (per slot)
 
@@ -24,4 +25,4 @@
 - Tour Stats: https://www.setlistpickem.com/tour-stats
 - Sphere Run 2026 Stats: https://www.setlistpickem.com/tour-stats/2026-sphere
 - Phish Setlist Prediction Game: https://www.setlistpickem.com/phish-setlist-prediction-game
-- Setlist data: https://phish.net (The Mockingbird Foundation)
+- Setlist data credit: https://phish.net (The Mockingbird Foundation)

--- a/src/features/landing/ui/HowItWorksPageContent.jsx
+++ b/src/features/landing/ui/HowItWorksPageContent.jsx
@@ -4,9 +4,6 @@ import { ArrowRight } from 'lucide-react';
 
 /**
  * Standalone "How It Works" content for the `/how-it-works` public page.
- * Mirrors `SplashHowItWorksSection` but replaces the scoring-rules modal
- * trigger with a direct `<Link>` to `/how-scoring-works`, so this component
- * can render without a `ScoringRulesModalProvider`.
  */
 export default function HowItWorksPageContent() {
   return (
@@ -15,44 +12,60 @@ export default function HowItWorksPageContent() {
         <h1 className="mb-4 text-center font-display text-display-lg font-bold text-slate-900 md:text-display-lg-lg">
           How to Play Setlist Pick&apos;Em
         </h1>
-        <p className="mb-12 text-center text-slate-600 text-lg max-w-2xl mx-auto">
-          The free live setlist prediction game for Phish fans. Lock your picks before the lights
-          go down and compete in real-time as songs are played.
+        <p className="mx-auto mb-6 max-w-2xl text-center text-lg text-slate-600">
+          The free live setlist prediction game for Phish fans—and a home for more
+          bands soon. Lock your picks before the lights go down, score as the
+          setlist unfolds, and compete with friends.
         </p>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 lg:gap-8">
-          <div className="rounded-2xl bg-white p-6 md:p-8 shadow-xl shadow-slate-200/50 ring-1 ring-slate-100 flex flex-col items-center text-center md:items-start md:text-left transition-transform hover:-translate-y-1 hover:shadow-2xl hover:shadow-slate-200/60 duration-300">
-            <div className="w-12 h-12 rounded-full bg-emerald-100 flex items-center justify-center text-emerald-600 font-black shrink-0 text-xl mb-5">1</div>
-            <h2 className="font-bold text-xl text-slate-900 mb-3">Lock It In</h2>
-            <p className="text-slate-600 leading-relaxed">
+        <p className="mx-auto mb-12 max-w-2xl text-center text-base leading-relaxed text-slate-500">
+          We keep an eye on the tour for you: key song trends and bustout signals
+          update every night the band plays live. Sign in to unlock personal stats
+          as you earn points and climb the board against other setlist pickers.
+        </p>
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-3 lg:gap-8">
+          <div className="flex flex-col items-center rounded-2xl bg-white p-6 text-center shadow-xl shadow-slate-200/50 ring-1 ring-slate-100 transition-transform duration-300 hover:-translate-y-1 hover:shadow-2xl hover:shadow-slate-200/60 md:items-start md:p-8 md:text-left">
+            <div className="mb-5 flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-emerald-100 text-xl font-black text-emerald-600">1</div>
+            <h2 className="mb-3 text-xl font-bold text-slate-900">Lock It In</h2>
+            <p className="leading-relaxed text-slate-600">
               Pick openers, closers, encore and wildcard before showtime. Earn points for correct
               picks, higher points for exact slot picks, plus a Bustout Boost&trade; for calling longshots.
             </p>
             <Link
               to="/how-scoring-works"
-              className="mt-4 inline-flex items-center gap-1 rounded-md text-sm font-bold text-emerald-700 underline underline-offset-4 decoration-emerald-300 transition-colors hover:text-emerald-800 hover:decoration-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue"
+              className="mt-4 inline-flex items-center gap-1 rounded-md text-sm font-bold text-emerald-700 underline decoration-emerald-300 underline-offset-4 transition-colors hover:text-emerald-800 hover:decoration-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue"
             >
               Learn how scoring works
               <ArrowRight className="h-4 w-4" aria-hidden />
             </Link>
           </div>
-          <div className="rounded-2xl bg-white p-6 md:p-8 shadow-xl shadow-slate-200/50 ring-1 ring-slate-100 flex flex-col items-center text-center md:items-start md:text-left transition-transform hover:-translate-y-1 hover:shadow-2xl hover:shadow-slate-200/60 duration-300">
-            <div className="w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center text-blue-600 font-black shrink-0 text-xl mb-5">2</div>
-            <h2 className="font-bold text-xl text-slate-900 mb-3">Watch It Unfold</h2>
-            <p className="text-slate-600 leading-relaxed">
-              Live scores and standings update in real-time as songs are played. See your picks and
-              everyone else&apos;s light up the leaderboard.
+          <div className="flex flex-col items-center rounded-2xl bg-white p-6 text-center shadow-xl shadow-slate-200/50 ring-1 ring-slate-100 transition-transform duration-300 hover:-translate-y-1 hover:shadow-2xl hover:shadow-slate-200/60 md:items-start md:p-8 md:text-left">
+            <div className="mb-5 flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-blue-100 text-xl font-black text-blue-600">2</div>
+            <h2 className="mb-3 text-xl font-bold text-slate-900">Watch It Unfold</h2>
+            <p className="leading-relaxed text-slate-600">
+              Live scores and standings update as songs are played. See your picks—and your
+              friends&apos;—light up the leaderboard.
             </p>
           </div>
-          <div className="rounded-2xl bg-white p-6 md:p-8 shadow-xl shadow-slate-200/50 ring-1 ring-slate-100 flex flex-col items-center text-center md:items-start md:text-left transition-transform hover:-translate-y-1 hover:shadow-2xl hover:shadow-slate-200/60 duration-300">
-            <div className="w-12 h-12 rounded-full bg-purple-100 flex items-center justify-center text-purple-600 font-black shrink-0 text-xl mb-5">3</div>
-            <h2 className="font-bold text-xl text-slate-900 mb-3">Claim the Crown</h2>
-            <p className="text-slate-600 leading-relaxed">
-              Challenge friends in private pools and compete in global standings with everyone
-              playing that night. See all-time stats in private pools to compete across tours and years.
+          <div className="flex flex-col items-center rounded-2xl bg-white p-6 text-center shadow-xl shadow-slate-200/50 ring-1 ring-slate-100 transition-transform duration-300 hover:-translate-y-1 hover:shadow-2xl hover:shadow-slate-200/60 md:items-start md:p-8 md:text-left">
+            <div className="mb-5 flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-purple-100 text-xl font-black text-purple-600">3</div>
+            <h2 className="mb-3 text-xl font-bold text-slate-900">Claim the Crown</h2>
+            <p className="leading-relaxed text-slate-600">
+              Challenge friends in private pools and compete in global standings. Your personal
+              stats grow with every show you play—across the tour and beyond.
             </p>
           </div>
         </div>
-        <div className="mt-14 flex justify-center">
+        <p className="mx-auto mt-10 max-w-2xl text-center text-sm leading-relaxed text-slate-500">
+          Peek at public{' '}
+          <Link
+            to="/tour-stats"
+            className="font-semibold text-emerald-700 underline decoration-emerald-300 underline-offset-2 hover:decoration-emerald-500"
+          >
+            tour setlist stats
+          </Link>{' '}
+          anytime—then play to unlock the personal side of the story.
+        </p>
+        <div className="mt-10 flex justify-center">
           <Link
             to="/"
             className="inline-flex items-center gap-2 rounded-xl bg-brand-primary px-10 py-3.5 text-base font-bold text-white shadow-[0_10px_20px_-10px_rgba(16,185,129,0.5)] transition-all hover:bg-brand-primary-hover hover:shadow-[0_15px_30px_-15px_rgba(16,185,129,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue"

--- a/src/features/landing/ui/HowItWorksPageContent.jsx
+++ b/src/features/landing/ui/HowItWorksPageContent.jsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowRight } from 'lucide-react';
 
+import {
+  CARD_LINK_ON_LIGHT,
+  LINK_ON_LIGHT,
+} from '../../../shared/ui/surfaceLinkStyles';
+
 /**
  * Standalone "How It Works" content for the `/how-it-works` public page.
  */
@@ -13,14 +18,20 @@ export default function HowItWorksPageContent() {
           How to Play Setlist Pick&apos;Em
         </h1>
         <p className="mx-auto mb-6 max-w-2xl text-center text-lg text-slate-600">
-          The free live setlist prediction game for Phish fans—and a home for more
-          bands soon. Lock your picks before the lights go down, score as the
-          setlist unfolds, and compete with friends.
+          The free live{' '}
+          <Link to="/phish-setlist-prediction-game" className={LINK_ON_LIGHT}>
+            setlist prediction game
+          </Link>{' '}
+          for Phish fans—and a home for more bands soon. Lock your picks before the lights go down,
+          score as the setlist unfolds, and compete with friends.
         </p>
         <p className="mx-auto mb-12 max-w-2xl text-center text-base leading-relaxed text-slate-500">
-          We keep an eye on the tour for you: key song trends and bustout signals
-          update every night the band plays live. Sign in to unlock personal stats
-          as you earn points and climb the board against other setlist pickers.
+          We keep an eye on the tour for you: key song trends and bustout signals on{' '}
+          <Link to="/tour-stats" className={LINK_ON_LIGHT}>
+            tour stats
+          </Link>{' '}
+          update every night the band plays live. Sign in to unlock personal stats as you earn points
+          and climb the board against other setlist pickers.
         </p>
         <div className="grid grid-cols-1 gap-6 md:grid-cols-3 lg:gap-8">
           <div className="flex flex-col items-center rounded-2xl bg-white p-6 text-center shadow-xl shadow-slate-200/50 ring-1 ring-slate-100 transition-transform duration-300 hover:-translate-y-1 hover:shadow-2xl hover:shadow-slate-200/60 md:items-start md:p-8 md:text-left">
@@ -30,10 +41,7 @@ export default function HowItWorksPageContent() {
               Pick openers, closers, encore and wildcard before showtime. Earn points for correct
               picks, higher points for exact slot picks, plus a Bustout Boost&trade; for calling longshots.
             </p>
-            <Link
-              to="/how-scoring-works"
-              className="mt-4 inline-flex items-center gap-1 rounded-md text-sm font-bold text-emerald-700 underline decoration-emerald-300 underline-offset-4 transition-colors hover:text-emerald-800 hover:decoration-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue"
-            >
+            <Link to="/how-scoring-works" className={CARD_LINK_ON_LIGHT}>
               Learn how scoring works
               <ArrowRight className="h-4 w-4" aria-hidden />
             </Link>
@@ -57,10 +65,7 @@ export default function HowItWorksPageContent() {
         </div>
         <p className="mx-auto mt-10 max-w-2xl text-center text-sm leading-relaxed text-slate-500">
           Peek at public{' '}
-          <Link
-            to="/tour-stats"
-            className="font-semibold text-emerald-700 underline decoration-emerald-300 underline-offset-2 hover:decoration-emerald-500"
-          >
+          <Link to="/tour-stats" className={LINK_ON_LIGHT}>
             tour setlist stats
           </Link>{' '}
           anytime—then play to unlock the personal side of the story.

--- a/src/features/landing/ui/HowItWorksPageContent.jsx
+++ b/src/features/landing/ui/HowItWorksPageContent.jsx
@@ -22,8 +22,8 @@ export default function HowItWorksPageContent() {
           <Link to="/phish-setlist-prediction-game" className={LINK_ON_LIGHT}>
             setlist prediction game
           </Link>{' '}
-          for Phish fans—and a home for more bands soon. Lock your picks before the lights go down,
-          score as the setlist unfolds, and compete with friends.
+          for Phish fans—and a home for more bands soon. Lock your setlist picks before the lights go
+          down, score as the setlist unfolds, and compete with friends predicting setlists together.
         </p>
         <p className="mx-auto mb-12 max-w-2xl text-center text-base leading-relaxed text-slate-500">
           We keep an eye on the tour for you: key song trends and bustout signals on{' '}

--- a/src/features/landing/ui/MarketingSiteNav.jsx
+++ b/src/features/landing/ui/MarketingSiteNav.jsx
@@ -5,14 +5,11 @@ import {
   MARKETING_LEGAL_NAV,
   MARKETING_PRIMARY_NAV,
 } from '../model/marketingNav';
-
-const FOOTER_LINK =
-  'text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200 hover:decoration-slate-400';
-
-const HEADER_LINK =
-  'rounded-sm text-xs font-semibold text-slate-400 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue lg:text-sm';
-
-const HEADER_LINK_ACTIVE = 'text-white';
+import {
+  FOOTER_LINK_ON_DARK,
+  HEADER_LINK_ACTIVE,
+  HEADER_LINK_ON_DARK,
+} from '../../../shared/ui/surfaceLinkStyles';
 
 /**
  * Compact primary nav for marketing page headers (#663).
@@ -30,7 +27,7 @@ export function MarketingHeaderNav({ className = 'hidden lg:flex' }) {
           <Link
             key={to}
             to={to}
-            className={`${HEADER_LINK} ${active ? HEADER_LINK_ACTIVE : ''}`.trim()}
+            className={`${HEADER_LINK_ON_DARK} ${active ? HEADER_LINK_ACTIVE : ''}`.trim()}
             aria-current={active ? 'page' : undefined}
           >
             {label}
@@ -49,7 +46,7 @@ export function MarketingFooterNav({ className = '' }) {
   return (
     <p className={`mt-2 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 ${className}`.trim()}>
       {links.map(({ to, label }) => (
-        <Link key={to} to={to} className={FOOTER_LINK}>
+        <Link key={to} to={to} className={FOOTER_LINK_ON_DARK}>
           {label}
         </Link>
       ))}

--- a/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
+++ b/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
@@ -4,7 +4,6 @@ import { ArrowRight } from 'lucide-react';
 
 /**
  * Keyword-intent educational page for `/phish-setlist-prediction-game` (#660).
- * Entity-dense copy for category queries — not a thin doorway.
  */
 export default function PhishSetlistPredictionGamePageContent() {
   return (
@@ -18,9 +17,9 @@ export default function PhishSetlistPredictionGamePageContent() {
         </h1>
         <p className="mb-10 text-center text-lg leading-relaxed text-slate-600">
           Setlist Pick&apos;Em (also called Setlist Pickem / Set Picks) is a live{' '}
-          <strong className="font-semibold text-slate-800">setlist prediction game</strong> for
-          Phish fans: lock openers, closers, encore, and a wildcard before showtime, then score as
-          the setlist unfolds.
+          <strong className="font-semibold text-slate-800">setlist prediction game</strong> built
+          first for Phish fans—and designed as a destination for more bands soon. Lock openers,
+          closers, encore, and a wildcard before showtime, then score as the night unfolds.
         </p>
 
         <section className="mb-12 space-y-4 text-base leading-relaxed text-slate-700">
@@ -29,68 +28,55 @@ export default function PhishSetlistPredictionGamePageContent() {
           </h2>
           <p>
             A Phish setlist game asks you to predict songs and slots for tonight&apos;s show—not to
-            archive what already happened. You compete against friends in private pools and against
-            everyone on the global board. Scores update live as songs are played.
+            dig through yesterday&apos;s archives. You compete with friends in private pools and
+            with everyone on the global board. Scores update live as songs are played.
           </p>
           <p>
-            Setlist Pick&apos;Em started covering the Sphere run in 2026 and follows each tour as
-            Phish.net publishes new dates. Tour-level song frequency, bustouts, and gap highlights
-            are available on our public{' '}
+            We follow the tour with you. Song frequency, bustouts, and gap highlights live on our{' '}
             <Link
               to="/tour-stats"
               className="font-semibold text-emerald-700 underline decoration-emerald-300 underline-offset-2 hover:decoration-emerald-500"
             >
               tour stats
             </Link>{' '}
-            pages so you can research picks without an account.
+            pages and refresh every night the band plays live—insights that help you stay sharp
+            between shows.
           </p>
         </section>
 
         <section className="mb-12 space-y-4 text-base leading-relaxed text-slate-700">
           <h2 className="font-display text-2xl font-bold text-slate-900">
-            Prediction game vs setlist trackers
+            More than a setlist archive
           </h2>
           <p>
-            Sites like Phish.net and setlist.fm are outstanding archives and reference libraries—
-            they document what was played. Setlist Pick&apos;Em is a{' '}
-            <strong className="font-semibold text-slate-800">game layer on top of that world</strong>
-            : you make picks before the lights go down, earn points for correct slots and wildcards,
-            and chase Bustout Boosts on longshot calls.
+            Setlist archives are great for looking back. Setlist Pick&apos;Em is about the night
+            ahead: make your calls, earn points for slots and wildcards, and chase Bustout Boosts
+            when you nail the longshots.
           </p>
           <ul className="list-disc space-y-2 pl-5">
             <li>
-              <strong className="text-slate-900">Before the show:</strong> lock picks; they freeze
-              near doors / showtime.
+              <strong className="text-slate-900">Before the show:</strong> lock picks before the
+              lights go down.
             </li>
             <li>
               <strong className="text-slate-900">During the show:</strong> live scoring and
-              standings as the setlist updates.
+              standings as the setlist unfolds.
             </li>
             <li>
               <strong className="text-slate-900">After the show:</strong> final grades, tour
-              standings, and aggregate song stats—not a replacement for the official archive.
+              standings, and personal stats that grow every night you play.
             </li>
           </ul>
           <p>
-            Song and setlist data for scoring and public stats are provided by{' '}
-            <a
-              href="https://phish.net"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-semibold text-emerald-700 underline decoration-emerald-300 underline-offset-2 hover:decoration-emerald-500"
-            >
-              The Mockingbird Foundation / Phish.Net
-            </a>
-            .
+            Playing the game unlocks those personal stats—so you can see how you stack up as you
+            accumulate points against other setlist pickers.
           </p>
         </section>
 
         <section className="mb-12 space-y-4 text-base leading-relaxed text-slate-700">
           <h2 className="font-display text-2xl font-bold text-slate-900">How to play</h2>
           <ol className="list-decimal space-y-3 pl-5">
-            <li>
-              Create a free account and open tonight&apos;s show on the dashboard.
-            </li>
+            <li>Create a free account and open tonight&apos;s show.</li>
             <li>
               Pick Set 1 opener/closer, Set 2 opener/closer, encore, and a wildcard.
             </li>

--- a/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
+++ b/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
@@ -16,7 +16,7 @@ export default function PhishSetlistPredictionGamePageContent() {
           The free Phish setlist prediction game
         </h1>
         <p className="mb-10 text-center text-lg leading-relaxed text-slate-600">
-          Setlist Pick&apos;Em (also called Setlist Pickem / Set Picks) is a live{' '}
+          Setlist Pick&apos;Em (also called Setlist Pickem) is a live{' '}
           <strong className="font-semibold text-slate-800">setlist prediction game</strong> built
           first for Phish fans—and designed as a destination for more bands soon. Lock openers,
           closers, encore, and a wildcard before showtime, then score as the night unfolds.

--- a/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
+++ b/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowRight } from 'lucide-react';
 
+import { LINK_ON_LIGHT } from '../../../shared/ui/surfaceLinkStyles';
+
 /**
  * Keyword-intent educational page for `/phish-setlist-prediction-game` (#660).
  */
@@ -29,14 +31,16 @@ export default function PhishSetlistPredictionGamePageContent() {
           <p>
             A Phish setlist game asks you to predict songs and slots for tonight&apos;s show—not to
             dig through yesterday&apos;s archives. You compete with friends in private pools and
-            with everyone on the global board. Scores update live as songs are played.
+            with everyone on the global board. Scores update live as songs are played. Prefer a
+            short walkthrough? See{' '}
+            <Link to="/how-it-works" className={LINK_ON_LIGHT}>
+              how it works
+            </Link>
+            .
           </p>
           <p>
             We follow the tour with you. Song frequency, bustouts, and gap highlights live on our{' '}
-            <Link
-              to="/tour-stats"
-              className="font-semibold text-emerald-700 underline decoration-emerald-300 underline-offset-2 hover:decoration-emerald-500"
-            >
+            <Link to="/tour-stats" className={LINK_ON_LIGHT}>
               tour stats
             </Link>{' '}
             pages and refresh every night the band plays live—insights that help you stay sharp
@@ -51,7 +55,11 @@ export default function PhishSetlistPredictionGamePageContent() {
           <p>
             Setlist archives are great for looking back. Setlist Pick&apos;Em is about the night
             ahead: make your calls, earn points for slots and wildcards, and chase Bustout Boosts
-            when you nail the longshots.
+            when you nail the longshots. Full point values are on{' '}
+            <Link to="/how-scoring-works" className={LINK_ON_LIGHT}>
+              how scoring works
+            </Link>
+            .
           </p>
           <ul className="list-disc space-y-2 pl-5">
             <li>
@@ -87,16 +95,20 @@ export default function PhishSetlistPredictionGamePageContent() {
           <p className="flex flex-wrap gap-x-4 gap-y-2">
             <Link
               to="/how-it-works"
-              className="inline-flex items-center gap-1 font-semibold text-emerald-700 underline decoration-emerald-300 underline-offset-2 hover:decoration-emerald-500"
+              className={`inline-flex items-center gap-1 ${LINK_ON_LIGHT}`}
             >
               How it works
               <ArrowRight className="h-4 w-4" aria-hidden />
             </Link>
             <Link
               to="/how-scoring-works"
-              className="inline-flex items-center gap-1 font-semibold text-emerald-700 underline decoration-emerald-300 underline-offset-2 hover:decoration-emerald-500"
+              className={`inline-flex items-center gap-1 ${LINK_ON_LIGHT}`}
             >
               How scoring works
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Link>
+            <Link to="/tour-stats" className={`inline-flex items-center gap-1 ${LINK_ON_LIGHT}`}>
+              Tour stats
               <ArrowRight className="h-4 w-4" aria-hidden />
             </Link>
           </p>

--- a/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
+++ b/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
@@ -26,13 +26,13 @@ export default function PhishSetlistPredictionGamePageContent() {
 
         <section className="mb-12 space-y-4 text-base leading-relaxed text-slate-700">
           <h2 className="font-display text-2xl font-bold text-slate-900">
-            What is a Phish setlist game?
+            What is a setlist prediction game?
           </h2>
           <p>
-            A Phish setlist game asks you to predict songs and slots for tonight&apos;s show—not to
-            dig through yesterday&apos;s archives. You compete with friends in private pools and
-            with everyone on the global board. Scores update live as songs are played. Prefer a
-            short walkthrough? See{' '}
+            For jam bands like Phish, every night is a new setlist—so a setlist prediction game asks
+            you to call songs and slots before showtime, not dig through yesterday&apos;s archives.
+            You compete with friends in private pools and with everyone on the global board. Scores
+            update live as songs are played. Prefer a short walkthrough? See{' '}
             <Link to="/how-it-works" className={LINK_ON_LIGHT}>
               how it works
             </Link>
@@ -44,7 +44,7 @@ export default function PhishSetlistPredictionGamePageContent() {
               tour stats
             </Link>{' '}
             pages and refresh every night the band plays live—insights that help you stay sharp
-            between shows.
+            between shows. We&apos;re live with Phish today and building toward more bands soon.
           </p>
         </section>
 

--- a/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
+++ b/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
@@ -18,10 +18,11 @@ export default function PhishSetlistPredictionGamePageContent() {
           The free Phish setlist prediction game
         </h1>
         <p className="mb-10 text-center text-lg leading-relaxed text-slate-600">
-          Setlist Pick&apos;Em (also called Setlist Pickem) is a live{' '}
-          <strong className="font-semibold text-slate-800">setlist prediction game</strong> built
-          first for Phish fans—and designed as a destination for more bands soon. Lock openers,
-          closers, encore, and a wildcard before showtime, then score as the night unfolds.
+          Setlist Pick&apos;Em is a free live{' '}
+          <strong className="font-semibold text-slate-800">setlist picks game</strong> for fans who
+          love predicting setlists—built first for Phish, and designed as a home for more bands soon.
+          Lock openers, closers, encore, and a wildcard before showtime, then score as the night
+          unfolds.
         </p>
 
         <section className="mb-12 space-y-4 text-base leading-relaxed text-slate-700">
@@ -29,14 +30,21 @@ export default function PhishSetlistPredictionGamePageContent() {
             What is a setlist prediction game?
           </h2>
           <p>
-            For jam bands like Phish, every night is a new setlist—so a setlist prediction game asks
-            you to call songs and slots before showtime, not dig through yesterday&apos;s archives.
-            You compete with friends in private pools and with everyone on the global board. Scores
-            update live as songs are played. Prefer a short walkthrough? See{' '}
+            For jam bands like Phish, every night is a new setlist. A setlist prediction game—sometimes
+            called a <strong className="font-semibold text-slate-800">fantasy setlist</strong> game—asks
+            you to call songs and slots before the lights go down, not dig through yesterday&apos;s
+            archives. You compete with friends in private pools and with everyone on the global board.
+            Scores update live as songs are played. Prefer a short walkthrough? See{' '}
             <Link to="/how-it-works" className={LINK_ON_LIGHT}>
               how it works
             </Link>
             .
+          </p>
+          <p>
+            Fans have been calling the set on paper, in group chats, and on couch tour for years.
+            Setlist Pick&apos;Em turns that ritual into a live game: lock your setlist picks, watch
+            the show, and climb the board together. We&apos;re live with Phish today and building
+            toward more bands soon.
           </p>
           <p>
             We follow the tour with you. Song frequency, bustouts, and gap highlights live on our{' '}
@@ -44,18 +52,18 @@ export default function PhishSetlistPredictionGamePageContent() {
               tour stats
             </Link>{' '}
             pages and refresh every night the band plays live—insights that help you stay sharp
-            between shows. We&apos;re live with Phish today and building toward more bands soon.
+            between shows.
           </p>
         </section>
 
         <section className="mb-12 space-y-4 text-base leading-relaxed text-slate-700">
           <h2 className="font-display text-2xl font-bold text-slate-900">
-            More than a setlist archive
+            Fantasy setlists, without the spreadsheet
           </h2>
           <p>
-            Setlist archives are great for looking back. Setlist Pick&apos;Em is about the night
-            ahead: make your calls, earn points for slots and wildcards, and chase Bustout Boosts
-            when you nail the longshots. Full point values are on{' '}
+            Setlist archives are great for looking back. A fantasy setlist night is about the show
+            ahead: make your calls, earn points for slots and wildcards, and chase Bustout Boosts when
+            you nail the longshots. Full point values are on{' '}
             <Link to="/how-scoring-works" className={LINK_ON_LIGHT}>
               how scoring works
             </Link>
@@ -68,7 +76,7 @@ export default function PhishSetlistPredictionGamePageContent() {
             </li>
             <li>
               <strong className="text-slate-900">During the show:</strong> live scoring and
-              standings as the setlist unfolds.
+              standings as the setlist unfolds—at the venue or on couch tour.
             </li>
             <li>
               <strong className="text-slate-900">After the show:</strong> final grades, tour
@@ -76,8 +84,8 @@ export default function PhishSetlistPredictionGamePageContent() {
             </li>
           </ul>
           <p>
-            Playing the game unlocks those personal stats—so you can see how you stack up as you
-            accumulate points against other setlist pickers.
+            Playing unlocks those personal stats—so you can see how you stack up as you accumulate
+            points against other setlist pickers.
           </p>
         </section>
 
@@ -119,7 +127,7 @@ export default function PhishSetlistPredictionGamePageContent() {
             to="/"
             className="inline-flex items-center gap-2 rounded-xl bg-brand-primary px-10 py-3.5 text-base font-bold text-white shadow-[0_10px_20px_-10px_rgba(16,185,129,0.5)] transition-all hover:bg-brand-primary-hover hover:shadow-[0_15px_30px_-15px_rgba(16,185,129,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue"
           >
-            Play the Phish setlist prediction game
+            Start predicting setlists
           </Link>
         </div>
       </div>

--- a/src/features/landing/ui/SplashAboutSection.jsx
+++ b/src/features/landing/ui/SplashAboutSection.jsx
@@ -2,15 +2,13 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 import Button from '../../../shared/ui/Button';
+import { LINK_ON_DARK } from '../../../shared/ui/surfaceLinkStyles';
 
 export default function SplashAboutSection({
   sectionRef,
   headingRef,
   onGetStartedClick,
 }) {
-  const linkButtonClassName =
-    'rounded-sm text-sm font-bold text-slate-400 underline underline-offset-2 decoration-slate-500 outline-none transition-colors hover:text-white hover:decoration-white focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg';
-
   return (
     <section
       ref={sectionRef}
@@ -66,9 +64,19 @@ export default function SplashAboutSection({
               and <strong className="text-white">more interesting</strong>.{' '}
               <strong className="text-transparent bg-clip-text bg-gradient-to-r from-red-500 to-blue-500">Setlist Pick &apos;Em</strong> is that vision taken
               to its logical conclusion: an <strong className="text-white">interactive</strong> home
-              for passionate fans who crave <strong className="text-white">competition</strong>,{' '}
-              <strong className="text-white">show stats</strong>, and{' '}
-              <strong className="text-white">fun with friends</strong>.
+              for passionate fans who crave competition,{' '}
+              <Link to="/tour-stats" className={LINK_ON_DARK}>
+                tour stats
+              </Link>
+              , and fun with friends. Prefer the short version? Read{' '}
+              <Link to="/how-it-works" className={LINK_ON_DARK}>
+                how it works
+              </Link>{' '}
+              or what makes this a{' '}
+              <Link to="/phish-setlist-prediction-game" className={LINK_ON_DARK}>
+                Phish setlist prediction game
+              </Link>
+              .
             </p>
 
             <div className="block lg:hidden mt-10">
@@ -80,22 +88,27 @@ export default function SplashAboutSection({
         </div>
 
         <nav
-          className="mt-16 flex flex-wrap items-center justify-start gap-x-2 gap-y-2 border-t border-slate-800 pt-8 text-center lg:justify-end"
+          className="mt-16 flex flex-wrap items-center justify-start gap-x-2 gap-y-2 border-t border-slate-800 pt-8 text-center text-sm lg:justify-end"
           aria-label="Jump to How it works or Get started"
         >
-          <Link to="/how-it-works" className={linkButtonClassName}>
+          <Link to="/how-it-works" className={LINK_ON_DARK}>
             How it works
           </Link>
-          <span className="mx-2 select-none text-slate-700" aria-hidden>
+          <span className="mx-2 select-none text-slate-600" aria-hidden>
             ·
           </span>
-          <Link to="/tour-stats" className={linkButtonClassName}>
+          <Link to="/tour-stats" className={LINK_ON_DARK}>
             Tour stats
           </Link>
-          <span className="mx-2 select-none text-slate-700" aria-hidden>
+          <span className="mx-2 select-none text-slate-600" aria-hidden>
             ·
           </span>
-          <Button variant="link" type="button" onClick={onGetStartedClick} className={linkButtonClassName}>
+          <Button
+            variant="link"
+            type="button"
+            onClick={onGetStartedClick}
+            className={LINK_ON_DARK}
+          >
             Get started
           </Button>
         </nav>

--- a/src/features/landing/ui/SplashHeroSection.jsx
+++ b/src/features/landing/ui/SplashHeroSection.jsx
@@ -3,9 +3,7 @@ import { Link } from 'react-router-dom';
 
 import Button from '../../../shared/ui/Button';
 import SplashHeroWordmark from './SplashHeroWordmark';
-
-const secondaryLinkClassName =
-  'underline decoration-slate-600 underline-offset-4 transition-colors hover:text-emerald-400';
+import { LINK_ON_DARK } from '../../../shared/ui/surfaceLinkStyles';
 
 /**
  * Splash hero — primary CTA stays auth/get-started; secondary links are real
@@ -32,11 +30,21 @@ export default function SplashHeroSection({ onPlayNowClick }) {
           </p>
 
           <p className="text-base font-normal leading-relaxed text-slate-300 sm:leading-snug md:text-lg md:leading-relaxed">
-            Make picks for tonight&apos;s show, watch scores update as songs are played, and compete with your tour crew for the top spot.
+            Make picks for tonight&apos;s show, watch scores update as songs are played, and compete
+            with your tour crew for the top spot.
           </p>
 
           <p className="mt-4 text-base font-normal leading-relaxed text-slate-300 sm:leading-snug md:text-lg md:leading-relaxed">
-            What started as a game on paper 25 years ago is now a fully automated, live setlist game for friends to play at the show and on couch tour. Invite your friends, track stats, and make every show count.
+            What started as a game on paper 25 years ago is now a live setlist game for friends at
+            the show and on couch tour. Invite your friends, track{' '}
+            <Link to="/tour-stats" className={LINK_ON_DARK}>
+              tour stats
+            </Link>
+            , and make every show count. New here? See{' '}
+            <Link to="/how-it-works" className={LINK_ON_DARK}>
+              how it works
+            </Link>
+            .
           </p>
         </div>
 
@@ -53,20 +61,20 @@ export default function SplashHeroSection({ onPlayNowClick }) {
           >
             Make picks now
           </Button>
-          <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm font-semibold text-slate-400">
-            <Link to="/how-it-works" className={secondaryLinkClassName}>
+          <nav
+            className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm"
+            aria-label="Learn more"
+          >
+            <Link to="/how-it-works" className={LINK_ON_DARK}>
               How it works
             </Link>
-            <Link to="/tour-stats" className={secondaryLinkClassName}>
+            <Link to="/tour-stats" className={LINK_ON_DARK}>
               Tour stats
             </Link>
-            <Link
-              to="/phish-setlist-prediction-game"
-              className={secondaryLinkClassName}
-            >
+            <Link to="/phish-setlist-prediction-game" className={LINK_ON_DARK}>
               What is this game?
             </Link>
-          </div>
+          </nav>
         </div>
 
         <div className="min-h-2 flex-1 sm:hidden" aria-hidden />

--- a/src/features/landing/ui/SplashHowItWorksSection.jsx
+++ b/src/features/landing/ui/SplashHowItWorksSection.jsx
@@ -46,7 +46,7 @@ export default function SplashHowItWorksSection({ sectionRef, headingRef, onCrea
             </div>
             <h3 className="font-bold text-xl text-slate-900 mb-3">Watch It Unfold</h3>
             <p className="text-slate-600 leading-relaxed">
-              Live scores and standings update in real-time as songs are played. See your picks and everyone else's light up the leaderboard.
+              Live scores and standings update as songs are played. See your picks—and your friends&apos;—light up the leaderboard.
             </p>
           </div>
 
@@ -56,7 +56,8 @@ export default function SplashHowItWorksSection({ sectionRef, headingRef, onCrea
             </div>
             <h3 className="font-bold text-xl text-slate-900 mb-3">Claim the Crown</h3>
             <p className="text-slate-600 leading-relaxed">
-              Challenge friends in private pools and compete in global standings with everyone playing that night. See all-time stats in private pools to compete across tours and years.          </p>
+              Challenge friends in private pools and compete in global standings. Your personal stats grow with every show you play—across the tour and beyond.
+            </p>
           </div>
         </div>
 

--- a/src/features/landing/ui/SplashHowItWorksSection.jsx
+++ b/src/features/landing/ui/SplashHowItWorksSection.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { ArrowRight } from 'lucide-react';
 
-import { useScoringRulesModal } from '../../scoring';
 import Button from '../../../shared/ui/Button';
+import {
+  CARD_LINK_ON_LIGHT,
+  LINK_ON_LIGHT,
+} from '../../../shared/ui/surfaceLinkStyles';
 
 export default function SplashHowItWorksSection({ sectionRef, headingRef, onCreateAccountClick }) {
-  const { openScoringRules } = useScoringRulesModal();
-
   return (
     <section
       ref={sectionRef}
@@ -16,10 +18,21 @@ export default function SplashHowItWorksSection({ sectionRef, headingRef, onCrea
         <h2
           ref={headingRef}
           tabIndex={-1}
-          className="mb-12 rounded-md text-center font-display text-display-lg font-bold text-slate-900 outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue md:text-display-lg-lg"
+          className="mb-4 rounded-md text-center font-display text-display-lg font-bold text-slate-900 outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue md:text-display-lg-lg"
         >
           Game Format
         </h2>
+        <p className="mx-auto mb-12 max-w-2xl text-center text-base leading-relaxed text-slate-600">
+          Three steps—then you&apos;re in. Prefer the full walkthrough? See{' '}
+          <Link to="/how-it-works" className={LINK_ON_LIGHT}>
+            how it works
+          </Link>
+          , or peek at{' '}
+          <Link to="/tour-stats" className={LINK_ON_LIGHT}>
+            tour stats
+          </Link>{' '}
+          before you lock picks.
+        </p>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 lg:gap-8">
           <div className="rounded-2xl bg-white p-6 md:p-8 shadow-xl shadow-slate-200/50 ring-1 ring-slate-100 flex flex-col items-center text-center md:items-start md:text-left transition-transform hover:-translate-y-1 hover:shadow-2xl hover:shadow-slate-200/60 duration-300">
@@ -30,14 +43,10 @@ export default function SplashHowItWorksSection({ sectionRef, headingRef, onCrea
             <p className="text-slate-600 leading-relaxed">
               Pick openers, closers, encore and wildcard before showtime. Earn points for correct picks, higher points for exact slot picks, plus a Bustout Boost™ for calling longshots.
             </p>
-            <button
-              type="button"
-              onClick={openScoringRules}
-              className="mt-4 inline-flex items-center gap-1 rounded-md text-sm font-bold text-emerald-700 underline underline-offset-4 decoration-emerald-300 transition-colors hover:text-emerald-800 hover:decoration-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue"
-            >
+            <Link to="/how-scoring-works" className={CARD_LINK_ON_LIGHT}>
               Learn how scoring works
               <ArrowRight className="h-4 w-4" aria-hidden />
-            </button>
+            </Link>
           </div>
 
           <div className="rounded-2xl bg-white p-6 md:p-8 shadow-xl shadow-slate-200/50 ring-1 ring-slate-100 flex flex-col items-center text-center md:items-start md:text-left transition-transform hover:-translate-y-1 hover:shadow-2xl hover:shadow-slate-200/60 duration-300">
@@ -61,7 +70,7 @@ export default function SplashHowItWorksSection({ sectionRef, headingRef, onCrea
           </div>
         </div>
 
-        <div className="mt-14 flex justify-center">
+        <div className="mt-14 flex flex-col items-center gap-4">
           <Button
             variant="primary"
             type="button"
@@ -70,6 +79,13 @@ export default function SplashHowItWorksSection({ sectionRef, headingRef, onCrea
           >
             Create Account
           </Button>
+          <p className="text-center text-sm text-slate-500">
+            Or read the full{' '}
+            <Link to="/how-it-works" className={LINK_ON_LIGHT}>
+              how to play
+            </Link>{' '}
+            guide.
+          </p>
         </div>
       </div>
     </section>

--- a/src/features/profile/model/badgeCatalog.js
+++ b/src/features/profile/model/badgeCatalog.js
@@ -16,7 +16,7 @@ export const PROFILE_BADGES = Object.freeze([
   {
     id: 'shows_played_1',
     name: 'First Show Scored',
-    blurb: 'Scored your first Set Picks show.',
+    blurb: "Scored your first Setlist Pick 'Em show.",
     tier: 'common',
     src: '/badges/shows_played_1.svg',
   },

--- a/src/features/tour-stats/ui/PublicTourStatsPanel.jsx
+++ b/src/features/tour-stats/ui/PublicTourStatsPanel.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import TourStatsView from '../ui/TourStatsView';
 
 /**
- * Public marketing chrome around aggregate tour stats (#665).
+ * Public marketing chrome around tour stats (#665).
  */
 export default function PublicTourStatsPanel({
   tours,
@@ -27,14 +27,16 @@ export default function PublicTourStatsPanel({
           Phish tour setlist stats
         </h1>
         <p className="text-base leading-relaxed text-slate-300">
-          Aggregate song frequency, bustouts, and gap highlights for each tour —
-          the same non-personal stats players use when locking picks. We start
-          with the Sphere run (when Setlist Pick &apos;Em launched) and add tours
-          as Phish.net publishes new dates on the calendar.
+          We track the setlist stories that help you make better picks—most-played
+          songs, bustouts, and gap highlights for each tour. Stats refresh every
+          night the band plays live, so the picture keeps getting sharper as the
+          tour rolls on.
         </p>
         <p className="text-sm leading-relaxed text-slate-400">
-          Full nightly setlists stay in the app for signed-in players. This page
-          never lists an entire show&apos;s set — only tour-level song datasets.
+          We&apos;re starting with Phish and building toward more bands soon.
+          Playing the game unlocks your personal stats as you rack up points and
+          compete with other setlist pickers. This page stays focused on tour-wide
+          song trends—not a full night-by-night setlist archive.
         </p>
       </header>
 

--- a/src/features/tour-stats/ui/PublicTourStatsPanel.jsx
+++ b/src/features/tour-stats/ui/PublicTourStatsPanel.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 import TourStatsView from '../ui/TourStatsView';
+import { LINK_ON_DARK } from '../../../shared/ui/surfaceLinkStyles';
 
 /**
  * Public marketing chrome around tour stats (#665).
@@ -35,8 +36,16 @@ export default function PublicTourStatsPanel({
         <p className="text-sm leading-relaxed text-slate-400">
           We&apos;re starting with Phish and building toward more bands soon.
           Playing the game unlocks your personal stats as you rack up points and
-          compete with other setlist pickers. This page stays focused on tour-wide
-          song trends—not a full night-by-night setlist archive.
+          compete with other setlist pickers. New to the format? See{' '}
+          <Link to="/how-it-works" className={LINK_ON_DARK}>
+            how it works
+          </Link>{' '}
+          or what makes this a{' '}
+          <Link to="/phish-setlist-prediction-game" className={LINK_ON_DARK}>
+            Phish setlist prediction game
+          </Link>
+          . This page stays focused on tour-wide song trends—not a full
+          night-by-night setlist archive.
         </p>
       </header>
 
@@ -78,9 +87,13 @@ export default function PublicTourStatsPanel({
         overlayLoading={false}
       />
 
-      <div className="mt-10 flex flex-col items-center gap-3 border-t border-white/10 pt-8 sm:flex-row sm:justify-between">
+      <div className="mt-10 flex flex-col items-center gap-4 border-t border-white/10 pt-8 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-sm text-slate-400">
-          Ready to compete on the next show?
+          Ready to compete on the next show? Or skim{' '}
+          <Link to="/how-scoring-works" className={LINK_ON_DARK}>
+            how scoring works
+          </Link>{' '}
+          first.
         </p>
         <Link
           to="/"

--- a/src/pages/marketing/HowScoringWorksPage.jsx
+++ b/src/pages/marketing/HowScoringWorksPage.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
+import { Link } from 'react-router-dom';
 
 import { ScoringRulesContent } from '../../features/scoring';
 import { MarketingPageShell } from '../../features/landing';
 import { SEO_CONFIG } from '../../shared/config/seo';
 import { getPrerenderRoute } from '../../shared/config/seoRoutes';
+import { LINK_ON_LIGHT } from '../../shared/ui/surfaceLinkStyles';
 
 const route = getPrerenderRoute('/how-scoring-works');
 
@@ -34,6 +36,21 @@ export default function HowScoringWorksPage() {
       <MarketingPageShell>
         <div className="w-full max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-24">
           <ScoringRulesContent />
+          <p className="mt-10 text-center text-sm leading-relaxed text-slate-500">
+            Next:{' '}
+            <Link to="/how-it-works" className={LINK_ON_LIGHT}>
+              how it works
+            </Link>
+            , browse{' '}
+            <Link to="/tour-stats" className={LINK_ON_LIGHT}>
+              tour stats
+            </Link>
+            , or{' '}
+            <Link to="/" className={LINK_ON_LIGHT}>
+              start playing
+            </Link>
+            .
+          </p>
         </div>
       </MarketingPageShell>
     </>

--- a/src/pages/marketing/PublicTourStatsPage.jsx
+++ b/src/pages/marketing/PublicTourStatsPage.jsx
@@ -32,7 +32,7 @@ export default function PublicTourStatsPage() {
   const title = route?.title || `Tour stats | ${SEO_CONFIG.siteName}`;
   const description =
     route?.description ||
-    'Aggregate Phish tour setlist stats — most-played songs, bustouts, and gap highlights.';
+    'Phish tour setlist stats — most-played songs, bustouts, and gap highlights. Updated every night the band plays live.';
   const canonical =
     route?.canonicalUrl ||
     `${SEO_CONFIG.siteUrl}/tour-stats/${screen.activeSlug}`;

--- a/src/shared/config/seo.js
+++ b/src/shared/config/seo.js
@@ -13,7 +13,7 @@ export const SEO_CONFIG = {
   publisherName: 'Road2 Media LLC',
   defaultTitle: "Setlist Pick'em | The Ultimate Live Music Prediction Game",
   defaultDescription:
-    "Setlist Pick 'Em is a free live setlist prediction game for Phish fans. Pick openers, closers, encore, and a wildcard before each show; scores update in real time as songs are played. Compete in a global pool or create private pools with friends.",
+    "Setlist Pick 'Em is a free live setlist prediction game built for Phish fans—and more bands soon. Lock openers, closers, encore, and a wildcard before each show; scores update live as songs are played. Tour insights refresh every night the band plays live. Play to unlock personal stats and compete with friends.",
   /** Absolute URL for Open Graph / Twitter cards (`public/branding/og-card-1200x630.jpg`). */
   ogImageUrl: `https://www.setlistpickem.com/branding/og-card-1200x630.jpg?v=${OG_IMAGE_VERSION}`,
   ogImageType: 'image/jpeg',

--- a/src/shared/config/seoRoutes.js
+++ b/src/shared/config/seoRoutes.js
@@ -472,7 +472,7 @@ export const PRERENDER_ROUTES = [
     canonicalUrl: KEYWORD_PAGE_URL,
     h1: 'The free Phish setlist prediction game',
     paragraphs: [
-      "Setlist Pick'Em (also called Setlist Pickem / Set Picks) is a live setlist prediction game built first for Phish fans—and designed for more bands soon.",
+      "Setlist Pick'Em (also called Setlist Pickem) is a live setlist prediction game built first for Phish fans—and designed for more bands soon.",
       'Predict songs and slots for tonight\'s show, compete with friends, and score live as the setlist unfolds.',
       'Tour stats refresh every night the band plays live. Playing unlocks personal stats as you accumulate points against other setlist pickers.',
     ],

--- a/src/shared/config/seoRoutes.js
+++ b/src/shared/config/seoRoutes.js
@@ -259,7 +259,7 @@ const KEYWORD_PAGE_PATH = '/phish-setlist-prediction-game';
 const KEYWORD_PAGE_TITLE =
   "Phish Setlist Prediction Game | Setlist Pick'Em";
 const KEYWORD_PAGE_DESCRIPTION =
-  "Setlist Pick'Em is the free Phish setlist prediction game: lock openers, closers, encore, and a wildcard before showtime, score live, and unlock personal stats as you compete. Built for Phish today—more bands soon.";
+  "Free Phish setlist prediction game and fantasy setlist picks—lock openers, closers, encore, and a wildcard before showtime, score live, and compete with friends. Built for jam bands; live with Phish today, more soon.";
 const KEYWORD_PAGE_URL = `${SEO_CONFIG.siteUrl}${KEYWORD_PAGE_PATH}`;
 
 function buildKeywordIntentPageJsonLd() {
@@ -282,7 +282,15 @@ function buildKeywordIntentPageJsonLd() {
             name: 'What is a setlist prediction game?',
             acceptedAnswer: {
               '@type': 'Answer',
-              text: "For jam bands like Phish, every night is a new setlist. A setlist prediction game asks fans to call songs and slots before the show. Setlist Pick'Em scores picks live as the setlist unfolds and ranks players in private pools and global standings—live with Phish today, with more bands ahead.",
+              text: "For jam bands like Phish, every night is a new setlist. A setlist prediction game—sometimes called a fantasy setlist game—asks fans to call songs and slots before the show. Setlist Pick'Em is a free setlist picks game that scores live and ranks players in private pools and global standings—live with Phish today, with more bands ahead.",
+            },
+          },
+          {
+            '@type': 'Question',
+            name: 'Is Setlist Pick\'Em a fantasy setlist game?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: "Yes—if you mean predicting setlists before the show and competing on points. Lock openers, closers, encore, and a wildcard, then score live as songs are played. No spreadsheet required.",
             },
           },
           {
@@ -290,7 +298,7 @@ function buildKeywordIntentPageJsonLd() {
             name: "How is Setlist Pick'Em different from a setlist archive?",
             acceptedAnswer: {
               '@type': 'Answer',
-              text: "Archives look back at what was played. Setlist Pick'Em is a free live prediction game: you make picks before the show, score as songs land, and build personal stats as you compete with other fans.",
+              text: "Archives look back at what was played. Setlist Pick'Em is about the night ahead: make your setlist picks before showtime, score as songs land, and build personal stats as you compete with other fans.",
             },
           },
           {
@@ -472,8 +480,8 @@ export const PRERENDER_ROUTES = [
     canonicalUrl: KEYWORD_PAGE_URL,
     h1: 'The free Phish setlist prediction game',
     paragraphs: [
-      "Setlist Pick'Em (also called Setlist Pickem) is a live setlist prediction game built first for Phish fans—and designed for more bands soon.",
-      'For jam bands like Phish, every night is a new setlist—so you predict songs and slots before showtime, compete with friends, and score live as the night unfolds.',
+      "Setlist Pick'Em is a free setlist picks game for fans who love predicting setlists—built first for Phish fans, and designed for more bands soon.",
+      'For jam bands like Phish, every night is a new setlist. A setlist prediction game—sometimes called a fantasy setlist game—asks you to call songs and slots before showtime, then score live as the night unfolds.',
       'Tour stats refresh every night the band plays live. Playing unlocks personal stats as you accumulate points against other setlist pickers.',
     ],
     buildJsonLd: buildKeywordIntentPageJsonLd,

--- a/src/shared/config/seoRoutes.js
+++ b/src/shared/config/seoRoutes.js
@@ -2,8 +2,8 @@
  * Public marketing SEO route registry — Helmet pages + build-time prerender (#659).
  *
  * Post-build `scripts/prerender-seo.mjs` writes crawler-visible HTML into `dist/`.
- * Public tour-stats (#665): `/tour-stats` + default Sphere slug; other tours
- * hydrate client-side from `public_tour_stats` (aggregates only).
+ * Public tour-stats (#665): `/tour-stats` (+ Sphere slug for SEO); other tours
+ * hydrate in the browser from public tour-stats docs.
  *
  * Do not list `/dashboard/*`, `/invite/*`, or `/join/*`.
  *
@@ -61,7 +61,7 @@ export const LANDING_FAQ_MAIN_ENTITY = [
     name: 'Which bands does it support today?',
     acceptedAnswer: {
       '@type': 'Answer',
-      text: 'The game is built for Phish tours. Support for additional acts may be added later.',
+      text: "We're live with Phish today, and Setlist Pick 'Em is built to grow into a home for more bands soon.",
     },
   },
   {
@@ -106,7 +106,7 @@ function buildHomeJsonLd() {
           {
             '@type': 'HowToStep',
             name: 'Watch It Unfold',
-            text: 'Watch the setlist and your scores update in real-time.',
+            text: 'Watch the setlist and your scores update live as songs are played.',
           },
           {
             '@type': 'HowToStep',
@@ -125,7 +125,7 @@ function buildHomeJsonLd() {
 
 const HOW_IT_WORKS_TITLE = "How to Play Setlist Pick'Em | The Live Music Prediction Game";
 const HOW_IT_WORKS_DESCRIPTION =
-  "Learn how Setlist Pick'Em works: lock your song picks before showtime, score points for openers, closers, encore, and wildcard predictions, and compete live on the leaderboard.";
+  "Learn how Setlist Pick'Em works: lock song picks before showtime, score live as the setlist unfolds, and unlock personal stats as you compete with other setlist pickers. Live with Phish today—more bands soon.";
 const HOW_IT_WORKS_URL = `${SEO_CONFIG.siteUrl}/how-it-works`;
 
 function buildHowItWorksJsonLd() {
@@ -155,13 +155,13 @@ function buildHowItWorksJsonLd() {
             '@type': 'HowToStep',
             position: 2,
             name: 'Watch It Unfold',
-            text: "Live scores and standings update in real-time as songs are played. See your picks and everyone else's light up the leaderboard.",
+            text: "Live scores and standings update as songs are played. See your picks and everyone else's light up the leaderboard.",
           },
           {
             '@type': 'HowToStep',
             position: 3,
             name: 'Claim the Crown',
-            text: 'Challenge friends in private pools and compete in global standings with everyone playing that night.',
+            text: 'Challenge friends in private pools and compete in global standings. Your personal stats grow with every show you play.',
           },
         ],
       },
@@ -175,12 +175,12 @@ const HOW_SCORING_URL = `${SEO_CONFIG.siteUrl}/how-scoring-works`;
 
 const TOUR_STATS_HUB_TITLE = "Phish Tour Stats | Setlist Pick'Em";
 const TOUR_STATS_HUB_DESCRIPTION =
-  "Aggregate Phish tour setlist stats — most-played songs, bustouts, and gap highlights. Starts with the Sphere run (when Setlist Pick 'Em launched); tours update as Phish.net publishes new dates.";
+  "Phish tour setlist stats for Setlist Pick 'Em fans — most-played songs, bustouts, and gap highlights. Updated every night the band plays live. Play the game to unlock personal stats.";
 const TOUR_STATS_HUB_URL = `${SEO_CONFIG.siteUrl}/tour-stats`;
 
 const TOUR_STATS_SPHERE_TITLE = "2026 Sphere Tour Stats | Setlist Pick'Em";
 const TOUR_STATS_SPHERE_DESCRIPTION =
-  "2026 Sphere setlist stats for Setlist Pick 'Em — most-played songs, bustouts, and gap highlights from the inaugural Pick'em tour. Aggregate song data only; not full nightly setlists.";
+  "2026 Sphere setlist stats for Setlist Pick 'Em — most-played songs, bustouts, and gap highlights from the inaugural tour. Updated after every live show night.";
 const TOUR_STATS_SPHERE_URL = `${SEO_CONFIG.siteUrl}/tour-stats/2026-sphere`;
 
 function buildTourStatsHubJsonLd() {
@@ -259,7 +259,7 @@ const KEYWORD_PAGE_PATH = '/phish-setlist-prediction-game';
 const KEYWORD_PAGE_TITLE =
   "Phish Setlist Prediction Game | Setlist Pick'Em";
 const KEYWORD_PAGE_DESCRIPTION =
-  "Setlist Pick'Em is the free Phish setlist prediction game: lock openers, closers, encore, and a wildcard before showtime, score live as songs are played, and compete with friends. Not a setlist archive — a game.";
+  "Setlist Pick'Em is the free Phish setlist prediction game: lock openers, closers, encore, and a wildcard before showtime, score live, and unlock personal stats as you compete. Built for Phish today—more bands soon.";
 const KEYWORD_PAGE_URL = `${SEO_CONFIG.siteUrl}${KEYWORD_PAGE_PATH}`;
 
 function buildKeywordIntentPageJsonLd() {
@@ -287,10 +287,10 @@ function buildKeywordIntentPageJsonLd() {
           },
           {
             '@type': 'Question',
-            name: 'How is Setlist Pick\'Em different from Phish.net or setlist.fm?',
+            name: "How is Setlist Pick'Em different from a setlist archive?",
             acceptedAnswer: {
               '@type': 'Answer',
-              text: 'Phish.net and setlist.fm are setlist archives and references. Setlist Pick\'Em is a free live prediction game that uses official setlist data for scoring — you compete before and during the show rather than only browsing what was played.',
+              text: "Archives look back at what was played. Setlist Pick'Em is a free live prediction game: you make picks before the show, score as songs land, and build personal stats as you compete with other fans.",
             },
           },
           {
@@ -403,11 +403,11 @@ export const PRERENDER_ROUTES = [
     title: SEO_CONFIG.defaultTitle,
     description: SEO_CONFIG.defaultDescription,
     canonicalUrl: `${SEO_CONFIG.siteUrl}/`,
-    h1: "Setlist Pick 'Em — the free live setlist prediction game for Phish fans",
+    h1: "Setlist Pick 'Em — the free live setlist prediction game for Phish fans (more bands soon)",
     paragraphs: [
-      'Predict the setlist. Win the night. Now live on Phish Tour.',
+      'Predict the setlist. Win the night. Now live on Phish Tour—and building toward more bands soon.',
       "Make picks for tonight's show, watch scores update as songs are played, and compete with your tour crew for the top spot.",
-      "Lock It In: predict openers, closers, encore, and a wildcard before the lights go down. Watch It Unfold as scores update in real time. Claim the Crown in the global pool or private pools with friends.",
+      "Lock It In: predict openers, closers, encore, and a wildcard before the lights go down. Watch It Unfold as scores update live. Claim the Crown in the global pool or private pools with friends. Play to unlock personal stats as you accumulate points.",
     ],
     buildJsonLd: buildHomeJsonLd,
   },
@@ -418,9 +418,10 @@ export const PRERENDER_ROUTES = [
     canonicalUrl: HOW_IT_WORKS_URL,
     h1: "How to Play Setlist Pick'Em",
     paragraphs: [
-      'The free live setlist prediction game for Phish fans. Lock your picks before the lights go down, score as the setlist unfolds, and compete with friends.',
+      'The free live setlist prediction game for Phish fans—and a home for more bands soon. Lock your picks before the lights go down, score as the setlist unfolds, and compete with friends.',
+      'We track key tour insights and refresh them every night the band plays live. Sign in to unlock personal stats as you earn points against other setlist pickers.',
       'Lock It In: Pick openers, closers, encore, and a wildcard before showtime.',
-      'Watch It Unfold: Live scores and standings update in real-time as songs are played.',
+      'Watch It Unfold: Live scores and standings update as songs are played.',
       'Claim the Crown: Challenge friends in private pools and compete in global standings.',
     ],
     buildJsonLd: buildHowItWorksJsonLd,
@@ -445,9 +446,9 @@ export const PRERENDER_ROUTES = [
     canonicalUrl: TOUR_STATS_HUB_URL,
     h1: 'Phish tour setlist stats',
     paragraphs: [
-      'Aggregate song frequency, bustouts, and gap highlights for each Phish tour — the same non-personal stats players use when locking picks.',
-      'We start with the Sphere run (when Setlist Pick \'Em launched) and add tours as Phish.net publishes new dates on the calendar.',
-      'Full nightly setlists stay in the signed-in app. This page never lists an entire show\'s set — only tour-level song datasets.',
+      'We track the setlist stories that help you make better picks—most-played songs, bustouts, and gap highlights for each Phish tour.',
+      'Stats refresh every night the band plays live. Playing the game unlocks your personal stats as you rack up points against other setlist pickers.',
+      'We\'re starting with Phish and building toward more bands soon. This page focuses on tour-wide song trends—not a full night-by-night setlist archive.',
     ],
     buildJsonLd: buildTourStatsHubJsonLd,
   },
@@ -458,9 +459,9 @@ export const PRERENDER_ROUTES = [
     canonicalUrl: TOUR_STATS_SPHERE_URL,
     h1: '2026 Sphere tour stats',
     paragraphs: [
-      'Most-played songs, bustouts, and gap highlights from the 2026 Sphere run — the inaugural Setlist Pick \'Em tour.',
-      'Tour names and dates sync from Phish.net as new shows publish so stats stay current while you make picks for every show.',
-      'Aggregate song data only — not night-by-night full setlists.',
+      'Most-played songs, bustouts, and gap highlights from the 2026 Sphere run—the inaugural Setlist Pick \'Em tour.',
+      'Stats refresh every night the band plays live, so the picture keeps getting sharper as you make picks.',
+      'Tour-wide song trends for fans—play the game to unlock personal stats as you compete.',
     ],
     buildJsonLd: buildTourStatsSphereJsonLd,
   },
@@ -471,9 +472,9 @@ export const PRERENDER_ROUTES = [
     canonicalUrl: KEYWORD_PAGE_URL,
     h1: 'The free Phish setlist prediction game',
     paragraphs: [
-      "Setlist Pick'Em (also called Setlist Pickem / Set Picks) is a live setlist prediction game for Phish fans: lock openers, closers, encore, and a wildcard before showtime, then score as the setlist unfolds.",
-      'A Phish setlist game asks you to predict songs and slots for tonight\'s show—not to archive what already happened. You compete against friends in private pools and against everyone on the global board.',
-      'Sites like Phish.net and setlist.fm are outstanding archives. Setlist Pick\'Em is a game layer: you make picks before the lights go down and earn points as songs are played.',
+      "Setlist Pick'Em (also called Setlist Pickem / Set Picks) is a live setlist prediction game built first for Phish fans—and designed for more bands soon.",
+      'Predict songs and slots for tonight\'s show, compete with friends, and score live as the setlist unfolds.',
+      'Tour stats refresh every night the band plays live. Playing unlocks personal stats as you accumulate points against other setlist pickers.',
     ],
     buildJsonLd: buildKeywordIntentPageJsonLd,
   },

--- a/src/shared/config/seoRoutes.js
+++ b/src/shared/config/seoRoutes.js
@@ -279,10 +279,10 @@ function buildKeywordIntentPageJsonLd() {
         mainEntity: [
           {
             '@type': 'Question',
-            name: 'What is a Phish setlist prediction game?',
+            name: 'What is a setlist prediction game?',
             acceptedAnswer: {
               '@type': 'Answer',
-              text: "A Phish setlist prediction game asks fans to predict songs and slots before the show. Setlist Pick'Em scores picks live as the setlist unfolds and ranks players in private pools and global standings.",
+              text: "For jam bands like Phish, every night is a new setlist. A setlist prediction game asks fans to call songs and slots before the show. Setlist Pick'Em scores picks live as the setlist unfolds and ranks players in private pools and global standings—live with Phish today, with more bands ahead.",
             },
           },
           {
@@ -473,7 +473,7 @@ export const PRERENDER_ROUTES = [
     h1: 'The free Phish setlist prediction game',
     paragraphs: [
       "Setlist Pick'Em (also called Setlist Pickem) is a live setlist prediction game built first for Phish fans—and designed for more bands soon.",
-      'Predict songs and slots for tonight\'s show, compete with friends, and score live as the setlist unfolds.',
+      'For jam bands like Phish, every night is a new setlist—so you predict songs and slots before showtime, compete with friends, and score live as the night unfolds.',
       'Tour stats refresh every night the band plays live. Playing unlocks personal stats as you accumulate points against other setlist pickers.',
     ],
     buildJsonLd: buildKeywordIntentPageJsonLd,

--- a/src/shared/ui/surfaceLinkStyles.js
+++ b/src/shared/ui/surfaceLinkStyles.js
@@ -1,0 +1,26 @@
+/**
+ * Readable secondary hyperlinks on dark vs light surfaces.
+ * Prefer these over muted slate text for in-page / marketing navigation.
+ */
+
+/** Inline links on dark backgrounds (teal reads as a link, not muted chrome). */
+export const LINK_ON_DARK =
+  'rounded-sm font-semibold text-teal-300 underline decoration-teal-500/70 underline-offset-4 transition-colors hover:text-teal-200 hover:decoration-teal-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue';
+
+/** Compact header chrome on dark. */
+export const HEADER_LINK_ON_DARK =
+  'rounded-sm text-xs font-semibold text-slate-200 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue lg:text-sm';
+
+export const HEADER_LINK_ACTIVE = 'text-white';
+
+/** Footer / legal on dark. */
+export const FOOTER_LINK_ON_DARK =
+  'font-medium text-slate-300 underline decoration-slate-500 underline-offset-2 transition-colors hover:text-teal-300 hover:decoration-teal-400';
+
+/** Inline links on light pages (slate-50 marketing). */
+export const LINK_ON_LIGHT =
+  'font-semibold text-emerald-700 underline decoration-emerald-300 underline-offset-2 transition-colors hover:text-emerald-800 hover:decoration-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue';
+
+/** Card “learn more” row on light. */
+export const CARD_LINK_ON_LIGHT =
+  'mt-4 inline-flex items-center gap-1 rounded-md text-sm font-bold text-emerald-700 underline decoration-emerald-300 underline-offset-4 transition-colors hover:text-emerald-800 hover:decoration-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue';


### PR DESCRIPTION
## Summary
- Rewrites public tour-stats, how-it-works, keyword page, splash how-it-works, `llms.txt`, and meta/OG mirrors so stats refresh **every night the band plays live** (never “when Phish.net publishes”).
- Emphasizes always-updating fan insights and **personal stats** unlocked by playing / competing with other setlist pickers.
- Frames Phish as the live start of a multi-band destination; keeps GEO/SEO keywords without technical jargon.

## Test plan
- [ ] `/tour-stats` intro copy matches the new cadence + personal-stats framing
- [ ] `/how-it-works` and splash “Game Format” cards align
- [ ] `/phish-setlist-prediction-game` still reads as keyword-aware but personal
- [ ] View-source / prerender: meta descriptions and FAQ JSON-LD have no Phish.net-publish language
- [ ] Footer Phish.Net attribution still present as data credit only


Made with [Cursor](https://cursor.com)