### PR TITLE
hotfix: pool invite join + picks lock doors+1:25 (1.35.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ No unreleased changes.
 
 ---
 
+## [1.35.5] — 2026-07-22
+
+### Fixed
+- **Pool invite join** — Firestore rules now allow `memberJoinedAt` on self-join for `from_membership` pools (new pools since #417). Without this, every invite-link join failed with permission denied and surfaced “Could not join the pool.”
+- **Pool invite flash** — `/join/:code` server-rendered SPA shell no longer injects the home-page SEO prerender body into `#root` before React boots (eliminates the brief “About Setlist Pick'Em” marketing copy flash).
+- **Pending invite retry** — Deep-link join keeps the stored invite code in `localStorage` until join succeeds or is definitively invalid, so transient failures can be retried from the Pools tab without re-opening the link.
+
+### Changed
+- **Picks lock offset** — doors-based wall clock moves from doors+100 (1h40) to doors+85 (1h25): safety buffer raised 19 → 34 against the Summer Tour 2026 avg doors→start of 119. Client + Functions + lock-reminder copy share the same resolver.
+
+---
+
 ## [1.35.4] — 2026-07-21
 
 ### Changed

--- a/api/inviteOgHelpers.mjs
+++ b/api/inviteOgHelpers.mjs
@@ -219,9 +219,22 @@ ${buildOgMetaTags(og)}
  * @param {{ title: string, description: string, url: string, image: string }} og
  * @returns {string}
  */
+/**
+ * Post-build SEO prerender injects crawler copy into `#root` on `dist/index.html`.
+ * Invite landings must not flash that home-page body before React boots.
+ */
+export function stripPrerenderBodyFromSpaShell(spaHtml) {
+  if (typeof spaHtml !== 'string' || !spaHtml) return spaHtml;
+  return spaHtml.replace(
+    /<div id="root">[\s\S]*?<\/div>/i,
+    '<div id="root"></div>',
+  );
+}
+
 export function injectOgIntoSpa(spaHtml, og) {
   const dynamicTags = buildOgMetaTags(og);
-  return spaHtml.replace(
+  const cleanedShell = stripPrerenderBodyFromSpaShell(spaHtml);
+  return cleanedShell.replace(
     /(<meta\s+charset[^>]*\/?>)/i,
     `$1\n${dynamicTags}`,
   );

--- a/api/inviteOgHelpers.test.js
+++ b/api/inviteOgHelpers.test.js
@@ -12,6 +12,8 @@ import {
   POOL_INVITE_GENERIC_DESCRIPTION,
   resolveInviteOgContent,
   SITE_INVITE_DESCRIPTION,
+  injectOgIntoSpa,
+  stripPrerenderBodyFromSpaShell,
 } from './inviteOgHelpers.mjs';
 
 describe('inviteOgHelpers', () => {
@@ -80,5 +82,22 @@ describe('inviteOgHelpers', () => {
       title: buildPoolInviteShareTitle(),
       description: POOL_INVITE_GENERIC_DESCRIPTION,
     });
+  });
+
+  it('strips SEO prerender body from SPA shell before invite boot', () => {
+    const shell = `<!DOCTYPE html><html><head><meta charset="UTF-8" /></head><body><div id="root"><!--seo-prerender:/-->
+  <main data-seo-prerender="true"><h1>About Setlist Pick'Em</h1></main></div></body></html>`;
+    expect(stripPrerenderBodyFromSpaShell(shell)).toBe(
+      '<!DOCTYPE html><html><head><meta charset="UTF-8" /></head><body><div id="root"></div></body></html>',
+    );
+    const injected = injectOgIntoSpa(shell, {
+      title: 'Pool invite',
+      description: 'Join the pool',
+      url: 'https://www.setlistpickem.com/join/YEM42',
+      image: 'https://www.setlistpickem.com/branding/og-card-1200x630.jpg',
+    });
+    expect(injected).toContain('<div id="root"></div>');
+    expect(injected).not.toContain('About Setlist Pick');
+    expect(injected).toContain('property="og:title"');
   });
 });

--- a/docs/API.md
+++ b/docs/API.md
@@ -109,7 +109,7 @@ Tour and show date metadata. Read by `resolveCurrentTour` and `resolveSelectable
 | `scheduleSourceUrl` | string? | Official date-page URL |
 | `picksLockLocal` | string? | Venue-local picks lock `HH:mm` when materialized/overridden |
 
-**Picks wall-clock lock (#522):** when `doorsLocal` (or a seeded doors time) is known, lock = doors + (tour avg doors→start − safety). Summer Tour 2026 defaults: avg **119** min, safety **19** → **doors + 100 min**. When doors are unknown, fallback is **19:30** venue-local. Admin `show_lock_state` and (planned) setlist `s1o` still win as earlier signals.
+**Picks wall-clock lock (#522):** when `doorsLocal` (or a seeded doors time) is known, lock = doors + (tour avg doors→start − safety). Summer Tour 2026 defaults: avg **119** min, safety **34** → **doors + 85 min** (1h25). When doors are unknown, fallback is **19:30** venue-local. Admin `show_lock_state` and (planned) setlist `s1o` still win as earlier signals.
 
 `scheduledPhishnetShowCalendar` runs daily at 06:00 ET. Phish.net is canonical for dates/tours/venues; the sync then fetches Phish.com upcoming date pages for timing. A Phish.com failure does not fail or erase the calendar: prior timing is preserved.
 

--- a/docs/PICKS_LOCK_ADMIN_RUNBOOK.md
+++ b/docs/PICKS_LOCK_ADMIN_RUNBOOK.md
@@ -27,7 +27,7 @@ Operational guide for **`lockPicksForShowNow`** — the War Room **Lock picks no
 1. Admin clicks **Lock picks now** in War Room while the show is `NEXT`.
 2. Client calls `lockPicksForShowNow({ showDate })`.
 3. Callable writes `show_lock_state/{showDate}` with `lockReason: admin_override`.
-4. All clients subscribed to that doc treat picks as locked even before the per-show wall clock (doors+1:40 when doors known; else 7:30 PM venue-local).
+4. All clients subscribed to that doc treat picks as locked even before the per-show wall clock (doors+1:25 when doors known; else 7:30 PM venue-local).
 
 Idempotent: re-running on an already-stamped doc returns `{ alreadyLocked: true }` without rewriting timestamps.
 

--- a/docs/comms-triggers/TRIGGER_CATALOG.md
+++ b/docs/comms-triggers/TRIGGER_CATALOG.md
@@ -41,7 +41,7 @@ Every template draws from this shared set. Each trigger declares the subset it u
 | `{{venue_name}}` | `show_calendar` snapshot | — |
 | `{{venue_city}}` | `show_calendar` snapshot | — |
 | `{{time_to_lock}}` | Computed at send time | — |
-| `{{lock_time_local}}` | Computed (doors+1:40 when doors known; else 19:30 venue-local) | `7:30 PM` |
+| `{{lock_time_local}}` | Computed (doors+1:25 when doors known; else 19:30 venue-local) | `7:30 PM` |
 | `{{tour_name}}` | Tour metadata | — |
 | `{{days_remaining}}` | Computed from tour start date | — |
 | `{{first_show_date}}` | Tour first show | — |

--- a/firestore.rules
+++ b/firestore.rules
@@ -16,17 +16,39 @@ service cloud.firestore {
     }
 
     /**
-     * Join flow: only `members` may change; array grows by one and includes the caller.
+     * Join flow: `members` grows by one and includes the caller. `from_membership`
+     * pools (#417) also stamp `memberJoinedAt.{uid}` on self-join.
      */
-    function isPoolSelfJoin() {
+    function isPoolMembersSelfJoin() {
       return signedIn()
         && resource.data.members is list
         && request.resource.data.members is list
         && !(request.auth.uid in resource.data.members)
         && request.auth.uid in request.resource.data.members
-        && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['members'])
         && request.resource.data.members.hasAll(resource.data.members)
         && request.resource.data.members.size() == resource.data.members.size() + 1;
+    }
+
+    function isPoolSelfJoinMembershipTimestamp() {
+      let prior = resource.data.get('memberJoinedAt', {});
+      let next = request.resource.data.memberJoinedAt;
+      // Only the joiner's key may be added; existing timestamps must be unchanged.
+      return next is map
+        && next.diff(prior).affectedKeys().hasOnly([request.auth.uid])
+        && request.auth.uid in next
+        && !(request.auth.uid in prior)
+        && next[request.auth.uid] is string;
+    }
+
+    function isPoolSelfJoin() {
+      return isPoolMembersSelfJoin()
+        && (
+          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['members'])
+          || (
+            request.resource.data.diff(resource.data).affectedKeys().hasOnly(['members', 'memberJoinedAt'])
+            && isPoolSelfJoinMembershipTimestamp()
+          )
+        );
     }
 
     match /pools/{poolId} {

--- a/firestore.rules.test.cjs
+++ b/firestore.rules.test.cjs
@@ -512,3 +512,78 @@ test("users: signed-in user may query profiles (standings/pool lookup)", async (
   );
   assert.ok(snap && snap.size >= 2);
 });
+
+// ─── pools/{poolId} ──────────────────────────────────────────────────────────
+
+test("pools: member may self-join a legacy pool (members only)", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "pools", "pool1"), {
+      name: "Legacy Crew",
+      inviteCode: "ABCDE",
+      ownerId: "alice",
+      members: ["alice"],
+      status: "active",
+    });
+    await setDoc(doc(adminDb, "users", "bob"), { handle: "bob", pools: [] });
+  });
+
+  const db = signedInAs("bob");
+  await assertSucceeds(
+    updateDoc(doc(db, "pools", "pool1"), {
+      members: ["alice", "bob"],
+    })
+  );
+});
+
+test("pools: member may self-join a from_membership pool with memberJoinedAt", async () => {
+  const joinedAt = "2026-07-22T12:00:00.000Z";
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "pools", "pool1"), {
+      name: "Tour Crew",
+      inviteCode: "FGHJK",
+      ownerId: "alice",
+      members: ["alice"],
+      status: "active",
+      standingsScope: "from_membership",
+      memberJoinedAt: { alice: "2026-07-01T12:00:00.000Z" },
+    });
+    await setDoc(doc(adminDb, "users", "bob"), { handle: "bob", pools: [] });
+  });
+
+  const db = signedInAs("bob");
+  await assertSucceeds(
+    updateDoc(doc(db, "pools", "pool1"), {
+      members: ["alice", "bob"],
+      memberJoinedAt: {
+        alice: "2026-07-01T12:00:00.000Z",
+        bob: joinedAt,
+      },
+    })
+  );
+});
+
+test("pools: self-join cannot rewrite another member's memberJoinedAt", async () => {
+  await seed(async (adminDb) => {
+    await setDoc(doc(adminDb, "pools", "pool1"), {
+      name: "Tour Crew",
+      inviteCode: "FGHJK",
+      ownerId: "alice",
+      members: ["alice"],
+      status: "active",
+      standingsScope: "from_membership",
+      memberJoinedAt: { alice: "2026-07-01T12:00:00.000Z" },
+    });
+    await setDoc(doc(adminDb, "users", "bob"), { handle: "bob", pools: [] });
+  });
+
+  const db = signedInAs("bob");
+  await assertFails(
+    updateDoc(doc(db, "pools", "pool1"), {
+      members: ["alice", "bob"],
+      memberJoinedAt: {
+        alice: "2026-01-01T00:00:00.000Z",
+        bob: "2026-07-22T12:00:00.000Z",
+      },
+    })
+  );
+});

--- a/functions/picksLockTime.js
+++ b/functions/picksLockTime.js
@@ -7,7 +7,7 @@
 
 const DEFAULT_PICKS_LOCK_HM = Object.freeze({ hour: 19, minute: 30 });
 const TOUR_AVG_DOORS_TO_START_MIN = 119;
-const PICKS_LOCK_SAFETY_MIN = 19;
+const PICKS_LOCK_SAFETY_MIN = 34;
 
 const SHOW_DOORS_LOCAL_BY_DATE = Object.freeze({
   "2026-07-18": "17:30",

--- a/functions/picksLockTime.test.js
+++ b/functions/picksLockTime.test.js
@@ -8,17 +8,17 @@ const {
   resolvePicksLockHm,
 } = require("./picksLockTime");
 
-test("lockHmFromDoors uses doors+100 for Summer Tour 2026 defaults", () => {
+test("lockHmFromDoors uses doors+85 for Summer Tour 2026 defaults", () => {
   assert.deepEqual(lockHmFromDoors({ hour: 17, minute: 30 }), {
-    hour: 19,
-    minute: 10,
+    hour: 18,
+    minute: 55,
   });
 });
 
 test("resolvePicksLockHm seeds Merriweather and falls back", () => {
   assert.deepEqual(resolvePicksLockHm({ date: "2026-07-18" }), {
-    hour: 19,
-    minute: 10,
+    hour: 18,
+    minute: 55,
     source: "doors",
     doorsLocal: "17:30",
   });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.35.4",
+  "version": "1.35.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/admin/ui/AdminPicksLockControls.jsx
+++ b/src/features/admin/ui/AdminPicksLockControls.jsx
@@ -15,7 +15,7 @@ export default function AdminPicksLockControls({
   const canLock = showStatus === 'NEXT' && !picksAlreadyLocked && !disabled;
 
   let helperText =
-    'Picks lock at doors + ~1:40 (tour avg start − safety), at fallback 7:30 PM venue-local when doors are unknown, when set 1 starts on Phish.net, or when you lock them here.';
+    'Picks lock at doors + ~1:25 (tour avg start − safety), at fallback 7:30 PM venue-local when doors are unknown, when set 1 starts on Phish.net, or when you lock them here.';
   if (showStatus && showStatus !== 'NEXT') {
     helperText = 'Lock picks now is only available while this show is NEXT (before wall-clock lock).';
   } else if (adminLockActive) {

--- a/src/features/picks/ui/PicksLockTimingBanner.test.js
+++ b/src/features/picks/ui/PicksLockTimingBanner.test.js
@@ -8,11 +8,11 @@ describe('buildPicksLockTimingMessage', () => {
       buildPicksLockTimingMessage({
         date: '2026-07-18',
         doorsLocal: '17:30',
-        picksLockLocal: '19:10',
+        picksLockLocal: '18:55',
         picksLockSource: 'doors',
       })
     ).toBe(
-      'Picks lock at 7:10 PM — 1 hour 40 minutes after tonight’s published doors time (5:30 PM).'
+      'Picks lock at 6:55 PM — 1 hour 25 minutes after tonight’s published doors time (5:30 PM).'
     );
   });
 

--- a/src/features/pool-invite/api/joinPool.js
+++ b/src/features/pool-invite/api/joinPool.js
@@ -3,7 +3,7 @@ import { joinPool as joinPoolFromPools } from '../../pools';
 /**
  * Join via invite code for the deep-link flow.
  * @param {{ userId: string, inviteCode: string, showDates?: Array<string | { date?: string }> }} params
- * @returns {Promise<'joined' | 'already-member' | 'invalid-code' | 'pool-full'>}
+ * @returns {Promise<'joined' | 'already-member' | 'invalid-code' | 'pool-full' | 'pool-archived'>}
  */
 export async function joinPoolByInviteCode({ userId, inviteCode, showDates }) {
   try {
@@ -12,6 +12,7 @@ export async function joinPoolByInviteCode({ userId, inviteCode, showDates }) {
   } catch (err) {
     if (err?.code === 'invalid-invite-code') return 'invalid-code';
     if (err?.code === 'pool-full') return 'pool-full';
+    if (err?.code === 'pool-archived') return 'pool-archived';
     if (err?.code === 'already-in-pool') return 'already-member';
     throw err;
   }

--- a/src/features/pool-invite/model/usePendingPoolJoin.js
+++ b/src/features/pool-invite/model/usePendingPoolJoin.js
@@ -32,8 +32,6 @@ export function usePendingPoolJoin(showDates = []) {
     pendingJoinKeyInFlight = dedupeKey;
 
     (async () => {
-      removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
-
       try {
         const outcome = await joinPoolByInviteCode({
           userId,
@@ -42,23 +40,32 @@ export function usePendingPoolJoin(showDates = []) {
         });
 
         if (outcome === 'joined') {
+          removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
           invalidateUserPools();
           showSuccessToast('You joined the pool!');
           navigate('/dashboard/pools', { replace: true });
           return;
         }
         if (outcome === 'already-member') {
+          removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
           invalidateUserPools();
           showSuccessToast("You're already in this pool.");
           navigate('/dashboard/pools', { replace: true });
           return;
         }
         if (outcome === 'invalid-code') {
+          removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
           showErrorToast('That invite link is invalid or expired.');
           return;
         }
         if (outcome === 'pool-full') {
+          removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
           showErrorToast('This pool is full.');
+          return;
+        }
+        if (outcome === 'pool-archived') {
+          removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
+          showErrorToast('That pool is archived and no longer accepts new members.');
           return;
         }
       } catch {

--- a/src/shared/utils/picksLockTime.js
+++ b/src/shared/utils/picksLockTime.js
@@ -2,7 +2,7 @@
  * Per-show picks wall-clock lock (#522).
  *
  * When doors are known: lock = doors + (tourAvgDoorsToStart − safety).
- * Summer Tour 2026 setlist.fm avg doors→start is 1h59m (119); safety 19 → doors+100.
+ * Summer Tour 2026 setlist.fm avg doors→start is 1h59m (119); safety 34 → doors+85 (1h25).
  * Fallback when doors unknown: 19:30 venue-local.
  */
 
@@ -16,8 +16,8 @@ export const SHOW_PICKS_LOCK_MINUTE_LOCAL = DEFAULT_PICKS_LOCK_HM.minute;
 /** setlist.fm Summer Tour 2026 “Avg start time after doors”. */
 export const TOUR_AVG_DOORS_TO_START_MIN = 119;
 
-/** Minutes before average start to lock picks (doors+100 when avg is 119). */
-export const PICKS_LOCK_SAFETY_MIN = 19;
+/** Minutes before average start to lock picks (doors+85 when avg is 119). */
+export const PICKS_LOCK_SAFETY_MIN = 34;
 
 /**
  * Known doors times (venue-local 24h `HH:mm`) from setlist.fm / tickets.

--- a/src/shared/utils/picksLockTime.test.js
+++ b/src/shared/utils/picksLockTime.test.js
@@ -19,29 +19,29 @@ describe('parseLocalHm', () => {
 });
 
 describe('lockHmFromDoors', () => {
-  it('locks doors+100 when avg=119 and safety=19', () => {
-    expect(lockHmFromDoors({ hour: 17, minute: 30 })).toEqual({ hour: 19, minute: 10 });
-    expect(lockHmFromDoors({ hour: 18, minute: 30 })).toEqual({ hour: 20, minute: 10 });
-    expect(lockHmFromDoors({ hour: 17, minute: 0 })).toEqual({ hour: 18, minute: 40 });
+  it('locks doors+85 when avg=119 and safety=34', () => {
+    expect(lockHmFromDoors({ hour: 17, minute: 30 })).toEqual({ hour: 18, minute: 55 });
+    expect(lockHmFromDoors({ hour: 18, minute: 30 })).toEqual({ hour: 19, minute: 55 });
+    expect(lockHmFromDoors({ hour: 17, minute: 0 })).toEqual({ hour: 18, minute: 25 });
   });
 });
 
 describe('resolvePicksLockHm (#522)', () => {
   it('uses seeded doors for Merriweather / MSG / Fenway', () => {
     expect(resolvePicksLockHm({ date: '2026-07-18' })).toMatchObject({
-      hour: 19,
-      minute: 10,
+      hour: 18,
+      minute: 55,
       source: 'doors',
       doorsLocal: '17:30',
     });
     expect(resolvePicksLockHm({ date: '2026-07-22' })).toMatchObject({
-      hour: 20,
-      minute: 10,
+      hour: 19,
+      minute: 55,
       source: 'doors',
     });
     expect(resolvePicksLockHm({ date: '2026-07-31' })).toMatchObject({
       hour: 18,
-      minute: 40,
+      minute: 25,
       source: 'doors',
     });
   });
@@ -68,7 +68,7 @@ describe('resolvePicksLockHm (#522)', () => {
         date: '2099-01-01',
         doorsLocal: '18:00',
       })
-    ).toMatchObject({ hour: 19, minute: 40, source: 'doors', doorsLocal: '18:00' });
+    ).toMatchObject({ hour: 19, minute: 25, source: 'doors', doorsLocal: '18:00' });
   });
 
   it('formats labels', () => {

--- a/src/shared/utils/timeLogic.test.js
+++ b/src/shared/utils/timeLogic.test.js
@@ -67,10 +67,10 @@ describe('venue-local lock + status (#278)', () => {
     expect(getShowStatus('2099-06-15', shows)).toBe('LIVE');
   });
 
-  it('locks Merriweather at doors+100 (7:10 PM ET) before fallback 7:30', () => {
+  it('locks Merriweather at doors+85 (6:55 PM ET) before fallback 7:30', () => {
     vi.useFakeTimers();
-    // 2026-07-18 23:15Z = 7:15 PM ET → past 7:10 lock, before 7:30 fallback.
-    vi.setSystemTime(new Date('2026-07-18T23:15:00.000Z'));
+    // 2026-07-18 23:00Z = 7:00 PM ET → past 6:55 lock, before 7:30 fallback.
+    vi.setSystemTime(new Date('2026-07-18T23:00:00.000Z'));
 
     const shows = [
       {
@@ -83,9 +83,9 @@ describe('venue-local lock + status (#278)', () => {
     expect(getShowStatus('2026-07-18', shows)).toBe('LIVE');
   });
 
-  it('keeps Merriweather NEXT at 7:00 PM ET (before doors+100 lock)', () => {
+  it('keeps Merriweather NEXT at 6:45 PM ET (before doors+85 lock)', () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-07-18T23:00:00.000Z'));
+    vi.setSystemTime(new Date('2026-07-18T22:45:00.000Z'));
 
     const shows = [
       {


### PR DESCRIPTION
## Summary
Selective **main** hotfix so Sprint 13 prediction train stays on `staging`.

- **Pool invite (#723)** — allow `memberJoinedAt` on `from_membership` self-join; strip SEO prerender flash on `/join`; keep pending invite until join resolves
- **Picks lock** — raise safety 19 → 34 so wall clock is **doors + 85 min (1h25)** instead of doors+100 (1h40). Client + Functions + docs aligned.

SemVer: **1.35.5** PATCH on `main` (does not roll up staging 1.36–1.39).

## Test plan
- [x] Client + Functions unit tests for lock offset
- [x] Invite OG helper tests
- [ ] CI verify + rules
- [ ] After merge: confirm tonight MSG lock banner shows ~7:55 PM for 6:30 doors
- [ ] Deploy: `firestore:rules` (if not already live) + `scheduledPicksLockReminder` / phishnet bundle that ships `picksLockTime.js`


Made with [Cursor](https://cursor.com)