### PR TITLE
Promote staging → main (v1.35.3 crowd pulse polish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ No unreleased changes.
 
 ---
 
+## [1.35.3] — 2026-07-20
+
+### Added
+- **Crowd pulse GA4 (#694)** — `crowd_pulse_view`, `crowd_pulse_full_expand`, `crowd_pulse_section_open` on Standings (see `docs/API.md`).
+
+### Changed
+- **Crowd pulse Standings polish (#694)** — top-5 Song · Pickers · Gap · Last table; full-stats expandable sections; setlist-hit highlight; frozen `songGaps` preferred over live catalog for historical nights.
+
+### Fixed
+- **Crowd pulse gap on past shows** — use `official_setlists.songGaps` pre-show gap so played titles match the setlist card instead of post-play catalog reset.
+
+---
+
 ## [1.35.2] — 2026-07-20
 
 ### Changed

--- a/docs/API.md
+++ b/docs/API.md
@@ -369,7 +369,7 @@ These routes are part of the public surface. Renaming or removing them is a MAJO
 
 Dashboard sub-routes are documented in `docs/DASHBOARD_IA.md`. Notable secondary route: **`/dashboard/tour-stats`** (**v1.30.0 / #555**) — private tour stats explorer (unique songs, frequency, bustouts, self pick overlay). Peer Standings chrome tab (**Stats** alongside Show / Tour / Pools); shares tour scope (`?tour=`) with Tour view. Standings nav stays active. **Public** counterpart: **`/tour-stats`** (**v1.33.0 / #665**) — aggregates only, no self overlay, not under `/dashboard/`.
 
-**Standings Show — Crowd pulse (**v1.35.0 / #687**):** client-side aggregate of submitted picks for the selected `showDate` (multi-picker songs always; gap / vintage / leaders blurred while `showStatus === 'NEXT'`). No new Firestore collection or callable. Productization follow-ups: #694.
+**Standings Show — Crowd pulse (**v1.35.0 / #687**, productized **#694**):** client-side aggregate of submitted picks for the selected `showDate` (multi-picker songs always; gap / vintage / leaders blurred while `showStatus === 'NEXT'`). No new Firestore collection or callable. **GA4 (client):** `crowd_pulse_view` `{ show_date, deep_stats: locked|open, pickers }`, `crowd_pulse_full_expand` `{ show_date }`, `crowd_pulse_section_open` `{ show_date, section }` where `section` is `multi_picker` | `highest_gaps` | `vintage` | `leaders`.
 
 ### 3.1 Email CTA click-through host (`click.setlistpickem.com`)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.35.2",
+  "version": "1.35.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/crowd-picks/index.js
+++ b/src/features/crowd-picks/index.js
@@ -1,11 +1,14 @@
 export {
   aggregateCrowdNightSongs,
   crowdNightCardSummary,
+  enrichSongRowsWithCatalog,
+  enrichTopMultiWithCatalog,
 } from './model/aggregateCrowdNightSongs';
 export {
   aggregateCrowdNightCatalog,
   buildCatalogLookups,
   computeSlotWeightedVintage,
+  mergeCrowdGapByName,
   parseCatalogGap,
   rankCrowdNightByGap,
 } from './model/aggregateCrowdNightCatalog';
@@ -13,8 +16,22 @@ export {
   LEADERS_TOP_K,
   aggregateLeadersTonightPicks,
 } from './model/aggregateLeadersTonightPicks';
-export { useCrowdNightStats } from './model/useCrowdNightStats';
+export {
+  CROWD_PULSE_TOP_N,
+  useCrowdNightStats,
+} from './model/useCrowdNightStats';
 export { meterIntensity } from './model/meterIntensity';
+export { formatCatalogLastShort } from './model/formatCatalogLastShort';
 export { shouldBlurDeepCrowdStats } from './model/shouldBlurDeepCrowdStats';
+export {
+  trackCrowdPulseView,
+  trackCrowdPulseFullExpand,
+  trackCrowdPulseSectionOpen,
+} from './model/crowdPulseAnalytics';
+export {
+  buildOfficialPlayedTitleSet,
+  isCrowdSongPlayed,
+} from './model/buildOfficialPlayedTitleSet';
 export { default as CrowdNightPulsePanel } from './ui/CrowdNightPulsePanel';
+export { default as CrowdPulseTopTable } from './ui/CrowdPulseTopTable';
 export { default as FrequencyMeterRow } from './ui/FrequencyMeterRow';

--- a/src/features/crowd-picks/model/aggregateCrowdNightCatalog.js
+++ b/src/features/crowd-picks/model/aggregateCrowdNightCatalog.js
@@ -21,10 +21,11 @@ export function parseCatalogGap(gap) {
 }
 
 /**
- * @param {{ name?: unknown, gap?: unknown, debut?: unknown }[] | null | undefined} songs
+ * @param {{ name?: unknown, gap?: unknown, debut?: unknown, last?: unknown }[] | null | undefined} songs
  * @returns {{
  *   gapByName: Map<string, number>,
  *   debutYearByName: Map<string, number>,
+ *   lastByName: Map<string, string>,
  * }}
  */
 export function buildCatalogLookups(songs) {
@@ -32,7 +33,11 @@ export function buildCatalogLookups(songs) {
   const gapByName = new Map();
   /** @type {Map<string, number>} */
   const debutYearByName = new Map();
-  if (!Array.isArray(songs)) return { gapByName, debutYearByName };
+  /** @type {Map<string, string>} */
+  const lastByName = new Map();
+  if (!Array.isArray(songs)) {
+    return { gapByName, debutYearByName, lastByName };
+  }
   for (const song of songs) {
     const name =
       typeof song?.name === 'string' ? song.name.trim().toLowerCase() : '';
@@ -45,8 +50,46 @@ export function buildCatalogLookups(songs) {
       const y = debutYearFromCatalogDebut(song?.debut);
       if (y != null) debutYearByName.set(name, y);
     }
+    if (!lastByName.has(name) && typeof song?.last === 'string') {
+      const last = song.last.trim();
+      if (last && last !== '—' && last !== '-') {
+        lastByName.set(name, last);
+      }
+    }
   }
-  return { gapByName, debutYearByName };
+  return { gapByName, debutYearByName, lastByName };
+}
+
+/**
+ * Merge live catalog gaps with per-show frozen pre-show gaps
+ * (`official_setlists.songGaps`, #587). Frozen values win so historical
+ * nights match Standings / Tour Stats instead of post-play catalog resets.
+ *
+ * @param {Map<string, number>} catalogGapByName
+ * @param {Map<string, number> | Record<string, number> | null | undefined} frozenGaps
+ * @returns {Map<string, number>}
+ */
+export function mergeCrowdGapByName(catalogGapByName, frozenGaps) {
+  const out = new Map(
+    catalogGapByName instanceof Map ? catalogGapByName : new Map()
+  );
+  if (!frozenGaps) return out;
+  const entries =
+    frozenGaps instanceof Map
+      ? frozenGaps.entries()
+      : typeof frozenGaps === 'object' && !Array.isArray(frozenGaps)
+        ? Object.entries(frozenGaps)
+        : [];
+  for (const [rawKey, rawVal] of entries) {
+    const key = String(rawKey ?? '')
+      .trim()
+      .toLowerCase();
+    const gap =
+      typeof rawVal === 'number' ? rawVal : Number(rawVal);
+    if (!key || !Number.isFinite(gap) || gap < 0) continue;
+    out.set(key, Math.trunc(gap));
+  }
+  return out;
 }
 
 /**
@@ -153,7 +196,10 @@ export function computeSlotWeightedVintage(submittedDocs, debutYearByName) {
 /**
  * @param {import('./aggregateCrowdNightSongs').CrowdNightSongStats} nightStats
  * @param {{ name?: unknown, gap?: unknown, debut?: unknown }[] | null | undefined} catalogSongs
- * @param {{ gapTopN?: number }} [options]
+ * @param {{
+ *   gapTopN?: number,
+ *   frozenGaps?: Map<string, number> | Record<string, number> | null,
+ * }} [options]
  */
 export function aggregateCrowdNightCatalog(nightStats, catalogSongs, options = {}) {
   const { gapByName, debutYearByName } = buildCatalogLookups(catalogSongs);
@@ -161,8 +207,9 @@ export function aggregateCrowdNightCatalog(nightStats, catalogSongs, options = {
     typeof options.gapTopN === 'number' && options.gapTopN > 0
       ? Math.trunc(options.gapTopN)
       : 10;
+  const gapLookup = mergeCrowdGapByName(gapByName, options.frozenGaps);
   return {
-    highestGap: rankCrowdNightByGap(nightStats?.songs, gapByName, {
+    highestGap: rankCrowdNightByGap(nightStats?.songs, gapLookup, {
       topN: gapTopN,
     }),
     vintage: computeSlotWeightedVintage(

--- a/src/features/crowd-picks/model/aggregateCrowdNightCatalog.test.js
+++ b/src/features/crowd-picks/model/aggregateCrowdNightCatalog.test.js
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { aggregateCrowdNightSongs } from './aggregateCrowdNightSongs';
 import {
   aggregateCrowdNightCatalog,
+  mergeCrowdGapByName,
   parseCatalogGap,
   rankCrowdNightByGap,
   computeSlotWeightedVintage,
@@ -14,6 +15,18 @@ describe('parseCatalogGap', () => {
     expect(parseCatalogGap('12')).toBe(12);
     expect(parseCatalogGap('—')).toBeNull();
     expect(parseCatalogGap('')).toBeNull();
+  });
+});
+
+describe('mergeCrowdGapByName', () => {
+  it('lets frozen pre-show gaps override catalog', () => {
+    const catalog = new Map([
+      ['ghost', 0],
+      ['free', 20],
+    ]);
+    const merged = mergeCrowdGapByName(catalog, { ghost: 47 });
+    expect(merged.get('ghost')).toBe(47);
+    expect(merged.get('free')).toBe(20);
   });
 });
 
@@ -63,6 +76,20 @@ describe('aggregateCrowdNightCatalog (#691)', () => {
     expect(highestGap[0].title).toBe('Ghost');
     expect(highestGap[0].gap).toBe(100);
     expect(highestGap.every((r) => typeof r.gap === 'number')).toBe(true);
+  });
+
+  it('prefers frozen pre-show songGaps over live catalog gap', () => {
+    const night = aggregateCrowdNightSongs('2026-07-17', docs);
+    // Catalog already refreshed post-show (Ghost gap reset to 0).
+    const postShowCatalog = catalog.map((s) =>
+      s.name === 'Ghost' ? { ...s, gap: '0' } : s
+    );
+    const { highestGap } = aggregateCrowdNightCatalog(night, postShowCatalog, {
+      gapTopN: 3,
+      frozenGaps: { ghost: 47 },
+    });
+    expect(highestGap[0].title).toBe('Ghost');
+    expect(highestGap[0].gap).toBe(47);
   });
 
   it('computes slot-weighted vintage', () => {

--- a/src/features/crowd-picks/model/aggregateCrowdNightSongs.js
+++ b/src/features/crowd-picks/model/aggregateCrowdNightSongs.js
@@ -1,6 +1,8 @@
 import { FORM_FIELDS } from '../../../shared/data/gameConfig';
 import { hasNonEmptyPicksObject } from '../../../shared/utils/showAggregation';
 
+import { buildCatalogLookups, mergeCrowdGapByName } from './aggregateCrowdNightCatalog';
+
 const SLOT_IDS = FORM_FIELDS.map((f) => f.id);
 
 /**
@@ -114,7 +116,7 @@ export function crowdNightCardSummary(stats, options = {}) {
   const topN =
     typeof options.topN === 'number' && options.topN > 0
       ? Math.trunc(options.topN)
-      : 3;
+      : 5;
   return {
     pickers: stats.pickers,
     uniqueSongs: stats.uniqueSongs,
@@ -124,4 +126,51 @@ export function crowdNightCardSummary(stats, options = {}) {
       pctOfPickers: s.pctOfPickers,
     })),
   };
+}
+
+/**
+ * Attach gap + last-played onto crowd song rows (preserves extra fields).
+ * Prefer frozen per-show `songGaps` (pre-show) over live catalog gap so
+ * historical nights match Standings / Tour Stats (#587).
+ *
+ * @template {{ title?: string, gap?: number | null }} T
+ * @param {T[] | null | undefined} rows
+ * @param {{ name?: unknown, gap?: unknown, last?: unknown }[] | null | undefined} catalogSongs
+ * @param {{
+ *   frozenGaps?: Map<string, number> | Record<string, number> | null,
+ * }} [options]
+ * @returns {Array<T & { gap: number | null, last: string | null }>}
+ */
+export function enrichSongRowsWithCatalog(rows, catalogSongs, options = {}) {
+  const { gapByName, lastByName } = buildCatalogLookups(catalogSongs);
+  const gapLookup = mergeCrowdGapByName(gapByName, options.frozenGaps);
+  return (Array.isArray(rows) ? rows : []).map((s) => {
+    const key = typeof s?.title === 'string' ? s.title.trim().toLowerCase() : '';
+    const gapFromLookup = key ? gapLookup.get(key) : undefined;
+    const last = key ? lastByName.get(key) : undefined;
+    const gap =
+      typeof gapFromLookup === 'number'
+        ? gapFromLookup
+        : typeof s?.gap === 'number'
+          ? s.gap
+          : null;
+    return {
+      ...s,
+      gap,
+      last: typeof last === 'string' ? last : null,
+    };
+  });
+}
+
+/**
+ * Attach catalog gap + last-played onto card top rows.
+ *
+ * @param {Array<{ title: string, cardCount: number, pctOfPickers: number }>} topMulti
+ * @param {{ name?: unknown, gap?: unknown, last?: unknown }[] | null | undefined} catalogSongs
+ * @param {{
+ *   frozenGaps?: Map<string, number> | Record<string, number> | null,
+ * }} [options]
+ */
+export function enrichTopMultiWithCatalog(topMulti, catalogSongs, options = {}) {
+  return enrichSongRowsWithCatalog(topMulti, catalogSongs, options);
 }

--- a/src/features/crowd-picks/model/aggregateCrowdNightSongs.test.js
+++ b/src/features/crowd-picks/model/aggregateCrowdNightSongs.test.js
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import {
   aggregateCrowdNightSongs,
   crowdNightCardSummary,
+  enrichSongRowsWithCatalog,
+  enrichTopMultiWithCatalog,
 } from './aggregateCrowdNightSongs';
 
 const DOCS = [
@@ -60,5 +62,45 @@ describe('aggregateCrowdNightSongs (#690)', () => {
     expect(card.uniqueSongs).toBe(stats.uniqueSongs);
     expect(card.topMulti.length).toBeLessThanOrEqual(2);
     expect(card.topMulti.every((s) => s.cardCount >= 2)).toBe(true);
+  });
+
+  it('defaults to top 5 and enriches gap/last from catalog', () => {
+    const stats = aggregateCrowdNightSongs('2026-07-17', DOCS);
+    const card = crowdNightCardSummary(stats);
+    expect(card.topMulti.length).toBeLessThanOrEqual(5);
+    const enriched = enrichTopMultiWithCatalog(card.topMulti, [
+      { name: 'Tweezer', gap: '12', last: '2024-07-19' },
+      { name: 'Ghost', gap: '100', last: '2023-01-01' },
+    ]);
+    const tweezer = enriched.find((s) => s.title === 'Tweezer');
+    expect(tweezer?.gap).toBe(12);
+    expect(tweezer?.last).toBe('2024-07-19');
+  });
+
+  it('enrichSongRowsWithCatalog prefers frozen songGaps over catalog', () => {
+    const enriched = enrichSongRowsWithCatalog(
+      [{ title: 'Ghost', cardCount: 2, pctOfPickers: 50 }],
+      [{ name: 'Ghost', gap: '0', last: '2026-07-19' }],
+      { frozenGaps: { ghost: 47 } }
+    );
+    expect(enriched[0].gap).toBe(47);
+    expect(enriched[0].last).toBe('2026-07-19');
+  });
+
+  it('enrichSongRowsWithCatalog preserves row fields and falls back to row gap', () => {
+    const enriched = enrichSongRowsWithCatalog(
+      [
+        {
+          title: 'Weird Fishes',
+          cardCount: 2,
+          gap: 44,
+          subtitle: 'alice, bob',
+        },
+      ],
+      [{ name: 'Weird Fishes', last: '2022-06-01' }]
+    );
+    expect(enriched[0].gap).toBe(44);
+    expect(enriched[0].last).toBe('2022-06-01');
+    expect(enriched[0].subtitle).toBe('alice, bob');
   });
 });

--- a/src/features/crowd-picks/model/buildOfficialPlayedTitleSet.js
+++ b/src/features/crowd-picks/model/buildOfficialPlayedTitleSet.js
@@ -1,0 +1,66 @@
+/**
+ * Normalized titles played on a night from `official_setlists` payload.
+ * Mirrors scoring’s “anywhere in the show” set: slot strings + ordered
+ * `officialSetlist` (LIVE polls grow this list in real time).
+ *
+ * @param {Record<string, unknown> | null | undefined} actualSetlist
+ * @returns {Set<string>} lowercased trimmed titles
+ */
+export function buildOfficialPlayedTitleSet(actualSetlist) {
+  /** @type {Set<string>} */
+  const out = new Set();
+  if (!actualSetlist || typeof actualSetlist !== 'object') return out;
+
+  const NON_SONG_KEYS = new Set([
+    'officialSetlist',
+    'encoreSongs',
+    'id',
+    'bustouts',
+    'songGaps',
+  ]);
+
+  for (const [key, val] of Object.entries(actualSetlist)) {
+    if (NON_SONG_KEYS.has(key)) continue;
+    if (typeof val !== 'string') continue;
+    const t = val.trim().toLowerCase();
+    if (t) out.add(t);
+  }
+
+  const rawOfficial = actualSetlist.officialSetlist;
+  if (Array.isArray(rawOfficial)) {
+    for (const raw of rawOfficial) {
+      const t =
+        typeof raw === 'string'
+          ? raw.trim().toLowerCase()
+          : String(raw ?? '')
+              .trim()
+              .toLowerCase();
+      if (t) out.add(t);
+    }
+  }
+
+  const encoreSongs = actualSetlist.encoreSongs;
+  if (Array.isArray(encoreSongs)) {
+    for (const raw of encoreSongs) {
+      const t =
+        typeof raw === 'string'
+          ? raw.trim().toLowerCase()
+          : String(raw ?? '')
+              .trim()
+              .toLowerCase();
+      if (t) out.add(t);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * @param {string | null | undefined} title
+ * @param {Set<string> | null | undefined} playedTitles
+ */
+export function isCrowdSongPlayed(title, playedTitles) {
+  if (!(playedTitles instanceof Set) || playedTitles.size === 0) return false;
+  const key = typeof title === 'string' ? title.trim().toLowerCase() : '';
+  return Boolean(key) && playedTitles.has(key);
+}

--- a/src/features/crowd-picks/model/buildOfficialPlayedTitleSet.test.js
+++ b/src/features/crowd-picks/model/buildOfficialPlayedTitleSet.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildOfficialPlayedTitleSet,
+  isCrowdSongPlayed,
+} from './buildOfficialPlayedTitleSet';
+
+describe('buildOfficialPlayedTitleSet', () => {
+  it('returns empty set when setlist missing', () => {
+    expect(buildOfficialPlayedTitleSet(null).size).toBe(0);
+    expect(buildOfficialPlayedTitleSet(undefined).size).toBe(0);
+  });
+
+  it('unions slot songs, officialSetlist, and encoreSongs', () => {
+    const played = buildOfficialPlayedTitleSet({
+      s1o: 'Tweezer',
+      s2c: 'Ghost',
+      officialSetlist: ['Free', 'Tweezer', 'YEM'],
+      encoreSongs: ['Zero'],
+      songGaps: { tweezer: 12 },
+      bustouts: ['Ghost'],
+    });
+    expect(played.has('tweezer')).toBe(true);
+    expect(played.has('ghost')).toBe(true);
+    expect(played.has('free')).toBe(true);
+    expect(played.has('yem')).toBe(true);
+    expect(played.has('zero')).toBe(true);
+    // Metadata keys must not leak as titles
+    expect([...played].some((t) => t.includes('12'))).toBe(false);
+  });
+});
+
+describe('isCrowdSongPlayed', () => {
+  it('matches case-insensitively', () => {
+    const played = buildOfficialPlayedTitleSet({
+      officialSetlist: ['Bathtub Gin'],
+    });
+    expect(isCrowdSongPlayed('bathtub gin', played)).toBe(true);
+    expect(isCrowdSongPlayed('Ghost', played)).toBe(false);
+  });
+});

--- a/src/features/crowd-picks/model/crowdPulseAnalytics.js
+++ b/src/features/crowd-picks/model/crowdPulseAnalytics.js
@@ -1,0 +1,48 @@
+import { ga4Event } from '../../../shared/lib/ga4';
+
+/**
+ * Crowd pulse card is shown on Standings (#694).
+ *
+ * @param {{
+ *   show_date?: string,
+ *   deep_stats?: 'locked' | 'open',
+ *   pickers?: number,
+ * }} [payload]
+ */
+export function trackCrowdPulseView({
+  show_date,
+  deep_stats,
+  pickers,
+} = {}) {
+  ga4Event('crowd_pulse_view', {
+    show_date: show_date ?? '',
+    deep_stats: deep_stats === 'locked' ? 'locked' : 'open',
+    pickers: typeof pickers === 'number' && Number.isFinite(pickers) ? pickers : 0,
+  });
+}
+
+/**
+ * User expands “Full crowd stats” disclosure.
+ *
+ * @param {{ show_date?: string }} [payload]
+ */
+export function trackCrowdPulseFullExpand({ show_date } = {}) {
+  ga4Event('crowd_pulse_full_expand', {
+    show_date: show_date ?? '',
+  });
+}
+
+/**
+ * User opens one of the deep-stat section cards.
+ *
+ * @param {{
+ *   show_date?: string,
+ *   section?: 'multi_picker' | 'highest_gaps' | 'vintage' | 'leaders' | string,
+ * }} [payload]
+ */
+export function trackCrowdPulseSectionOpen({ show_date, section } = {}) {
+  ga4Event('crowd_pulse_section_open', {
+    show_date: show_date ?? '',
+    section: section ?? '',
+  });
+}

--- a/src/features/crowd-picks/model/crowdPulseAnalytics.test.js
+++ b/src/features/crowd-picks/model/crowdPulseAnalytics.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../shared/lib/ga4', () => ({
+  ga4Event: vi.fn(),
+}));
+
+import { ga4Event } from '../../../shared/lib/ga4';
+import {
+  trackCrowdPulseView,
+  trackCrowdPulseFullExpand,
+  trackCrowdPulseSectionOpen,
+} from './crowdPulseAnalytics';
+
+describe('crowdPulseAnalytics', () => {
+  beforeEach(() => {
+    ga4Event.mockClear();
+  });
+
+  it('trackCrowdPulseView emits pickers + deep_stats', () => {
+    trackCrowdPulseView({
+      show_date: '2026-07-19',
+      deep_stats: 'locked',
+      pickers: 12,
+    });
+    expect(ga4Event).toHaveBeenCalledWith('crowd_pulse_view', {
+      show_date: '2026-07-19',
+      deep_stats: 'locked',
+      pickers: 12,
+    });
+  });
+
+  it('trackCrowdPulseView defaults safely', () => {
+    trackCrowdPulseView();
+    expect(ga4Event).toHaveBeenCalledWith('crowd_pulse_view', {
+      show_date: '',
+      deep_stats: 'open',
+      pickers: 0,
+    });
+  });
+
+  it('trackCrowdPulseFullExpand emits show_date', () => {
+    trackCrowdPulseFullExpand({ show_date: '2026-07-19' });
+    expect(ga4Event).toHaveBeenCalledWith('crowd_pulse_full_expand', {
+      show_date: '2026-07-19',
+    });
+  });
+
+  it('trackCrowdPulseSectionOpen emits section', () => {
+    trackCrowdPulseSectionOpen({
+      show_date: '2026-07-19',
+      section: 'highest_gaps',
+    });
+    expect(ga4Event).toHaveBeenCalledWith('crowd_pulse_section_open', {
+      show_date: '2026-07-19',
+      section: 'highest_gaps',
+    });
+  });
+});

--- a/src/features/crowd-picks/model/formatCatalogLastShort.js
+++ b/src/features/crowd-picks/model/formatCatalogLastShort.js
@@ -1,0 +1,23 @@
+/**
+ * Truncate catalog `last` (usually YYYY-MM-DD) for compact UI columns.
+ * @param {unknown} raw
+ * @returns {string} e.g. `7/19/24`, or `—` when missing
+ */
+export function formatCatalogLastShort(raw) {
+  if (typeof raw !== 'string') return '—';
+  const t = raw.trim();
+  if (!t || t === '—' || t === '-' || /^never$/i.test(t)) return '—';
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(t);
+  if (m) {
+    const y = Number(m[1]);
+    const mo = Number(m[2]);
+    const d = Number(m[3]);
+    if (!Number.isFinite(y) || !Number.isFinite(mo) || !Number.isFinite(d)) {
+      return '—';
+    }
+    const yy = String(y % 100).padStart(2, '0');
+    return `${mo}/${d}/${yy}`;
+  }
+  // Already short / freeform — keep a tight slice
+  return t.length > 8 ? t.slice(0, 8) : t;
+}

--- a/src/features/crowd-picks/model/formatCatalogLastShort.test.js
+++ b/src/features/crowd-picks/model/formatCatalogLastShort.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatCatalogLastShort } from './formatCatalogLastShort';
+
+describe('formatCatalogLastShort', () => {
+  it('formats ISO dates as M/D/YY', () => {
+    expect(formatCatalogLastShort('2024-07-19')).toBe('7/19/24');
+    expect(formatCatalogLastShort('2026-01-05')).toBe('1/5/26');
+  });
+
+  it('maps empty / never to em dash', () => {
+    expect(formatCatalogLastShort('')).toBe('—');
+    expect(formatCatalogLastShort('—')).toBe('—');
+    expect(formatCatalogLastShort('Never')).toBe('—');
+    expect(formatCatalogLastShort(null)).toBe('—');
+  });
+});

--- a/src/features/crowd-picks/model/useCrowdNightStats.js
+++ b/src/features/crowd-picks/model/useCrowdNightStats.js
@@ -1,16 +1,29 @@
 import { useMemo } from 'react';
 
+import { sanitizeSongGaps } from '../../../shared/utils/officialSetlistSanitize';
 import { useSongCatalog } from '../../song-catalog';
 
 import { aggregateCrowdNightCatalog } from './aggregateCrowdNightCatalog';
 import {
   aggregateCrowdNightSongs,
   crowdNightCardSummary,
+  enrichSongRowsWithCatalog,
+  enrichTopMultiWithCatalog,
 } from './aggregateCrowdNightSongs';
 import {
   aggregateLeadersTonightPicks,
   LEADERS_TOP_K,
 } from './aggregateLeadersTonightPicks';
+import { buildOfficialPlayedTitleSet } from './buildOfficialPlayedTitleSet';
+
+/** Visible teaser row count on Standings crowd pulse. */
+export const CROWD_PULSE_TOP_N = 5;
+
+/** Cap for “All multi-picker songs” in full stats. */
+export const CROWD_PULSE_MULTI_FULL_N = 20;
+
+/** Cap for leaders song list in full stats. */
+export const CROWD_PULSE_LEADERS_SONGS_N = 12;
 
 /**
  * Compose C1–C3 crowd night stats for a show date (#694 / Standings).
@@ -18,8 +31,17 @@ import {
  * @param {string} showDate
  * @param {Array<Record<string, unknown>> | null | undefined} pickDocs
  * @param {Array<{ uid: string, handle?: string, totalPoints?: number }> | null | undefined} tourLeaders
+ * @param {{
+ *   songGaps?: Record<string, number> | null,
+ * } | null | undefined} [actualSetlist] — when present, frozen pre-show
+ *   `songGaps` override live catalog gap (historical nights).
  */
-export function useCrowdNightStats(showDate, pickDocs, tourLeaders) {
+export function useCrowdNightStats(
+  showDate,
+  pickDocs,
+  tourLeaders,
+  actualSetlist = null
+) {
   const { songs: catalogSongs, isLoading: catalogLoading } = useSongCatalog();
 
   return useMemo(() => {
@@ -31,25 +53,102 @@ export function useCrowdNightStats(showDate, pickDocs, tourLeaders) {
         night: null,
         catalog: null,
         leaders: null,
+        playedTitles: null,
       };
     }
 
+    const frozenGaps = sanitizeSongGaps(actualSetlist?.songGaps);
+    const enrichOpts = { frozenGaps };
+    const playedTitles = buildOfficialPlayedTitleSet(actualSetlist);
+
     const night = aggregateCrowdNightSongs(showDate, pickDocs);
-    const card = crowdNightCardSummary(night, { topN: 3 });
-    const catalog = aggregateCrowdNightCatalog(night, catalogSongs, {
+    const baseCard = crowdNightCardSummary(night, { topN: CROWD_PULSE_TOP_N });
+    const card = {
+      ...baseCard,
+      topMulti: enrichTopMultiWithCatalog(
+        baseCard.topMulti,
+        catalogSongs,
+        enrichOpts
+      ),
+    };
+
+    const baseCatalog = aggregateCrowdNightCatalog(night, catalogSongs, {
       gapTopN: 10,
+      frozenGaps,
     });
-    const leaders = aggregateLeadersTonightPicks(tourLeaders, pickDocs, {
+    /** @type {Map<string, number>} */
+    const pctByKey = new Map(
+      (night.songs || []).map((s) => [
+        String(s.title || '')
+          .trim()
+          .toLowerCase(),
+        s.pctOfPickers,
+      ])
+    );
+    const catalog = {
+      ...baseCatalog,
+      highestGap: enrichSongRowsWithCatalog(
+        (baseCatalog.highestGap || []).map((s) => ({
+          title: s.title,
+          cardCount: s.cardCount,
+          gap: s.gap,
+          pctOfPickers:
+            pctByKey.get(
+              String(s.title || '')
+                .trim()
+                .toLowerCase()
+            ) ?? 0,
+        })),
+        catalogSongs,
+        enrichOpts
+      ),
+    };
+
+    const baseLeaders = aggregateLeadersTonightPicks(tourLeaders, pickDocs, {
       topK: LEADERS_TOP_K,
     });
+    const leaders = {
+      ...baseLeaders,
+      songs: enrichSongRowsWithCatalog(
+        (baseLeaders.songs || [])
+          .slice(0, CROWD_PULSE_LEADERS_SONGS_N)
+          .map((s) => ({
+            title: s.title,
+            cardCount: s.cardCount,
+            subtitle:
+              Array.isArray(s.amongLeaders) && s.amongLeaders.length
+                ? s.amongLeaders.join(', ')
+                : null,
+          })),
+        catalogSongs,
+        enrichOpts
+      ),
+    };
+
+    const multiPickerFull = enrichSongRowsWithCatalog(
+      night.multiPickerSongs.slice(0, CROWD_PULSE_MULTI_FULL_N),
+      catalogSongs,
+      enrichOpts
+    );
 
     return {
       ready: true,
       catalogLoading,
       card,
-      night,
+      night: {
+        ...night,
+        multiPickerFull,
+      },
       catalog,
       leaders,
+      playedTitles,
     };
-  }, [showDate, pickDocs, tourLeaders, catalogSongs, catalogLoading]);
+  }, [
+    showDate,
+    pickDocs,
+    tourLeaders,
+    actualSetlist,
+    catalogSongs,
+    catalogLoading,
+  ]);
 }

--- a/src/features/crowd-picks/ui/CrowdNightPulsePanel.jsx
+++ b/src/features/crowd-picks/ui/CrowdNightPulsePanel.jsx
@@ -1,7 +1,12 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { ChevronDown, Lock } from 'lucide-react';
 
-import FrequencyMeterRow from './FrequencyMeterRow';
+import {
+  trackCrowdPulseFullExpand,
+  trackCrowdPulseSectionOpen,
+  trackCrowdPulseView,
+} from '../model/crowdPulseAnalytics';
+import CrowdPulseTopTable from './CrowdPulseTopTable';
 
 /**
  * Crowd pulse summary + expandable deep analysis (#694 ship).
@@ -9,23 +14,40 @@ import FrequencyMeterRow from './FrequencyMeterRow';
  * leaders blur until showtime. Presentational — data from `useCrowdNightStats`.
  *
  * @param {object} props
- * @param {import('../model/aggregateCrowdNightSongs').CrowdNightSongStats | null} props.night
- * @param {{ pickers: number, uniqueSongs: number, topMulti: Array<{ title: string, cardCount: number, pctOfPickers: number }> } | null} props.card
- * @param {{ highestGap: Array<{ title: string, gap: number, cardCount: number }>, vintage: { avgYear: number | null, medianYear: number | null, coveragePct: number, datedSlots: number, totalSlots: number } } | null} props.catalog
- * @param {{ lockedInLabel: string, leaders: Array<{ rank: number, handle: string, totalPoints: number }>, songs: Array<{ title: string, cardCount: number, amongLeaders: string[] }> } | null} props.leaders
+ * @param {string} [props.showDate]
+ * @param {import('../model/aggregateCrowdNightSongs').CrowdNightSongStats & {
+ *   multiPickerFull?: Array<{
+ *     title: string,
+ *     cardCount: number,
+ *     pctOfPickers: number,
+ *     gap?: number | null,
+ *     last?: string | null,
+ *   }>
+ * } | null} props.night
+ * @param {{ pickers: number, uniqueSongs: number, topMulti: Array<{ title: string, cardCount: number, pctOfPickers: number, gap?: number | null, last?: string | null }> } | null} props.card
+ * @param {{ highestGap: Array<{ title: string, cardCount: number, pctOfPickers?: number, gap: number, last?: string | null }>, vintage: { avgYear: number | null, medianYear: number | null, coveragePct: number, datedSlots: number, totalSlots: number } } | null} props.catalog
+ * @param {{ lockedInLabel: string, leaders: Array<{ rank: number, handle: string, totalPoints: number }>, songs: Array<{ title: string, cardCount: number, subtitle?: string | null, gap?: number | null, last?: string | null }> } | null} props.leaders
  * @param {boolean} [props.catalogLoading]
  * @param {boolean} [props.blurDeepStats] — true while picks still editable (NEXT)
+ * @param {Set<string> | null} [props.playedTitles] — official setlist hits (LIVE + PAST)
  * @param {string} [props.className]
  */
 export default function CrowdNightPulsePanel({
+  showDate = '',
   night,
   card,
   catalog,
   leaders,
   catalogLoading = false,
   blurDeepStats = false,
+  playedTitles = null,
   className = '',
 }) {
+  const pickers =
+    card && night && night.pickers > 0 ? card.pickers : 0;
+
+  useCrowdPulseViewTelemetry(showDate, blurDeepStats, pickers);
+
   if (!card || !night || night.pickers === 0) {
     return (
       <section
@@ -49,10 +71,15 @@ export default function CrowdNightPulsePanel({
         ? '…'
         : '—';
 
-  const maxCards = card.topMulti.reduce(
-    (m, s) => Math.max(m, s.cardCount),
-    0
-  );
+  const multiFull = night.multiPickerFull || night.multiPickerSongs || [];
+  const showPlayedLegend =
+    playedTitles instanceof Set && playedTitles.size > 0;
+
+  const onFullToggle = (event) => {
+    if (event.currentTarget.open) {
+      trackCrowdPulseFullExpand({ show_date: showDate || '' });
+    }
+  };
 
   return (
     <section
@@ -65,7 +92,7 @@ export default function CrowdNightPulsePanel({
             Crowd pulse
           </p>
           <p className="mt-0.5 text-[10px] font-medium text-content-secondary">
-            Songs more than one picker locked in
+            Top multi-picker songs tonight
           </p>
         </div>
         <p className="text-[10px] font-semibold text-content-secondary">
@@ -73,30 +100,37 @@ export default function CrowdNightPulsePanel({
         </p>
       </div>
 
+      {showPlayedLegend ? (
+        <p className="mt-2 inline-flex items-center gap-1.5 text-[9px] font-semibold uppercase tracking-wider text-content-secondary">
+          <span
+            className="inline-block h-2.5 w-2.5 shrink-0 rounded-sm bg-gradient-to-r from-brand-accent-red to-brand-accent-blue"
+            aria-hidden
+          />
+          Highlight = played in setlist
+        </p>
+      ) : null}
+
       {card.topMulti.length > 0 ? (
-        <ul className="mt-2.5 space-y-2">
-          {card.topMulti.map((s) => (
-            <FrequencyMeterRow
-              key={s.title}
-              title={s.title}
-              meta={`${s.cardCount} · ${s.pctOfPickers}%`}
-              count={s.cardCount}
-              maxCount={maxCards}
-            />
-          ))}
-        </ul>
+        <CrowdPulseTopTable
+          rows={card.topMulti}
+          playedTitles={playedTitles}
+          catalogLoading={catalogLoading}
+        />
       ) : (
         <p className="mt-2 text-[11px] text-content-secondary">
           No multi-picker songs yet (everyone unique).
         </p>
       )}
 
-      <details className="group mt-3 border-t border-border-subtle pt-2">
-        <summary className="flex cursor-pointer list-none items-center justify-between gap-2 text-[10px] font-black uppercase tracking-widest text-content-secondary transition-colors hover:text-white [&::-webkit-details-marker]:hidden">
+      <details
+        className="group mt-3 border-t border-border-subtle pt-2"
+        onToggle={onFullToggle}
+      >
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-2 text-[10px] font-black uppercase tracking-widest text-brand-primary transition-colors hover:text-brand-primary-strong [&::-webkit-details-marker]:hidden">
           <span className="inline-flex items-center gap-1.5">
             Full crowd stats
             {blurDeepStats ? (
-              <Lock className="h-3 w-3 shrink-0" aria-hidden />
+              <Lock className="h-3 w-3 shrink-0 opacity-80" aria-hidden />
             ) : null}
           </span>
           <ChevronDown
@@ -115,94 +149,87 @@ export default function CrowdNightPulsePanel({
                 Unlocks at showtime
               </p>
               <p className="max-w-[16rem] text-[10px] font-medium text-content-secondary">
-                Gap, vintage, and tour leaders stay private until picks lock
+                Full tables, vintage, and tour leaders stay private until picks
+                lock
               </p>
             </div>
           ) : null}
 
           <div
-            className={`space-y-4 text-[11px] md:text-xs ${
+            className={`space-y-2 ${
               blurDeepStats
                 ? 'pointer-events-none select-none blur-sm'
                 : ''
             }`}
             aria-hidden={blurDeepStats || undefined}
           >
-            <div>
-              <p className="mb-1.5 text-[10px] font-black uppercase tracking-widest text-content-secondary">
-                Multi-picker songs
-              </p>
-              <CrowdTable
-                headers={['Song', 'Cards', '%']}
-                rows={night.multiPickerSongs.slice(0, 20).map((s) => [
-                  s.title,
-                  String(s.cardCount),
-                  `${s.pctOfPickers}%`,
-                ])}
+            <CrowdDeepSection
+              title="Multi-picker songs"
+              subtitle="Every song on 2+ cards tonight"
+              sectionId="multi_picker"
+              showDate={showDate}
+            >
+              <CrowdPulseTopTable
+                rows={multiFull}
+                playedTitles={playedTitles}
+                catalogLoading={catalogLoading}
+                className=""
               />
-            </div>
+            </CrowdDeepSection>
 
-            <div>
-              <p className="mb-1.5 text-[10px] font-black uppercase tracking-widest text-content-secondary">
-                Highest gap (top 10)
-              </p>
+            <CrowdDeepSection
+              title="Highest gaps"
+              subtitle="Top 10 picks by pre-show gap"
+              sectionId="highest_gaps"
+              showDate={showDate}
+            >
               {catalogLoading && !catalog?.highestGap?.length ? (
-                <p className="text-content-secondary">Loading catalog…</p>
+                <p className="text-[11px] text-content-secondary md:text-xs">
+                  Loading catalog…
+                </p>
               ) : (
-                <CrowdTable
-                  headers={['Song', 'Gap', 'Cards']}
-                  rows={(catalog?.highestGap || []).map((s) => [
-                    s.title,
-                    String(s.gap),
-                    String(s.cardCount),
-                  ])}
+                <CrowdPulseTopTable
+                  rows={catalog?.highestGap || []}
+                  playedTitles={playedTitles}
+                  catalogLoading={catalogLoading}
+                  className=""
                 />
               )}
-            </div>
+            </CrowdDeepSection>
 
-            <div>
-              <p className="mb-1.5 text-[10px] font-black uppercase tracking-widest text-content-secondary">
-                Vintage (slot-weighted)
-              </p>
-              <p className="font-medium text-white">
+            <CrowdDeepSection
+              title="Crowd vintage"
+              subtitle="Slot-weighted debut years across all picks"
+              sectionId="vintage"
+              showDate={showDate}
+            >
+              <p className="text-[12px] font-semibold text-white md:text-sm">
                 Mean debut {vintageLabel}
                 {catalog?.vintage?.medianYear != null
                   ? ` · median ${Math.round(catalog.vintage.medianYear)}`
                   : ''}
               </p>
-              <p className="mt-0.5 text-content-secondary">
+              <p className="mt-1 text-[10px] font-medium text-content-secondary md:text-[11px]">
                 Coverage {catalog?.vintage?.coveragePct ?? 0}% (
                 {catalog?.vintage?.datedSlots ?? 0}/
                 {catalog?.vintage?.totalSlots ?? 0} slots)
               </p>
-            </div>
+            </CrowdDeepSection>
 
-            <div>
-              <p className="mb-1.5 text-[10px] font-black uppercase tracking-widest text-content-secondary">
-                Tour leaders tonight ({leaders?.lockedInLabel || '0/5'})
-              </p>
-              {leaders?.leaders?.length ? (
-                <ol className="mb-2 space-y-0.5 text-content-secondary">
-                  {leaders.leaders.map((l) => (
-                    <li key={l.uid || l.rank}>
-                      #{l.rank}{' '}
-                      <span className="font-semibold text-white">{l.handle}</span>
-                      {typeof l.totalPoints === 'number'
-                        ? ` · ${l.totalPoints} pts`
-                        : ''}
-                    </li>
-                  ))}
-                </ol>
-              ) : null}
-              <CrowdTable
-                headers={['Song', 'Among top 5', 'Who']}
-                rows={(leaders?.songs || []).slice(0, 12).map((s) => [
-                  s.title,
-                  String(s.cardCount),
-                  (s.amongLeaders || []).join(', '),
-                ])}
+            <CrowdDeepSection
+              title="Songs from top tour leaders"
+              subtitle="What the tour top 5 locked in tonight"
+              sectionId="leaders"
+              showDate={showDate}
+            >
+              <CrowdPulseTopTable
+                rows={leaders?.songs || []}
+                playedTitles={playedTitles}
+                catalogLoading={catalogLoading}
+                countHeader="Among"
+                className=""
               />
-            </div>
+            </CrowdDeepSection>
           </div>
         </div>
       </details>
@@ -211,41 +238,80 @@ export default function CrowdNightPulsePanel({
 }
 
 /**
- * @param {{ headers: string[], rows: string[][] }} props
+ * @param {string} showDate
+ * @param {boolean} blurDeepStats
+ * @param {number} pickers
  */
-function CrowdTable({ headers, rows }) {
-  if (!rows.length) {
-    return <p className="text-content-secondary">None yet.</p>;
-  }
+function useCrowdPulseViewTelemetry(showDate, blurDeepStats, pickers) {
+  const viewLoggedRef = useRef('');
+  useEffect(() => {
+    if (!showDate) return;
+    const deep_stats = blurDeepStats ? 'locked' : 'open';
+    const sig = `${showDate}|${deep_stats}|${pickers}`;
+    if (viewLoggedRef.current === sig) return;
+    viewLoggedRef.current = sig;
+    trackCrowdPulseView({
+      show_date: showDate,
+      deep_stats,
+      pickers,
+    });
+  }, [showDate, blurDeepStats, pickers]);
+}
+
+/**
+ * Independently expandable deep-stats card.
+ *
+ * @param {{
+ *   title: string,
+ *   subtitle?: string,
+ *   sectionId: string,
+ *   showDate?: string,
+ *   children: React.ReactNode,
+ *   defaultOpen?: boolean,
+ * }} props
+ */
+function CrowdDeepSection({
+  title,
+  subtitle,
+  sectionId,
+  showDate = '',
+  children,
+  defaultOpen = false,
+}) {
+  const onToggle = (event) => {
+    if (event.currentTarget.open) {
+      trackCrowdPulseSectionOpen({
+        show_date: showDate || '',
+        section: sectionId,
+      });
+    }
+  };
+
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full min-w-[16rem] border-collapse text-left">
-        <thead>
-          <tr className="text-[10px] uppercase tracking-wider text-content-secondary">
-            {headers.map((h) => (
-              <th key={h} className="pb-1 pr-2 font-bold">
-                {h}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row, i) => (
-            <tr key={`${row[0]}-${i}`} className="border-t border-border-subtle/60">
-              {row.map((cell, j) => (
-                <td
-                  key={j}
-                  className={`py-1 pr-2 align-top ${
-                    j === 0 ? 'font-semibold text-white' : 'text-content-secondary'
-                  }`}
-                >
-                  {cell}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <details
+      className="group/deep rounded-lg border border-border-subtle/70 bg-brand-bg/35 open:bg-brand-bg/50"
+      open={defaultOpen || undefined}
+      onToggle={onToggle}
+    >
+      <summary className="flex cursor-pointer list-none items-start justify-between gap-2 px-2.5 py-2 transition-colors hover:bg-white/[0.03] [&::-webkit-details-marker]:hidden">
+        <div className="min-w-0">
+          <p className="text-[12px] font-bold leading-snug text-white md:text-[13px]">
+            {title}
+          </p>
+          {subtitle ? (
+            <p className="mt-0.5 text-[10px] font-medium leading-snug text-content-secondary md:text-[11px]">
+              {subtitle}
+            </p>
+          ) : null}
+        </div>
+        <ChevronDown
+          className="mt-0.5 h-3.5 w-3.5 shrink-0 text-content-secondary transition-transform group-open/deep:rotate-180"
+          aria-hidden
+        />
+      </summary>
+      <div className="border-t border-border-subtle/50 px-2.5 pb-2.5 pt-2">
+        {children}
+      </div>
+    </details>
   );
 }

--- a/src/features/crowd-picks/ui/CrowdPulseTopTable.jsx
+++ b/src/features/crowd-picks/ui/CrowdPulseTopTable.jsx
@@ -1,0 +1,143 @@
+import { meterIntensity } from '../model/meterIntensity';
+import { formatCatalogLastShort } from '../model/formatCatalogLastShort';
+import { isCrowdSongPlayed } from '../model/buildOfficialPlayedTitleSet';
+
+/** Shared inset so header + rows stay column-aligned with/without highlight. */
+const ROW_SHELL = 'rounded-lg p-[1.5px]';
+const ROW_INNER = 'rounded-[6.5px] px-2 py-1.5';
+const HEADER_INSET = 'px-[calc(0.5rem+1.5px)]';
+
+/**
+ * Crowd song table: Song · Pickers (or custom) · Gap · Last, optional intensity meters.
+ * Rows that appear in the official setlist get a red→blue gradient highlight.
+ *
+ * @param {object} props
+ * @param {Array<{
+ *   title: string,
+ *   cardCount: number,
+ *   pctOfPickers?: number | null,
+ *   gap?: number | null,
+ *   last?: string | null,
+ *   subtitle?: string | null,
+ * }>} props.rows
+ * @param {Set<string> | null} [props.playedTitles] — normalized titles from official setlist
+ * @param {boolean} [props.catalogLoading]
+ * @param {string} [props.countHeader='Pickers']
+ * @param {boolean} [props.showMeter=true]
+ * @param {string} [props.className]
+ * @param {string} [props.emptyLabel='None yet.']
+ */
+export default function CrowdPulseTopTable({
+  rows,
+  playedTitles = null,
+  catalogLoading = false,
+  countHeader = 'Pickers',
+  showMeter = true,
+  className = 'mt-2.5',
+  emptyLabel = 'None yet.',
+}) {
+  if (!rows?.length) {
+    return <p className="text-content-secondary">{emptyLabel}</p>;
+  }
+
+  const maxCards = rows.reduce(
+    (m, s) => Math.max(m, typeof s.cardCount === 'number' ? s.cardCount : 0),
+    0
+  );
+
+  const gridCols =
+    'grid-cols-[minmax(0,1fr)_4.5rem_2.75rem_3.5rem] md:grid-cols-[minmax(0,1fr)_5rem_3rem_3.75rem]';
+
+  return (
+    <div className={className}>
+      <div
+        className={`mb-1.5 grid ${gridCols} ${HEADER_INSET} items-end gap-x-2 text-[9px] font-black uppercase tracking-wider text-content-secondary md:text-[10px]`}
+        role="row"
+      >
+        <span>Song</span>
+        <span className="text-right">{countHeader}</span>
+        <span className="text-right">Gap</span>
+        <span className="text-right">Last</span>
+      </div>
+      <ul className="space-y-2.5">
+        {rows.map((s) => {
+          const intensity = meterIntensity(s.cardCount, maxCards);
+          const gapLabel =
+            typeof s.gap === 'number'
+              ? String(s.gap)
+              : catalogLoading
+                ? '…'
+                : '—';
+          const lastLabel =
+            catalogLoading && s.last == null
+              ? '…'
+              : formatCatalogLastShort(s.last);
+          const showPct =
+            typeof s.pctOfPickers === 'number' && Number.isFinite(s.pctOfPickers);
+          const played = isCrowdSongPlayed(s.title, playedTitles);
+          return (
+            <li
+              key={s.title}
+              className={`${ROW_SHELL} ${
+                played
+                  ? 'bg-gradient-to-r from-brand-accent-red via-violet-500 to-brand-accent-blue shadow-[0_0_14px_-3px_rgba(59,130,246,0.55)]'
+                  : 'bg-transparent'
+              }`}
+            >
+              <div
+                className={`${ROW_INNER} ${played ? 'bg-brand-bg/95' : 'bg-transparent'}`}
+              >
+                <div
+                  className={`grid ${gridCols} items-baseline gap-x-2 text-[11px] md:text-xs`}
+                >
+                  <div className="min-w-0">
+                    <span className="block truncate font-semibold text-white">
+                      {s.title}
+                      {played ? (
+                        <span className="sr-only"> (played in setlist)</span>
+                      ) : null}
+                    </span>
+                    {s.subtitle ? (
+                      <span className="mt-0.5 block truncate text-[10px] font-medium text-content-secondary">
+                        {s.subtitle}
+                      </span>
+                    ) : null}
+                  </div>
+                  <span className="text-right font-medium tabular-nums text-content-secondary">
+                    {s.cardCount}
+                    {showPct ? (
+                      <span className="text-content-secondary/70">
+                        {' '}
+                        · {s.pctOfPickers}%
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className="text-right font-medium tabular-nums text-content-secondary">
+                    {gapLabel}
+                  </span>
+                  <span
+                    className="text-right font-medium tabular-nums text-content-secondary"
+                    title={typeof s.last === 'string' ? s.last : undefined}
+                  >
+                    {lastLabel}
+                  </span>
+                </div>
+                {showMeter ? (
+                  <div
+                    className="mt-1 h-1.5 overflow-hidden rounded-full bg-surface-field"
+                    aria-hidden
+                  >
+                    <div
+                      className="h-full rounded-full bg-gradient-to-r from-brand-primary/90 to-brand-primary/40"
+                      style={{ width: `${Math.round(intensity * 100)}%` }}
+                    />
+                  </div>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/scoring/ui/StandingsCrowdPulse.jsx
+++ b/src/features/scoring/ui/StandingsCrowdPulse.jsx
@@ -13,10 +13,14 @@ import {
  * Blur gate: `showStatus === 'NEXT'` → deep stats locked until showtime
  * (LIVE/PAST). See `docs/picks-rollup/04-prelock-disclosure.md`.
  *
+ * Gap + played rings: uses `actualSetlist` (LIVE subscription / historical
+ * fetch) for frozen `songGaps` and played-title hits.
+ *
  * @param {object} props
  * @param {string} props.showDate
  * @param {Array<Record<string, unknown>> | null | undefined} props.picks
  * @param {Array<{ uid: string, handle?: string, totalPoints?: number }> | null | undefined} props.tourLeaders
+ * @param {Record<string, unknown> | null | undefined} [props.actualSetlist]
  * @param {string} [props.showStatus] — NEXT blurs deep stats; LIVE/PAST unlock
  * @param {string} [props.className]
  */
@@ -24,21 +28,24 @@ export default function StandingsCrowdPulse({
   showDate,
   picks,
   tourLeaders,
+  actualSetlist = null,
   showStatus = '',
   className = '',
 }) {
-  const { card, night, catalog, leaders, catalogLoading, ready } =
-    useCrowdNightStats(showDate, picks, tourLeaders);
+  const { card, night, catalog, leaders, catalogLoading, ready, playedTitles } =
+    useCrowdNightStats(showDate, picks, tourLeaders, actualSetlist);
 
   if (!ready) return null;
 
   return (
     <CrowdNightPulsePanel
       className={className}
+      showDate={showDate}
       card={card}
       night={night}
       catalog={catalog}
       leaders={leaders}
+      playedTitles={playedTitles}
       catalogLoading={catalogLoading}
       blurDeepStats={shouldBlurDeepCrowdStats(showStatus)}
     />

--- a/src/features/scoring/ui/StandingsShowOrPoolView.jsx
+++ b/src/features/scoring/ui/StandingsShowOrPoolView.jsx
@@ -132,6 +132,7 @@ export default function StandingsShowOrPoolView({ screen }) {
           showDate={selectedDate}
           picks={picks}
           tourLeaders={crowdTourLeaders}
+          actualSetlist={actualSetlist}
           showStatus={showStatus}
         />
         {displayedPicks.length > 0 ? (
@@ -277,6 +278,7 @@ export default function StandingsShowOrPoolView({ screen }) {
           showDate={selectedDate}
           picks={picks}
           tourLeaders={crowdTourLeaders}
+          actualSetlist={actualSetlist}
           showStatus={showStatus}
         />
       ) : null}


### PR DESCRIPTION
## Summary
- Roll up **staging** → **main** for **v1.35.3**
- Crowd pulse Standings polish (#694): Song/Pickers/Gap/Last tables, frozen pre-show gaps, setlist-hit highlights, expandable full stats, GA4 `crowd_pulse_*`

## Test plan
- [x] Feature PR #702 required checks (`verify`, Vercel) passed
- [ ] Spot-check Standings Show on production after deploy


Made with [Cursor](https://cursor.com)