### PR TITLE
feat(backtest): calibrate explainable recommendation model (#649)

### DIFF
--- a/docs/RELEASE_TRAIN_SPRINT_13.md
+++ b/docs/RELEASE_TRAIN_SPRINT_13.md
@@ -163,4 +163,5 @@ Agent-assisted eng-day ranges used to size waves (not a commit):
 | 2026-07-21 | Baseline | Confirm `main`/`staging` at **1.35.4** | Fast-forward train branch to `main` tip |
 | 2026-07-21 | 0 | [#714](https://github.com/pat792/set-picks/pull/714) merged | Manifest on staging |
 | 2026-07-21 | 1 | [#715](https://github.com/pat792/set-picks/pull/715) merged + deployed | #647 archives verified (`…/archive/2026-07-22T04-55-51Z.json`); issue closed |
-| 2026-07-21 | 2 | #648 in flight | Offline import + leakage-safe baseline backtest harness |
+| 2026-07-21 | 2 | [#716](https://github.com/pat792/set-picks/pull/716) (#648) | Offline import + leakage-safe baseline harness |
+| 2026-07-21 | 2 | #649 in flight | Combined explainable model `v0.1.0-explainable` + go/no-go |

--- a/docs/scoring-analysis/06-predictive-picker-framework.md
+++ b/docs/scoring-analysis/06-predictive-picker-framework.md
@@ -50,7 +50,7 @@ Keep in `features/picks` (api/model/ui). Extend `SongAutocomplete` only with gen
 
 ## Rollout
 
-1. Offline backtest (#648–#649) — see [07-backtest-harness.md](./07-backtest-harness.md)  
+1. Offline backtest (#648–#649) — see [07-backtest-harness.md](./07-backtest-harness.md) and [08-recommendation-model.md](./08-recommendation-model.md)  
 2. Artifact (#650)  
 3. Prediction Lab (#651)  
 4. Predictive Mode if panel evidence OK (#652)  

--- a/docs/scoring-analysis/07-backtest-harness.md
+++ b/docs/scoring-analysis/07-backtest-harness.md
@@ -55,7 +55,7 @@ npm run test:prediction-backtest
 | `gap_ascending` | Reconstructed shows-since-last-play (low gap first), then plays — mirrors autocomplete heuristic |
 | `recent_frequency` | Plays in trailing N shows (default 25) before `T` |
 
-These are **slot-agnostic**. #649 adds play-likelihood × slot affinity and must beat these on the same harness.
+These are **slot-agnostic**. #649 adds `combined_explainable` (play × slot affinity) on the same harness — see [08-recommendation-model.md](./08-recommendation-model.md).
 
 ## Interpreting the report
 

--- a/docs/scoring-analysis/08-recommendation-model.md
+++ b/docs/scoring-analysis/08-recommendation-model.md
@@ -1,0 +1,55 @@
+# Combined recommendation model (#649)
+
+Frozen explainable play × slot model used by the offline harness and (later) `#650` artifact.
+
+| Field | Value |
+|-------|--------|
+| `modelVersion` | `v0.1.0-explainable` |
+| Training | Rolling-origin on cached Phish.net setlists (`showDate < target`) |
+| Formula | `slotScore = playProb × smoothedSlotAffinity` · `wildcardScore = playProb` |
+| Risk bands | `safe` / `slot_fit` / `long_shot` (bustout gap ≥ 30 + low playProb) |
+
+## Features (leakage-safe)
+
+- Recent play rates over trailing 10 / 25 / 50 shows
+- Lifetime frequency with shrinkage
+- Nonlinear gap vs expected return interval (gap 0 after prior night is penalized)
+- Prior-night repeat penalty
+- Days-since-prior-show rest bonus
+- Empirical smoothed slot affinity for s1o/s1c/s2o/s2c/enc
+
+**Never** uses target-night `songGaps` / official setlist as candidate features.
+
+## Go / no-go
+
+```bash
+npm run backtest:import-setlists -- --years=2
+npm run backtest:recommendations
+```
+
+PASS when `combined_explainable` meets or beats each baseline on **slotHit@5** or **recall@10**. Exit code `2` on FAIL.
+
+Weights live in `scripts/prediction-backtest/lib/model.mjs` (`MODEL_WEIGHTS`). Bump `MODEL_VERSION` when weights change and re-run the harness.
+
+## Empirical freeze note (2026-07-22)
+
+On a 41-show 2024 cache (`minTrain=15`, 26 eval nights), `v0.1.0-explainable` **PASS**ed go/no-go:
+
+| Model | recall@10 | slotHit@5 | zeroScoreRate |
+|-------|----------:|----------:|--------------:|
+| global_popularity | 0.078 | 0.008 | 1.00 |
+| gap_ascending | 0.013 | 0.000 | 1.00 |
+| recent_frequency | 0.070 | 0.031 | 0.96 |
+| **combined_explainable** | **0.186** | **0.185** | **0.31** |
+
+Re-run on a wider window before Wave 3; bump `MODEL_VERSION` if weights change.
+
+## Explanations
+
+Each ranked song carries up to two short reasons, e.g.:
+
+- strong s1o history (12/40)
+- frequent this tour window
+- due vs cadence (gap 8)
+- unlikely repeat after prior night
+- bustout / long-shot upside (gap 42)

--- a/scripts/prediction-backtest/import-setlists.mjs
+++ b/scripts/prediction-backtest/import-setlists.mjs
@@ -71,8 +71,15 @@ if (!apiKey) {
 const { fetchAllShowsNormalized } = loadShowCalendar();
 const { fetchPhishnetSetlistForDate } = loadSetlistAutomation();
 
-console.log(`Listing Phish.net shows ${from} → ${to}…`);
-const allShows = await fetchAllShowsNormalized({ apiKey });
+const fromYear = Number(from.slice(0, 4));
+const toYear = Number(to.slice(0, 4));
+
+console.log(`Listing Phish.net shows ${from} → ${to} (years ${fromYear}–${toYear})…`);
+const allShows = await fetchAllShowsNormalized({
+  apiKey,
+  minYear: fromYear,
+  maxYear: toYear,
+});
 const dates = allShows
   .map((s) => s.date)
   .filter((d) => typeof d === "string" && d >= from && d <= to)

--- a/scripts/prediction-backtest/lib/backtest.mjs
+++ b/scripts/prediction-backtest/lib/backtest.mjs
@@ -1,8 +1,13 @@
 /**
- * Rolling-origin backtest loop (#648).
+ * Rolling-origin backtest loop (#648 / #649).
  */
 import { priorShows } from "./features.mjs";
 import { runBaseline } from "./baselines.mjs";
+import {
+  rankCombinedPlayOnly,
+  rankCombinedForSlot,
+  MODEL_VERSION,
+} from "./model.mjs";
 import {
   playedSongRecallAtK,
   exactSlotHitAtK,
@@ -13,7 +18,7 @@ import {
   crossSlotOverlap,
 } from "./metrics.mjs";
 import { playedKeys } from "./dataset.mjs";
-import { POSITIONAL_SLOTS } from "./shared.mjs";
+import { POSITIONAL_SLOTS, normalizeTitle } from "./shared.mjs";
 
 export const BASELINE_NAMES = [
   "global_popularity",
@@ -21,22 +26,52 @@ export const BASELINE_NAMES = [
   "recent_frequency",
 ];
 
+export const MODEL_NAME = "combined_explainable";
+
+/**
+ * Exact-slot hit using per-slot rankings (combined model).
+ * @param {Record<string, string>} slots
+ * @param {Record<string, { songKey: string }[]>} rankedBySlot
+ * @param {number} k
+ */
+function exactSlotHitAtKPerSlot(slots, rankedBySlot, k) {
+  /** @type {Record<string, number>} */
+  const bySlot = {};
+  let sum = 0;
+  let n = 0;
+  for (const slot of POSITIONAL_SLOTS) {
+    const truth = normalizeTitle(slots?.[slot]);
+    if (!truth) continue;
+    const top = new Set(
+      (rankedBySlot[slot] || []).slice(0, k).map((r) => r.songKey)
+    );
+    const hit = top.has(truth) ? 1 : 0;
+    bySlot[slot] = hit;
+    sum += hit;
+    n += 1;
+  }
+  return { bySlot, mean: n ? sum / n : 0 };
+}
+
 /**
  * @param {import('./features.mjs').ShowRecord[]} historySortedAsc
  * @param {{
  *   minTrainShows?: number,
  *   recentWindow?: number,
  *   baselines?: string[],
+ *   includeCombined?: boolean,
  * }} [opts]
  */
 export function runRollingBacktest(historySortedAsc, opts = {}) {
   const minTrainShows = opts.minTrainShows ?? 30;
   const baselines = opts.baselines ?? BASELINE_NAMES;
   const recentWindow = opts.recentWindow ?? 25;
+  const includeCombined = opts.includeCombined !== false;
 
   /** @type {Record<string, object[]>} */
   const byBaseline = {};
   for (const name of baselines) byBaseline[name] = [];
+  if (includeCombined) byBaseline[MODEL_NAME] = [];
 
   for (let i = 0; i < historySortedAsc.length; i += 1) {
     const target = historySortedAsc[i];
@@ -58,7 +93,6 @@ export function runRollingBacktest(historySortedAsc, opts = {}) {
       const sim = simulatedPickCardOutcome(slotLabels, labels, ranked);
       const concentration = top3Concentration(ranked);
 
-      // Slot-agnostic baselines share one list → overlap = 1 by construction.
       /** @type {Record<string, typeof ranked>} */
       const bySlot = {};
       for (const slot of POSITIONAL_SLOTS) bySlot[slot] = ranked;
@@ -78,11 +112,57 @@ export function runRollingBacktest(historySortedAsc, opts = {}) {
         crossSlotOverlapAt5: overlap,
       });
     }
+
+    if (includeCombined) {
+      const playRanked = rankCombinedPlayOnly(priors, target.showDate);
+      /** @type {Record<string, ReturnType<typeof rankCombinedForSlot>>} */
+      const rankedBySlot = {};
+      for (const slot of POSITIONAL_SLOTS) {
+        rankedBySlot[slot] = rankCombinedForSlot(
+          priors,
+          target.showDate,
+          slot
+        );
+      }
+      const recallAt5 = playedSongRecallAtK(labels, playRanked, 5);
+      const recallAt10 = playedSongRecallAtK(labels, playRanked, 10);
+      const slot5 = exactSlotHitAtKPerSlot(slotLabels, rankedBySlot, 5);
+      const slot10 = exactSlotHitAtKPerSlot(slotLabels, rankedBySlot, 10);
+      const { brier } = rankBrierScore(labels, playRanked, 100);
+      let exactHits = 0;
+      let inSetlistHits = 0;
+      const played = new Set(labels.map(normalizeTitle));
+      for (const slot of POSITIONAL_SLOTS) {
+        const pick = rankedBySlot[slot][0]?.songKey;
+        if (!pick) continue;
+        const truth = normalizeTitle(slotLabels?.[slot]);
+        if (truth && pick === truth) exactHits += 1;
+        else if (played.has(pick)) inSetlistHits += 1;
+      }
+      const zeroScore = exactHits + inSetlistHits === 0;
+      const overlap = crossSlotOverlap(rankedBySlot, 5);
+
+      byBaseline[MODEL_NAME].push({
+        showDate: target.showDate,
+        trainShows: priors.length,
+        modelVersion: MODEL_VERSION,
+        recallAt5,
+        recallAt10,
+        slotHitAt5: slot5.mean,
+        slotHitAt10: slot10.mean,
+        slotHitAt5BySlot: slot5.bySlot,
+        brier,
+        zeroScoreRate: zeroScore ? 1 : 0,
+        top3Concentration: top3Concentration(playRanked),
+        crossSlotOverlapAt5: overlap,
+      });
+    }
   }
 
   /** @type {Record<string, object>} */
   const summary = {};
-  for (const name of baselines) {
+  const names = Object.keys(byBaseline);
+  for (const name of names) {
     summary[name] = {
       ...aggregateNights(byBaseline[name]),
       meanCrossSlotOverlapAt5:
@@ -97,9 +177,44 @@ export function runRollingBacktest(historySortedAsc, opts = {}) {
     generatedAt: new Date().toISOString(),
     minTrainShows,
     recentWindow,
+    modelVersion: includeCombined ? MODEL_VERSION : null,
     historyShows: historySortedAsc.length,
     evaluatedNights: Object.values(byBaseline)[0]?.length ?? 0,
     summary,
     nights: byBaseline,
+  };
+}
+
+/**
+ * Go/no-go: combined model should meet or beat each baseline on slotHit@5 or recall@10.
+ * @param {ReturnType<typeof runRollingBacktest>} result
+ */
+export function evaluateGoNoGo(result) {
+  const combined = result.summary[MODEL_NAME];
+  if (!combined || !Number.isFinite(combined.slotHitAt5)) {
+    return { pass: false, reason: "combined model missing from summary" };
+  }
+  /** @type {string[]} */
+  const wins = [];
+  /** @type {string[]} */
+  const losses = [];
+  for (const name of BASELINE_NAMES) {
+    const base = result.summary[name];
+    if (!base) continue;
+    const beatSlot =
+      Number(combined.slotHitAt5) >= Number(base.slotHitAt5) - 1e-9;
+    const beatRecall =
+      Number(combined.recallAt10) >= Number(base.recallAt10) - 1e-9;
+    if (beatSlot || beatRecall) wins.push(name);
+    else losses.push(name);
+  }
+  const pass = losses.length === 0 && wins.length === BASELINE_NAMES.length;
+  return {
+    pass,
+    wins,
+    losses,
+    reason: pass
+      ? `combined_explainable (${MODEL_VERSION}) meets or beats all baselines on slotHit@5 or recall@10`
+      : `lags baselines: ${losses.join(", ")}`,
   };
 }

--- a/scripts/prediction-backtest/lib/model.mjs
+++ b/scripts/prediction-backtest/lib/model.mjs
@@ -1,0 +1,239 @@
+/**
+ * Explainable play × slot recommendation model (#649).
+ *
+ * modelVersion is frozen in MODEL_VERSION / docs after it beats baselines.
+ */
+import {
+  buildHistoryIndex,
+  recentPlayCounts,
+  reconstructGap,
+  assertNoTargetLeakage,
+  calendarContext,
+} from "./features.mjs";
+import { normalizeTitle, POSITIONAL_SLOTS } from "./shared.mjs";
+
+/** Frozen identifier once calibration ships — bump when weights change. */
+export const MODEL_VERSION = "v0.1.0-explainable";
+
+/** Training-window description for reports / artifact metadata. */
+export const MODEL_TRAINING_WINDOW =
+  "rolling-origin; features from all prior cached shows";
+
+/**
+ * Hand-tuned v0 weights — replace only with a version bump after re-backtest.
+ * Kept intentionally simple / explainable (no black-box ML).
+ */
+export const MODEL_WEIGHTS = {
+  recent10: 0.35,
+  recent25: 0.25,
+  recent50: 0.15,
+  lifetime: 0.15,
+  gapCadence: 0.2,
+  priorNightRepeatPenalty: 0.45,
+  daysSincePriorScale: 0.05,
+  slotSmoothingAlpha: 1.5,
+  bustoutGapMin: 30,
+};
+
+/**
+ * Precompute shared maps once per (priors, targetDate).
+ * @param {import('./features.mjs').ShowRecord[]} priors
+ * @param {string} targetDate
+ */
+function buildFeatureContext(priors, targetDate) {
+  const idx = buildHistoryIndex(priors);
+  const r10 = recentPlayCounts(priors, 10);
+  const r25 = recentPlayCounts(priors, 25);
+  const r50 = recentPlayCounts(priors, 50);
+  const lastPrior = priors[priors.length - 1] || null;
+  const priorNightKeys = new Set(
+    (lastPrior?.songs || []).map(normalizeTitle).filter(Boolean)
+  );
+  const { daysSincePriorShow } = calendarContext(priors, targetDate);
+  /** @type {Map<string, number>} */
+  const gaps = new Map();
+  for (const songKey of idx.songs) {
+    gaps.set(songKey, reconstructGap(priors, targetDate, songKey));
+  }
+  return {
+    idx,
+    r10,
+    r25,
+    r50,
+    priorNightKeys,
+    daysSincePriorShow,
+    gaps,
+  };
+}
+
+/**
+ * @param {ReturnType<typeof buildFeatureContext>} ctx
+ * @param {string} songKey
+ */
+function playFeaturesFromCtx(ctx, songKey) {
+  const plays = ctx.idx.playCount.get(songKey) || 0;
+  const showCount = Math.max(1, ctx.idx.showCount);
+  const recent10 = (ctx.r10.get(songKey) || 0) / Math.min(10, showCount);
+  const recent25 = (ctx.r25.get(songKey) || 0) / Math.min(25, showCount);
+  const recent50 = (ctx.r50.get(songKey) || 0) / Math.min(50, showCount);
+  const lifetime = (plays + 1) / (showCount + 10);
+  const gap = ctx.gaps.get(songKey) ?? Number.POSITIVE_INFINITY;
+
+  let gapCadence = 0.15;
+  if (Number.isFinite(gap) && plays > 0) {
+    const expectedReturn = Math.max(2, Math.round(1 / Math.max(lifetime, 0.02)));
+    const ratio = gap / expectedReturn;
+    gapCadence = Math.exp(-((ratio - 1) ** 2) / 0.7);
+  }
+
+  const restBonus =
+    ctx.daysSincePriorShow != null && ctx.daysSincePriorShow >= 3
+      ? Math.min(1, (ctx.daysSincePriorShow - 2) / 10)
+      : 0;
+
+  return {
+    recent10,
+    recent25,
+    recent50,
+    lifetime,
+    gap,
+    gapCadence,
+    playedPriorNight: ctx.priorNightKeys.has(songKey),
+    restBonus,
+    plays,
+  };
+}
+
+/**
+ * @param {ReturnType<typeof playFeaturesFromCtx>} f
+ * @returns {{ playProb: number, reasons: string[] }}
+ */
+function scorePlayLikelihood(f) {
+  const w = MODEL_WEIGHTS;
+  let raw =
+    w.recent10 * f.recent10 +
+    w.recent25 * f.recent25 +
+    w.recent50 * f.recent50 +
+    w.lifetime * f.lifetime +
+    w.gapCadence * f.gapCadence +
+    w.daysSincePriorScale * f.restBonus;
+
+  const reasons = [];
+  if (f.recent25 >= 0.2) reasons.push("frequent this tour window");
+  if (f.gapCadence >= 0.7 && Number.isFinite(f.gap)) {
+    reasons.push(`due vs cadence (gap ${f.gap})`);
+  }
+  if (f.playedPriorNight) {
+    raw *= 1 - w.priorNightRepeatPenalty;
+    reasons.push("unlikely repeat after prior night");
+  }
+  if (f.gap >= w.bustoutGapMin && Number.isFinite(f.gap)) {
+    reasons.push(`bustout / long-shot upside (gap ${f.gap})`);
+  }
+
+  const playProb = 1 / (1 + Math.exp(-6 * (raw - 0.25)));
+  return { playProb, reasons: reasons.slice(0, 2) };
+}
+
+/**
+ * @param {ReturnType<typeof buildFeatureContext>} ctx
+ * @param {string} songKey
+ * @param {string} slot
+ */
+function slotAffinityFromCtx(ctx, songKey, slot) {
+  const plays = ctx.idx.playCount.get(songKey) || 0;
+  const slotMap = ctx.idx.slotCounts.get(slot) || new Map();
+  const slotHits = slotMap.get(songKey) || 0;
+  const alpha = MODEL_WEIGHTS.slotSmoothingAlpha;
+  if (slot === "wild") {
+    return { affinity: 1, reason: null };
+  }
+  const affinity =
+    (slotHits + alpha) / (plays + alpha * POSITIONAL_SLOTS.length);
+  const reason =
+    slotHits > 0 ? `strong ${slot} history (${slotHits}/${plays || 0})` : null;
+  return { affinity, reason };
+}
+
+/**
+ * @param {number} playProb
+ * @param {number} gap
+ * @returns {'safe' | 'slot_fit' | 'long_shot'}
+ */
+export function riskBand(playProb, gap) {
+  if (playProb >= 0.55) return "safe";
+  if (
+    Number.isFinite(gap) &&
+    gap >= MODEL_WEIGHTS.bustoutGapMin &&
+    playProb < 0.4
+  ) {
+    return "long_shot";
+  }
+  return "slot_fit";
+}
+
+/**
+ * Rank songs for a single slot using playProb × slotAffinity.
+ *
+ * @param {import('./features.mjs').ShowRecord[]} priors
+ * @param {string} targetDate
+ * @param {string} slot
+ */
+export function rankCombinedForSlot(priors, targetDate, slot) {
+  assertNoTargetLeakage(priors, targetDate);
+  const ctx = buildFeatureContext(priors, targetDate);
+  /** @type {Array<{
+   *   songKey: string,
+   *   score: number,
+   *   playProb: number,
+   *   slotAffinity: number,
+   *   riskBand: string,
+   *   reasons: string[],
+   *   modelVersion: string,
+   * }>} */
+  const rows = [];
+
+  for (const songKey of ctx.idx.songs) {
+    const f = playFeaturesFromCtx(ctx, songKey);
+    const { playProb, reasons } = scorePlayLikelihood(f);
+    const aff = slotAffinityFromCtx(ctx, songKey, slot);
+    const score =
+      slot === "wild" ? playProb : playProb * Math.max(0.05, aff.affinity);
+    const band = riskBand(playProb, f.gap);
+    /** @type {string[]} */
+    const allReasons = [...reasons];
+    if (aff.reason) allReasons.unshift(aff.reason);
+
+    rows.push({
+      songKey,
+      score,
+      playProb,
+      slotAffinity: aff.affinity,
+      riskBand: band,
+      reasons: allReasons.slice(0, 2),
+      modelVersion: MODEL_VERSION,
+    });
+  }
+
+  return rows.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.songKey.localeCompare(b.songKey);
+  });
+}
+
+/**
+ * Slot-agnostic ranking (wildcard / play-only) for recall metrics.
+ * @param {import('./features.mjs').ShowRecord[]} priors
+ * @param {string} targetDate
+ */
+export function rankCombinedPlayOnly(priors, targetDate) {
+  return rankCombinedForSlot(priors, targetDate, "wild").map((r) => ({
+    songKey: r.songKey,
+    score: r.score,
+    reason: r.reasons.join("; ") || "combined_play",
+    playProb: r.playProb,
+    riskBand: r.riskBand,
+    reasons: r.reasons,
+    modelVersion: r.modelVersion,
+  }));
+}

--- a/scripts/prediction-backtest/lib/model.test.mjs
+++ b/scripts/prediction-backtest/lib/model.test.mjs
@@ -1,0 +1,90 @@
+/**
+ * Combined model unit tests (#649).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  rankCombinedForSlot,
+  rankCombinedPlayOnly,
+  riskBand,
+  MODEL_VERSION,
+} from "./model.mjs";
+import { priorShows } from "./features.mjs";
+import { runRollingBacktest, evaluateGoNoGo, MODEL_NAME } from "./backtest.mjs";
+
+/** @type {import('./features.mjs').ShowRecord[]} */
+function buildHistory(n = 40) {
+  /** @type {import('./features.mjs').ShowRecord[]} */
+  const out = [];
+  const openers = ["Alpha", "Beta", "Gamma", "Delta"];
+  for (let i = 0; i < n; i += 1) {
+    const d = new Date(Date.UTC(2023, 0, 1 + i * 3));
+    const showDate = d.toISOString().slice(0, 10);
+    const s1o = openers[i % openers.length];
+    const s1c = openers[(i + 1) % openers.length];
+    const s2o = openers[(i + 2) % openers.length];
+    const s2c = openers[(i + 3) % openers.length];
+    const enc = i % 5 === 0 ? "RareCut" : openers[i % openers.length];
+    const songs = [s1o, "FillA", s1c, s2o, "FillB", s2c, enc];
+    if (i % 7 === 0) songs.push("BustoutHero");
+    out.push({
+      showDate,
+      songs,
+      slots: { s1o, s1c, s2o, s2c, enc },
+      encoreSongs: [enc],
+    });
+  }
+  return out;
+}
+
+test("MODEL_VERSION is set", () => {
+  assert.match(MODEL_VERSION, /^v\d+\.\d+\.\d+/);
+});
+
+test("riskBand maps safe / long_shot", () => {
+  assert.equal(riskBand(0.7, 5), "safe");
+  assert.equal(riskBand(0.2, 40), "long_shot");
+  assert.equal(riskBand(0.45, 5), "slot_fit");
+});
+
+test("combined model is slot-aware and leakage-safe", () => {
+  const history = buildHistory(35);
+  const target = history[34];
+  const priors = priorShows(history, target.showDate);
+  const s1o = rankCombinedForSlot(priors, target.showDate, "s1o");
+  const enc = rankCombinedForSlot(priors, target.showDate, "enc");
+  assert.ok(s1o.length > 5);
+  assert.ok(enc.length > 5);
+  assert.ok(s1o[0].playProb > 0);
+  assert.ok(["safe", "slot_fit", "long_shot"].includes(s1o[0].riskBand));
+  // Slot affinity should change at least one score vs wild/play-only path
+  const playOnly = rankCombinedPlayOnly(priors, target.showDate);
+  const s1Scores = new Map(s1o.map((r) => [r.songKey, r.score]));
+  assert.ok(
+    playOnly.some((r) => Math.abs((s1Scores.get(r.songKey) || 0) - r.score) > 1e-9)
+  );
+  assert.throws(() =>
+    rankCombinedForSlot(history, history[0].showDate, "s1o")
+  );
+});
+
+test("play-only ranking exposes modelVersion", () => {
+  const history = buildHistory(35);
+  const target = history[34];
+  const priors = priorShows(history, target.showDate);
+  const ranked = rankCombinedPlayOnly(priors, target.showDate);
+  assert.equal(ranked[0].modelVersion, MODEL_VERSION);
+});
+
+test("synthetic backtest includes combined and go/no-go helper runs", () => {
+  const history = buildHistory(45);
+  const result = runRollingBacktest(history, {
+    minTrainShows: 20,
+    includeCombined: true,
+  });
+  assert.ok(result.summary[MODEL_NAME]);
+  assert.ok(result.evaluatedNights > 5);
+  const gate = evaluateGoNoGo(result);
+  assert.equal(typeof gate.pass, "boolean");
+  assert.ok(gate.reason);
+});

--- a/scripts/prediction-backtest/run-backtest.mjs
+++ b/scripts/prediction-backtest/run-backtest.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Run leakage-safe rolling-origin baseline backtest (#648).
+ * Run leakage-safe rolling-origin baseline + combined model backtest (#648/#649).
  *
  * Usage (repo root):
  *   npm run backtest:recommendations
@@ -15,7 +15,17 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { REPORTS_DIR } from "./lib/shared.mjs";
 import { loadAllShowRecords } from "./lib/dataset.mjs";
-import { runRollingBacktest, BASELINE_NAMES } from "./lib/backtest.mjs";
+import {
+  runRollingBacktest,
+  evaluateGoNoGo,
+  BASELINE_NAMES,
+  MODEL_NAME,
+} from "./lib/backtest.mjs";
+import {
+  MODEL_VERSION,
+  MODEL_WEIGHTS,
+  MODEL_TRAINING_WINDOW,
+} from "./lib/model.mjs";
 
 function parseArgs(argv) {
   /** @type {Record<string, string | boolean>} */
@@ -36,6 +46,7 @@ function fmt(n) {
 const args = parseArgs(process.argv.slice(2));
 const minTrainShows = Number(args["min-train"] || args.minTrain || 30);
 const recentWindow = Number(args["recent-window"] || args.recentWindow || 25);
+const baselinesOnly = Boolean(args["baselines-only"]);
 
 const history = loadAllShowRecords();
 if (history.length < minTrainShows + 5) {
@@ -54,12 +65,25 @@ const result = runRollingBacktest(history, {
   minTrainShows,
   recentWindow,
   baselines: BASELINE_NAMES,
+  includeCombined: !baselinesOnly,
 });
+
+const goNoGo = baselinesOnly
+  ? { pass: false, reason: "baselines-only run" }
+  : evaluateGoNoGo(result);
 
 mkdirSync(REPORTS_DIR, { recursive: true });
 const stamp = result.generatedAt.replace(/[:.]/g, "-");
 const jsonPath = join(REPORTS_DIR, `baseline-backtest-${stamp}.json`);
-writeFileSync(jsonPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+writeFileSync(
+  jsonPath,
+  `${JSON.stringify({ ...result, goNoGo, MODEL_WEIGHTS, MODEL_TRAINING_WINDOW }, null, 2)}\n`,
+  "utf8"
+);
+
+const rowNames = baselinesOnly
+  ? BASELINE_NAMES
+  : [...BASELINE_NAMES, MODEL_NAME];
 
 /** @type {string[]} */
 const md = [];
@@ -68,21 +92,31 @@ md.push("");
 md.push(`Generated: \`${result.generatedAt}\``);
 md.push(`History shows: **${result.historyShows}**`);
 md.push(`Evaluated nights: **${result.evaluatedNights}**`);
-md.push(`minTrainShows: **${result.minTrainShows}** · recentWindow: **${result.recentWindow}**`);
+md.push(
+  `minTrainShows: **${result.minTrainShows}** · recentWindow: **${result.recentWindow}**`
+);
+if (!baselinesOnly) {
+  md.push(`Combined model: **\`${MODEL_VERSION}\`**`);
+  md.push(`Go/no-go: **${goNoGo.pass ? "PASS" : "FAIL"}** — ${goNoGo.reason}`);
+}
 md.push("");
 md.push("## Leakage controls");
 md.push("");
 md.push("- Features use only shows with `showDate < targetDate`.");
-md.push("- Target-night `songGaps` / official setlist are **labels only**, never candidate features.");
-md.push("- Gaps for the gap-ascending baseline are **reconstructed** from prior history.");
+md.push(
+  "- Target-night `songGaps` / official setlist are **labels only**, never candidate features."
+);
+md.push(
+  "- Gaps for gap-ascending / combined cadence are **reconstructed** from prior history."
+);
 md.push("");
 md.push("## Summary (means across evaluated nights)");
 md.push("");
 md.push(
-  "| Baseline | recall@5 | recall@10 | slotHit@5 | slotHit@10 | Brier↓ | zeroScoreRate↓ | top3Conc |"
+  "| Model | recall@5 | recall@10 | slotHit@5 | slotHit@10 | Brier↓ | zeroScoreRate↓ | top3Conc |"
 );
 md.push("|---|---:|---:|---:|---:|---:|---:|---:|");
-for (const name of BASELINE_NAMES) {
+for (const name of rowNames) {
   const s = result.summary[name];
   md.push(
     `| \`${name}\` | ${fmt(s.recallAt5)} | ${fmt(s.recallAt10)} | ${fmt(s.slotHitAt5)} | ${fmt(s.slotHitAt10)} | ${fmt(s.brier)} | ${fmt(s.zeroScoreRate)} | ${fmt(s.top3Concentration)} |`
@@ -91,11 +125,19 @@ for (const name of BASELINE_NAMES) {
 md.push("");
 md.push("### How to read");
 md.push("");
-md.push("- **recall@K** — fraction of that night’s played songs appearing in the model’s top-K.");
-md.push("- **slotHit@K** — mean exact-slot hit rate (s1o/s1c/s2o/s2c/enc) in top-K.");
+md.push(
+  "- **recall@K** — fraction of that night’s played songs appearing in the model’s top-K."
+);
+md.push(
+  "- **slotHit@K** — mean exact-slot hit rate (s1o/s1c/s2o/s2c/enc) in top-K."
+);
 md.push("- **Brier** — rank-pseudo-probability calibration (lower better).");
-md.push("- **zeroScoreRate** — share of nights where locking top-1 for every slot would still score 0.");
-md.push("- Baselines are **slot-agnostic** by design; #649 adds play×slot affinity.");
+md.push(
+  "- **zeroScoreRate** — share of nights where locking recommended picks would still score 0."
+);
+md.push(
+  "- Combined model is **slot-aware**; baselines are slot-agnostic (#648)."
+);
 md.push("");
 md.push(`Raw JSON: \`${jsonPath}\``);
 md.push("");
@@ -105,3 +147,7 @@ writeFileSync(mdPath, `${md.join("\n")}\n`, "utf8");
 
 console.log(md.join("\n"));
 console.log(`\nWrote:\n  ${jsonPath}\n  ${mdPath}`);
+if (!baselinesOnly && !goNoGo.pass) {
+  console.error("\nGo/no-go FAILED — do not freeze model for Wave 3 artifact yet.");
+  process.exitCode = 2;
+}


### PR DESCRIPTION
Closes #649

## Summary
- Wave 2 continuation of Sprint 13 / epic #646 (follows #648 / merged #716).
- Explainable `combined_explainable` model (`modelVersion` **v0.1.0-explainable**): playProb × slot affinity, risk bands, short reasons.
- Harness go/no-go gate; import respects `--from`/`--to` year bounds.
- Docs: `docs/scoring-analysis/08-recommendation-model.md`.

## Backtest evidence (local, 41-show 2024 cache)
Go/no-go **PASS** — slotHit@5 **0.185** vs best baseline **0.031**; recall@10 **0.186** vs **0.078**; zeroScoreRate **0.31** vs ~1.0.

## Test plan
- [x] `npm run test:prediction-backtest` (16 tests)
- [x] `npm run backtest:recommendations -- --min-train=15` → PASS
- [ ] Optional: wider `--years=2` import, reconfirm go/no-go

Note: Replaces closed stacked PR #717 (auto-closed when #716 deleted its base branch).


Made with [Cursor](https://cursor.com)