### PR TITLE
feat(recommendations): pick-recommendations Storage artifact (#650)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,7 @@ VITE_SETLIST_API_SOURCE=phishin
 # Optional: full URL to song-catalog.json on your own CDN (anonymous GET + CORS). If unset, the app uses
 # Firebase getDownloadURL() for the default bucket object (Storage rules apply).
 # VITE_SONG_CATALOG_URL=
+# VITE_PICK_RECOMMENDATIONS_URL=
 
 # Optional: set true to render reserved sponsor/ad placements (shared/ui SponsorSlot; ads epic #419).
 # Off by default — placements render nothing when unset.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.37.0] — 2026-07-22
+
+### Added
+- **Pick recommendations Storage artifact (#650)** — `pick-recommendations.json` published by `scheduledPickRecommendations` / `refreshPickRecommendations` for the upcoming show (`modelVersion` v0.1.0-explainable). Client `usePickRecommendations` with TTL/stale fallback; optional `VITE_PICK_RECOMMENDATIONS_URL`. See `docs/PICK_RECOMMENDATIONS.md` / `docs/API.md`.
+
+---
+
 ## [1.36.0] — 2026-07-21
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -294,7 +294,7 @@ When `alreadyLocked` is `true`, the doc already carried `lockReason: admin_overr
 
 **Ops CLI (no War Room):** `cd functions && node scripts/lockPicksForShowNow.js --showDate=YYYY-MM-DD`
 
-### 2.3 `getPhishnetSetlist`, `scheduledPhishnetShowCalendar`, `refreshPhishnetShowCalendar`, `refreshLiveScoresForShow`, `scheduledPhishnetSongCatalog`, `refreshPhishnetSongCatalog`, `scheduledPhishnetLiveSetlistPoll`, `setLiveSetlistAutomationState`, `pollLiveSetlistNow`, `sendPushCanary`, `scheduledPublicTourStatsRefresh`, `refreshPublicTourStats`
+### 2.3 `getPhishnetSetlist`, `scheduledPhishnetShowCalendar`, `refreshPhishnetShowCalendar`, `refreshLiveScoresForShow`, `scheduledPhishnetSongCatalog`, `refreshPhishnetSongCatalog`, `scheduledPickRecommendations`, `refreshPickRecommendations`, `scheduledPhishnetLiveSetlistPoll`, `setLiveSetlistAutomationState`, `pollLiveSetlistNow`, `sendPushCanary`, `scheduledPublicTourStatsRefresh`, `refreshPublicTourStats`
 
 Phish.net integration, live scoring, and public tour-stats refresh. Deployed via `npm run deploy:functions:phishnet`. Internal admin use — request/response shapes documented in `docs/PHISHNET_CALLABLE_RUNBOOK.md`.
 
@@ -303,6 +303,8 @@ Phish.net integration, live scoring, and public tour-stats refresh. Deployed via
 **Storage object `song-catalog.json` (v1.25.0+, #554):** published by `scheduledPhishnetSongCatalog` / `refreshPhishnetSongCatalog`. Each song object includes `{ name, total, gap, last, debut }` where `debut` is a string (typically `YYYY-MM-DD`) or `""` when unknown. See `docs/SONG_CATALOG.md`. Adding `debut` is a **MINOR** catalog-field addition (clients may ignore unknown fields).
 
 **Storage archive `song-catalog/archive/{stamp}.json` (v1.36.0+, #647):** each catalog sync also writes a dated private snapshot (same JSON payload as live) at `song-catalog/archive/YYYY-MM-DDTHH-mm-ssZ.json` for leakage-safe recommendation backtests (#646). Not public-read (Admin SDK / ops only). Live client path is unchanged. `refreshPhishnetSongCatalog` may return optional `archivePath` (`string | null`) when the archive write succeeded.
+
+**Storage object `pick-recommendations.json` (v1.37.0+, #650):** published by `scheduledPickRecommendations` (cron `15 */6 * * *` ET) and admin callable `refreshPickRecommendations`. Payload includes `generatedAt`, `modelVersion`, `targetShow`, `historyShowCount`, `topK`, and `slots` (`s1o`/`s1c`/`s2o`/`s2c`/`enc`/`wild`) — each an array of `{ name, normalizedName, rank, score, playProb, slotAffinity, confidence, riskBand, reasons }`. Join to catalog by `normalizedName` / normalized title. No-op (skip publish) when there is no upcoming show or insufficient `official_setlists` history. Optional private archives under `pick-recommendations/archive/`. Client: Storage `getDownloadURL` + localStorage TTL (override `VITE_PICK_RECOMMENDATIONS_URL`). See `docs/PICK_RECOMMENDATIONS.md`.
 
 ### 2.4 Comms event adapters (v1.7.0+)
 
@@ -431,6 +433,7 @@ These `VITE_*` variables are read at build time. Adding or removing one is a MIN
 | `VITE_SETLIST_API_SOURCE` | No | Setlist data source override |
 | `VITE_USE_CALLABLE_PHISHNET_SETLIST` | No | Route fetches through callable |
 | `VITE_SONG_CATALOG_URL` | No | CDN URL override for song catalog |
+| `VITE_PICK_RECOMMENDATIONS_URL` | No | CDN URL override for pick recommendations (#650) |
 | `VITE_ENABLE_SPONSOR_SLOTS` | No | `true` renders reserved sponsor/ad placements (`SponsorSlot`); omit to hide (default) |
 
 ### 4.1 Cloud Functions runtime env vars

--- a/docs/PICK_RECOMMENDATIONS.md
+++ b/docs/PICK_RECOMMENDATIONS.md
@@ -1,0 +1,46 @@
+# Pick recommendations artifact (#650)
+
+Versioned Storage JSON for the upcoming show’s slot-aware song recommendations. Powers Prediction Lab (#651) and Predictive Mode (#652). Complements the song catalog — join by normalized title.
+
+## Publish path
+
+1. Resolve upcoming show from `show_calendar/snapshot` via `getNextShow`.
+2. Load prior `official_setlists` docs with document id `< targetDate` (leakage-safe).
+3. Rank with `v0.1.0-explainable` (`functions/pickRecommendationsModel.js`).
+4. Write live **`pick-recommendations.json`** (+ optional private archive).
+
+| Trigger | Export |
+|---------|--------|
+| Schedule `15 */6 * * *` ET | `scheduledPickRecommendations` |
+| Admin callable | `refreshPickRecommendations` |
+
+**No-op** when: no upcoming show, invalid target, or empty history (`skipped: true` + `reason`).
+
+Deploy: `npm run deploy:functions:phishnet` (includes both exports). Storage rules: `firebase deploy --only storage`.
+
+## Client
+
+- `usePickRecommendations()` in `features/picks` — Storage `getDownloadURL` + 6h localStorage TTL + stale fallback; `null` when missing.
+- Override: `VITE_PICK_RECOMMENDATIONS_URL`.
+
+## Payload (summary)
+
+```json
+{
+  "generatedAt": "ISO",
+  "modelVersion": "v0.1.0-explainable",
+  "targetShow": { "date", "venue", "city", "tour", "timeZone" },
+  "historyShowCount": 80,
+  "topK": 25,
+  "slots": {
+    "s1o": [{ "name", "normalizedName", "rank", "score", "playProb", "slotAffinity", "confidence", "riskBand", "reasons" }],
+    "s1c": [],
+    "s2o": [],
+    "s2c": [],
+    "enc": [],
+    "wild": []
+  }
+}
+```
+
+Model methodology: `docs/scoring-analysis/08-recommendation-model.md`.

--- a/docs/RELEASE_TRAIN_SPRINT_13.md
+++ b/docs/RELEASE_TRAIN_SPRINT_13.md
@@ -163,5 +163,5 @@ Agent-assisted eng-day ranges used to size waves (not a commit):
 | 2026-07-21 | Baseline | Confirm `main`/`staging` at **1.35.4** | Fast-forward train branch to `main` tip |
 | 2026-07-21 | 0 | [#714](https://github.com/pat792/set-picks/pull/714) merged | Manifest on staging |
 | 2026-07-21 | 1 | [#715](https://github.com/pat792/set-picks/pull/715) merged + deployed | #647 archives verified (`…/archive/2026-07-22T04-55-51Z.json`); issue closed |
-| 2026-07-21 | 2 | [#716](https://github.com/pat792/set-picks/pull/716) (#648) | Offline import + leakage-safe baseline harness |
-| 2026-07-21 | 2 | #649 in flight | Combined explainable model `v0.1.0-explainable` + go/no-go |
+| 2026-07-21 | 2 | [#716](https://github.com/pat792/set-picks/pull/716) + [#718](https://github.com/pat792/set-picks/pull/718) | #648/#649 closed; model go/no-go PASS |
+| 2026-07-21 | 3 | #650 in flight | `pick-recommendations.json` artifact + client cache |

--- a/docs/scoring-analysis/08-recommendation-model.md
+++ b/docs/scoring-analysis/08-recommendation-model.md
@@ -29,7 +29,7 @@ npm run backtest:recommendations
 
 PASS when `combined_explainable` meets or beats each baseline on **slotHit@5** or **recall@10**. Exit code `2` on FAIL.
 
-Weights live in `scripts/prediction-backtest/lib/model.mjs` (`MODEL_WEIGHTS`). Bump `MODEL_VERSION` when weights change and re-run the harness.
+Weights live in `scripts/prediction-backtest/lib/model.mjs` (`MODEL_WEIGHTS`) **and** the production CJS port `functions/pickRecommendationsModel.js` (keep in sync). Bump `MODEL_VERSION` when weights change and re-run the harness.
 
 ## Empirical freeze note (2026-07-22)
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -11,6 +11,9 @@ const {
   syncPhishnetSongCatalogToStorage,
 } = require("./phishnetSongCatalog");
 const {
+  syncPickRecommendationsToStorage,
+} = require("./pickRecommendations");
+const {
   candidateShowDates,
   parseShowCalendarSnapshotToShows,
   pollSingleShowDate,
@@ -1766,6 +1769,75 @@ exports.refreshPhishnetSongCatalog = onCall(
       throw new HttpsError(
         "failed-precondition",
         `refreshPhishnetSongCatalog failed: ${msg}`
+      );
+    }
+  }
+);
+
+/**
+ * Publish versioned `pick-recommendations.json` for the upcoming show (#650).
+ * Same 6h cadence as song catalog; no Phish.net secret required (uses Firestore history).
+ */
+exports.scheduledPickRecommendations = onSchedule(
+  {
+    schedule: "15 */6 * * *",
+    timeZone: "America/New_York",
+    region: PHISHNET_FUNCTIONS_REGION,
+  },
+  async () => {
+    try {
+      const result = await syncPickRecommendationsToStorage(admin.firestore(), {
+        logger,
+      });
+      if (result.skipped) {
+        logger.info("scheduledPickRecommendations skipped", result.reason);
+      } else {
+        logger.info(
+          "scheduledPickRecommendations public URL",
+          result.publicUrl,
+          result.targetDate
+        );
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      logger.error("scheduledPickRecommendations failed", msg, e);
+    }
+    return null;
+  }
+);
+
+/**
+ * Admin-only on-demand refresh of Storage `pick-recommendations.json` (#650).
+ */
+exports.refreshPickRecommendations = onCall(
+  {
+    region: PHISHNET_FUNCTIONS_REGION,
+    invoker: "public",
+    enforceAppCheck: false,
+  },
+  async (request) => {
+    try {
+      assertAdminClaim(request);
+      const result = await syncPickRecommendationsToStorage(admin.firestore(), {
+        logger,
+      });
+      return {
+        ok: true,
+        skipped: Boolean(result.skipped),
+        reason: result.reason ?? null,
+        targetDate: result.targetDate ?? null,
+        modelVersion: result.modelVersion ?? null,
+        historyShowCount: result.historyShowCount ?? null,
+        publicUrl: result.publicUrl ?? null,
+        archivePath: result.archivePath ?? null,
+      };
+    } catch (e) {
+      if (e instanceof HttpsError) throw e;
+      const msg = e instanceof Error ? e.message : String(e);
+      logger.error("refreshPickRecommendations unexpected error", msg, e);
+      throw new HttpsError(
+        "failed-precondition",
+        `refreshPickRecommendations failed: ${msg}`
       );
     }
   }

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
     "secrets:sync-phishnet": "node ../scripts/sync-phishnet-secret.mjs",
-    "deploy:functions:phishnet": "firebase deploy --only functions:getPhishnetSetlist,functions:scheduledPhishnetShowCalendar,functions:refreshPhishnetShowCalendar,functions:refreshLiveScoresForShow,functions:scheduledPhishnetSongCatalog,functions:refreshPhishnetSongCatalog,functions:scheduledPhishnetLiveSetlistPoll,functions:scheduledPicksLockReminder,functions:setLiveSetlistAutomationState,functions:pollLiveSetlistNow,functions:sendPushCanary,functions:lockPicksForShowNow",
+    "deploy:functions:phishnet": "firebase deploy --only functions:getPhishnetSetlist,functions:scheduledPhishnetShowCalendar,functions:refreshPhishnetShowCalendar,functions:refreshLiveScoresForShow,functions:scheduledPhishnetSongCatalog,functions:refreshPhishnetSongCatalog,functions:scheduledPickRecommendations,functions:refreshPickRecommendations,functions:scheduledPhishnetLiveSetlistPoll,functions:scheduledPicksLockReminder,functions:setLiveSetlistAutomationState,functions:pollLiveSetlistNow,functions:sendPushCanary,functions:lockPicksForShowNow",
     "lock:picks-now": "node scripts/lockPicksForShowNow.js",
     "diagnose:phishnet": "node ../scripts/diagnose-phishnet-local.mjs",
     "qa:clone-picks-for-show": "node scripts/clonePicksForShowQa.js",

--- a/functions/pickRecommendations.js
+++ b/functions/pickRecommendations.js
@@ -93,20 +93,21 @@ function showRecordFromOfficialDoc(data, showDate) {
  * @param {number} [limit]
  */
 async function loadPriorShowRecords(db, targetDate, limit = DEFAULT_HISTORY_LIMIT) {
-  const snap = await db
-    .collection("official_setlists")
-    .where(admin.firestore.FieldPath.documentId(), "<", targetDate)
-    .orderBy(admin.firestore.FieldPath.documentId(), "desc")
-    .limit(limit)
-    .get();
+  // Avoid documentId orderBy/startAfter index requirements on this collection.
+  // Game-scale official_setlists is small — filter + sort in memory.
+  const snap = await db.collection("official_setlists").get();
 
   /** @type {ReturnType<typeof showRecordFromOfficialDoc>[]} */
   const records = [];
   for (const doc of snap.docs) {
+    if (doc.id >= targetDate) continue;
     const rec = showRecordFromOfficialDoc(doc.data(), doc.id);
     if (rec) records.push(rec);
   }
-  records.reverse(); // ascending
+  records.sort((a, b) => a.showDate.localeCompare(b.showDate));
+  if (records.length > limit) {
+    return records.slice(records.length - limit);
+  }
   return records;
 }
 

--- a/functions/pickRecommendations.js
+++ b/functions/pickRecommendations.js
@@ -1,0 +1,344 @@
+/**
+ * Generate + publish versioned `pick-recommendations.json` to Storage (#650).
+ *
+ * Mirrors song-catalog publish: public live object + download token, scheduled
+ * and admin refresh. Uses official_setlists history with showDate < target only.
+ */
+"use strict";
+
+const crypto = require("node:crypto");
+const admin = require("firebase-admin");
+const {
+  MODEL_VERSION,
+  MODEL_TRAINING_WINDOW,
+  POSITIONAL_SLOTS,
+  normalizeTitle,
+  rankCombinedForSlot,
+  rankCombinedPlayOnly,
+} = require("./pickRecommendationsModel");
+const { getNextShow } = require("./showFinalizationGate");
+const {
+  parseShowCalendarSnapshotToShows,
+} = require("./phishnetLiveSetlistAutomation");
+
+const REC_STORAGE_PATH = "pick-recommendations.json";
+const REC_ARCHIVE_PREFIX = "pick-recommendations/archive/";
+const DEFAULT_HISTORY_LIMIT = 80;
+const DEFAULT_TOP_K = 25;
+
+/**
+ * @param {string} updatedAtIso
+ * @returns {string}
+ */
+function recommendationsArchiveObjectPath(updatedAtIso) {
+  const d = new Date(String(updatedAtIso || "").trim() || Date.now());
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`Invalid recommendations archive timestamp: ${updatedAtIso}`);
+  }
+  const stamp = d
+    .toISOString()
+    .replace(/\.\d{3}Z$/, "Z")
+    .replace(/:/g, "-");
+  return `${REC_ARCHIVE_PREFIX}${stamp}.json`;
+}
+
+/**
+ * @param {string} bucketName
+ * @returns {string}
+ */
+function publicGcsUrlForRecommendations(bucketName) {
+  return `https://storage.googleapis.com/${bucketName}/${REC_STORAGE_PATH}`;
+}
+
+/**
+ * @param {FirebaseFirestore.DocumentData | undefined} data
+ * @param {string} showDate
+ */
+function showRecordFromOfficialDoc(data, showDate) {
+  if (!data || typeof data !== "object") return null;
+  const officialSetlist = Array.isArray(data.officialSetlist)
+    ? data.officialSetlist.map((t) => String(t ?? "").trim()).filter(Boolean)
+    : [];
+  const setlist =
+    data.setlist && typeof data.setlist === "object" ? data.setlist : {};
+  if (!officialSetlist.length && !Object.values(setlist).some(Boolean)) {
+    return null;
+  }
+  const songs =
+    officialSetlist.length > 0
+      ? officialSetlist
+      : Object.values(setlist)
+          .map((t) => String(t ?? "").trim())
+          .filter(Boolean);
+  return {
+    showDate,
+    songs,
+    slots: {
+      s1o: String(setlist.s1o ?? "").trim(),
+      s1c: String(setlist.s1c ?? "").trim(),
+      s2o: String(setlist.s2o ?? "").trim(),
+      s2c: String(setlist.s2c ?? "").trim(),
+      enc: String(setlist.enc ?? "").trim(),
+      wild: "",
+    },
+    encoreSongs: Array.isArray(data.encoreSongs)
+      ? data.encoreSongs.map((t) => String(t ?? "").trim()).filter(Boolean)
+      : [],
+  };
+}
+
+/**
+ * @param {import('firebase-admin').firestore.Firestore} db
+ * @param {string} targetDate
+ * @param {number} [limit]
+ */
+async function loadPriorShowRecords(db, targetDate, limit = DEFAULT_HISTORY_LIMIT) {
+  const snap = await db
+    .collection("official_setlists")
+    .where(admin.firestore.FieldPath.documentId(), "<", targetDate)
+    .orderBy(admin.firestore.FieldPath.documentId(), "desc")
+    .limit(limit)
+    .get();
+
+  /** @type {ReturnType<typeof showRecordFromOfficialDoc>[]} */
+  const records = [];
+  for (const doc of snap.docs) {
+    const rec = showRecordFromOfficialDoc(doc.data(), doc.id);
+    if (rec) records.push(rec);
+  }
+  records.reverse(); // ascending
+  return records;
+}
+
+/**
+ * Display casing from last prior occurrence of a normalized key.
+ * @param {object[]} priors
+ * @param {string} songKey
+ */
+function displayNameFor(priors, songKey) {
+  for (let i = priors.length - 1; i >= 0; i -= 1) {
+    for (const t of priors[i].songs || []) {
+      if (normalizeTitle(t) === songKey) return t;
+    }
+  }
+  return songKey;
+}
+
+/**
+ * @param {object[]} ranked
+ * @param {object[]} priors
+ * @param {number} topK
+ */
+function serializeRanked(ranked, priors, topK) {
+  return ranked.slice(0, topK).map((r, i) => ({
+    name: displayNameFor(priors, r.songKey),
+    normalizedName: r.songKey,
+    rank: i + 1,
+    score: Number(r.score.toFixed(6)),
+    playProb: Number((r.playProb ?? r.score).toFixed(6)),
+    slotAffinity:
+      typeof r.slotAffinity === "number"
+        ? Number(r.slotAffinity.toFixed(6))
+        : null,
+    confidence: Number((r.playProb ?? r.score).toFixed(6)),
+    riskBand: r.riskBand || "slot_fit",
+    reasons: Array.isArray(r.reasons) ? r.reasons.slice(0, 2) : [],
+  }));
+}
+
+/**
+ * Pure builder — used by tests without Storage.
+ *
+ * @param {{
+ *   targetShow: { date: string, venue?: string, city?: string, tour?: string, timeZone?: string },
+ *   priors: object[],
+ *   topK?: number,
+ *   now?: Date,
+ * }} args
+ */
+function buildPickRecommendationsArtifact(args) {
+  const { targetShow, priors, topK = DEFAULT_TOP_K, now = new Date() } = args;
+  const targetDate = targetShow?.date;
+  if (!targetDate || !/^\d{4}-\d{2}-\d{2}$/.test(targetDate)) {
+    return { skipped: true, reason: "invalid-target-date" };
+  }
+  if (!Array.isArray(priors) || priors.length === 0) {
+    return { skipped: true, reason: "insufficient-history" };
+  }
+
+  /** @type {Record<string, ReturnType<typeof serializeRanked>>} */
+  const slots = {};
+  for (const slot of POSITIONAL_SLOTS) {
+    const ranked = rankCombinedForSlot(priors, targetDate, slot);
+    slots[slot] = serializeRanked(ranked, priors, topK);
+  }
+  const wildRanked = rankCombinedPlayOnly(priors, targetDate);
+  slots.wild = serializeRanked(wildRanked, priors, topK);
+
+  return {
+    skipped: false,
+    artifact: {
+      generatedAt: now.toISOString(),
+      modelVersion: MODEL_VERSION,
+      trainingWindow: MODEL_TRAINING_WINDOW,
+      targetShow: {
+        date: targetDate,
+        venue: targetShow.venue || "",
+        city: targetShow.city || "",
+        tour: targetShow.tour || "",
+        timeZone: targetShow.timeZone || "",
+      },
+      historyShowCount: priors.length,
+      topK,
+      slots,
+    },
+  };
+}
+
+/**
+ * Resolve upcoming show from calendar snapshot; null if none usable.
+ * @param {import('firebase-admin').firestore.Firestore} db
+ * @param {Date} [now]
+ */
+async function resolveUpcomingShow(db, now = new Date()) {
+  const snap = await db.collection("show_calendar").doc("snapshot").get();
+  if (!snap.exists) return null;
+  const shows = parseShowCalendarSnapshotToShows(snap.data());
+  if (!Array.isArray(shows) || shows.length === 0) return null;
+  try {
+    return getNextShow(shows, now);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {import('firebase-admin').firestore.Firestore} db
+ * @param {{
+ *   logger?: { info?: Function, warn?: Function, error?: Function },
+ *   bucketName?: string,
+ *   historyLimit?: number,
+ *   topK?: number,
+ *   now?: Date,
+ * }} [opts]
+ */
+async function syncPickRecommendationsToStorage(db, opts = {}) {
+  const {
+    logger,
+    bucketName,
+    historyLimit = DEFAULT_HISTORY_LIMIT,
+    topK = DEFAULT_TOP_K,
+    now = new Date(),
+  } = opts;
+
+  const upcoming = await resolveUpcomingShow(db, now);
+  if (!upcoming?.date) {
+    logger?.info?.("pick recommendations: no upcoming show; skip publish");
+    return {
+      skipped: true,
+      reason: "no-upcoming-show",
+      publicUrl: null,
+      archivePath: null,
+    };
+  }
+
+  const priors = await loadPriorShowRecords(db, upcoming.date, historyLimit);
+  const built = buildPickRecommendationsArtifact({
+    targetShow: upcoming,
+    priors,
+    topK,
+    now,
+  });
+  if (built.skipped) {
+    logger?.info?.("pick recommendations: skip publish", { reason: built.reason });
+    return {
+      skipped: true,
+      reason: built.reason,
+      publicUrl: null,
+      archivePath: null,
+      targetDate: upcoming.date,
+    };
+  }
+
+  const artifact = built.artifact;
+  const json = JSON.stringify(artifact);
+  const body = Buffer.from(json, "utf8");
+
+  const bucket = bucketName
+    ? admin.storage().bucket(bucketName)
+    : admin.storage().bucket();
+  const file = bucket.file(REC_STORAGE_PATH);
+
+  await file.save(body, {
+    metadata: {
+      contentType: "application/json; charset=utf-8",
+      cacheControl: "public, max-age=300",
+      metadata: {
+        firebaseStorageDownloadTokens: crypto.randomUUID(),
+      },
+    },
+  });
+
+  try {
+    await file.makePublic();
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logger?.warn?.(
+      "pick recommendations: makePublic failed (download URL may still work)",
+      msg
+    );
+  }
+
+  let archivePath = null;
+  try {
+    archivePath = recommendationsArchiveObjectPath(artifact.generatedAt);
+    await bucket.file(archivePath).save(body, {
+      metadata: {
+        contentType: "application/json; charset=utf-8",
+        cacheControl: "private, max-age=0",
+      },
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logger?.error?.(
+      "pick recommendations: archive failed (live object updated)",
+      msg,
+      e
+    );
+    archivePath = null;
+  }
+
+  const publicUrl = publicGcsUrlForRecommendations(bucket.name);
+  logger?.info?.("pick recommendations uploaded", {
+    targetDate: upcoming.date,
+    modelVersion: MODEL_VERSION,
+    historyShowCount: priors.length,
+    publicUrl,
+    archivePath,
+  });
+
+  return {
+    skipped: false,
+    reason: null,
+    targetDate: upcoming.date,
+    modelVersion: MODEL_VERSION,
+    historyShowCount: priors.length,
+    publicUrl,
+    bucket: bucket.name,
+    archivePath,
+  };
+}
+
+module.exports = {
+  REC_STORAGE_PATH,
+  REC_ARCHIVE_PREFIX,
+  DEFAULT_HISTORY_LIMIT,
+  DEFAULT_TOP_K,
+  recommendationsArchiveObjectPath,
+  publicGcsUrlForRecommendations,
+  showRecordFromOfficialDoc,
+  buildPickRecommendationsArtifact,
+  resolveUpcomingShow,
+  loadPriorShowRecords,
+  syncPickRecommendationsToStorage,
+};

--- a/functions/pickRecommendations.test.js
+++ b/functions/pickRecommendations.test.js
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for pick-recommendations artifact builder (#650).
+ */
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  buildPickRecommendationsArtifact,
+  showRecordFromOfficialDoc,
+  recommendationsArchiveObjectPath,
+  REC_STORAGE_PATH,
+} = require("./pickRecommendations");
+const { MODEL_VERSION } = require("./pickRecommendationsModel");
+
+test("REC_STORAGE_PATH is pick-recommendations.json", () => {
+  assert.equal(REC_STORAGE_PATH, "pick-recommendations.json");
+});
+
+test("recommendationsArchiveObjectPath uses colon-safe stamp", () => {
+  assert.equal(
+    recommendationsArchiveObjectPath("2026-07-22T12:30:00.000Z"),
+    "pick-recommendations/archive/2026-07-22T12-30-00Z.json"
+  );
+});
+
+test("showRecordFromOfficialDoc maps official_setlists shape", () => {
+  const rec = showRecordFromOfficialDoc(
+    {
+      officialSetlist: ["Alpha", "Beta", "Gamma"],
+      setlist: { s1o: "Alpha", s1c: "Beta", s2o: "Gamma", s2c: "Beta", enc: "Alpha" },
+      encoreSongs: ["Alpha"],
+    },
+    "2024-07-19"
+  );
+  assert.equal(rec.showDate, "2024-07-19");
+  assert.equal(rec.slots.s1o, "Alpha");
+  assert.deepEqual(rec.songs, ["Alpha", "Beta", "Gamma"]);
+});
+
+test("buildPickRecommendationsArtifact skips invalid target", () => {
+  const out = buildPickRecommendationsArtifact({
+    targetShow: { date: "" },
+    priors: [],
+  });
+  assert.equal(out.skipped, true);
+  assert.equal(out.reason, "invalid-target-date");
+});
+
+test("buildPickRecommendationsArtifact skips empty history", () => {
+  const out = buildPickRecommendationsArtifact({
+    targetShow: { date: "2024-08-01", venue: "MSG" },
+    priors: [],
+  });
+  assert.equal(out.skipped, true);
+  assert.equal(out.reason, "insufficient-history");
+});
+
+test("buildPickRecommendationsArtifact emits versioned slots", () => {
+  const priors = [
+    {
+      showDate: "2024-07-01",
+      songs: ["Alpha", "Beta", "Gamma"],
+      slots: { s1o: "Alpha", s1c: "Beta", s2o: "Gamma", s2c: "Alpha", enc: "Beta" },
+      encoreSongs: ["Beta"],
+    },
+    {
+      showDate: "2024-07-05",
+      songs: ["Beta", "Delta", "Alpha"],
+      slots: { s1o: "Beta", s1c: "Delta", s2o: "Alpha", s2c: "Beta", enc: "Delta" },
+      encoreSongs: ["Delta"],
+    },
+  ];
+  const out = buildPickRecommendationsArtifact({
+    targetShow: {
+      date: "2024-07-10",
+      venue: "Test Venue",
+      city: "Test City",
+      tour: "Summer 2024",
+    },
+    priors,
+    topK: 5,
+    now: new Date("2024-07-09T12:00:00.000Z"),
+  });
+  assert.equal(out.skipped, false);
+  assert.equal(out.artifact.modelVersion, MODEL_VERSION);
+  assert.equal(out.artifact.targetShow.date, "2024-07-10");
+  assert.equal(out.artifact.historyShowCount, 2);
+  assert.ok(Array.isArray(out.artifact.slots.s1o));
+  assert.ok(out.artifact.slots.s1o.length >= 1);
+  assert.equal(out.artifact.slots.s1o[0].rank, 1);
+  assert.ok(out.artifact.slots.s1o[0].normalizedName);
+  assert.ok(out.artifact.slots.s1o[0].riskBand);
+  assert.ok(Array.isArray(out.artifact.slots.wild));
+});

--- a/functions/pickRecommendationsModel.js
+++ b/functions/pickRecommendationsModel.js
@@ -1,0 +1,410 @@
+/**
+ * Production CJS port of the explainable recommendation model (#649/#650).
+ * Keep MODEL_VERSION / MODEL_WEIGHTS in sync with scripts/prediction-backtest/lib/model.mjs.
+ * Generated/maintained for Cloud Functions deploy (scripts/ is not packaged).
+ */
+"use strict";
+
+const POSITIONAL_SLOTS = ["s1o", "s1c", "s2o", "s2c", "enc"];
+
+function normalizeTitle(title) {
+  return String(title ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+}
+
+function daysBetween(a, b) {
+  const ta = Date.parse(a + "T12:00:00Z");
+  const tb = Date.parse(b + "T12:00:00Z");
+  if (!Number.isFinite(ta) || !Number.isFinite(tb)) return NaN;
+  return Math.round((tb - ta) / 86400000);
+}
+
+/**
+ * Feature extraction with strict showDate < targetDate cutoffs (#648).
+ * Never reads target-night labels as candidate features.
+ */
+/**
+ * @typedef {{
+ *   showDate: string,
+ *   songs: string[],
+ *   slots: Record<string, string>,
+ *   encoreSongs: string[],
+ * }} ShowRecord
+ */
+
+/**
+ * @param {ShowRecord[]} historySortedAsc
+ * @param {string} targetDate
+ * @returns {ShowRecord[]}
+ */
+function priorShows(historySortedAsc, targetDate) {
+  return historySortedAsc.filter((s) => s.showDate < targetDate);
+}
+
+/**
+ * Rebuild play counts and last-played dates from prior shows only.
+ * @param {ShowRecord[]} priors
+ * @returns {{
+ *   playCount: Map<string, number>,
+ *   lastPlayed: Map<string, string>,
+ *   slotCounts: Map<string, Map<string, number>>,
+ *   songs: Set<string>,
+ *   showCount: number,
+ * }}
+ */
+function buildHistoryIndex(priors) {
+  /** @type {Map<string, number>} */
+  const playCount = new Map();
+  /** @type {Map<string, string>} */
+  const lastPlayed = new Map();
+  /** @type {Map<string, Map<string, number>} */
+  const slotCounts = new Map();
+  /** @type {Set<string>} */
+  const songs = new Set();
+
+  for (const show of priors) {
+    const seenTonight = new Set();
+    for (const raw of show.songs) {
+      const key = normalizeTitle(raw);
+      if (!key || seenTonight.has(key)) continue;
+      seenTonight.add(key);
+      songs.add(key);
+      playCount.set(key, (playCount.get(key) || 0) + 1);
+      lastPlayed.set(key, show.showDate);
+    }
+    for (const [slot, title] of Object.entries(show.slots || {})) {
+      const key = normalizeTitle(title);
+      if (!key) continue;
+      if (!slotCounts.has(slot)) slotCounts.set(slot, new Map());
+      const m = slotCounts.get(slot);
+      m.set(key, (m.get(key) || 0) + 1);
+    }
+  }
+
+  return {
+    playCount,
+    lastPlayed,
+    slotCounts,
+    songs,
+    showCount: priors.length,
+  };
+}
+
+/**
+ * Shows-since-last-play reconstructed from prior history (not target songGaps).
+ * @param {ShowRecord[]} priors
+ * @param {string} targetDate
+ * @param {string} songKey normalized
+ * @returns {number} gap in shows; Infinity if never played
+ */
+function reconstructGap(priors, targetDate, songKey) {
+  let gap = 0;
+  for (let i = priors.length - 1; i >= 0; i -= 1) {
+    const show = priors[i];
+    if (show.showDate >= targetDate) continue;
+    const hit = show.songs.some((t) => normalizeTitle(t) === songKey);
+    if (hit) return gap;
+    gap += 1;
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
+/**
+ * Recent-window play counts ending strictly before targetDate.
+ * @param {ShowRecord[]} priors
+ * @param {number} window
+ * @returns {Map<string, number>}
+ */
+function recentPlayCounts(priors, window) {
+  const slice = priors.slice(Math.max(0, priors.length - window));
+  /** @type {Map<string, number>} */
+  const counts = new Map();
+  for (const show of slice) {
+    const seen = new Set();
+    for (const raw of show.songs) {
+      const key = normalizeTitle(raw);
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      counts.set(key, (counts.get(key) || 0) + 1);
+    }
+  }
+  return counts;
+}
+
+/**
+ * @param {ShowRecord[]} priors
+ * @param {string} targetDate
+ * @returns {{ daysSincePriorShow: number | null, priorShowDate: string | null }}
+ */
+function calendarContext(priors, targetDate) {
+  const prior = priors.length ? priors[priors.length - 1] : null;
+  if (!prior) return { daysSincePriorShow: null, priorShowDate: null };
+  return {
+    daysSincePriorShow: daysBetween(prior.showDate, targetDate),
+    priorShowDate: prior.showDate,
+  };
+}
+
+/**
+ * Guard: ensure labels for targetDate are not mixed into feature priors.
+ * @param {ShowRecord[]} priors
+ * @param {string} targetDate
+ */
+function assertNoTargetLeakage(priors, targetDate) {
+  for (const show of priors) {
+    if (show.showDate >= targetDate) {
+      throw new Error(
+        `Leakage: prior show ${show.showDate} is not strictly before target ${targetDate}`
+      );
+    }
+  }
+}
+
+
+/**
+ * Explainable play × slot recommendation model (#649).
+ *
+ * modelVersion is frozen in MODEL_VERSION / docs after it beats baselines.
+ */
+/** Frozen identifier once calibration ships — bump when weights change. */
+const MODEL_VERSION = "v0.1.0-explainable";
+
+/** Training-window description for reports / artifact metadata. */
+const MODEL_TRAINING_WINDOW =
+  "rolling-origin; features from all prior cached shows";
+
+/**
+ * Hand-tuned v0 weights — replace only with a version bump after re-backtest.
+ * Kept intentionally simple / explainable (no black-box ML).
+ */
+const MODEL_WEIGHTS = {
+  recent10: 0.35,
+  recent25: 0.25,
+  recent50: 0.15,
+  lifetime: 0.15,
+  gapCadence: 0.2,
+  priorNightRepeatPenalty: 0.45,
+  daysSincePriorScale: 0.05,
+  slotSmoothingAlpha: 1.5,
+  bustoutGapMin: 30,
+};
+
+/**
+ * Precompute shared maps once per (priors, targetDate).
+ * @param {import('./features.mjs').ShowRecord[]} priors
+ * @param {string} targetDate
+ */
+function buildFeatureContext(priors, targetDate) {
+  const idx = buildHistoryIndex(priors);
+  const r10 = recentPlayCounts(priors, 10);
+  const r25 = recentPlayCounts(priors, 25);
+  const r50 = recentPlayCounts(priors, 50);
+  const lastPrior = priors[priors.length - 1] || null;
+  const priorNightKeys = new Set(
+    (lastPrior?.songs || []).map(normalizeTitle).filter(Boolean)
+  );
+  const { daysSincePriorShow } = calendarContext(priors, targetDate);
+  /** @type {Map<string, number>} */
+  const gaps = new Map();
+  for (const songKey of idx.songs) {
+    gaps.set(songKey, reconstructGap(priors, targetDate, songKey));
+  }
+  return {
+    idx,
+    r10,
+    r25,
+    r50,
+    priorNightKeys,
+    daysSincePriorShow,
+    gaps,
+  };
+}
+
+/**
+ * @param {ReturnType<typeof buildFeatureContext>} ctx
+ * @param {string} songKey
+ */
+function playFeaturesFromCtx(ctx, songKey) {
+  const plays = ctx.idx.playCount.get(songKey) || 0;
+  const showCount = Math.max(1, ctx.idx.showCount);
+  const recent10 = (ctx.r10.get(songKey) || 0) / Math.min(10, showCount);
+  const recent25 = (ctx.r25.get(songKey) || 0) / Math.min(25, showCount);
+  const recent50 = (ctx.r50.get(songKey) || 0) / Math.min(50, showCount);
+  const lifetime = (plays + 1) / (showCount + 10);
+  const gap = ctx.gaps.get(songKey) ?? Number.POSITIVE_INFINITY;
+
+  let gapCadence = 0.15;
+  if (Number.isFinite(gap) && plays > 0) {
+    const expectedReturn = Math.max(2, Math.round(1 / Math.max(lifetime, 0.02)));
+    const ratio = gap / expectedReturn;
+    gapCadence = Math.exp(-((ratio - 1) ** 2) / 0.7);
+  }
+
+  const restBonus =
+    ctx.daysSincePriorShow != null && ctx.daysSincePriorShow >= 3
+      ? Math.min(1, (ctx.daysSincePriorShow - 2) / 10)
+      : 0;
+
+  return {
+    recent10,
+    recent25,
+    recent50,
+    lifetime,
+    gap,
+    gapCadence,
+    playedPriorNight: ctx.priorNightKeys.has(songKey),
+    restBonus,
+    plays,
+  };
+}
+
+/**
+ * @param {ReturnType<typeof playFeaturesFromCtx>} f
+ * @returns {{ playProb: number, reasons: string[] }}
+ */
+function scorePlayLikelihood(f) {
+  const w = MODEL_WEIGHTS;
+  let raw =
+    w.recent10 * f.recent10 +
+    w.recent25 * f.recent25 +
+    w.recent50 * f.recent50 +
+    w.lifetime * f.lifetime +
+    w.gapCadence * f.gapCadence +
+    w.daysSincePriorScale * f.restBonus;
+
+  const reasons = [];
+  if (f.recent25 >= 0.2) reasons.push("frequent this tour window");
+  if (f.gapCadence >= 0.7 && Number.isFinite(f.gap)) {
+    reasons.push(`due vs cadence (gap ${f.gap})`);
+  }
+  if (f.playedPriorNight) {
+    raw *= 1 - w.priorNightRepeatPenalty;
+    reasons.push("unlikely repeat after prior night");
+  }
+  if (f.gap >= w.bustoutGapMin && Number.isFinite(f.gap)) {
+    reasons.push(`bustout / long-shot upside (gap ${f.gap})`);
+  }
+
+  const playProb = 1 / (1 + Math.exp(-6 * (raw - 0.25)));
+  return { playProb, reasons: reasons.slice(0, 2) };
+}
+
+/**
+ * @param {ReturnType<typeof buildFeatureContext>} ctx
+ * @param {string} songKey
+ * @param {string} slot
+ */
+function slotAffinityFromCtx(ctx, songKey, slot) {
+  const plays = ctx.idx.playCount.get(songKey) || 0;
+  const slotMap = ctx.idx.slotCounts.get(slot) || new Map();
+  const slotHits = slotMap.get(songKey) || 0;
+  const alpha = MODEL_WEIGHTS.slotSmoothingAlpha;
+  if (slot === "wild") {
+    return { affinity: 1, reason: null };
+  }
+  const affinity =
+    (slotHits + alpha) / (plays + alpha * POSITIONAL_SLOTS.length);
+  const reason =
+    slotHits > 0 ? `strong ${slot} history (${slotHits}/${plays || 0})` : null;
+  return { affinity, reason };
+}
+
+/**
+ * @param {number} playProb
+ * @param {number} gap
+ * @returns {'safe' | 'slot_fit' | 'long_shot'}
+ */
+function riskBand(playProb, gap) {
+  if (playProb >= 0.55) return "safe";
+  if (
+    Number.isFinite(gap) &&
+    gap >= MODEL_WEIGHTS.bustoutGapMin &&
+    playProb < 0.4
+  ) {
+    return "long_shot";
+  }
+  return "slot_fit";
+}
+
+/**
+ * Rank songs for a single slot using playProb × slotAffinity.
+ *
+ * @param {import('./features.mjs').ShowRecord[]} priors
+ * @param {string} targetDate
+ * @param {string} slot
+ */
+function rankCombinedForSlot(priors, targetDate, slot) {
+  assertNoTargetLeakage(priors, targetDate);
+  const ctx = buildFeatureContext(priors, targetDate);
+  /** @type {Array<{
+   *   songKey: string,
+   *   score: number,
+   *   playProb: number,
+   *   slotAffinity: number,
+   *   riskBand: string,
+   *   reasons: string[],
+   *   modelVersion: string,
+   * }>} */
+  const rows = [];
+
+  for (const songKey of ctx.idx.songs) {
+    const f = playFeaturesFromCtx(ctx, songKey);
+    const { playProb, reasons } = scorePlayLikelihood(f);
+    const aff = slotAffinityFromCtx(ctx, songKey, slot);
+    const score =
+      slot === "wild" ? playProb : playProb * Math.max(0.05, aff.affinity);
+    const band = riskBand(playProb, f.gap);
+    /** @type {string[]} */
+    const allReasons = [...reasons];
+    if (aff.reason) allReasons.unshift(aff.reason);
+
+    rows.push({
+      songKey,
+      score,
+      playProb,
+      slotAffinity: aff.affinity,
+      riskBand: band,
+      reasons: allReasons.slice(0, 2),
+      modelVersion: MODEL_VERSION,
+    });
+  }
+
+  return rows.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.songKey.localeCompare(b.songKey);
+  });
+}
+
+/**
+ * Slot-agnostic ranking (wildcard / play-only) for recall metrics.
+ * @param {import('./features.mjs').ShowRecord[]} priors
+ * @param {string} targetDate
+ */
+function rankCombinedPlayOnly(priors, targetDate) {
+  return rankCombinedForSlot(priors, targetDate, "wild").map((r) => ({
+    songKey: r.songKey,
+    score: r.score,
+    reason: r.reasons.join("; ") || "combined_play",
+    playProb: r.playProb,
+    riskBand: r.riskBand,
+    reasons: r.reasons,
+    modelVersion: r.modelVersion,
+  }));
+}
+
+
+module.exports = {
+  MODEL_VERSION,
+  MODEL_TRAINING_WINDOW,
+  MODEL_WEIGHTS,
+  POSITIONAL_SLOTS,
+  normalizeTitle,
+  riskBand,
+  rankCombinedForSlot,
+  rankCombinedPlayOnly,
+  priorShows,
+  buildHistoryIndex,
+  assertNoTargetLeakage,
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.36.0",
+  "version": "1.37.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -18,7 +18,7 @@
     "generate:og-card": "node scripts/generate-og-card.mjs",
     "generate:email-wordmark": "node scripts/generate-email-wordmark.mjs",
     "secrets:sync-phishnet": "node scripts/sync-phishnet-secret.mjs",
-    "deploy:functions:phishnet": "firebase deploy --only functions:getPhishnetSetlist,functions:scheduledPhishnetShowCalendar,functions:refreshPhishnetShowCalendar,functions:refreshLiveScoresForShow,functions:scheduledPhishnetSongCatalog,functions:refreshPhishnetSongCatalog,functions:scheduledPhishnetLiveSetlistPoll,functions:scheduledPicksLockReminder,functions:setLiveSetlistAutomationState,functions:pollLiveSetlistNow,functions:sendPushCanary,functions:lockPicksForShowNow,functions:scheduledPublicTourStatsRefresh,functions:refreshPublicTourStats",
+    "deploy:functions:phishnet": "firebase deploy --only functions:getPhishnetSetlist,functions:scheduledPhishnetShowCalendar,functions:refreshPhishnetShowCalendar,functions:refreshLiveScoresForShow,functions:scheduledPhishnetSongCatalog,functions:refreshPhishnetSongCatalog,functions:scheduledPickRecommendations,functions:refreshPickRecommendations,functions:scheduledPhishnetLiveSetlistPoll,functions:scheduledPicksLockReminder,functions:setLiveSetlistAutomationState,functions:pollLiveSetlistNow,functions:sendPushCanary,functions:lockPicksForShowNow,functions:scheduledPublicTourStatsRefresh,functions:refreshPublicTourStats",
     "verify:phishnet-deploy-manifest": "node scripts/verify-phishnet-deploy-manifest.mjs",
     "diagnose:phishnet": "node scripts/diagnose-phishnet-local.mjs",
     "print:phishnet-tour-clusters": "node scripts/print-phishnet-tour-clusters.mjs",

--- a/scripts/verify-phishnet-deploy-manifest.mjs
+++ b/scripts/verify-phishnet-deploy-manifest.mjs
@@ -24,6 +24,8 @@ const REQUIRED_EXPORTS = [
   "refreshLiveScoresForShow",
   "scheduledPhishnetSongCatalog",
   "refreshPhishnetSongCatalog",
+  "scheduledPickRecommendations",
+  "refreshPickRecommendations",
   "scheduledPhishnetLiveSetlistPoll",
   "scheduledPicksLockReminder",
   "setLiveSetlistAutomationState",

--- a/src/features/picks/api/pickRecommendationsUrl.js
+++ b/src/features/picks/api/pickRecommendationsUrl.js
@@ -1,0 +1,23 @@
+import { loadFirebaseStorage } from '../../../shared/lib/firebaseStorage.js';
+
+const REC_OBJECT_PATH = 'pick-recommendations.json';
+
+/**
+ * Resolves the URL used to `fetch()` pick-recommendations JSON (#650).
+ *
+ * - **`VITE_PICK_RECOMMENDATIONS_URL`:** used as-is (CDN override).
+ * - **Default:** Firebase `getDownloadURL()` for `pick-recommendations.json`.
+ *
+ * @returns {Promise<string>}
+ */
+export async function resolvePickRecommendationsFetchUrl() {
+  const explicit = import.meta.env.VITE_PICK_RECOMMENDATIONS_URL;
+  if (typeof explicit === 'string' && explicit.trim()) {
+    return explicit.trim();
+  }
+  const { storage, ref, getDownloadURL } = await loadFirebaseStorage();
+  const r = ref(storage, REC_OBJECT_PATH);
+  return getDownloadURL(r);
+}
+
+export { REC_OBJECT_PATH };

--- a/src/features/picks/index.js
+++ b/src/features/picks/index.js
@@ -10,6 +10,7 @@ export { default as PicksSelfRecapSection } from './ui/PicksSelfRecapSection';
 export { default as usePicksForm } from './model/usePicksForm';
 export { usePicksSelfRecap } from './model/usePicksSelfRecap';
 export { useNextShowPicksStatus } from './model/useNextShowPicksStatus';
+export { usePickRecommendations } from './model/usePickRecommendations';
 export {
   hasNonEmptyPicksObject,
   pickEntryHasSubmission,

--- a/src/features/picks/model/pickRecommendationsConstants.js
+++ b/src/features/picks/model/pickRecommendationsConstants.js
@@ -1,0 +1,6 @@
+/** localStorage cache for Storage `pick-recommendations.json` (#650). */
+export const PICK_RECOMMENDATIONS_CACHE_KEY =
+  'set-picks.pickRecommendationsCache.v1';
+
+/** Align with ~6h scheduled refresh (+ :15 offset). */
+export const PICK_RECOMMENDATIONS_CACHE_MAX_AGE_MS = 6 * 60 * 60 * 1000;

--- a/src/features/picks/model/selectPickRecommendations.js
+++ b/src/features/picks/model/selectPickRecommendations.js
@@ -1,0 +1,18 @@
+/**
+ * @param {unknown} body
+ * @returns {object | null}
+ */
+export function selectPickRecommendations(body) {
+  if (!body || typeof body !== 'object') return null;
+  const rec = /** @type {Record<string, unknown>} */ (body);
+  if (typeof rec.modelVersion !== 'string' || !rec.modelVersion.trim()) {
+    return null;
+  }
+  if (!rec.targetShow || typeof rec.targetShow !== 'object') return null;
+  const date = /** @type {Record<string, unknown>} */ (rec.targetShow).date;
+  if (typeof date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return null;
+  }
+  if (!rec.slots || typeof rec.slots !== 'object') return null;
+  return /** @type {object} */ (body);
+}

--- a/src/features/picks/model/selectPickRecommendations.test.js
+++ b/src/features/picks/model/selectPickRecommendations.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { selectPickRecommendations } from './selectPickRecommendations.js';
+
+describe('selectPickRecommendations', () => {
+  it('rejects missing modelVersion / slots', () => {
+    expect(selectPickRecommendations(null)).toBeNull();
+    expect(
+      selectPickRecommendations({
+        targetShow: { date: '2024-07-19' },
+        slots: {},
+      }),
+    ).toBeNull();
+  });
+
+  it('accepts a minimal valid artifact', () => {
+    const body = {
+      modelVersion: 'v0.1.0-explainable',
+      targetShow: { date: '2024-07-19' },
+      slots: { s1o: [] },
+    };
+    expect(selectPickRecommendations(body)).toEqual(body);
+  });
+});

--- a/src/features/picks/model/usePickRecommendations.js
+++ b/src/features/picks/model/usePickRecommendations.js
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react';
+
+import { resolvePickRecommendationsFetchUrl } from '../api/pickRecommendationsUrl.js';
+import {
+  PICK_RECOMMENDATIONS_CACHE_KEY,
+  PICK_RECOMMENDATIONS_CACHE_MAX_AGE_MS,
+} from './pickRecommendationsConstants.js';
+import { selectPickRecommendations } from './selectPickRecommendations.js';
+
+/**
+ * @typedef {{ fetchedAt: number, artifact: object }} RecCacheV1
+ */
+
+/**
+ * @returns {RecCacheV1 | null}
+ */
+function readCache() {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(PICK_RECOMMENDATIONS_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      typeof parsed.fetchedAt !== 'number' ||
+      !parsed.artifact
+    ) {
+      return null;
+    }
+    return /** @type {RecCacheV1} */ (parsed);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {RecCacheV1} entry
+ */
+function writeCache(entry) {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(PICK_RECOMMENDATIONS_CACHE_KEY, JSON.stringify(entry));
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+/**
+ * Loads versioned pick recommendations from Storage with TTL + stale fallback (#650).
+ * Returns null artifact when unavailable (Lab / Predictive Mode stay dark).
+ *
+ * @returns {{
+ *   artifact: object | null,
+ *   loadError: Error | null,
+ *   isLoading: boolean,
+ *   loadedFromCache: boolean,
+ * }}
+ */
+export function usePickRecommendations() {
+  const [artifact, setArtifact] = useState(/** @type {object | null} */ (null));
+  const [loadError, setLoadError] = useState(/** @type {Error | null} */ (null));
+  const [resolved, setResolved] = useState(false);
+  const [loadedFromCache, setLoadedFromCache] = useState(false);
+
+  useEffect(() => {
+    const ac = new AbortController();
+    let cancelled = false;
+
+    async function load() {
+      setLoadError(null);
+      setLoadedFromCache(false);
+
+      const now = Date.now();
+      const cached = readCache();
+      const cachedOk =
+        cached && selectPickRecommendations(cached.artifact);
+
+      if (
+        cachedOk &&
+        now - cached.fetchedAt < PICK_RECOMMENDATIONS_CACHE_MAX_AGE_MS
+      ) {
+        if (!cancelled) {
+          setArtifact(cached.artifact);
+          setLoadedFromCache(true);
+          setResolved(true);
+        }
+        return;
+      }
+
+      let url;
+      try {
+        url = await resolvePickRecommendationsFetchUrl();
+      } catch (e) {
+        if (ac.signal.aborted || cancelled) return;
+        if (cachedOk) {
+          setArtifact(cached.artifact);
+          setResolved(true);
+          return;
+        }
+        setArtifact(null);
+        setLoadError(e instanceof Error ? e : new Error(String(e)));
+        setResolved(true);
+        return;
+      }
+
+      try {
+        const res = await fetch(url, {
+          signal: ac.signal,
+          headers: { Accept: 'application/json' },
+        });
+        if (!res.ok) {
+          throw new Error(`Pick recommendations HTTP ${res.status}`);
+        }
+        const body = await res.json();
+        const selected = selectPickRecommendations(body);
+        if (!selected) {
+          throw new Error('Pick recommendations JSON failed validation.');
+        }
+        writeCache({ fetchedAt: Date.now(), artifact: selected });
+        if (!cancelled) {
+          setArtifact(selected);
+          setResolved(true);
+        }
+      } catch (e) {
+        if (ac.signal.aborted || cancelled) return;
+        if (cachedOk) {
+          setArtifact(cached.artifact);
+          setLoadError(null);
+          setResolved(true);
+          return;
+        }
+        setArtifact(null);
+        setLoadError(e instanceof Error ? e : new Error(String(e)));
+        setResolved(true);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+      ac.abort();
+    };
+  }, []);
+
+  return {
+    artifact,
+    loadError,
+    isLoading: !resolved,
+    loadedFromCache,
+  };
+}

--- a/storage.rules
+++ b/storage.rules
@@ -12,5 +12,15 @@ service firebase.storage {
     match /song-catalog/archive/{fileName} {
       allow read, write: if false;
     }
+
+    // Upcoming-show recommendation artifact (#650). Client TTL fetch; Admin SDK write.
+    match /pick-recommendations.json {
+      allow read: if true;
+      allow write: if false;
+    }
+
+    match /pick-recommendations/archive/{fileName} {
+      allow read, write: if false;
+    }
   }
 }


### PR DESCRIPTION
Closes #650

## Summary
- Wave 3 of the [Sprint 13 release train](docs/RELEASE_TRAIN_SPRINT_13.md) / epic #646.
- Publishes versioned `pick-recommendations.json` for the upcoming show (`scheduledPickRecommendations` + admin `refreshPickRecommendations`).
- Leakage-safe: ranks from `official_setlists` with `showDate < target` only; no-op when no upcoming show / empty history.
- Client `usePickRecommendations` mirrors song-catalog TTL/stale fallback (no Lab UI yet).
- SemVer **1.37.0**; Storage rules + `docs/API.md` / `docs/PICK_RECOMMENDATIONS.md`.

## Test plan
- [x] `node --test functions/pickRecommendations.test.js`
- [x] `npm run verify:phishnet-deploy-manifest`
- [x] `npx vitest run src/features/picks/model/selectPickRecommendations.test.js`
- [ ] After merge: `firebase deploy --only storage` + `npm run deploy:functions:phishnet`
- [ ] Admin `refreshPickRecommendations` → confirm object + `modelVersion` / `targetShow.date`
- [ ] Confirm no Firestore reads on picks keystrokes (artifact is Storage-only)


Made with [Cursor](https://cursor.com)