### PR TITLE
feat(catalog): archive dated song-catalog snapshots (#647)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ No unreleased changes.
 
 ---
 
+## [1.36.0] — 2026-07-21
+
+### Added
+- **Song catalog archives (#647)** — each `scheduledPhishnetSongCatalog` / `refreshPhishnetSongCatalog` sync writes a private dated snapshot at `song-catalog/archive/YYYY-MM-DDTHH-mm-ssZ.json` (same payload as live) for leakage-safe prediction backtests (#646). Live `song-catalog.json` client path unchanged. Callable may return optional `archivePath`.
+
+### Changed
+- **`docs/SONG_CATALOG.md`** — documents the every-6h schedule (was stale “weekly”), archive layout/retention, and Storage rules for archive objects.
+
+---
+
 ## [1.35.4] — 2026-07-21
 
 ### Changed

--- a/docs/API.md
+++ b/docs/API.md
@@ -302,6 +302,8 @@ Phish.net integration, live scoring, and public tour-stats refresh. Deployed via
 
 **Storage object `song-catalog.json` (v1.25.0+, #554):** published by `scheduledPhishnetSongCatalog` / `refreshPhishnetSongCatalog`. Each song object includes `{ name, total, gap, last, debut }` where `debut` is a string (typically `YYYY-MM-DD`) or `""` when unknown. See `docs/SONG_CATALOG.md`. Adding `debut` is a **MINOR** catalog-field addition (clients may ignore unknown fields).
 
+**Storage archive `song-catalog/archive/{stamp}.json` (v1.36.0+, #647):** each catalog sync also writes a dated private snapshot (same JSON payload as live) at `song-catalog/archive/YYYY-MM-DDTHH-mm-ssZ.json` for leakage-safe recommendation backtests (#646). Not public-read (Admin SDK / ops only). Live client path is unchanged. `refreshPhishnetSongCatalog` may return optional `archivePath` (`string | null`) when the archive write succeeded.
+
 ### 2.4 Comms event adapters (v1.7.0+)
 
 Automated comms delivery triggered by Firestore writes, post-rollup hooks, live-scoring hooks, and scheduled jobs. All adapters route through `deliverCommsTrigger` and are **gated** by `COMMS_EVENT_ADAPTERS_ENABLED=true` (default off).

--- a/docs/SONG_CATALOG.md
+++ b/docs/SONG_CATALOG.md
@@ -1,22 +1,24 @@
 # Song catalog (picks autocomplete) — issue #158
 
-> **Scoring decoupled (#214):** As of #214, **scoring does not consult this catalog.** Bustout boosts come from the per-show `official_setlists/{showDate}.bustouts` snapshot (frozen at save time from Phish.net row `gap`). The Storage catalog and the bundled fallbacks (`src/shared/data/phishSongs.js`, `functions/phishSongs.js`) are retained solely for **UI concerns** — autocomplete, scoring-rules copy, and future upcoming-show bustout hints. Weekly refresh cadence is adequate for those uses; scoring accuracy no longer depends on it. See `docs/OFFICIAL_SETLISTS_SCHEMA.md` → “Bustout source — per-show snapshot (#214).”
+> **Scoring decoupled (#214):** As of #214, **scoring does not consult this catalog.** Bustout boosts come from the per-show `official_setlists/{showDate}.bustouts` snapshot (frozen at save time from Phish.net row `gap`). The Storage catalog and the bundled fallbacks (`src/shared/data/phishSongs.js`, `functions/phishSongs.js`) are retained solely for **UI concerns** — autocomplete, scoring-rules copy, and future upcoming-show bustout hints. The **~6 hour** refresh cadence (schedule + client TTL) is adequate for those uses; scoring accuracy no longer depends on it. See `docs/OFFICIAL_SETLISTS_SCHEMA.md` → “Bustout source — per-show snapshot (#214).”
 
 ## Data path
 
 1. **Source of truth (live):** Phish.net API v5 `GET /v5/songs.json` (server-side only, `PHISHNET_API_KEY`).
 2. **Publish:** Cloud Functions write **`song-catalog.json`** to the **default Firebase Storage bucket** (`makePublic()` is best-effort; not required for the default client path).
-3. **Client URL:** By default the app uses **`getDownloadURL()`** (Firebase Storage SDK) for `song-catalog.json`. That respects **`storage.rules`** (`allow read: if true`) and avoids opening the whole bucket on **GCS IAM**. A raw browser URL like `https://storage.googleapis.com/<bucket>/song-catalog.json` **does not** use Firebase rules and returns **`AccessDenied`** for anonymous users unless you add **`allUsers` → Storage Object Viewer** on the bucket (usually avoid on buckets that hold private uploads). Override with **`VITE_SONG_CATALOG_URL`** only if you host the JSON elsewhere (CDN) with anonymous GET + CORS.
-4. **Fetch + cache:** `useSongCatalog` **`fetch()`**s the resolved URL. **localStorage** (`set-picks.songCatalogCache.v2`): if data was saved **within the last 6 hours**, the hook **skips** both `getDownloadURL` and `fetch`. On failure, an **older cache** is used if present; otherwise **`src/shared/data/phishSongs.js`**.
-5. **Scoring does not read this catalog (post-#214).** `recomputeLiveScoresForShow` and `calculateSlotScore` in `functions/index.js` — and their client counterparts in `src/shared/utils/scoring.js` — read bustout membership from `actualSetlist.bustouts`. `functions/songCatalogSource.js` (5-minute TTL loader) is still present in-tree but is no longer threaded into grading; it can be removed in a follow-up once no code path imports it. The bundled catalogs (`src/shared/data/phishSongs.js`, `functions/phishSongs.js`) remain only as Storage-fallback seeds for `useSongCatalog` / the storage loader.
+3. **Archive (#647):** the same sync also writes a **private** dated copy under **`song-catalog/archive/YYYY-MM-DDTHH-mm-ssZ.json`** (colon-safe UTC stamp). Same JSON payload as live (`songs`, `songCount`, `source`, `updatedAt`). Used for leakage-safe recommendation backtests (#646 / #648); **not** fetched by the web client. Archive failure is logged and does not fail the live upload.
+4. **Client URL:** By default the app uses **`getDownloadURL()`** (Firebase Storage SDK) for `song-catalog.json`. That respects **`storage.rules`** (`allow read: if true`) and avoids opening the whole bucket on **GCS IAM**. A raw browser URL like `https://storage.googleapis.com/<bucket>/song-catalog.json` **does not** use Firebase rules and returns **`AccessDenied`** for anonymous users unless you add **`allUsers` → Storage Object Viewer** on the bucket (usually avoid on buckets that hold private uploads). Override with **`VITE_SONG_CATALOG_URL`** only if you host the JSON elsewhere (CDN) with anonymous GET + CORS.
+5. **Fetch + cache:** `useSongCatalog` **`fetch()`**s the resolved URL. **localStorage** (`set-picks.songCatalogCache.v2`): if data was saved **within the last 6 hours**, the hook **skips** both `getDownloadURL` and `fetch`. On failure, an **older cache** is used if present; otherwise **`src/shared/data/phishSongs.js`**.
+6. **Scoring does not read this catalog (post-#214).** `recomputeLiveScoresForShow` and `calculateSlotScore` in `functions/index.js` — and their client counterparts in `src/shared/utils/scoring.js` — read bustout membership from `actualSetlist.bustouts`. `functions/songCatalogSource.js` (5-minute TTL loader) is still present in-tree but is no longer threaded into grading; it can be removed in a follow-up once no code path imports it. The bundled catalogs (`src/shared/data/phishSongs.js`, `functions/phishSongs.js`) remain only as Storage-fallback seeds for `useSongCatalog` / the storage loader.
 
 ## Operations
 
-- **Weekly refresh:** `scheduledPhishnetSongCatalog` (Sunday 7:00 America/New_York) — uploads JSON and logs **`publicUrl`**.
-- **On-demand (designated admin only):** callable **`refreshPhishnetSongCatalog`** returns `{ songCount, publicUrl }`, or **Admin → Song catalog** accordion → **Refresh song catalog from Phish.net**.
+- **Scheduled refresh:** `scheduledPhishnetSongCatalog` — cron **`0 */6 * * *`** America/New_York (every 6 hours at 00/06/12/18 ET). Uploads live JSON + archive snapshot; logs **`publicUrl`** and archive object path.
+- **On-demand (designated admin only):** callable **`refreshPhishnetSongCatalog`** returns `{ songCount, publicUrl, archivePath }` (`archivePath` is `null` if the archive write failed), or **Admin → Song catalog** accordion → **Refresh song catalog from Phish.net**.
 - **Deploy:** `npm run deploy:functions:phishnet` includes song-catalog functions.
-- **Storage rules:** `storage.rules` — public **read** on `song-catalog.json` only. The web app uses **`getDownloadURL` + `fetch`** for that object by default (rules apply; no bucket-wide IAM required).
+- **Storage rules:** `storage.rules` — public **read** on `song-catalog.json` only. Archive objects under `song-catalog/archive/` are **not** publicly readable (Admin SDK / bucket IAM only). The web app uses **`getDownloadURL` + `fetch`** for the live object by default (rules apply; no bucket-wide IAM required).
 - **Firestore:** Legacy `song_catalog/snapshot` is **no longer** written; rules for that path were removed.
+- **Archive retention (#647):** v1 keeps all dated snapshots (no automatic TTL). Revisit lifecycle (e.g. keep N days / tour window) once #648 backtests define how many historical catalogs are needed. Disk cost is small (~one JSON per sync ≈ 4×/day).
 
 ### First-time / CORS
 
@@ -59,3 +61,11 @@ Edit **`scripts/song-catalog-storage-cors.json`** if your web origin is not alre
 | `debut` | string | First performance date/year (`debut`), typically `YYYY-MM-DD`; **empty string** when unknown (v1.25.0+, #554). Do **not** treat `gap` / `last` as vintage. |
 
 Bundled fallbacks (`src/shared/data/phishSongs.js`, `functions/phishSongs.js`) may omit `debut` — treat missing as unknown when computing avg song vintage.
+
+### Archive object naming
+
+| Live | Archive example |
+|------|-----------------|
+| `song-catalog.json` | `song-catalog/archive/2026-07-21T18-00-00Z.json` |
+
+Stamp is UTC from `updatedAt`, with `:` → `-` so object names stay path-safe. Payload is identical to the live catalog written in the same sync.

--- a/functions/index.js
+++ b/functions/index.js
@@ -1757,6 +1757,7 @@ exports.refreshPhishnetSongCatalog = onCall(
         ok: true,
         songCount: result.songCount,
         publicUrl: result.publicUrl,
+        archivePath: result.archivePath ?? null,
       };
     } catch (e) {
       if (e instanceof HttpsError) throw e;

--- a/functions/phishnetSongCatalog.js
+++ b/functions/phishnetSongCatalog.js
@@ -3,15 +3,39 @@
  *
  * Endpoint: `GET https://api.phish.net/v5/songs.json?order_by=song&direction=asc&limit=10000&apikey=…`
  *
- * Publishes `song-catalog.json` to the default Firebase Storage bucket (public read for CDN fetch).
+ * Publishes live `song-catalog.json` plus a dated private archive under
+ * `song-catalog/archive/` (#647) to the default Firebase Storage bucket.
  */
 
 const crypto = require("node:crypto");
 const admin = require("firebase-admin");
 
-/** Object path in the default Storage bucket. */
+/** Object path in the default Storage bucket (live autocomplete fast path). */
 const CATALOG_STORAGE_PATH = "song-catalog.json";
 
+/**
+ * Dated pre-show snapshots for leakage-safe recommendation backtests (#647 / #646).
+ * Not public-read — Admin SDK / ops only. Live clients keep using `song-catalog.json`.
+ */
+const CATALOG_ARCHIVE_PREFIX = "song-catalog/archive/";
+
+/**
+ * Build archive object path from an ISO timestamp.
+ * Example: `2026-07-21T18:00:00.000Z` → `song-catalog/archive/2026-07-21T18-00-00Z.json`
+ *
+ * @param {string} updatedAtIso
+ * @returns {string}
+ */
+function catalogArchiveObjectPath(updatedAtIso) {
+  const raw = String(updatedAtIso ?? "").trim();
+  const d = raw ? new Date(raw) : new Date();
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`Invalid catalog archive timestamp: ${raw}`);
+  }
+  const iso = d.toISOString(); // always `YYYY-MM-DDTHH:mm:ss.sssZ`
+  const stamp = iso.replace(/\.\d{3}Z$/, "Z").replace(/:/g, "-");
+  return `${CATALOG_ARCHIVE_PREFIX}${stamp}.json`;
+}
 /**
  * @param {unknown} data
  * @returns {boolean}
@@ -144,11 +168,13 @@ function publicGcsUrlForCatalog(bucketName) {
 }
 
 /**
- * Fetch from Phish.net, write `song-catalog.json` to Storage, make object world-readable for GET/fetch().
+ * Fetch from Phish.net, write live `song-catalog.json` plus a dated archive snapshot.
+ * Archive write is best-effort: live catalog failure throws; archive failure logs and continues
+ * so autocomplete never depends on archive success (#647).
  *
  * @param {string} apiKey
  * @param {{ logger?: { info?: Function, warn?: Function, error?: Function }, bucketName?: string }} [opts]
- * @returns {Promise<{ songCount: number, publicUrl: string, bucket: string }>}
+ * @returns {Promise<{ songCount: number, publicUrl: string, bucket: string, archivePath: string | null }>}
  */
 async function syncPhishnetSongCatalogToStorage(apiKey, opts = {}) {
   const { logger, bucketName } = opts;
@@ -161,13 +187,14 @@ async function syncPhishnetSongCatalogToStorage(apiKey, opts = {}) {
     updatedAt,
   };
   const json = JSON.stringify(payload);
+  const body = Buffer.from(json, "utf8");
 
   const bucket = bucketName
     ? admin.storage().bucket(bucketName)
     : admin.storage().bucket();
   const file = bucket.file(CATALOG_STORAGE_PATH);
 
-  await file.save(Buffer.from(json, "utf8"), {
+  await file.save(body, {
     metadata: {
       contentType: "application/json; charset=utf-8",
       cacheControl: "public, max-age=300",
@@ -188,15 +215,47 @@ async function syncPhishnetSongCatalogToStorage(apiKey, opts = {}) {
     );
   }
 
+  let archivePath = null;
+  try {
+    archivePath = catalogArchiveObjectPath(updatedAt);
+    const archiveFile = bucket.file(archivePath);
+    await archiveFile.save(body, {
+      metadata: {
+        contentType: "application/json; charset=utf-8",
+        // Private ops object — no download token / makePublic.
+        cacheControl: "private, max-age=0",
+      },
+    });
+    logger?.info?.("song catalog archive uploaded", {
+      songCount: songs.length,
+      bucket: bucket.name,
+      object: archivePath,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logger?.error?.(
+      "song catalog: archive snapshot failed (live catalog still updated)",
+      msg,
+      e
+    );
+    archivePath = null;
+  }
+
   const publicUrl = publicGcsUrlForCatalog(bucket.name);
   logger?.info?.("song catalog uploaded to Storage", {
     songCount: songs.length,
     publicUrl,
     bucket: bucket.name,
     object: CATALOG_STORAGE_PATH,
+    archivePath,
   });
 
-  return { songCount: songs.length, publicUrl, bucket: bucket.name };
+  return {
+    songCount: songs.length,
+    publicUrl,
+    bucket: bucket.name,
+    archivePath,
+  };
 }
 
 module.exports = {
@@ -204,6 +263,8 @@ module.exports = {
   normalizePhishnetSongRow,
   normalizeDebutField,
   isPhishNetPayloadOk,
+  catalogArchiveObjectPath,
   CATALOG_STORAGE_PATH,
+  CATALOG_ARCHIVE_PREFIX,
   publicGcsUrlForCatalog,
 };

--- a/functions/phishnetSongCatalog.test.js
+++ b/functions/phishnetSongCatalog.test.js
@@ -3,6 +3,8 @@ const assert = require("node:assert/strict");
 const {
   normalizePhishnetSongRow,
   isPhishNetPayloadOk,
+  catalogArchiveObjectPath,
+  CATALOG_ARCHIVE_PREFIX,
 } = require("./phishnetSongCatalog.js");
 
 test("isPhishNetPayloadOk accepts error:false", () => {
@@ -39,6 +41,21 @@ test("normalizePhishnetSongRow maps missing debut to empty string", () => {
 
 test("normalizePhishnetSongRow returns null for empty song", () => {
   assert.equal(normalizePhishnetSongRow({ song: "  " }), null);
+});
+
+test("catalogArchiveObjectPath uses colon-safe UTC stamp under archive prefix", () => {
+  assert.equal(
+    catalogArchiveObjectPath("2026-07-21T18:00:00.000Z"),
+    `${CATALOG_ARCHIVE_PREFIX}2026-07-21T18-00-00Z.json`
+  );
+  assert.equal(
+    catalogArchiveObjectPath("2026-07-21T06:30:45.123Z"),
+    `${CATALOG_ARCHIVE_PREFIX}2026-07-21T06-30-45Z.json`
+  );
+});
+
+test("catalogArchiveObjectPath rejects invalid timestamps", () => {
+  assert.throws(() => catalogArchiveObjectPath("not-a-date"), /Invalid catalog archive/);
 });
 
 // Regression guard for #261: the displayed `Gap` and `Last` in

--- a/functions/songCatalogSource.js
+++ b/functions/songCatalogSource.js
@@ -1,7 +1,7 @@
 /**
  * Song catalog source for Cloud Function grading (issue #167).
  *
- * Reads the authoritative `song-catalog.json` that the weekly
+ * Reads the authoritative `song-catalog.json` that the every-6h
  * `scheduledPhishnetSongCatalog` / admin `refreshPhishnetSongCatalog` callable
  * publishes to Firebase Storage, so live scoring uses the same catalog the
  * client uses (see `src/shared/data/phishSongs.js` / `useSongCatalog`).
@@ -17,7 +17,7 @@
 const admin = require("firebase-admin");
 const { CATALOG_STORAGE_PATH } = require("./phishnetSongCatalog");
 
-/** 5 minute in-memory cache; catalog refreshes weekly. */
+/** 5 minute in-memory cache; live catalog refreshes on a ~6h schedule. */
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
 let cached = null;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.35.4",
+  "version": "1.36.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/storage.rules
+++ b/storage.rules
@@ -6,5 +6,11 @@ service firebase.storage {
       allow read: if true;
       allow write: if false;
     }
+
+    // Dated catalog archives for prediction backtests (#647). Admin SDK only —
+    // do not grant public read (live clients use song-catalog.json).
+    match /song-catalog/archive/{fileName} {
+      allow read, write: if false;
+    }
   }
 }


### PR DESCRIPTION
Closes #647

## Summary
- Wave 1 of the [Sprint 13 release train](https://github.com/pat792/set-picks/pull/714) / epic #646.
- Each catalog sync writes a private dated snapshot at `song-catalog/archive/YYYY-MM-DDTHH-mm-ssZ.json` alongside live `song-catalog.json`.
- Archive failure is best-effort (logged); live autocomplete path unchanged.
- Storage rules explicitly deny client read/write on archive objects; docs + `docs/API.md` updated; SemVer **1.36.0**.

## Test plan
- [x] `cd functions && node --test phishnetSongCatalog.test.js`
- [x] After deploy: admin refresh → confirm live catalog still loads in picks UI
- [ ] Confirm archive object appears under `song-catalog/archive/` (not publicly fetchable)
- [ ] Deploy Storage rules with Functions (or `firebase deploy --only storage`)


Made with [Cursor](https://cursor.com)