### PR TITLE
feat(dashboard): shared card system + stats naming and tour stats polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ No unreleased changes.
 - **Dashboard card system (#710)** — shared `dashboardCardClasses` module (radius, pad, L1/L2 heights, type scale); `standingsSurfaceClasses` re-exports it; Standings, crowd pulse, SponsorSlot, and Tour Stats consume the shared tokens.
 - **Stats naming polish (#710)** — "Picking average" unified across profile + tour stats with batting-average display (`.167`); "Avg pts / show" → "Points per show" with PPG tooltip; public profile stats gain InfoTooltips (footnote paragraph removed).
 - **Tour stats view (#710)** — "Your picks this tour" on shared `StatTile` (bottom-pinned `x/y correct` sub-line); personal section recolored to the muted blue family with an emerald hybrid Bustout Boost band; `InfoTooltip` accepts `triggerClassName`.
+- **Badge hierarchy + shadow shelf (#710)** — explicit `rank` on the badge catalog (Ten-Show Run > First Night Win > Five on the Board > First Show Scored) so standings avatar pins showcase the highest earned badge; Badges shelf now renders the full ladder with dimmed shadow tiles for unearned milestones.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ No unreleased changes.
 
 ---
 
+## [1.35.4] — 2026-07-21
+
+### Changed
+- **Dashboard card system (#710)** — shared `dashboardCardClasses` module (radius, pad, L1/L2 heights, type scale); `standingsSurfaceClasses` re-exports it; Standings, crowd pulse, SponsorSlot, and Tour Stats consume the shared tokens.
+- **Stats naming polish (#710)** — "Picking average" unified across profile + tour stats with batting-average display (`.167`); "Avg pts / show" → "Points per show" with PPG tooltip; public profile stats gain InfoTooltips (footnote paragraph removed).
+- **Tour stats view (#710)** — "Your picks this tour" on shared `StatTile` (bottom-pinned `x/y correct` sub-line); personal section recolored to the muted blue family with an emerald hybrid Bustout Boost band; `InfoTooltip` accepts `triggerClassName`.
+
+---
+
 ## [1.35.3] — 2026-07-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.35.3",
+  "version": "1.35.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/crowd-picks/ui/CrowdNightPulsePanel.jsx
+++ b/src/features/crowd-picks/ui/CrowdNightPulsePanel.jsx
@@ -1,6 +1,15 @@
 import React, { useEffect, useRef } from 'react';
-import { ChevronDown, Lock } from 'lucide-react';
+import { ChevronDown, Lock, Radio } from 'lucide-react';
 
+import {
+  DASHBOARD_CARD_BODY,
+  DASHBOARD_CARD_CHEVRON,
+  DASHBOARD_CARD_EYEBROW,
+  DASHBOARD_CARD_EYEBROW_ICON,
+  DASHBOARD_CARD_L2_MIN_H,
+  DASHBOARD_CARD_PAD,
+  DASHBOARD_CARD_RADIUS,
+} from '../../../shared/ui/dashboardCardClasses';
 import {
   trackCrowdPulseFullExpand,
   trackCrowdPulseSectionOpen,
@@ -10,6 +19,9 @@ import CrowdPulseTopTable from './CrowdPulseTopTable';
 
 /**
  * Crowd pulse summary + expandable deep analysis (#694 ship).
+ * Collapsed by default to match sibling Standings card heights: the summary
+ * row teases the leading multi-picker song; expanding reveals the top table
+ * and the "Full crowd stats" disclosure.
  * Pre-lock (NEXT): top multi-picker songs stay visible; gap / vintage /
  * leaders blur until showtime. Presentational — data from `useCrowdNightStats`.
  *
@@ -51,13 +63,16 @@ export default function CrowdNightPulsePanel({
   if (!card || !night || night.pickers === 0) {
     return (
       <section
-        className={`rounded-xl border border-border-subtle bg-surface-panel/60 px-3.5 py-3 ${className}`}
+        className={`flex ${DASHBOARD_CARD_L2_MIN_H} flex-col justify-center ${DASHBOARD_CARD_RADIUS} border border-border-subtle bg-surface-panel/60 ${DASHBOARD_CARD_PAD} ${className}`}
         aria-label="Crowd pulse"
       >
-        <p className="text-[10px] font-black uppercase tracking-widest text-content-secondary">
+        <p
+          className={`inline-flex items-center gap-1.5 ${DASHBOARD_CARD_EYEBROW} text-content-secondary`}
+        >
+          <Radio className={DASHBOARD_CARD_EYEBROW_ICON} aria-hidden />
           Crowd pulse
         </p>
-        <p className="mt-1 text-[11px] font-medium text-content-secondary md:text-xs">
+        <p className={`mt-1 ${DASHBOARD_CARD_BODY}`}>
           No submitted picks for this show yet.
         </p>
       </section>
@@ -81,157 +96,179 @@ export default function CrowdNightPulsePanel({
     }
   };
 
+  const onPanelToggle = (event) => {
+    if (event.currentTarget.open) {
+      trackCrowdPulseSectionOpen({
+        show_date: showDate || '',
+        section: 'top_songs',
+      });
+    }
+  };
+
+  const topSong = card.topMulti[0] || null;
+  const teaser = topSong
+    ? `“${topSong.title}” leads on ${topSong.cardCount} cards`
+    : 'No multi-picker songs yet (everyone unique).';
+
   return (
     <section
-      className={`rounded-xl border border-border-subtle bg-surface-panel/60 px-3.5 py-3 md:px-4 md:py-3.5 ${className}`}
+      className={`flex ${DASHBOARD_CARD_L2_MIN_H} flex-col justify-center ${DASHBOARD_CARD_RADIUS} border border-border-subtle bg-surface-panel/60 ${DASHBOARD_CARD_PAD} ${className}`}
       aria-label="Crowd pulse"
     >
-      <div className="flex flex-wrap items-baseline justify-between gap-2">
-        <div>
-          <p className="text-[10px] font-black uppercase tracking-widest text-brand-primary">
-            Crowd pulse
-          </p>
-          <p className="mt-0.5 text-[10px] font-medium text-content-secondary">
-            Top multi-picker songs tonight
-          </p>
-        </div>
-        <p className="text-[10px] font-semibold text-content-secondary">
-          {card.pickers} pickers · {card.uniqueSongs} songs
-        </p>
-      </div>
-
-      {showPlayedLegend ? (
-        <p className="mt-2 inline-flex items-center gap-1.5 text-[9px] font-semibold uppercase tracking-wider text-content-secondary">
-          <span
-            className="inline-block h-2.5 w-2.5 shrink-0 rounded-sm bg-gradient-to-r from-brand-accent-red to-brand-accent-blue"
-            aria-hidden
-          />
-          Highlight = played in setlist
-        </p>
-      ) : null}
-
-      {card.topMulti.length > 0 ? (
-        <CrowdPulseTopTable
-          rows={card.topMulti}
-          playedTitles={playedTitles}
-          catalogLoading={catalogLoading}
-        />
-      ) : (
-        <p className="mt-2 text-[11px] text-content-secondary">
-          No multi-picker songs yet (everyone unique).
-        </p>
-      )}
-
-      <details
-        className="group mt-3 border-t border-border-subtle pt-2"
-        onToggle={onFullToggle}
-      >
-        <summary className="flex cursor-pointer list-none items-center justify-between gap-2 text-[10px] font-black uppercase tracking-widest text-brand-primary transition-colors hover:text-brand-primary-strong [&::-webkit-details-marker]:hidden">
-          <span className="inline-flex items-center gap-1.5">
-            Full crowd stats
-            {blurDeepStats ? (
-              <Lock className="h-3 w-3 shrink-0 opacity-80" aria-hidden />
-            ) : null}
-          </span>
-          <ChevronDown
-            className="h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-180"
-            aria-hidden
-          />
+      <details className="group/pulse" onToggle={onPanelToggle}>
+        <summary className="cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+          <div className="flex items-center justify-between gap-2">
+            <p
+              className={`inline-flex items-center gap-1.5 ${DASHBOARD_CARD_EYEBROW} text-brand-primary transition-colors group-hover/pulse:text-brand-primary-strong`}
+            >
+              <Radio className={DASHBOARD_CARD_EYEBROW_ICON} aria-hidden />
+              Crowd pulse
+            </p>
+            <p className="inline-flex shrink-0 items-center gap-1.5 text-[10px] font-semibold text-content-secondary">
+              {card.pickers} pickers · {card.uniqueSongs} songs
+              <ChevronDown
+                className={`${DASHBOARD_CARD_CHEVRON} group-open/pulse:rotate-180`}
+                aria-hidden
+              />
+            </p>
+          </div>
+          {/* Full-width row so long song titles get the whole card width. */}
+          <p className={`mt-0.5 truncate ${DASHBOARD_CARD_BODY}`}>{teaser}</p>
         </summary>
 
-        <div className="relative mt-3 min-h-[7rem]">
-          {blurDeepStats ? (
-            <div
-              className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-1 rounded-lg px-3 text-center"
-              role="status"
-            >
-              <p className="text-[11px] font-bold text-white md:text-xs">
-                Unlocks at showtime
-              </p>
-              <p className="max-w-[16rem] text-[10px] font-medium text-content-secondary">
-                Full tables, vintage, and tour leaders stay private until picks
-                lock
-              </p>
-            </div>
-          ) : null}
+        {showPlayedLegend ? (
+          <p className="mt-2 inline-flex items-center gap-1.5 text-[9px] font-semibold uppercase tracking-wider text-content-secondary">
+            <span
+              className="inline-block h-2.5 w-2.5 shrink-0 rounded-sm bg-brand-primary/80"
+              aria-hidden
+            />
+            Highlight = played in setlist
+          </p>
+        ) : null}
 
-          <div
-            className={`space-y-2 ${
-              blurDeepStats
-                ? 'pointer-events-none select-none blur-sm'
-                : ''
-            }`}
-            aria-hidden={blurDeepStats || undefined}
-          >
-            <CrowdDeepSection
-              title="Multi-picker songs"
-              subtitle="Every song on 2+ cards tonight"
-              sectionId="multi_picker"
-              showDate={showDate}
-            >
-              <CrowdPulseTopTable
-                rows={multiFull}
-                playedTitles={playedTitles}
-                catalogLoading={catalogLoading}
-                className=""
-              />
-            </CrowdDeepSection>
+        {card.topMulti.length > 0 ? (
+          <CrowdPulseTopTable
+            rows={card.topMulti}
+            playedTitles={playedTitles}
+            catalogLoading={catalogLoading}
+          />
+        ) : (
+          <p className="mt-2 text-[11px] text-content-secondary">
+            No multi-picker songs yet (everyone unique).
+          </p>
+        )}
 
-            <CrowdDeepSection
-              title="Highest gaps"
-              subtitle="Top 10 picks by pre-show gap"
-              sectionId="highest_gaps"
-              showDate={showDate}
-            >
-              {catalogLoading && !catalog?.highestGap?.length ? (
-                <p className="text-[11px] text-content-secondary md:text-xs">
-                  Loading catalog…
+        <details
+          className="group mt-3 border-t border-border-subtle pt-2"
+          onToggle={onFullToggle}
+        >
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-2 text-[10px] font-black uppercase tracking-widest text-brand-primary transition-colors hover:text-brand-primary-strong [&::-webkit-details-marker]:hidden">
+            <span className="inline-flex items-center gap-1.5">
+              Full crowd stats
+              {blurDeepStats ? (
+                <Lock className="h-3 w-3 shrink-0 opacity-80" aria-hidden />
+              ) : null}
+            </span>
+            <ChevronDown
+              className="h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-180"
+              aria-hidden
+            />
+          </summary>
+
+          <div className="relative mt-3 min-h-[7rem]">
+            {blurDeepStats ? (
+              <div
+                className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-1 rounded-lg px-3 text-center"
+                role="status"
+              >
+                <p className="text-[11px] font-bold text-white md:text-xs">
+                  Unlocks at showtime
                 </p>
-              ) : (
+                <p className="max-w-[16rem] text-[10px] font-medium text-content-secondary">
+                  Full tables, vintage, and tour leaders stay private until
+                  picks lock
+                </p>
+              </div>
+            ) : null}
+
+            <div
+              className={`space-y-2 ${
+                blurDeepStats
+                  ? 'pointer-events-none select-none blur-sm'
+                  : ''
+              }`}
+              aria-hidden={blurDeepStats || undefined}
+            >
+              <CrowdDeepSection
+                title="Multi-picker songs"
+                subtitle="Every song on 2+ cards tonight"
+                sectionId="multi_picker"
+                showDate={showDate}
+              >
                 <CrowdPulseTopTable
-                  rows={catalog?.highestGap || []}
+                  rows={multiFull}
                   playedTitles={playedTitles}
                   catalogLoading={catalogLoading}
                   className=""
                 />
-              )}
-            </CrowdDeepSection>
+              </CrowdDeepSection>
 
-            <CrowdDeepSection
-              title="Crowd vintage"
-              subtitle="Slot-weighted debut years across all picks"
-              sectionId="vintage"
-              showDate={showDate}
-            >
-              <p className="text-[12px] font-semibold text-white md:text-sm">
-                Mean debut {vintageLabel}
-                {catalog?.vintage?.medianYear != null
-                  ? ` · median ${Math.round(catalog.vintage.medianYear)}`
-                  : ''}
-              </p>
-              <p className="mt-1 text-[10px] font-medium text-content-secondary md:text-[11px]">
-                Coverage {catalog?.vintage?.coveragePct ?? 0}% (
-                {catalog?.vintage?.datedSlots ?? 0}/
-                {catalog?.vintage?.totalSlots ?? 0} slots)
-              </p>
-            </CrowdDeepSection>
+              <CrowdDeepSection
+                title="Highest gaps"
+                subtitle="Top 10 picks by pre-show gap"
+                sectionId="highest_gaps"
+                showDate={showDate}
+              >
+                {catalogLoading && !catalog?.highestGap?.length ? (
+                  <p className="text-[11px] text-content-secondary md:text-xs">
+                    Loading catalog…
+                  </p>
+                ) : (
+                  <CrowdPulseTopTable
+                    rows={catalog?.highestGap || []}
+                    playedTitles={playedTitles}
+                    catalogLoading={catalogLoading}
+                    className=""
+                  />
+                )}
+              </CrowdDeepSection>
 
-            <CrowdDeepSection
-              title="Songs from top tour leaders"
-              subtitle="What the tour top 5 locked in tonight"
-              sectionId="leaders"
-              showDate={showDate}
-            >
-              <CrowdPulseTopTable
-                rows={leaders?.songs || []}
-                playedTitles={playedTitles}
-                catalogLoading={catalogLoading}
-                countHeader="Among"
-                className=""
-              />
-            </CrowdDeepSection>
+              <CrowdDeepSection
+                title="Crowd vintage"
+                subtitle="Slot-weighted debut years across all picks"
+                sectionId="vintage"
+                showDate={showDate}
+              >
+                <p className="text-[12px] font-semibold text-white md:text-sm">
+                  Mean debut {vintageLabel}
+                  {catalog?.vintage?.medianYear != null
+                    ? ` · median ${Math.round(catalog.vintage.medianYear)}`
+                    : ''}
+                </p>
+                <p className="mt-1 text-[10px] font-medium text-content-secondary md:text-[11px]">
+                  Coverage {catalog?.vintage?.coveragePct ?? 0}% (
+                  {catalog?.vintage?.datedSlots ?? 0}/
+                  {catalog?.vintage?.totalSlots ?? 0} slots)
+                </p>
+              </CrowdDeepSection>
+
+              <CrowdDeepSection
+                title="Songs from top tour leaders"
+                subtitle="What the tour top 5 locked in tonight"
+                sectionId="leaders"
+                showDate={showDate}
+              >
+                <CrowdPulseTopTable
+                  rows={leaders?.songs || []}
+                  playedTitles={playedTitles}
+                  catalogLoading={catalogLoading}
+                  countHeader="Among"
+                  className=""
+                />
+              </CrowdDeepSection>
+            </div>
           </div>
-        </div>
+        </details>
       </details>
     </section>
   );

--- a/src/features/crowd-picks/ui/CrowdPulseTopTable.jsx
+++ b/src/features/crowd-picks/ui/CrowdPulseTopTable.jsx
@@ -9,7 +9,9 @@ const HEADER_INSET = 'px-[calc(0.5rem+1.5px)]';
 
 /**
  * Crowd song table: Song · Pickers (or custom) · Gap · Last, optional intensity meters.
- * Rows that appear in the official setlist get a red→blue gradient highlight.
+ * Rows that appear in the official setlist get a brand-teal highlight
+ * (success/score role per docs/design.md §2) so they contrast with the
+ * red→blue intensity meters.
  *
  * @param {object} props
  * @param {Array<{
@@ -80,7 +82,7 @@ export default function CrowdPulseTopTable({
               key={s.title}
               className={`${ROW_SHELL} ${
                 played
-                  ? 'bg-gradient-to-r from-brand-accent-red via-violet-500 to-brand-accent-blue shadow-[0_0_14px_-3px_rgba(59,130,246,0.55)]'
+                  ? 'bg-brand-primary/80 shadow-[0_0_14px_-3px_rgba(45,212,191,0.55)]'
                   : 'bg-transparent'
               }`}
             >
@@ -128,7 +130,7 @@ export default function CrowdPulseTopTable({
                     aria-hidden
                   >
                     <div
-                      className="h-full rounded-full bg-gradient-to-r from-brand-primary/90 to-brand-primary/40"
+                      className="h-full rounded-full bg-gradient-to-r from-brand-accent-red to-brand-accent-blue"
                       style={{ width: `${Math.round(intensity * 100)}%` }}
                     />
                   </div>

--- a/src/features/crowd-picks/ui/FrequencyMeterRow.jsx
+++ b/src/features/crowd-picks/ui/FrequencyMeterRow.jsx
@@ -2,7 +2,7 @@ import { meterIntensity } from '../model/meterIntensity';
 
 /**
  * One song row with label, count line, and intensity meter (#694).
- * Standings uses brand gradient; profile strip keeps its own colors.
+ * Standings uses the red→blue accent gradient; profile strip keeps its own colors.
  *
  * @param {object} props
  * @param {string} props.title
@@ -17,7 +17,7 @@ export default function FrequencyMeterRow({
   meta,
   count,
   maxCount,
-  barClassName = 'bg-gradient-to-r from-brand-primary/90 to-brand-primary/40',
+  barClassName = 'bg-gradient-to-r from-brand-accent-red to-brand-accent-blue',
   titleClassName = 'font-semibold text-white',
   metaClassName = 'font-medium tabular-nums text-content-secondary',
 }) {

--- a/src/features/profile/index.js
+++ b/src/features/profile/index.js
@@ -26,4 +26,6 @@ export {
 export {
   debutYearFromCatalogDebut,
   buildDebutYearBySongName,
+  formatAvgCorrectPicksPerShow,
+  PROFILE_SLOTS_PER_SHOW,
 } from './model/profileAverages';

--- a/src/features/profile/model/badgeCatalog.js
+++ b/src/features/profile/model/badgeCatalog.js
@@ -1,6 +1,12 @@
 /**
  * Milestone badge catalog (#568) — v1 Participation + win_1.
  * Assets under `/badges/{id}.svg`.
+ *
+ * `rank` is the explicit badge hierarchy (1 = most valuable). It drives which
+ * badge shows on standings avatar pins (highest earned) and the ladder order
+ * on the Badges shelf. Ranks must be unique, contiguous from 1, and never
+ * contradict tier order (a `common` badge cannot outrank an `uncommon` one) —
+ * enforced by `badgeCatalog.test.js`.
  */
 
 /** @typedef {{
@@ -8,6 +14,7 @@
  *   name: string,
  *   blurb: string,
  *   tier: 'common' | 'uncommon' | 'rare' | 'legendary',
+ *   rank: number,
  *   src: string,
  * }} BadgeDefinition */
 
@@ -18,6 +25,7 @@ export const PROFILE_BADGES = Object.freeze([
     name: 'First Show Scored',
     blurb: "Scored your first Setlist Pick 'Em show.",
     tier: 'common',
+    rank: 4,
     src: '/badges/shows_played_1.svg',
   },
   {
@@ -25,6 +33,7 @@ export const PROFILE_BADGES = Object.freeze([
     name: 'Five on the Board',
     blurb: 'Played five scored shows.',
     tier: 'common',
+    rank: 3,
     src: '/badges/shows_played_5.svg',
   },
   {
@@ -32,6 +41,7 @@ export const PROFILE_BADGES = Object.freeze([
     name: 'Ten-Show Run',
     blurb: 'Played ten scored shows.',
     tier: 'uncommon',
+    rank: 1,
     src: '/badges/shows_played_10.svg',
   },
   {
@@ -39,11 +49,12 @@ export const PROFILE_BADGES = Object.freeze([
     name: 'First Night Win',
     blurb: 'Topped a scored show.',
     tier: 'uncommon',
+    rank: 2,
     src: '/badges/win_1.svg',
   },
 ]);
 
-const TIER_ORDER = Object.freeze({
+export const BADGE_TIER_ORDER = Object.freeze({
   legendary: 0,
   rare: 1,
   uncommon: 2,
@@ -53,6 +64,21 @@ const TIER_ORDER = Object.freeze({
 const BADGE_BY_ID = new Map(PROFILE_BADGES.map((b) => [b.id, b]));
 
 /**
+ * @param {unknown} entry raw users/{uid}.badges[id] value
+ * @returns {{ awardedAt: unknown, scope?: string }}
+ */
+function toAwardMeta(entry) {
+  const record = /** @type {Record<string, unknown>} */ (entry);
+  return {
+    awardedAt: record.awardedAt,
+    scope: typeof record.scope === 'string' ? record.scope : undefined,
+  };
+}
+
+/**
+ * Earned badges sorted by hierarchy (`rank` ascending — most valuable first),
+ * so `[0]` is the badge to showcase on avatar pins.
+ *
  * @param {unknown} badgesMap users/{uid}.badges
  * @returns {Array<BadgeDefinition & { awardedAt: unknown, scope?: string }>}
  */
@@ -67,23 +93,38 @@ export function resolveEarnedBadges(badgesMap) {
     if (!entry || typeof entry !== 'object') continue;
     const def = BADGE_BY_ID.get(id);
     if (!def) continue;
-    earned.push({
-      ...def,
-      awardedAt: /** @type {Record<string, unknown>} */ (entry).awardedAt,
-      scope:
-        typeof /** @type {Record<string, unknown>} */ (entry).scope === 'string'
-          ? /** @type {string} */ (
-              /** @type {Record<string, unknown>} */ (entry).scope
-            )
-          : undefined,
-    });
+    earned.push({ ...def, ...toAwardMeta(entry) });
   }
 
-  earned.sort((a, b) => {
-    const ta = TIER_ORDER[a.tier] ?? 99;
-    const tb = TIER_ORDER[b.tier] ?? 99;
-    if (ta !== tb) return ta - tb;
-    return a.name.localeCompare(b.name);
-  });
+  earned.sort((a, b) => a.rank - b.rank);
   return earned;
+}
+
+/**
+ * Full catalog ladder in hierarchy order (most valuable first), flagging what
+ * this user has earned — unearned entries render as shadow/locked tiles on
+ * the Badges shelf.
+ *
+ * @param {unknown} badgesMap users/{uid}.badges
+ * @returns {Array<BadgeDefinition & {
+ *   earned: boolean,
+ *   awardedAt?: unknown,
+ *   scope?: string,
+ * }>}
+ */
+export function resolveBadgeLadder(badgesMap) {
+  const map =
+    badgesMap && typeof badgesMap === 'object' && !Array.isArray(badgesMap)
+      ? /** @type {Record<string, unknown>} */ (badgesMap)
+      : {};
+
+  return [...PROFILE_BADGES]
+    .sort((a, b) => a.rank - b.rank)
+    .map((def) => {
+      const entry = map[def.id];
+      const earned = Boolean(entry && typeof entry === 'object');
+      return earned
+        ? { ...def, earned: true, ...toAwardMeta(entry) }
+        : { ...def, earned: false };
+    });
 }

--- a/src/features/profile/model/badgeCatalog.test.js
+++ b/src/features/profile/model/badgeCatalog.test.js
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { PROFILE_BADGES, resolveEarnedBadges } from './badgeCatalog';
+import {
+  BADGE_TIER_ORDER,
+  PROFILE_BADGES,
+  resolveBadgeLadder,
+  resolveEarnedBadges,
+} from './badgeCatalog';
 
 describe('badgeCatalog', () => {
   it('includes v1 participation + win badges', () => {
@@ -13,7 +18,21 @@ describe('badgeCatalog', () => {
     ]);
   });
 
-  it('resolves earned badges sorted by tier then name', () => {
+  it('has unique contiguous ranks starting at 1', () => {
+    const ranks = PROFILE_BADGES.map((b) => b.rank).sort((a, b) => a - b);
+    expect(ranks).toEqual(PROFILE_BADGES.map((_, i) => i + 1));
+  });
+
+  it('never lets a lower tier outrank a higher tier', () => {
+    const byRank = [...PROFILE_BADGES].sort((a, b) => a.rank - b.rank);
+    for (let i = 1; i < byRank.length; i += 1) {
+      expect(BADGE_TIER_ORDER[byRank[i].tier]).toBeGreaterThanOrEqual(
+        BADGE_TIER_ORDER[byRank[i - 1].tier],
+      );
+    }
+  });
+
+  it('resolves earned badges sorted by hierarchy rank (highest first)', () => {
     const earned = resolveEarnedBadges({
       shows_played_1: { awardedAt: null, scope: 'career' },
       win_1: { awardedAt: null, scope: 'career' },
@@ -23,8 +42,37 @@ describe('badgeCatalog', () => {
     expect(earned[0].name).toBe('First Night Win');
   });
 
+  it('showcases the ten-show run over a first night win (#710)', () => {
+    const earned = resolveEarnedBadges({
+      win_1: { awardedAt: null, scope: 'career' },
+      shows_played_10: { awardedAt: null, scope: 'career' },
+    });
+    expect(earned[0].id).toBe('shows_played_10');
+  });
+
   it('returns empty for missing map', () => {
     expect(resolveEarnedBadges(null)).toEqual([]);
     expect(resolveEarnedBadges(undefined)).toEqual([]);
+  });
+
+  it('resolveBadgeLadder returns the full catalog in rank order with earned flags', () => {
+    const ladder = resolveBadgeLadder({
+      win_1: { awardedAt: 123, scope: 'career' },
+    });
+    expect(ladder.map((b) => b.id)).toEqual([
+      'shows_played_10',
+      'win_1',
+      'shows_played_5',
+      'shows_played_1',
+    ]);
+    expect(ladder.map((b) => b.earned)).toEqual([false, true, false, false]);
+    expect(ladder[1].awardedAt).toBe(123);
+    expect(ladder[0].awardedAt).toBeUndefined();
+  });
+
+  it('resolveBadgeLadder tolerates a missing badges map', () => {
+    const ladder = resolveBadgeLadder(null);
+    expect(ladder).toHaveLength(PROFILE_BADGES.length);
+    expect(ladder.every((b) => b.earned === false)).toBe(true);
   });
 });

--- a/src/features/profile/model/profileAverages.js
+++ b/src/features/profile/model/profileAverages.js
@@ -65,18 +65,17 @@ export function computeAvgCorrectPicksPerShow(stats) {
 }
 
 /**
- * @param {number | null | undefined} avg
+ * Displayed batting-average style (".167", "1.000") — the bare ratio
+ * ("0.17") read like a count of correct picks (#554 follow-up).
+ *
+ * @param {number | null | undefined} avg — slot-hit ratio in [0, 1]
  * @returns {string}
  */
 export function formatAvgCorrectPicksPerShow(avg) {
   if (typeof avg !== 'number' || !Number.isFinite(avg)) return '—';
-  const rounded = Math.round(avg * 100) / 100;
-  if (Number.isInteger(rounded)) return String(rounded);
-  const one = Math.round(avg * 10) / 10;
-  if (Math.abs(one - rounded) < 1e-9) {
-    return Number.isInteger(one) ? String(one) : one.toFixed(1);
-  }
-  return rounded.toFixed(2);
+  const fixed = avg.toFixed(3);
+  // Batting-average convention: drop the leading zero (.167), keep 1.000.
+  return fixed.startsWith('0.') ? fixed.slice(1) : fixed;
 }
 
 /**

--- a/src/features/profile/model/profileAverages.test.js
+++ b/src/features/profile/model/profileAverages.test.js
@@ -83,7 +83,9 @@ describe('profileAverages', () => {
       computeAvgCorrectPicksPerShow({ careerCorrectSlots: 9, shows: 3 })
     ).toBe(0.5);
     expect(computeAvgCorrectPicksPerShow({ shows: 3 })).toBeNull();
-    expect(formatAvgCorrectPicksPerShow(0.5)).toBe('0.5');
+    expect(formatAvgCorrectPicksPerShow(0.5)).toBe('.500');
+    expect(formatAvgCorrectPicksPerShow(1 / 6)).toBe('.167');
+    expect(formatAvgCorrectPicksPerShow(1)).toBe('1.000');
     expect(formatAvgCorrectPicksPerShow(null)).toBe('—');
   });
 });

--- a/src/features/profile/ui/BadgeShelf.jsx
+++ b/src/features/profile/ui/BadgeShelf.jsx
@@ -1,26 +1,27 @@
 import React, { useEffect, useRef } from 'react';
 
 import { FeatureNewBadge } from '../../feature-discovery';
-import { resolveEarnedBadges } from '../model/badgeCatalog';
+import { resolveBadgeLadder } from '../model/badgeCatalog';
 import { trackBadgeShelfView } from '../model/profileEngagementAnalytics';
 
 /**
- * Earned milestone badges shelf (#568).
+ * Milestone badges shelf (#568): the full catalog ladder in hierarchy order.
+ * Earned badges render in color; unearned ones as shadow (grayscale/dimmed)
+ * tiles so the remaining milestones are visible (#710).
  *
  * @param {{
  *   badges?: Record<string, unknown> | null,
- *   emptyLabel?: string,
  *   surface?: 'profile' | 'public_profile',
  *   showNewBadge?: boolean,
  * }} props
  */
 export default function BadgeShelf({
   badges = null,
-  emptyLabel = 'No badges yet — play a scored show to start earning.',
   surface = 'profile',
   showNewBadge = false,
 }) {
-  const earned = resolveEarnedBadges(badges);
+  const ladder = resolveBadgeLadder(badges);
+  const earnedCount = ladder.filter((b) => b.earned).length;
   const viewLoggedRef = useRef(false);
 
   useEffect(() => {
@@ -28,9 +29,9 @@ export default function BadgeShelf({
     viewLoggedRef.current = true;
     trackBadgeShelfView({
       surface,
-      badge_count: earned.length,
+      badge_count: earnedCount,
     });
-  }, [surface, earned.length]);
+  }, [surface, earnedCount]);
 
   return (
     <section className="mt-6 rounded-3xl border border-border-subtle bg-surface-panel p-6 shadow-inset-glass">
@@ -38,33 +39,40 @@ export default function BadgeShelf({
         Badges
         {showNewBadge ? <FeatureNewBadge title="New: milestone badges" /> : null}
       </h2>
-      {earned.length === 0 ? (
-        <p className="text-sm font-bold text-content-secondary">{emptyLabel}</p>
-      ) : (
-        <ul className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          {earned.map((badge) => (
-            <li
-              key={badge.id}
-              className="flex flex-col items-center gap-2 rounded-2xl border border-border-subtle bg-surface-field px-2 py-3 text-center"
+      <ul className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {ladder.map((badge) => (
+          <li
+            key={badge.id}
+            title={badge.blurb}
+            className={`flex flex-col items-center gap-2 rounded-2xl border px-2 py-3 text-center ${
+              badge.earned
+                ? 'border-border-subtle bg-surface-field'
+                : 'border-dashed border-border-subtle/60 bg-surface-field/40'
+            }`}
+          >
+            <img
+              src={badge.src}
+              alt=""
+              width={48}
+              height={48}
+              className={`h-12 w-12 ${
+                badge.earned ? '' : 'opacity-30 grayscale'
+              }`}
+              decoding="async"
+            />
+            <p
+              className={`text-[11px] font-black uppercase leading-snug tracking-wide ${
+                badge.earned ? 'text-brand-primary' : 'text-content-secondary/70'
+              }`}
+              aria-label={`${badge.name}. ${badge.blurb}${
+                badge.earned ? '' : ' Not earned yet.'
+              }`}
             >
-              <img
-                src={badge.src}
-                alt=""
-                width={48}
-                height={48}
-                className="h-12 w-12"
-                decoding="async"
-              />
-              <p
-                className="text-[11px] font-black uppercase leading-snug tracking-wide text-brand-primary"
-                aria-label={`${badge.name}. ${badge.blurb}`}
-              >
-                {badge.name}
-              </p>
-            </li>
-          ))}
-        </ul>
-      )}
+              {badge.name}
+            </p>
+          </li>
+        ))}
+      </ul>
     </section>
   );
 }

--- a/src/features/profile/ui/ProfileSelfStatsPanel.jsx
+++ b/src/features/profile/ui/ProfileSelfStatsPanel.jsx
@@ -45,16 +45,17 @@ export default function ProfileSelfStatsPanel({ uid }) {
   const columns = [
     {
       key: 'avgPts',
-      label: 'Avg pts / show',
+      label: 'Points per show',
       value: avgPoints,
-      definition: 'Mean points per graded show across your career.',
+      definition:
+        'Like points per game in basketball — mean points per graded show across your career.',
     },
     {
       key: 'avgCorrect',
-      label: 'Avg correct / show',
+      label: 'Picking average',
       value: avgCorrect,
       definition:
-        'Mean correct pick slots per graded show. Shows — until your account has been rolled up after a finalize.',
+        'Like a batting average in baseball — lifetime correct picks ÷ total picks across your graded shows (.500 means half your picks hit). Shows — until your account has been rolled up after a finalize.',
     },
     {
       key: 'vintage',

--- a/src/features/profile/ui/PublicProfileView.jsx
+++ b/src/features/profile/ui/PublicProfileView.jsx
@@ -3,6 +3,9 @@ import { Loader2 } from 'lucide-react';
 
 import { formatMonthYear } from '../../../shared';
 import BackButton from '../../../shared/ui/BackButton';
+import InfoTooltip, {
+  InfoTooltipProvider,
+} from '../../../shared/ui/InfoTooltip';
 import {
   computeAvgCorrectPicksPerShow,
   computeAvgPointsPerShow,
@@ -52,15 +55,39 @@ export default function PublicProfileView({
   );
 
   const statColumns = [
-    { key: 'points', label: 'Total points', value: totalPoints },
-    { key: 'avg', label: 'Avg pts / show', value: avgPointsDisplay },
+    {
+      key: 'points',
+      label: 'Total points',
+      value: totalPoints,
+      definition: 'Career points across every graded show.',
+    },
+    {
+      key: 'avg',
+      label: 'Points per show',
+      value: avgPointsDisplay,
+      definition:
+        'Like points per game in basketball — mean points per graded show.',
+    },
     {
       key: 'avgCorrect',
-      label: 'Avg correct / show',
+      label: 'Picking average',
       value: avgCorrectDisplay,
+      definition:
+        'Like a batting average in baseball — lifetime correct picks ÷ total picks across graded shows (.500 means half of picks hit).',
     },
-    { key: 'wins', label: 'Wins', value: wins },
-    { key: 'shows', label: 'Shows', value: shows },
+    {
+      key: 'wins',
+      label: 'Wins',
+      value: wins,
+      definition:
+        'Nights with the overall top score across all players — not just within a single pool.',
+    },
+    {
+      key: 'shows',
+      label: 'Shows',
+      value: shows,
+      definition: 'Finalized shows with graded picks.',
+    },
   ];
 
   return (
@@ -121,34 +148,32 @@ export default function PublicProfileView({
           <h2 className="mb-4 text-xs font-black uppercase tracking-widest text-content-secondary">
             Stats
           </h2>
-          <div className="grid grid-cols-2 gap-3 text-center sm:grid-cols-3">
-            {statColumns.map(({ key, label, value }) => (
-              <div key={key} className="flex flex-col gap-1.5">
-                <p className="flex flex-1 items-end justify-center px-0.5 text-[10px] font-black uppercase leading-snug tracking-wider text-content-secondary">
-                  {label}
-                </p>
-                <div className="flex min-h-[3.25rem] items-center justify-center rounded-2xl border border-border-subtle bg-surface-field px-2 py-3">
-                  {statsLoading ? (
-                    <Loader2
-                      className="h-5 w-5 shrink-0 animate-spin text-brand-primary"
-                      aria-label={`Loading ${label}`}
-                    />
-                  ) : (
-                    <span className="text-2xl font-black tabular-nums leading-none tracking-tight text-brand-primary">
-                      {value}
-                    </span>
-                  )}
+          <InfoTooltipProvider>
+            <div className="grid grid-cols-2 gap-3 text-center sm:grid-cols-3">
+              {statColumns.map(({ key, label, value, definition }) => (
+                <div key={key} className="flex flex-col gap-1.5">
+                  <div className="flex flex-1 items-end justify-center gap-1 px-0.5">
+                    <p className="text-[10px] font-black uppercase leading-snug tracking-wider text-content-secondary">
+                      {label}
+                    </p>
+                    <InfoTooltip label={label} definition={definition} />
+                  </div>
+                  <div className="flex min-h-[3.25rem] items-center justify-center rounded-2xl border border-border-subtle bg-surface-field px-2 py-3">
+                    {statsLoading ? (
+                      <Loader2
+                        className="h-5 w-5 shrink-0 animate-spin text-brand-primary"
+                        aria-label={`Loading ${label}`}
+                      />
+                    ) : (
+                      <span className="text-2xl font-black tabular-nums leading-none tracking-tight text-brand-primary">
+                        {value}
+                      </span>
+                    )}
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
-          <p className="mt-3 text-[11px] font-medium leading-relaxed text-content-secondary">
-            Running totals across every graded night. Avg pts / show is total
-            points divided by shows played. Avg correct / show is correct
-            slots per show (6 slots) when the career rollup is present;
-            otherwise —. Wins count nights with the overall top score, not
-            just in a single pool.
-          </p>
+              ))}
+            </div>
+          </InfoTooltipProvider>
         </section>
 
         <BadgeShelf

--- a/src/features/profile/ui/PublicProfileView.jsx
+++ b/src/features/profile/ui/PublicProfileView.jsx
@@ -176,11 +176,7 @@ export default function PublicProfileView({
           </InfoTooltipProvider>
         </section>
 
-        <BadgeShelf
-          badges={profile.badges}
-          emptyLabel="No badges earned yet."
-          surface="public_profile"
-        />
+        <BadgeShelf badges={profile.badges} surface="public_profile" />
       </div>
     </div>
   );

--- a/src/features/scoring/ui/StandingsActiveShowCard.jsx
+++ b/src/features/scoring/ui/StandingsActiveShowCard.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ListMusic, Loader2, Pencil } from 'lucide-react';
+import { ListMusic, Loader2, Pencil, Ticket } from 'lucide-react';
 
 import Button from '../../../shared/ui/Button';
 import Card from '../../../shared/ui/Card';
 import {
   STANDINGS_BOX_BODY,
   STANDINGS_BOX_EYEBROW,
+  STANDINGS_BOX_EYEBROW_ICON,
   STANDINGS_BOX_TITLE,
   STANDINGS_CARD_SHELL,
 } from './standingsSurfaceClasses';
@@ -58,7 +59,13 @@ export default function StandingsActiveShowCard({
     <Card as="section" variant="venue" padding="none" className={STANDINGS_CARD_SHELL}>
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="min-w-0 space-y-1">
-          <p className={`${STANDINGS_BOX_EYEBROW} text-brand-primary`}>
+          <p
+            className={`inline-flex items-center gap-1.5 ${STANDINGS_BOX_EYEBROW} text-brand-primary`}
+          >
+            <Ticket
+              className={`${STANDINGS_BOX_EYEBROW_ICON} text-brand-primary`}
+              aria-hidden
+            />
             {eyebrow}
           </p>
           {showLabel ? (

--- a/src/features/scoring/ui/StandingsBannerWaitingSetlist.jsx
+++ b/src/features/scoring/ui/StandingsBannerWaitingSetlist.jsx
@@ -21,7 +21,7 @@ export default function StandingsBannerWaitingSetlist() {
   const copy = 'Waiting for official setlist. Stay tuned...';
 
   return (
-    <div className="mb-3 md:mb-6">
+    <div className="mb-3">
       <div className="md:hidden">
         <button
           type="button"

--- a/src/features/scoring/ui/StandingsInvitePromo.jsx
+++ b/src/features/scoring/ui/StandingsInvitePromo.jsx
@@ -2,6 +2,14 @@ import React from 'react';
 import { UserPlus } from 'lucide-react';
 
 import Button from '../../../shared/ui/Button';
+import {
+  STANDINGS_BOX_BODY,
+  STANDINGS_BOX_L1_MIN_H,
+  STANDINGS_BOX_MEDIA_TILE,
+  STANDINGS_BOX_PAD,
+  STANDINGS_BOX_RADIUS,
+  STANDINGS_BOX_TITLE,
+} from './standingsSurfaceClasses';
 
 /**
  * Prominent Invite promo for Standings (#609) — same visual weight as a
@@ -18,18 +26,22 @@ export default function StandingsInvitePromo({ onInvite, className = '' }) {
       aria-label="Invite friends"
       className={['w-full', className].filter(Boolean).join(' ')}
     >
-      <div className="flex min-h-[5.75rem] w-full items-center gap-3.5 rounded-xl border border-border-subtle/60 bg-surface-panel/40 px-3.5 py-3.5 md:min-h-[6.25rem] md:gap-4 md:px-4 md:py-4">
-        <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl border-2 border-brand-primary/50 bg-transparent md:h-16 md:w-16">
+      <div
+        className={`flex ${STANDINGS_BOX_L1_MIN_H} w-full items-center gap-3.5 ${STANDINGS_BOX_RADIUS} border border-border-subtle/60 bg-surface-panel/40 ${STANDINGS_BOX_PAD} md:gap-4`}
+      >
+        <div
+          className={`flex ${STANDINGS_BOX_MEDIA_TILE} items-center justify-center border-2 border-brand-primary/50 bg-transparent md:h-16 md:w-16`}
+        >
           <UserPlus
             className="mt-1 h-7 w-7 text-brand-primary md:h-8 md:w-8"
             aria-hidden
           />
         </div>
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-bold leading-snug text-brand-primary md:text-base">
-            Invite your crew
+          <p className={`truncate ${STANDINGS_BOX_TITLE}`}>
+            <span className="text-brand-primary">Invite your crew</span>
           </p>
-          <p className="mt-0.5 line-clamp-2 text-[11px] font-medium leading-snug text-content-secondary md:text-xs">
+          <p className={`mt-0.5 line-clamp-2 ${STANDINGS_BOX_BODY}`}>
             Click Invite to send a personalized invite via text or social
           </p>
         </div>

--- a/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
+++ b/src/features/scoring/ui/StandingsOfficialSetlistCard.jsx
@@ -22,7 +22,10 @@ import {
 import OfficialPickSlotsGrid from './OfficialPickSlotsGrid';
 import {
   STANDINGS_BOX_BODY,
+  STANDINGS_BOX_CHEVRON,
   STANDINGS_BOX_EYEBROW,
+  STANDINGS_BOX_EYEBROW_ICON,
+  STANDINGS_BOX_L2_MIN_H,
   STANDINGS_BOX_TITLE,
   STANDINGS_CARD_SHELL,
 } from './standingsSurfaceClasses';
@@ -156,7 +159,7 @@ export default function StandingsOfficialSetlistCard({
       as="section"
       variant="default"
       padding="none"
-      className={`mb-3 ${STANDINGS_CARD_SHELL} ${className}`.trim()}
+      className={`mb-3 flex ${STANDINGS_BOX_L2_MIN_H} flex-col justify-center ${STANDINGS_CARD_SHELL} ${className}`.trim()}
     >
       <details
         className="group"
@@ -167,7 +170,7 @@ export default function StandingsOfficialSetlistCard({
           <div className="min-w-0 space-y-1">
             <div className="flex flex-wrap items-center gap-2">
               <ListMusic
-                className="h-4 w-4 shrink-0 text-brand-primary"
+                className={`${STANDINGS_BOX_EYEBROW_ICON} text-brand-primary`}
                 aria-hidden
               />
               <p className={`${STANDINGS_BOX_EYEBROW} text-brand-primary`}>
@@ -193,7 +196,7 @@ export default function StandingsOfficialSetlistCard({
             )}
           </div>
           <ChevronDown
-            className="mt-1 h-5 w-5 shrink-0 text-content-secondary transition-transform group-open:rotate-180"
+            className={`mt-0.5 ${STANDINGS_BOX_CHEVRON} group-open:rotate-180`}
             aria-hidden
           />
         </summary>

--- a/src/features/scoring/ui/StandingsSelfRecapCard.jsx
+++ b/src/features/scoring/ui/StandingsSelfRecapCard.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { ChevronDown } from 'lucide-react';
+import { ChartNoAxesCombined, ChevronDown } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 import {
@@ -8,6 +8,14 @@ import {
   STANDINGS_SHARE_AFTER_FINALIZE_INLINE,
 } from '../../../shared/config/dashboardVocabulary';
 import GradedPicksShareBar from './GradedPicksShareBar';
+import {
+  STANDINGS_BOX_CHEVRON,
+  STANDINGS_BOX_EYEBROW,
+  STANDINGS_BOX_EYEBROW_ICON,
+  STANDINGS_BOX_L2_MIN_H,
+  STANDINGS_BOX_PAD,
+  STANDINGS_BOX_RADIUS,
+} from './standingsSurfaceClasses';
 
 /**
  * Self recap: rank + points (no handle — user is always “you” here), share after finalize,
@@ -109,7 +117,13 @@ export default function StandingsSelfRecapCard({
       className={`flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 ${useCollapsible ? 'flex-1' : 'w-full'} ${showEyebrow ? 'justify-between' : 'justify-end'} ${rowLeading}`}
     >
       {showEyebrow ? (
-        <span className="shrink-0 text-xs font-black uppercase tracking-widest text-amber-200/90">
+        <span
+          className={`inline-flex shrink-0 items-center gap-1.5 ${STANDINGS_BOX_EYEBROW} text-amber-200/90`}
+        >
+          <ChartNoAxesCombined
+            className={`${STANDINGS_BOX_EYEBROW_ICON} text-amber-200/90`}
+            aria-hidden
+          />
           {STANDINGS_SELF_RECAP_EYEBROW}
         </span>
       ) : null}
@@ -137,7 +151,7 @@ export default function StandingsSelfRecapCard({
 
   const chevronToggle = useCollapsible ? (
     <ChevronDown
-      className="h-4 w-4 shrink-0 text-content-secondary opacity-80 transition-transform duration-200 ease-out group-open:rotate-180"
+      className={`${STANDINGS_BOX_CHEVRON} duration-200 ease-out group-open:rotate-180`}
       aria-hidden
     />
   ) : null;
@@ -204,7 +218,7 @@ export default function StandingsSelfRecapCard({
       </p>
     ) : null;
 
-  const shellClass = `rounded-xl border border-border-subtle/55 bg-surface-panel/55 px-3.5 py-3.5 shadow-inset-glass ring-1 ring-brand-primary/15 md:px-4 md:py-4 ${className}`;
+  const shellClass = `flex ${STANDINGS_BOX_L2_MIN_H} flex-col justify-center ${STANDINGS_BOX_RADIUS} border border-border-subtle/55 bg-surface-panel/55 ${STANDINGS_BOX_PAD} shadow-inset-glass ring-1 ring-brand-primary/15 ${className}`;
 
   if (useCollapsible) {
     return (

--- a/src/features/scoring/ui/StandingsShowOrPoolView.jsx
+++ b/src/features/scoring/ui/StandingsShowOrPoolView.jsx
@@ -136,7 +136,7 @@ export default function StandingsShowOrPoolView({ screen }) {
           showStatus={showStatus}
         />
         {displayedPicks.length > 0 ? (
-          <div className="mt-4 md:mt-6">
+          <div className="mt-3">
             {!actualSetlist && picks.length > 0 ? (
               <StandingsBannerWaitingSetlist />
             ) : null}
@@ -255,7 +255,7 @@ export default function StandingsShowOrPoolView({ screen }) {
           actualSetlist={actualSetlist}
           shareGradedRecapAllowed={shareGradedRecapAllowed}
           collapsible
-          className="mb-2"
+          className="mb-3"
         />
       ) : null}
 

--- a/src/features/scoring/ui/StandingsSponsorPreview.jsx
+++ b/src/features/scoring/ui/StandingsSponsorPreview.jsx
@@ -4,6 +4,11 @@ import {
   BRAND_APP_CHROME_MARK_SRC,
 } from '../../../shared/config/branding';
 import Button from '../../../shared/ui/Button';
+import {
+  STANDINGS_BOX_BODY,
+  STANDINGS_BOX_MEDIA_TILE,
+  STANDINGS_BOX_TITLE,
+} from './standingsSurfaceClasses';
 
 /**
  * Local house-promo mock for the Standings `SponsorSlot` seam (#609).
@@ -20,14 +25,14 @@ export default function StandingsSponsorPreview({ onCtaClick }) {
         alt=""
         width={56}
         height={56}
-        className="h-14 w-14 shrink-0 rounded-xl object-contain"
+        className={`${STANDINGS_BOX_MEDIA_TILE} object-contain`}
         decoding="async"
       />
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-bold leading-snug text-white md:text-base">
+        <p className={`truncate ${STANDINGS_BOX_TITLE}`}>
           Bring your crew to Standings
         </p>
-        <p className="mt-0.5 line-clamp-2 text-[11px] font-medium leading-snug text-content-secondary md:text-xs">
+        <p className={`mt-0.5 line-clamp-2 ${STANDINGS_BOX_BODY}`}>
           Invite friends to a pool — share the board, own the night.
         </p>
       </div>

--- a/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
+++ b/src/features/scoring/ui/StandingsWinnerOfTheNightBanner.jsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, Trophy } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import {
@@ -8,6 +8,13 @@ import {
 } from '../../../shared/config/dashboardVocabulary';
 import DashboardRowPill from '../../../shared/ui/DashboardRowPill';
 import PlayerHandleLink from '../../../shared/ui/PlayerHandleLink';
+import {
+  STANDINGS_BOX_EYEBROW,
+  STANDINGS_BOX_EYEBROW_ICON,
+  STANDINGS_BOX_L2_MIN_H,
+  STANDINGS_BOX_PAD,
+  STANDINGS_BOX_RADIUS,
+} from './standingsSurfaceClasses';
 
 /**
  * "Overall winner of the night" callout for `/dashboard/standings` (#218).
@@ -73,8 +80,8 @@ export default function StandingsWinnerOfTheNightBanner({
       aria-label={`${heading}: ${handlesLabel} — ${max} points`}
       className={
         compact
-          ? 'relative mx-0.5 mb-2 rounded-xl border border-amber-500/35 bg-gradient-to-br from-amber-500/[0.1] via-amber-500/[0.05] to-brand-primary/[0.06] px-3.5 py-3 shadow-inset-glass'
-          : 'relative mx-0.5 mb-4 rounded-xl border border-amber-500/40 bg-gradient-to-br from-amber-500/[0.12] via-amber-500/[0.06] to-brand-primary/[0.08] px-3.5 py-3.5 shadow-inset-glass md:px-4 md:py-4'
+          ? `relative mx-0.5 mb-3 flex ${STANDINGS_BOX_L2_MIN_H} flex-col justify-center ${STANDINGS_BOX_RADIUS} border border-amber-500/35 bg-gradient-to-br from-amber-500/[0.1] via-amber-500/[0.05] to-brand-primary/[0.06] ${STANDINGS_BOX_PAD} shadow-inset-glass`
+          : `relative mx-0.5 mb-3 flex ${STANDINGS_BOX_L2_MIN_H} flex-col justify-center ${STANDINGS_BOX_RADIUS} border border-amber-500/40 bg-gradient-to-br from-amber-500/[0.12] via-amber-500/[0.06] to-brand-primary/[0.08] ${STANDINGS_BOX_PAD} shadow-inset-glass`
       }
     >
       <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1">
@@ -82,7 +89,13 @@ export default function StandingsWinnerOfTheNightBanner({
           If the heading flex item ever paints over the pill (min-width / overflow),
           keep the link above in the hit-test order.
         */}
-        <p className="relative z-0 min-w-0 text-[10px] font-black uppercase tracking-widest text-amber-300">
+        <p
+          className={`relative z-0 inline-flex min-w-0 items-center gap-1.5 ${STANDINGS_BOX_EYEBROW} text-amber-300`}
+        >
+          <Trophy
+            className={`${STANDINGS_BOX_EYEBROW_ICON} text-amber-300`}
+            aria-hidden
+          />
           {heading}
         </p>
         {showViewResultsLink ? (

--- a/src/features/scoring/ui/standingsSurfaceClasses.js
+++ b/src/features/scoring/ui/standingsSurfaceClasses.js
@@ -1,29 +1,22 @@
 /**
- * Standings content-box geometry + type scale — aligned to Invite promo /
- * SponsorSlot shells (`rounded-xl`, ~`px-3.5 py-3.5`, title `text-sm`,
- * body `text-[11px]`). Colors stay per-surface; only shape + fonts are shared.
+ * Standings content-box geometry + type scale — now backed by the shared
+ * dashboard card system (`shared/ui/dashboardCardClasses`) so Standings,
+ * Tour Stats, and crowd-picks cards stay harmonized. This module keeps the
+ * `STANDINGS_*` names as the scoring-local alias.
+ *
+ * Size levels: L1 = promo/banner (Invite, Sponsor); L2 = summary-row
+ * (Your rank, Setlist, Crowd pulse, Winner). See the shared module docs.
  */
-
-/** Outer radius for every Standings content card/banner. */
-export const STANDINGS_BOX_RADIUS = 'rounded-xl';
-
-/** Even padding matching Invite promo (md bump matches invite md). */
-export const STANDINGS_BOX_PAD = 'px-3.5 py-3.5 md:px-4 md:py-4';
-
-/**
- * Card className override — force invite/sponsor radius + pad over Card
- * variant defaults (`rounded-2xl`/`3xl`, `p-4`–`p-8`).
- */
-export const STANDINGS_CARD_SHELL = `!${STANDINGS_BOX_RADIUS} !p-3.5 md:!p-4`;
-
-/** Primary title inside a Standings box (venue, setlist, empty-state heading). */
-export const STANDINGS_BOX_TITLE =
-  'text-sm font-bold leading-snug text-white md:text-base';
-
-/** Secondary / body copy inside a Standings box. */
-export const STANDINGS_BOX_BODY =
-  'text-[11px] font-medium leading-snug text-content-secondary md:text-xs';
-
-/** Uppercase eyebrow above a box title. */
-export const STANDINGS_BOX_EYEBROW =
-  'text-[10px] font-black uppercase tracking-widest';
+export {
+  DASHBOARD_CARD_RADIUS as STANDINGS_BOX_RADIUS,
+  DASHBOARD_CARD_PAD as STANDINGS_BOX_PAD,
+  DASHBOARD_CARD_SHELL as STANDINGS_CARD_SHELL,
+  DASHBOARD_CARD_L1_MIN_H as STANDINGS_BOX_L1_MIN_H,
+  DASHBOARD_CARD_L2_MIN_H as STANDINGS_BOX_L2_MIN_H,
+  DASHBOARD_CARD_MEDIA_TILE as STANDINGS_BOX_MEDIA_TILE,
+  DASHBOARD_CARD_EYEBROW_ICON as STANDINGS_BOX_EYEBROW_ICON,
+  DASHBOARD_CARD_CHEVRON as STANDINGS_BOX_CHEVRON,
+  DASHBOARD_CARD_TITLE as STANDINGS_BOX_TITLE,
+  DASHBOARD_CARD_BODY as STANDINGS_BOX_BODY,
+  DASHBOARD_CARD_EYEBROW as STANDINGS_BOX_EYEBROW,
+} from '../../../shared/ui/dashboardCardClasses';

--- a/src/features/tour-stats/ui/TourStatsView.jsx
+++ b/src/features/tour-stats/ui/TourStatsView.jsx
@@ -5,14 +5,18 @@ import Card from '../../../shared/ui/Card';
 import InfoTooltip, {
   InfoTooltipProvider,
 } from '../../../shared/ui/InfoTooltip';
+import {
+  formatAvgCorrectPicksPerShow,
+  PROFILE_SLOTS_PER_SHOW,
+} from '../../profile';
 import { SCORING_RULES } from '../../../shared/utils/scoring';
+import {
+  DASHBOARD_CARD_EYEBROW as STANDINGS_BOX_EYEBROW,
+  DASHBOARD_CARD_SHELL as STANDINGS_CARD_SHELL,
+} from '../../../shared/ui/dashboardCardClasses';
 import { TOUR_STATS_GAP_HIGHLIGHT_MIN } from '../model/aggregateTourSetlistStats';
 
 const { BUSTOUT_MIN_GAP } = SCORING_RULES;
-
-/** Matches Standings content-box shell (`standingsSurfaceClasses.js`). */
-const STANDINGS_CARD_SHELL = '!rounded-xl !p-3.5 md:!p-4';
-const STANDINGS_BOX_EYEBROW = 'text-[10px] font-black uppercase tracking-widest';
 
 /** Invisible 3-col grid: # | Song | Plays — fixed tracks keep columns aligned. */
 const TOP_SONGS_ROW_GRID =
@@ -162,17 +166,45 @@ export default function TourStatsView({
         ) : overlay ? (
           <TourStatsSectionCard
             title="Your picks this tour"
-            variant="venue"
-            headerTone="personal"
+            headerTone="muted"
           >
-            <div className="grid grid-cols-2 gap-x-4 gap-y-4 sm:grid-cols-4 sm:gap-x-6">
-              <OverlayStat label="Shows" value={overlay.showsPicked} />
-              <OverlayStat
-                label="Correct"
-                value={`${overlay.slotsCorrect}/${overlay.slotsFilled}`}
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <StatTile
+                label="Shows"
+                value={overlay.showsPicked}
+                accent="personal"
+                definition="Tour shows where you submitted picks."
               />
-              <OverlayStat label="Bustout hits" value={overlay.bustoutHits} />
-              <OverlayStat label="In most played" value={overlay.topSongOverlap} />
+              <StatTile
+                label="Picking average"
+                value={formatAvgCorrectPicksPerShow(
+                  overlay.showsPicked > 0
+                    ? overlay.slotsCorrect /
+                        (overlay.showsPicked * PROFILE_SLOTS_PER_SHOW)
+                    : null
+                )}
+                sub={
+                  overlay.showsPicked > 0
+                    ? `${overlay.slotsCorrect}/${
+                        overlay.showsPicked * PROFILE_SLOTS_PER_SHOW
+                      } correct`
+                    : null
+                }
+                accent="personal"
+                definition={`Like a batting average in baseball — correct picks ÷ total picks (${PROFILE_SLOTS_PER_SHOW} per show) across your tour shows (.500 means half your picks hit).`}
+              />
+              <StatTile
+                label="Bustout Boost"
+                value={overlay.bustoutHits}
+                accent="personalBustout"
+                definition={`Picks that earned the Bustout Boost — a hit on a song with a pre-show gap ≥ ${BUSTOUT_MIN_GAP}.`}
+              />
+              <StatTile
+                label="In most played"
+                value={overlay.topSongOverlap}
+                accent="personal"
+                definition="How many of this tour's most-played songs you've picked."
+              />
             </div>
           </TourStatsSectionCard>
         ) : null}
@@ -305,10 +337,6 @@ const HEADER_TONE = {
     bar: 'border-brand-primary/35 bg-brand-primary/10',
     text: 'text-brand-primary',
   },
-  personal: {
-    bar: 'border-brand-primary/45 bg-gradient-to-r from-brand-primary/15 to-transparent',
-    text: 'text-brand-primary',
-  },
   bustout: {
     bar: 'border-amber-500/35 bg-amber-500/10',
     text: 'text-amber-200',
@@ -324,7 +352,6 @@ const HEADER_TONE = {
  *   title: string,
  *   definition?: string,
  *   headerTone?: keyof typeof HEADER_TONE,
- *   variant?: 'frosted' | 'venue',
  *   children: React.ReactNode,
  * }} props
  */
@@ -332,13 +359,12 @@ function TourStatsSectionCard({
   title,
   definition,
   headerTone = 'default',
-  variant = 'frosted',
   children,
 }) {
   const tone = HEADER_TONE[headerTone] ?? HEADER_TONE.default;
 
   return (
-    <Card variant={variant} padding="none" className={STANDINGS_CARD_SHELL}>
+    <Card variant="frosted" padding="none" className={STANDINGS_CARD_SHELL}>
       <div className={`-mx-3.5 -mt-3.5 mb-3 rounded-t-xl border-b px-3.5 py-2.5 md:-mx-4 md:-mt-4 md:px-4 ${tone.bar}`}>
         <div className="flex items-center gap-1">
           <p className={`${STANDINGS_BOX_EYEBROW} ${tone.text}`}>{title}</p>
@@ -352,64 +378,89 @@ function TourStatsSectionCard({
   );
 }
 
-/**
- * @param {{ label: string, value: React.ReactNode }} props
- */
-function OverlayStat({ label, value }) {
-  return (
-    <div className="flex min-w-0 flex-col items-center text-center">
-      <p className="flex min-h-[2.25rem] w-full items-end justify-center text-[10px] font-black uppercase leading-tight tracking-wider text-brand-primary/90">
-        {label}
-      </p>
-      <p className="mt-1 w-full text-xl font-black tabular-nums text-white sm:text-2xl">
-        {value}
-      </p>
-    </div>
-  );
-}
+const TILE_ACCENT = {
+  /** Tour-wide row — brand teal. */
+  default: {
+    band: 'border-brand-primary/30 bg-brand-primary/10',
+    label: 'text-brand-primary',
+    value: 'text-brand-primary',
+    tooltip: 'text-brand-primary/85 hover:text-brand-primary',
+  },
+  /** Bustout gold (tour-wide Bustouts tile). */
+  bustout: {
+    band: 'border-amber-500/30 bg-amber-500/10',
+    label: 'text-amber-200',
+    value: 'text-amber-200',
+    tooltip: 'text-amber-200/85 hover:text-amber-200',
+  },
+  /**
+   * "Your picks this tour" tiles — band matches the muted section header
+   * blue; numbers stay brand teal so values read consistently across rows.
+   */
+  personal: {
+    band: 'border-brand-accent-blue/30 bg-brand-accent-blue/10',
+    label: 'text-blue-200',
+    value: 'text-brand-primary',
+    tooltip: 'text-blue-200/85 hover:text-blue-200',
+  },
+  /**
+   * Personal Bustout Boost — gold+blue hybrid (light green) band; label,
+   * number, and tooltip keep bustout gold so "amber = bustout" still reads.
+   */
+  personalBustout: {
+    band: 'border-emerald-400/30 bg-emerald-400/10',
+    label: 'text-amber-200',
+    value: 'text-amber-200',
+    tooltip: 'text-amber-200/85 hover:text-amber-200',
+  },
+};
 
 /**
  * @param {{
  *   label: string,
  *   value: React.ReactNode,
  *   definition: string,
- *   accent?: 'default' | 'bustout',
+ *   accent?: keyof typeof TILE_ACCENT,
+ *   sub?: React.ReactNode,
  * }} props
  */
-function StatTile({ label, value, definition, accent = 'default' }) {
-  const isBustout = accent === 'bustout';
+function StatTile({ label, value, definition, accent = 'default', sub = null }) {
+  const tone = TILE_ACCENT[accent] ?? TILE_ACCENT.default;
 
   return (
     <Card
       variant="frosted"
       padding="none"
-      className={`${STANDINGS_CARD_SHELL} flex flex-col gap-1 text-center`}
+      className={`${STANDINGS_CARD_SHELL} relative flex flex-col gap-1 text-center`}
     >
       <div
-        className={`-mx-3.5 -mt-3.5 mb-1 rounded-t-xl border-b px-2 py-2 md:-mx-4 md:-mt-4 ${
-          isBustout
-            ? 'border-amber-500/30 bg-amber-500/10'
-            : 'border-brand-primary/30 bg-brand-primary/10'
-        }`}
+        className={`-mx-3.5 -mt-3.5 mb-1 rounded-t-xl border-b px-2 py-2 md:-mx-4 md:-mt-4 ${tone.band}`}
       >
-        <div className="flex items-start justify-center gap-1">
-          <p
-            className={`min-w-0 ${STANDINGS_BOX_EYEBROW} ${
-              isBustout ? 'text-amber-200' : 'text-brand-primary'
-            }`}
-          >
+        {/* min-h fits a two-line label so one-line tiles (Bustouts) keep the
+            same header band height as wrapping ones at desktop width */}
+        <div className="flex min-h-[1.875rem] items-center justify-center gap-1">
+          <p className={`min-w-0 ${STANDINGS_BOX_EYEBROW} ${tone.label}`}>
             {label}
           </p>
-          <InfoTooltip label={label} definition={definition} />
+          <InfoTooltip
+            label={label}
+            definition={definition}
+            triggerClassName={tone.tooltip}
+          />
         </div>
       </div>
       <p
-        className={`px-2 pb-1 pt-0.5 text-2xl font-black tabular-nums ${
-          isBustout ? 'text-amber-200' : 'text-brand-primary'
-        }`}
+        className={`flex flex-1 items-center justify-center px-2 pb-1 pt-0.5 text-2xl font-black tabular-nums ${tone.value}`}
       >
         {value}
       </p>
+      {/* Pinned to the tile bottom (out of flow) so the big number stays
+          vertically aligned with sub-less sibling tiles in the same row */}
+      {sub ? (
+        <p className="absolute inset-x-0 bottom-1 text-[10px] font-semibold tabular-nums text-content-secondary">
+          {sub}
+        </p>
+      ) : null}
     </Card>
   );
 }

--- a/src/pages/standings/StandingsPage.jsx
+++ b/src/pages/standings/StandingsPage.jsx
@@ -62,14 +62,14 @@ export default function StandingsPage({ selectedDate, onSelectShowDate }) {
       <div className="mt-4 md:mt-5">
         <StandingsInvitePromo
           onInvite={invite.openChooser}
-          className="mb-4"
+          className="mb-3"
         />
 
         {/*
           Ads epic #419 Phase 1 seam — no-op unless VITE_ENABLE_SPONSOR_SLOTS.
           Filled house-promo mock for local layout QA (#609); #121 replaces this.
         */}
-        <SponsorSlot slotId="dashboard-standings-top" className="mb-4">
+        <SponsorSlot slotId="dashboard-standings-top" className="mb-3">
           <StandingsSponsorPreview onCtaClick={invite.openChooser} />
         </SponsorSlot>
 

--- a/src/shared/ui/InfoTooltip.jsx
+++ b/src/shared/ui/InfoTooltip.jsx
@@ -80,9 +80,14 @@ function clampTooltipPosition(triggerRect, tooltipWidth, tooltipHeight) {
  * @param {{
  *   label: string,
  *   definition: string,
+ *   triggerClassName?: string, // color override for the info icon button
  * }} props
  */
-export default function InfoTooltip({ label, definition }) {
+export default function InfoTooltip({
+  label,
+  definition,
+  triggerClassName = 'text-brand-primary/85 hover:text-brand-primary',
+}) {
   const reactId = useId();
   const tooltipId = `info-tip-${reactId}`;
   const { openId, setOpenId } = useContext(InfoTooltipContext);
@@ -158,7 +163,7 @@ export default function InfoTooltip({ label, definition }) {
       <button
         ref={triggerRef}
         type="button"
-        className="shrink-0 rounded p-0.5 text-brand-primary/85 transition-colors hover:text-brand-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
+        className={`shrink-0 rounded p-0.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg ${triggerClassName}`}
         aria-label={`About ${label}`}
         aria-expanded={open}
         aria-controls={tooltipId}

--- a/src/shared/ui/SponsorSlot.jsx
+++ b/src/shared/ui/SponsorSlot.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { DASHBOARD_CARD_L1_MIN_H } from './dashboardCardClasses';
+
 /**
  * Reserved, clearly-labeled promo/sponsor placement (domain-agnostic).
  *
@@ -35,8 +37,10 @@ export default function SponsorSlot({
   const enabled = import.meta.env.VITE_ENABLE_SPONSOR_SLOTS === 'true';
   if (!enabled) return null;
 
+  // Banner variant reserves the shared L1 promo height so it lines up with
+  // sibling L1 cards (e.g. Invite promo) in dashboard stacks.
   const minHeight =
-    variant === 'card' ? 'min-h-[7.5rem]' : 'min-h-[5rem] md:min-h-[5.5rem]';
+    variant === 'card' ? 'min-h-[7.5rem]' : DASHBOARD_CARD_L1_MIN_H;
 
   return (
     <aside

--- a/src/shared/ui/dashboardCardClasses.js
+++ b/src/shared/ui/dashboardCardClasses.js
@@ -1,0 +1,61 @@
+/**
+ * Dashboard content-card system — shared geometry, size levels, and type
+ * scale for stacked cards on dashboard surfaces (Standings, Tour Stats, …).
+ *
+ * Size levels (collapsed/default state only; expanded height stays
+ * content-driven):
+ * - **L1 (promo/banner):** media tile (~56px) + title + subcopy + CTA.
+ *   Examples: Invite promo, sponsor slot.
+ * - **L2 (summary row):** inline 16px icon + eyebrow + optional one-line
+ *   subcopy + right meta/chevron. Examples: Your rank, Setlist, Crowd pulse,
+ *   Winner banner.
+ *
+ * Colors stay per-surface; only shape, size, and fonts are shared.
+ */
+
+/** Outer radius for every dashboard content card/banner. */
+export const DASHBOARD_CARD_RADIUS = 'rounded-xl';
+
+/** Even padding for card shells (md bump included). */
+export const DASHBOARD_CARD_PAD = 'px-3.5 py-3.5 md:px-4 md:py-4';
+
+/**
+ * `Card` className override — force card radius + pad over Card variant
+ * defaults (`rounded-2xl`/`3xl`, `p-4`–`p-8`).
+ */
+export const DASHBOARD_CARD_SHELL = `!${DASHBOARD_CARD_RADIUS} !p-3.5 md:!p-4`;
+
+/** L1 promo/banner reserved height (media tile + copy + CTA). */
+export const DASHBOARD_CARD_L1_MIN_H = 'min-h-[5.75rem] md:min-h-[6.25rem]';
+
+/**
+ * L2 summary-row reserved height. Sized to the tallest natural L2 header
+ * (eyebrow row + title line) so single-row cards center up to match.
+ * Pair with `flex flex-col justify-center` on the shell.
+ */
+export const DASHBOARD_CARD_L2_MIN_H = 'min-h-[4.25rem] md:min-h-[4.5rem]';
+
+/** 56px square media tile on L1 cards (logo/icon); border per surface. */
+export const DASHBOARD_CARD_MEDIA_TILE = 'h-14 w-14 shrink-0 rounded-xl';
+
+/** Inline icon before an L2 eyebrow; color per surface. */
+export const DASHBOARD_CARD_EYEBROW_ICON = 'h-4 w-4 shrink-0';
+
+/**
+ * Top-right expand/collapse chevron on collapsible cards. Add the surface's
+ * own `group-open:*:rotate-180` class for the flip.
+ */
+export const DASHBOARD_CARD_CHEVRON =
+  'h-4 w-4 shrink-0 text-content-secondary transition-transform';
+
+/** Primary title inside a card (color: white; wrap accent spans inside). */
+export const DASHBOARD_CARD_TITLE =
+  'text-sm font-bold leading-snug text-white md:text-base';
+
+/** Secondary / body copy inside a card. */
+export const DASHBOARD_CARD_BODY =
+  'text-[11px] font-medium leading-snug text-content-secondary md:text-xs';
+
+/** Uppercase eyebrow above a card title; color per surface. */
+export const DASHBOARD_CARD_EYEBROW =
+  'text-[10px] font-black uppercase tracking-widest';


### PR DESCRIPTION
Closes #710

## Summary
- **Shared dashboard card system:** new `src/shared/ui/dashboardCardClasses.js` (radius, pad, shell, L1/L2 min-heights, media tile, eyebrow/title/body/chevron type scale). `standingsSurfaceClasses.js` becomes a re-export alias so Standings, crowd pulse panels, `SponsorSlot`, and Tour Stats all share one geometry/type source.
- **Stats naming polish (rules: one metaphor per stat, metaphor matches number shape, label literal / tooltip carries the sport):** "Picking average" unified across profile + tour stats with batting-average display (`.167`, `1.000`); "Avg pts / show" → "Points per show" with a PPG tooltip; public profile stats gain InfoTooltips (footnote paragraph removed) plus Wins/Shows/Total points definitions.
- **Tour stats view:** "Your picks this tour" renders on the shared `StatTile` (new `sub` slot, bottom-pinned `x/y correct` line so numbers align across the row); personal section recolored to the muted `brand-accent-blue` family with an emerald gold×blue hybrid band on Bustout Boost (amber label/number preserved); `InfoTooltip` gains optional `triggerClassName`.
- SemVer: PATCH → **1.35.4** (style/copy polish, no public API surface change).
- Deferred to #709: all-songs + per-card pagination on Most played / Bustouts / High gaps.

## Test plan
- [x] `npm run lint`
- [x] `npm test` (442 passing)
- [x] `npm run verify:dashboard-meta` / `npm run verify:dashboard-ui`
- [ ] Preview: Tour Stats — personal section blue header + tile bands, emerald Bustout Boost band, Picking average number aligned with sibling tiles, `x/y correct` pinned at tile bottom
- [ ] Preview: self profile + public profile — "Points per show" / "Picking average" labels, tooltips open, `.167`-style display
- [ ] Preview: Standings — card geometry unchanged after the shared-token refactor (Invite, Sponsor, rank/setlist/crowd pulse cards)

Made with [Cursor](https://cursor.com)