### PR TITLE
feat(standings): ship crowd pulse productization (#694)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.35.2] — 2026-07-20
+
+### Changed
+- **Crowd pulse ship (#694)** — drop Standings “prototype” label; final chrome/copy; extract `FrequencyMeterRow`; blur gate helper + tests. Stats deep-dive / picks helper remain on #694 P1–P2.
+
+---
+
 ## [1.35.1] — 2026-07-20
 
 ### Changed
@@ -24,7 +31,7 @@ No unreleased changes.
 ## [1.35.0] — 2026-07-20
 
 ### Added
-- **Crowd pulse on Standings Show (#687 / #689)** — pre-show summary of tonight’s multi-picker songs (frequency meters); deep stats (gap, vintage, tour leaders) blur until picks lock. Feature module `src/features/crowd-picks/`. Further Stats page / helper work parked in #694.
+- **Crowd pulse on Standings Show (#687 / #689)** — pre-show summary of tonight’s multi-picker songs (frequency meters); deep stats (gap, vintage, tour leaders) blur until picks lock. Feature module `src/features/crowd-picks/`. Standings productization in **1.35.2** (#694); Stats page / helper remain #694 P1–P2.
 - **Internal picks rollup report (#687)** — `functions/scripts/picksRollupReport.js` + methodology under `docs/picks-rollup/` for nightly picker volume and song insights.
 
 ---

--- a/docs/picks-rollup/04-prelock-disclosure.md
+++ b/docs/picks-rollup/04-prelock-disclosure.md
@@ -1,6 +1,8 @@
-# Pre-lock disclosure: crowd pulse (#689)
+# Pre-lock disclosure: crowd pulse (#689 / #694)
 
 **Decision (2026-07-20):** Pre-lock, **top songs stay visible**; gap / vintage / leaders / full tables **blur until showtime** (picks lock → LIVE).
+
+**Ship status:** Standings crowd pulse productized in #694 (no “prototype” label). Stats deep-dive + picks helper remain P1/P2 on that issue.
 
 ## Product split
 
@@ -20,12 +22,13 @@ Rationale: named chalk is the engagement hook (“the room is on X”); deep cat
 
 ## UI notes
 
-- Top songs use profile-style **frequency meters** (Standings brand gradient, not profile red→blue).
+- Top songs use **frequency meters** via `crowd-picks/ui/FrequencyMeterRow` (Standings brand gradient).
 - Blur is presentation-only; aggregators still compute (needed for unlock + CLI).
-- Gate: `blurDeepStats={showStatus === 'NEXT'}` on `CrowdNightPulsePanel`.
+- Gate: `blurDeepStats={showStatus === 'NEXT'}` on `CrowdNightPulsePanel` (wired in `StandingsCrowdPulse`).
 
 ## Out of scope (later)
 
 - Opt-out pref for competitive players (“hide crowd pulse”)
 - Picks helper: live consensus chips only post-lock; historical tour chalk pre-lock
 - Telemetry: teaser expand attempts vs post-lock full expand
+- Link to dedicated Stats surface (P1 on #694)

--- a/docs/picks-rollup/README.md
+++ b/docs/picks-rollup/README.md
@@ -8,8 +8,8 @@ Internal analytics for **nightly picker volume** and **crowd pick composition**.
 |-------|------|--------|
 | **A** | Admin report script + methodology | Done (PR #688) |
 | **B** | Human review of Summer Tour reports | Done — see [02-phase-b-review.md](./02-phase-b-review.md) |
-| **C** | Stats candidates + C1–C3 + UI prototype | Spec [#689](https://github.com/pat792/set-picks/issues/689); pre-lock [04-prelock-disclosure.md](./04-prelock-disclosure.md) |
-| **Parked** | Stats page, helper, ship polish | [#694](https://github.com/pat792/set-picks/issues/694) |
+| **C** | Stats candidates + C1–C3 + Standings UI | Spec [#689](https://github.com/pat792/set-picks/issues/689); pre-lock [04-prelock-disclosure.md](./04-prelock-disclosure.md); **Standings ship** [#694](https://github.com/pat792/set-picks/issues/694) P0 |
+| **Later** | Stats page deep dive, picks helper | [#694](https://github.com/pat792/set-picks/issues/694) P1–P2 |
 
 ## Data spine
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.35.1",
+  "version": "1.35.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/crowd-picks/index.js
+++ b/src/features/crowd-picks/index.js
@@ -14,4 +14,7 @@ export {
   aggregateLeadersTonightPicks,
 } from './model/aggregateLeadersTonightPicks';
 export { useCrowdNightStats } from './model/useCrowdNightStats';
+export { meterIntensity } from './model/meterIntensity';
+export { shouldBlurDeepCrowdStats } from './model/shouldBlurDeepCrowdStats';
 export { default as CrowdNightPulsePanel } from './ui/CrowdNightPulsePanel';
+export { default as FrequencyMeterRow } from './ui/FrequencyMeterRow';

--- a/src/features/crowd-picks/model/meterIntensity.js
+++ b/src/features/crowd-picks/model/meterIntensity.js
@@ -1,0 +1,14 @@
+/**
+ * Relative bar fill for frequency meters (crowd pulse / similar strips).
+ * Floors at 0.12 so tiny counts stay visible.
+ *
+ * @param {number} count
+ * @param {number} max
+ * @returns {number} 0–1
+ */
+export function meterIntensity(count, max) {
+  const c = typeof count === 'number' ? count : 0;
+  const m = typeof max === 'number' ? max : 0;
+  if (m <= 0) return 0.12;
+  return Math.max(0.12, c / m);
+}

--- a/src/features/crowd-picks/model/meterIntensity.test.js
+++ b/src/features/crowd-picks/model/meterIntensity.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { meterIntensity } from './meterIntensity';
+
+describe('meterIntensity (#694)', () => {
+  it('floors tiny shares so the bar stays visible', () => {
+    expect(meterIntensity(1, 100)).toBe(0.12);
+  });
+
+  it('scales to max', () => {
+    expect(meterIntensity(5, 5)).toBe(1);
+    expect(meterIntensity(2, 4)).toBe(0.5);
+  });
+
+  it('handles empty max', () => {
+    expect(meterIntensity(3, 0)).toBe(0.12);
+  });
+});

--- a/src/features/crowd-picks/model/shouldBlurDeepCrowdStats.js
+++ b/src/features/crowd-picks/model/shouldBlurDeepCrowdStats.js
@@ -1,0 +1,10 @@
+/**
+ * Pre-lock disclosure gate (#689 / #694).
+ * Deep crowd stats stay blurred while picks are still editable.
+ *
+ * @param {string} [showStatus]
+ * @returns {boolean}
+ */
+export function shouldBlurDeepCrowdStats(showStatus) {
+  return showStatus === 'NEXT';
+}

--- a/src/features/crowd-picks/model/shouldBlurDeepCrowdStats.test.js
+++ b/src/features/crowd-picks/model/shouldBlurDeepCrowdStats.test.js
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldBlurDeepCrowdStats } from './shouldBlurDeepCrowdStats';
+
+describe('shouldBlurDeepCrowdStats (#694 / #689)', () => {
+  it('blurs only while picks are still editable (NEXT)', () => {
+    expect(shouldBlurDeepCrowdStats('NEXT')).toBe(true);
+    expect(shouldBlurDeepCrowdStats('LIVE')).toBe(false);
+    expect(shouldBlurDeepCrowdStats('PAST')).toBe(false);
+    expect(shouldBlurDeepCrowdStats('')).toBe(false);
+  });
+});

--- a/src/features/crowd-picks/model/useCrowdNightStats.js
+++ b/src/features/crowd-picks/model/useCrowdNightStats.js
@@ -13,7 +13,7 @@ import {
 } from './aggregateLeadersTonightPicks';
 
 /**
- * Compose C1–C3 crowd night stats for a show date (prototype / #689).
+ * Compose C1–C3 crowd night stats for a show date (#694 / Standings).
  *
  * @param {string} showDate
  * @param {Array<Record<string, unknown>> | null | undefined} pickDocs

--- a/src/features/crowd-picks/ui/CrowdNightPulsePanel.jsx
+++ b/src/features/crowd-picks/ui/CrowdNightPulsePanel.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { ChevronDown, Lock } from 'lucide-react';
 
+import FrequencyMeterRow from './FrequencyMeterRow';
+
 /**
- * Crowd pulse summary + expandable deep analysis (C4 prototype).
+ * Crowd pulse summary + expandable deep analysis (#694 ship).
  * Pre-lock (NEXT): top multi-picker songs stay visible; gap / vintage /
  * leaders blur until showtime. Presentational — data from `useCrowdNightStats`.
  *
@@ -31,7 +33,7 @@ export default function CrowdNightPulsePanel({
         aria-label="Crowd pulse"
       >
         <p className="text-[10px] font-black uppercase tracking-widest text-content-secondary">
-          Crowd pulse · prototype
+          Crowd pulse
         </p>
         <p className="mt-1 text-[11px] font-medium text-content-secondary md:text-xs">
           No submitted picks for this show yet.
@@ -58,9 +60,14 @@ export default function CrowdNightPulsePanel({
       aria-label="Crowd pulse"
     >
       <div className="flex flex-wrap items-baseline justify-between gap-2">
-        <p className="text-[10px] font-black uppercase tracking-widest text-brand-primary">
-          Crowd pulse · prototype
-        </p>
+        <div>
+          <p className="text-[10px] font-black uppercase tracking-widest text-brand-primary">
+            Crowd pulse
+          </p>
+          <p className="mt-0.5 text-[10px] font-medium text-content-secondary">
+            Songs more than one picker locked in
+          </p>
+        </div>
         <p className="text-[10px] font-semibold text-content-secondary">
           {card.pickers} pickers · {card.uniqueSongs} songs
         </p>
@@ -68,31 +75,15 @@ export default function CrowdNightPulsePanel({
 
       {card.topMulti.length > 0 ? (
         <ul className="mt-2.5 space-y-2">
-          {card.topMulti.map((s) => {
-            const intensity =
-              maxCards > 0 ? Math.max(0.12, s.cardCount / maxCards) : 0.12;
-            return (
-              <li key={s.title}>
-                <div className="flex items-baseline justify-between gap-3 text-[11px] md:text-xs">
-                  <span className="min-w-0 truncate font-semibold text-white">
-                    {s.title}
-                  </span>
-                  <span className="shrink-0 font-medium tabular-nums text-content-secondary">
-                    {s.cardCount} · {s.pctOfPickers}%
-                  </span>
-                </div>
-                <div
-                  className="mt-1 h-1.5 overflow-hidden rounded-full bg-surface-field"
-                  aria-hidden
-                >
-                  <div
-                    className="h-full rounded-full bg-gradient-to-r from-brand-primary/90 to-brand-primary/40"
-                    style={{ width: `${Math.round(intensity * 100)}%` }}
-                  />
-                </div>
-              </li>
-            );
-          })}
+          {card.topMulti.map((s) => (
+            <FrequencyMeterRow
+              key={s.title}
+              title={s.title}
+              meta={`${s.cardCount} · ${s.pctOfPickers}%`}
+              count={s.cardCount}
+              maxCount={maxCards}
+            />
+          ))}
         </ul>
       ) : (
         <p className="mt-2 text-[11px] text-content-secondary">

--- a/src/features/crowd-picks/ui/FrequencyMeterRow.jsx
+++ b/src/features/crowd-picks/ui/FrequencyMeterRow.jsx
@@ -1,0 +1,42 @@
+import { meterIntensity } from '../model/meterIntensity';
+
+/**
+ * One song row with label, count line, and intensity meter (#694).
+ * Standings uses brand gradient; profile strip keeps its own colors.
+ *
+ * @param {object} props
+ * @param {string} props.title
+ * @param {string} props.meta — right-side tabular label (e.g. "3 · 42%")
+ * @param {number} props.count
+ * @param {number} props.maxCount
+ * @param {string} [props.titleClassName]
+ * @param {string} [props.metaClassName]
+ */
+export default function FrequencyMeterRow({
+  title,
+  meta,
+  count,
+  maxCount,
+  barClassName = 'bg-gradient-to-r from-brand-primary/90 to-brand-primary/40',
+  titleClassName = 'font-semibold text-white',
+  metaClassName = 'font-medium tabular-nums text-content-secondary',
+}) {
+  const intensity = meterIntensity(count, maxCount);
+  return (
+    <li>
+      <div className="flex items-baseline justify-between gap-3 text-[11px] md:text-xs">
+        <span className={`min-w-0 truncate ${titleClassName}`}>{title}</span>
+        <span className={`shrink-0 ${metaClassName}`}>{meta}</span>
+      </div>
+      <div
+        className="mt-1 h-1.5 overflow-hidden rounded-full bg-surface-field"
+        aria-hidden
+      >
+        <div
+          className={`h-full rounded-full ${barClassName}`}
+          style={{ width: `${Math.round(intensity * 100)}%` }}
+        />
+      </div>
+    </li>
+  );
+}

--- a/src/features/scoring/ui/StandingsCrowdPulse.jsx
+++ b/src/features/scoring/ui/StandingsCrowdPulse.jsx
@@ -2,12 +2,16 @@ import React from 'react';
 
 import {
   CrowdNightPulsePanel,
+  shouldBlurDeepCrowdStats,
   useCrowdNightStats,
 } from '../../crowd-picks';
 
 /**
- * Standings wiring for crowd pulse prototype — keeps Firestore-derived
+ * Standings wiring for crowd pulse (#694) — keeps Firestore-derived
  * picks/tour leaders in scoring while presentation lives in crowd-picks.
+ *
+ * Blur gate: `showStatus === 'NEXT'` → deep stats locked until showtime
+ * (LIVE/PAST). See `docs/picks-rollup/04-prelock-disclosure.md`.
  *
  * @param {object} props
  * @param {string} props.showDate
@@ -36,7 +40,7 @@ export default function StandingsCrowdPulse({
       catalog={catalog}
       leaders={leaders}
       catalogLoading={catalogLoading}
-      blurDeepStats={showStatus === 'NEXT'}
+      blurDeepStats={shouldBlurDeepCrowdStats(showStatus)}
     />
   );
 }


### PR DESCRIPTION
Closes #694 (P0 Standings ship; P1–P2 stay open on the issue for Stats/helper).

## Summary
- Remove “prototype” label; final Standings copy/chrome
- Extract `FrequencyMeterRow` + `meterIntensity`
- Encode blur gate as `shouldBlurDeepCrowdStats` (`NEXT` only) with unit tests
- Docs: disclosure + picks-rollup README status
- PATCH `1.35.2`

## Test plan
- [x] `npm test -- src/features/crowd-picks`
- [x] lint clean on touched paths
- [ ] Standings Show on preview: NEXT → deep stats blurred; LIVE/PAST → clear
- [ ] Empty / no multi-picker states still read cleanly


Made with [Cursor](https://cursor.com)