### PR TITLE
fix(invite): Wave 0 join UX (#727 #728 #729)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ No unreleased changes.
 ### Fixed
 - **Invite auth loading gap (#727)** — guest → sign-in keeps auth `loading` until the first profile snapshot, so returning users are not dumped onto Almost There. Profile setup subcopy uses pool-enter framing only when a pending invite breadcrumb is present.
 - **Pending pool join UX (#728)** — post-auth with a stored invite lands on `/dashboard/pools` (overrides remembered last-tab). Pending-join status machine drives “Joining your pool…” chrome; `useUserPools` splits `listLoading` vs `actionLoading` so Join/Create buttons no longer flash from list refresh.
-- **Join backfill + timeout (#729)** — legacy pick-doc pool snapshot backfill no longer blocks `joinPool` after membership commit. Pending join times out at ~15s with Retry (breadcrumb kept; in-flight dedupe cleared).
+- **Join backfill + timeout (#729)** — legacy pick-doc pool snapshot backfill no longer blocks `joinPool` after membership commit. Pending join times out at ~15s with Retry (breadcrumb kept; in-flight dedupe cleared). Pending-join effect no longer cancels on calendar `showDates` identity churn (avoids stuck invite breadcrumb after a successful membership write).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ No unreleased changes.
 
 ---
 
+## [1.39.3] — 2026-07-22
+
+### Fixed
+- **Invite auth loading gap (#727)** — guest → sign-in keeps auth `loading` until the first profile snapshot, so returning users are not dumped onto Almost There. Profile setup subcopy uses pool-enter framing only when a pending invite breadcrumb is present.
+- **Pending pool join UX (#728)** — post-auth with a stored invite lands on `/dashboard/pools` (overrides remembered last-tab). Pending-join status machine drives “Joining your pool…” chrome; `useUserPools` splits `listLoading` vs `actionLoading` so Join/Create buttons no longer flash from list refresh.
+- **Join backfill + timeout (#729)** — legacy pick-doc pool snapshot backfill no longer blocks `joinPool` after membership commit. Pending join times out at ~15s with Retry (breadcrumb kept; in-flight dedupe cleared).
+
+---
+
 ## [1.39.2] — 2026-07-22
 
 ### Changed

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -42,7 +42,9 @@ npm run qa:auth-scenarios # full auth telemetry + routing matrix (QA_TEST_* only
 
 This materializes `.env.qa.local` from injected secrets, runs `qa:cache` (email returning user), and `qa:google-signup` gating tests.
 
-**Pool invite E2E (`qa:auth-scenarios` UR-B2):** signs in as `QA_TEST_*`, creates a throwaway pool, signs out, opens `/join/:code`, signs back in. Because the QA user already owns the pool, deferred join resolves as **already-member** — still validates Wave 0 invite storage, pools landing override, and no Almost There flash. A true first-membership join needs a second joiner account (not automated yet).
+**Pool invite E2E (`qa:auth-scenarios`):**
+- **UR-B2** — `QA_TEST_*` creates a pool, signs out, rejoins via `/join/:code` (**already-member**).
+- **UR-B3** — same create path, then a **disposable** email signup completes Almost There (pool-enter copy), joins as a first-time member, and self-deletes via Account → Delete account (no second permanent QA secret).
 
 ### Secret inventory
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -37,9 +37,12 @@ Whenever you need to simulate a brand new user hitting the site for the very fir
 ```bash
 npm run qa:setup          # materialize-env + qa:cache + qa:google-signup gating
 npm run qa:auth-scenarios # full auth telemetry + routing matrix (QA_TEST_* only)
+# includes UR-B2: create pool → /join/:code → existing user (already-member)
 ```
 
 This materializes `.env.qa.local` from injected secrets, runs `qa:cache` (email returning user), and `qa:google-signup` gating tests.
+
+**Pool invite E2E (`qa:auth-scenarios` UR-B2):** signs in as `QA_TEST_*`, creates a throwaway pool, signs out, opens `/join/:code`, signs back in. Because the QA user already owns the pool, deferred join resolves as **already-member** — still validates Wave 0 invite storage, pools landing override, and no Almost There flash. A true first-membership join needs a second joiner account (not automated yet).
 
 ### Secret inventory
 

--- a/docs/USER_ROUTING_AND_JOURNEYS.md
+++ b/docs/USER_ROUTING_AND_JOURNEYS.md
@@ -97,10 +97,10 @@ If nothing is stored, stored JSON is invalid, or the path is ineligible → **`/
 
 1. `usePoolInviteCodeStorage` (`src/features/pool-invite/model/usePoolInviteCodeStorage.js`): valid code → saved under pool-invite storage key → **VIP landing stays on `/join/:code`** (`InviteVipLanding` via `PoolInvitePage`). Optional `?from=` resolves inviter handle for personalized H1.
 2. User taps **Create account** or **Sign in** → splash auth modals with pool join banner (`poolInvitePending`). Create account honors legal checkbox (#577).
-3. After auth → `useInviteLanding` redirect → `getDashboardEntryHref` → usually **`/dashboard`** (new device/browser).
-4. `DashboardRoute` → **`/setup`** if no profile; after setup → **`/dashboard`** (then step 5).
-5. `usePendingPoolJoin` (`src/features/pool-invite/model/usePendingPoolJoin.js`) inside `DashboardLayout`: consumes invite code, joins pool → on **`joined`** or **`already-member`** → **`navigate('/dashboard/pools', { replace: true })`**. This **overrides** the URL from step 3–4 for those outcomes.
-6. Invalid/expired code: no navigation to Pools; user stays on the URL from `getDashboardEntryHref` (often Picks).
+3. After auth → `useInviteLanding` redirect → `getDashboardEntryHref` → **`/dashboard/pools`** while invite breadcrumb is present (overrides remembered last-tab for that session, #728).
+4. `DashboardRoute` → **`/setup`** if no profile; after setup → **`/dashboard/pools`** again via the same invite override.
+5. `usePendingPoolJoin` (`src/features/pool-invite/model/usePendingPoolJoin.js`) inside `DashboardLayout`: status machine `idle | joining | succeeded | failed`; consumes invite code, joins pool. Pools UI shows **“Joining your pool…”** (never empty-state) while `joining`. On **`joined`** / **`already-member`** → toast + navigate to **pool detail** when id known, else **`/dashboard/pools`**. Timeout (~15s) keeps breadcrumb + Retry (#729).
+6. Invalid/expired code: no navigation to pool detail; user stays on Pools; breadcrumb cleared.
 
 ### B2. First-time user with site invite (`/invite/:handle`)
 
@@ -116,9 +116,9 @@ If nothing is stored, stored JSON is invalid, or the path is ineligible → **`/
 ### D. Existing user with a new invite link
 
 1. **Pool:** Same as B.1–B.2 (code stored on landing; signed-in visitors redirect immediately to dashboard with code already in storage).
-2. After sign-in, **`getDashboardEntryHref`** may briefly send the user to a **remembered** tab (e.g. Standings). Once `DashboardLayout` mounts, **`usePendingPoolJoin`** runs. On successful join / already-member → **`/dashboard/pools`** with **`replace: true`**.
+2. After sign-in, **`getDashboardEntryHref`** returns **`/dashboard/pools`** while the invite breadcrumb is present (not the remembered tab). **`usePendingPoolJoin`** runs with honest joining chrome on Pools.
 
-**Priority:** successful **invite join navigation** overrides the restored tab for those outcomes.
+**Priority:** pending-invite entry to **Pools** + successful **invite join navigation** (pool detail when known) override the restored tab for those outcomes.
 
 ### E. Signed out → sign in again
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-"version": "1.39.2",
+"version": "1.39.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -70,6 +70,7 @@ console.
 | `chunk-split.mjs` | `npm run qa:chunks` | §A chunk-load |
 | `firestore-cache.mjs` | `npm run qa:cache` | §B Firestore read cache |
 | `preview-cache-headers.mjs` | `npm run qa:preview-headers` | §C cache-control on **deployed** preview |
+| `auth-scenarios.mjs` | `npm run qa:auth-scenarios` | Auth/routing matrix + UR-B2 create-pool → `/join/:code` existing user |
 | `google-new-user-signup.mjs` | `npm run qa:google-signup` | Google new-user sign-up gating + optional OAuth |
 
 Playwright runners (`qa:chunks`, `qa:cache`, `qa:google-signup`) spawn `vite preview`

--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -70,7 +70,7 @@ console.
 | `chunk-split.mjs` | `npm run qa:chunks` | §A chunk-load |
 | `firestore-cache.mjs` | `npm run qa:cache` | §B Firestore read cache |
 | `preview-cache-headers.mjs` | `npm run qa:preview-headers` | §C cache-control on **deployed** preview |
-| `auth-scenarios.mjs` | `npm run qa:auth-scenarios` | Auth/routing matrix + UR-B2 create-pool → `/join/:code` existing user |
+| `auth-scenarios.mjs` | `npm run qa:auth-scenarios` | Auth/routing matrix; UR-B2 already-member + UR-B3 disposable new-user join |
 | `google-new-user-signup.mjs` | `npm run qa:google-signup` | Google new-user sign-up gating + optional OAuth |
 
 Playwright runners (`qa:chunks`, `qa:cache`, `qa:google-signup`) spawn `vite preview`

--- a/scripts/qa/auth-scenarios.mjs
+++ b/scripts/qa/auth-scenarios.mjs
@@ -230,6 +230,80 @@ async function signInViaPoolInvite(page, origin, inviteCode, email, password) {
   await page.waitForURL(/\/dashboard/, { timeout: 60_000 });
 }
 
+/**
+ * Unsigned VIP landing → Create account → wait for /setup (new user).
+ * @param {import('playwright').Page} page
+ * @param {string} origin
+ * @param {string} inviteCode
+ * @param {{ email: string, password: string }} creds
+ */
+async function signUpViaPoolInvite(page, origin, inviteCode, creds) {
+  const base = origin.replace(/\/$/, '');
+  const code = inviteCode.trim().toUpperCase();
+  await page.goto(`${base}/join/${code}`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 60_000,
+  });
+  await page
+    .getByText(/^pool invite$/i)
+    .waitFor({ state: 'visible', timeout: 30_000 });
+  await page.getByRole('button', { name: /create account/i }).click();
+  const dialog = page.getByRole('dialog', { name: /^create account$/i });
+  await dialog.waitFor({ state: 'visible', timeout: 15_000 });
+  await dialog
+    .getByText(/you're joining a pool/i)
+    .waitFor({ state: 'visible', timeout: 5_000 });
+  await dialog.locator('input[type="checkbox"]').check();
+  await dialog.locator('#su-email').fill(creds.email);
+  await dialog.locator('#su-pass').fill(creds.password);
+  await dialog.locator('#su-confirm').fill(creds.password);
+  await dialog.locator('button[type="submit"]').click();
+  await page.waitForURL(/\/setup/, { timeout: 60_000 });
+}
+
+/**
+ * Complete Almost There profile setup.
+ * @param {import('playwright').Page} page
+ * @param {string} handle
+ */
+async function completeProfileSetup(page, handle) {
+  await page.getByRole('heading', { name: /almost there/i }).waitFor({
+    state: 'visible',
+    timeout: 30_000,
+  });
+  await page
+    .getByText(/complete your profile to enter the pool/i)
+    .waitFor({ state: 'visible', timeout: 5_000 });
+  await page.getByPlaceholder(/lawnboy99/i).fill(handle);
+  await page.getByRole('button', { name: /lock profile in/i }).click();
+  await page.waitForURL(/\/dashboard/, { timeout: 60_000 });
+}
+
+/**
+ * Self-serve delete for disposable QA joiners (must not own pools).
+ * @param {import('playwright').Page} page
+ * @param {string} origin
+ */
+async function deleteAccountViaUi(page, origin) {
+  const base = origin.replace(/\/$/, '');
+  await page.goto(`${base}/dashboard/profile/account`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 60_000,
+  });
+  const expand = page.getByRole('button', {
+    name: /i need to delete my account/i,
+  });
+  await expand.waitFor({ state: 'visible', timeout: 30_000 });
+  await expand.scrollIntoViewIfNeeded();
+  await expand.click({ timeout: 30_000 });
+  await page.locator('input[type="checkbox"]').check();
+  await page.locator('#delete-account-phrase').fill('DELETE MY ACCOUNT');
+  await page
+    .getByRole('button', { name: /delete my account forever/i })
+    .click();
+  await page.waitForURL((url) => url.pathname === '/', { timeout: 60_000 });
+}
+
 function requireQaCreds() {
   const email = process.env.QA_TEST_EMAIL?.trim();
   const password = process.env.QA_TEST_PASSWORD?.trim();
@@ -424,6 +498,85 @@ async function main() {
       results,
     );
 
+    // ── ROUTING B3 / Wave 0: create pool → /join → disposable new user ─────
+    // True first-membership write + Almost There pool-enter copy, then cleanup
+    // via self-serve delete (no second permanent QA secret required).
+    await runScenario(
+      'UR-B3',
+      'Create pool → /join/:code → new user join + delete cleanup (Wave 0)',
+      async () => {
+        await dismissSplashChrome(page, dev.url);
+        const stamp = Date.now().toString(36);
+        const joinerEmail = `qa.wave0.${stamp}@setlistpickem-qa.test`;
+        const joinerPassword = `QaWave0-${stamp}!`;
+        const joinerHandle = `qa${stamp}`.slice(0, 20);
+        let createdJoiner = false;
+
+        try {
+          if (!page.url().includes('/dashboard')) {
+            await signInEmail(page, dev.url, email, password);
+          }
+
+          const poolName = `QA Wave0 New ${stamp.slice(-6)}`;
+          const inviteCode = await createPoolViaUi(page, dev.url, poolName);
+          await signOutViaAccount(page, dev.url);
+
+          await signUpViaPoolInvite(page, dev.url, inviteCode, {
+            email: joinerEmail,
+            password: joinerPassword,
+          });
+          createdJoiner = true;
+
+          await completeProfileSetup(page, joinerHandle);
+
+          await page.waitForURL(
+            (url) =>
+              url.pathname === '/dashboard/pools' ||
+              /^\/dashboard\/pool\/[A-Za-z0-9_-]+$/.test(url.pathname),
+            { timeout: 45_000 },
+          );
+
+          await page.waitForFunction(
+            () => !localStorage.getItem('phish_pool_pending_invite')?.trim(),
+            null,
+            { timeout: 30_000 },
+          );
+
+          const empty = page.getByText(/you are not in any pools yet/i);
+          if (await empty.isVisible().catch(() => false)) {
+            throw new Error('empty pools copy visible after new-user invite join');
+          }
+
+          await deleteAccountViaUi(page, dev.url);
+          createdJoiner = false;
+        } finally {
+          if (createdJoiner) {
+            try {
+              await deleteAccountViaUi(page, dev.url);
+            } catch (cleanupErr) {
+              console.warn(
+                '[qa:auth-scenarios] UR-B3 cleanup delete failed:',
+                cleanupErr?.message || cleanupErr,
+              );
+            }
+          }
+          try {
+            if (page.url().includes('/dashboard')) {
+              await signOutViaAccount(page, dev.url);
+            }
+          } catch {
+            await page.evaluate(() => {
+              localStorage.removeItem('phish_pool_pending_invite');
+            });
+            await page.goto(dev.url.replace(/\/$/, ''), {
+              waitUntil: 'domcontentloaded',
+            });
+          }
+        }
+      },
+      results,
+    );
+
     // ── ROUTING E partial: ?login=true ─────────────────────────────────────
     await runScenario(
       'UR-E1',
@@ -549,13 +702,10 @@ async function main() {
     }
 
     console.log('\n### Not automated here (interactive / Google OAuth popup)');
-    console.log('- UF-1 / UR-A: first-time new user → /setup (agent UI or reset test account)');
-    console.log('- AT-5: sign_up telemetry (new account creation)');
+    console.log('- UF-1 / UR-A: first-time new user → /setup without invite (agent UI)');
+    console.log('- AT-5: sign_up telemetry (organic new account, no invite)');
     console.log('- AT-6: signin_modal_new_user_blocked (Google on Sign-in modal)');
-    console.log('- AT-7: auth_partial_profile / auth_rollback* (anomaly paths)');
-    console.log(
-      '- UR-B3: first-time membership write via /join (needs second QA joiner account)',
-    );  } finally {
+    console.log('- AT-7: auth_partial_profile / auth_rollback* (anomaly paths)');  } finally {
     await Promise.race([
       (async () => {
         await browser.close().catch(() => {});

--- a/scripts/qa/auth-scenarios.mjs
+++ b/scripts/qa/auth-scenarios.mjs
@@ -115,6 +115,13 @@ async function signOutViaAccount(page, origin) {
   });
   await page.getByRole('button', { name: /^log out$/i }).click();
   await page.waitForURL((url) => url.pathname === '/', { timeout: 30_000 });
+  // Sign-out clears invite breadcrumb and may lag AuthProvider — wait for splash
+  // CTAs so a follow-up /join/:code is not treated as signed-in.
+  await page
+    .getByRole('button', { name: /create account/i })
+    .first()
+    .waitFor({ state: 'visible', timeout: 30_000 });
+  await page.waitForTimeout(500);
 }
 
 /**
@@ -149,6 +156,74 @@ async function openSignInModal(page, origin) {
  */
 async function signInEmail(page, origin, email, password) {
   const dialog = await openSignInModal(page, origin);
+  await dialog.locator('#si-email').fill(email);
+  await dialog.locator('#si-pass').fill(password);
+  await dialog.locator('button[type="submit"]').click();
+  await page.waitForURL(/\/dashboard/, { timeout: 60_000 });
+}
+
+/**
+ * Create a pool on /dashboard/pools and return its 5-char invite code.
+ * @param {import('playwright').Page} page
+ * @param {string} origin
+ * @param {string} poolName
+ */
+async function createPoolViaUi(page, origin, poolName) {
+  const base = origin.replace(/\/$/, '');
+  await page.goto(`${base}/dashboard/pools`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 60_000,
+  });
+  // Tab vs submit share a case-insensitive accessible name — use type=submit.
+  await page.getByRole('button', { name: 'Create Pool', exact: true }).click();
+  await page.locator('#pool-create-name').fill(poolName);
+  await page.locator('form').filter({ has: page.locator('#pool-create-name') })
+    .locator('button[type="submit"]')
+    .click();
+  await page.getByText(/pool created!/i).waitFor({ timeout: 30_000 });
+  const code = (await page.locator('code').first().innerText()).trim().toUpperCase();
+  if (!/^[A-Z0-9]{5}$/.test(code)) {
+    throw new Error(`expected 5-char invite code, got ${JSON.stringify(code)}`);
+  }
+  return code;
+}
+
+/**
+ * Unsigned VIP landing → Sign in → wait for dashboard (invite breadcrumb preserved).
+ * @param {import('playwright').Page} page
+ * @param {string} origin
+ * @param {string} inviteCode
+ * @param {string} email
+ * @param {string} password
+ */
+async function signInViaPoolInvite(page, origin, inviteCode, email, password) {
+  const base = origin.replace(/\/$/, '');
+  const code = inviteCode.trim().toUpperCase();
+  await page.goto(`${base}/join/${code}`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 60_000,
+  });
+  // Wait for unsigned VIP chrome — if auth is still settling, /join redirects to
+  // dashboard and pending-join can clear the breadcrumb before we assert (#728).
+  await page
+    .getByText(/^pool invite$/i)
+    .waitFor({ state: 'visible', timeout: 30_000 });
+  await page.getByRole('button', { name: /^sign in$/i }).waitFor({
+    state: 'visible',
+    timeout: 15_000,
+  });
+  const stored = await page.evaluate(() =>
+    localStorage.getItem('phish_pool_pending_invite'),
+  );
+  if (stored !== code) {
+    throw new Error(`expected invite ${code} in storage, got ${stored}`);
+  }
+  await page.getByRole('button', { name: /^sign in$/i }).click();
+  const dialog = page.getByRole('dialog', { name: /^sign in$/i });
+  await dialog.waitFor({ state: 'visible', timeout: 15_000 });
+  await dialog
+    .getByText(/you're joining a pool/i)
+    .waitFor({ state: 'visible', timeout: 5_000 });
   await dialog.locator('#si-email').fill(email);
   await dialog.locator('#si-pass').fill(password);
   await dialog.locator('button[type="submit"]').click();
@@ -241,14 +316,20 @@ async function main() {
       results,
     );
 
-    // ── ROUTING B: invite link opens create-account modal ──────────────────
+    // ── ROUTING B: invite VIP landing stores code + opens create-account ───
     await runScenario(
       'UR-B1',
-      '/join/:code stores invite + opens create-account modal',
+      '/join/:code VIP landing stores invite + opens create-account modal',
       async () => {
         await signOutViaAccount(page, dev.url);
-        await page.goto(`${dev.url}/join/YEM42`, { waitUntil: 'domcontentloaded' });
-        await page.waitForURL((url) => url.pathname === '/', { timeout: 30_000 });
+        await page.goto(`${dev.url}/join/YEM42`, {
+          waitUntil: 'domcontentloaded',
+          timeout: 60_000,
+        });
+        await page.waitForURL((url) => url.pathname === '/join/YEM42', {
+          timeout: 15_000,
+        });
+        await page.getByRole('button', { name: /create account/i }).click();
         const dialog = page.getByRole('dialog', { name: /^create account$/i });
         await dialog.waitFor({ state: 'visible', timeout: 15_000 });
         await dialog
@@ -269,6 +350,75 @@ async function main() {
         );
         if (stillStored !== 'YEM42') {
           throw new Error(`invite cleared after switcher, got ${stillStored}`);
+        }
+        await page.keyboard.press('Escape');
+      },
+      results,
+    );
+
+    // ── ROUTING B2 / Wave 0: create pool → join link → existing user ───────
+    // QA_TEST_* owns the pool, so deferred join resolves as already-member
+    // (still exercises invite storage, pools landing override, no Almost There).
+    await runScenario(
+      'UR-B2',
+      'Create pool → /join/:code → existing user (already-member, Wave 0)',
+      async () => {
+        await dismissSplashChrome(page, dev.url);
+        try {
+          // Ensure signed in as QA returning user.
+          if (!page.url().includes('/dashboard')) {
+            await signInEmail(page, dev.url, email, password);
+          }
+
+          const poolName = `QA Wave0 ${Date.now().toString(36).slice(-6)}`;
+          const inviteCode = await createPoolViaUi(page, dev.url, poolName);
+
+          await signOutViaAccount(page, dev.url);
+          await signInViaPoolInvite(page, dev.url, inviteCode, email, password);
+
+          // Wave 0: pending invite overrides last-tab → pools (then may replace
+          // to pool detail on already-member success).
+          await page.waitForURL(
+            (url) =>
+              url.pathname === '/dashboard/pools' ||
+              /^\/dashboard\/pool\/[A-Za-z0-9_-]+$/.test(url.pathname),
+            { timeout: 45_000 },
+          );
+
+          if (page.url().includes('/setup')) {
+            throw new Error(`Almost There /setup after invite sign-in: ${page.url()}`);
+          }
+          const almostThere = page.getByRole('heading', { name: /almost there/i });
+          if (await almostThere.count()) {
+            throw new Error('Almost There heading visible after invite sign-in');
+          }
+
+          // Breadcrumb cleared after joined / already-member.
+          await page.waitForFunction(
+            () => !localStorage.getItem('phish_pool_pending_invite')?.trim(),
+            null,
+            { timeout: 30_000 },
+          );
+
+          // Empty-state copy must not win once membership is known.
+          const empty = page.getByText(/you are not in any pools yet/i);
+          if (await empty.isVisible().catch(() => false)) {
+            throw new Error('empty pools copy visible after invite join');
+          }
+        } finally {
+          // Leave unsigned so later splash-modal scenarios are not redirected.
+          try {
+            if (page.url().includes('/dashboard')) {
+              await signOutViaAccount(page, dev.url);
+            }
+          } catch {
+            await page.evaluate(() => {
+              localStorage.removeItem('phish_pool_pending_invite');
+            });
+            await page.goto(dev.url.replace(/\/$/, ''), {
+              waitUntil: 'domcontentloaded',
+            });
+          }
         }
       },
       results,
@@ -403,8 +553,9 @@ async function main() {
     console.log('- AT-5: sign_up telemetry (new account creation)');
     console.log('- AT-6: signin_modal_new_user_blocked (Google on Sign-in modal)');
     console.log('- AT-7: auth_partial_profile / auth_rollback* (anomaly paths)');
-    console.log('- UR-B2: post-auth pool join → /dashboard/pools (needs valid pool code + Firestore)');
-  } finally {
+    console.log(
+      '- UR-B3: first-time membership write via /join (needs second QA joiner account)',
+    );  } finally {
     await Promise.race([
       (async () => {
         await browser.close().catch(() => {});

--- a/src/app/routes/profileGuardDecision.test.js
+++ b/src/app/routes/profileGuardDecision.test.js
@@ -60,6 +60,18 @@ describe('decideDashboardRoute', () => {
       .toEqual({ kind: 'loading' });
   });
 
+  it('guest→sign-in profile-pending window never chooses setup (#727)', () => {
+    // AuthProvider must set loading:true after setUser until the first profile
+    // snapshot. Without that, loading:false + user + profile:null dumps
+    // returning users onto Almost There.
+    expect(
+      decideDashboardRoute({ loading: true, user, userProfile: null }),
+    ).toEqual({ kind: 'loading' });
+    expect(
+      decideSetupRoute({ loading: true, user, userProfile: null }),
+    ).toEqual({ kind: 'loading' });
+  });
+
   it('redirects unsigned-in visitors to the splash', () => {
     expect(decideDashboardRoute({ loading: false, user: null, userProfile: null }))
       .toEqual({ kind: 'redirect-home' });

--- a/src/features/auth/model/AuthContext.jsx
+++ b/src/features/auth/model/AuthContext.jsx
@@ -47,7 +47,12 @@ export function AuthProvider({ children }) {
         return;
       }
 
+      // Guest → sign-in (and user switches): keep guards in `loading` until the
+      // first profile snapshot. Otherwise `loading:false + user + profile:null`
+      // briefly looks like "needs setup" and dumps returning users onto Almost There (#727).
       setUser(u);
+      setUserProfile(null);
+      setLoading(true);
 
       resolveIsAdmin(u)
         .then((flag) => {

--- a/src/features/pool-invite/api/joinPool.js
+++ b/src/features/pool-invite/api/joinPool.js
@@ -3,17 +3,28 @@ import { joinPool as joinPoolFromPools } from '../../pools';
 /**
  * Join via invite code for the deep-link flow.
  * @param {{ userId: string, inviteCode: string, showDates?: Array<string | { date?: string }> }} params
- * @returns {Promise<'joined' | 'already-member' | 'invalid-code' | 'pool-full' | 'pool-archived'>}
+ * @returns {Promise<{
+ *   outcome: 'joined' | 'already-member' | 'invalid-code' | 'pool-full' | 'pool-archived',
+ *   poolId?: string,
+ * }>}
  */
 export async function joinPoolByInviteCode({ userId, inviteCode, showDates }) {
   try {
-    await joinPoolFromPools({ userId, inviteCode, showDates });
-    return 'joined';
+    const pool = await joinPoolFromPools({ userId, inviteCode, showDates });
+    return {
+      outcome: 'joined',
+      poolId: typeof pool?.id === 'string' ? pool.id : undefined,
+    };
   } catch (err) {
-    if (err?.code === 'invalid-invite-code') return 'invalid-code';
-    if (err?.code === 'pool-full') return 'pool-full';
-    if (err?.code === 'pool-archived') return 'pool-archived';
-    if (err?.code === 'already-in-pool') return 'already-member';
+    if (err?.code === 'invalid-invite-code') return { outcome: 'invalid-code' };
+    if (err?.code === 'pool-full') return { outcome: 'pool-full' };
+    if (err?.code === 'pool-archived') return { outcome: 'pool-archived' };
+    if (err?.code === 'already-in-pool') {
+      return {
+        outcome: 'already-member',
+        poolId: typeof err?.poolId === 'string' ? err.poolId : undefined,
+      };
+    }
     throw err;
   }
 }

--- a/src/features/pool-invite/index.js
+++ b/src/features/pool-invite/index.js
@@ -4,4 +4,12 @@ export {
   storePoolInviteCodeFromParam,
   usePoolInviteCodeStorage,
 } from './model/usePoolInviteCodeStorage';
-export { usePendingPoolJoin } from './model/usePendingPoolJoin';
+export {
+  clearPendingPoolJoinInFlight,
+  usePendingPoolJoin,
+} from './model/usePendingPoolJoin';
+export { usePendingPoolJoinStatus } from './model/usePendingPoolJoinStatus';
+export {
+  resetPendingPoolJoinStatus,
+  setPendingPoolJoinStatus,
+} from './model/pendingPoolJoinStatus';

--- a/src/features/pool-invite/model/pendingPoolJoinStatus.js
+++ b/src/features/pool-invite/model/pendingPoolJoinStatus.js
@@ -1,0 +1,63 @@
+/**
+ * Cross-feature pending-join status (#728).
+ * `usePendingPoolJoin` writes; pools UI subscribes via {@link usePendingPoolJoinStatus}.
+ *
+ * @typedef {'idle' | 'joining' | 'succeeded' | 'failed'} PendingPoolJoinState
+ * @typedef {{
+ *   state: PendingPoolJoinState,
+ *   inviteCode: string | null,
+ *   poolId: string | null,
+ *   errorKind: 'timeout' | 'generic' | 'invalid-code' | 'pool-full' | 'pool-archived' | null,
+ * }} PendingPoolJoinStatus
+ */
+
+/** @type {PendingPoolJoinStatus} */
+const IDLE = {
+  state: 'idle',
+  inviteCode: null,
+  poolId: null,
+  errorKind: null,
+};
+
+/** @type {PendingPoolJoinStatus} */
+let status = { ...IDLE };
+const listeners = new Set();
+
+function emit() {
+  listeners.forEach((fn) => {
+    try {
+      fn(status);
+    } catch {
+      // ignore listener errors
+    }
+  });
+}
+
+/** @returns {PendingPoolJoinStatus} */
+export function getPendingPoolJoinStatus() {
+  return status;
+}
+
+/**
+ * @param {Partial<PendingPoolJoinStatus>} patch
+ */
+export function setPendingPoolJoinStatus(patch) {
+  status = { ...status, ...patch };
+  emit();
+}
+
+export function resetPendingPoolJoinStatus() {
+  status = { ...IDLE };
+  emit();
+}
+
+/**
+ * @param {(next: PendingPoolJoinStatus) => void} listener
+ * @returns {() => void}
+ */
+export function subscribePendingPoolJoinStatus(listener) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/src/features/pool-invite/model/usePendingPoolJoin.js
+++ b/src/features/pool-invite/model/usePendingPoolJoin.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useAuthSession } from '../../auth';
@@ -30,11 +30,45 @@ export function clearPendingPoolJoinInFlight() {
 }
 
 /**
+ * @param {string | null | undefined} poolId
+ * @param {import('react-router-dom').NavigateFunction} navigate
+ * @param {boolean} shouldNavigate
+ */
+function finishSuccessfulJoin({
+  outcome,
+  poolId,
+  navigate,
+  shouldNavigate,
+}) {
+  removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
+  invalidateUserPools();
+  setPendingPoolJoinStatus({
+    state: 'succeeded',
+    inviteCode: null,
+    poolId: poolId ?? null,
+    errorKind: null,
+  });
+  if (!shouldNavigate) return;
+  if (outcome === 'joined') {
+    showSuccessToast('You joined the pool!');
+  } else {
+    showSuccessToast("You're already in this pool.");
+  }
+  const href = poolId ? `/dashboard/pool/${poolId}` : '/dashboard/pools';
+  navigate(href, { replace: true });
+}
+
+/**
  * @param {Array<string | { date?: string }>} showDates Season calendar dates for pick-doc pool snapshot backfill after join.
  */
 export function usePendingPoolJoin(showDates = []) {
   const { userId } = useAuthSession();
   const navigate = useNavigate();
+  // Calendar identity often changes FALLBACK → live while join is in flight.
+  // Do not re-run / cancel the effect on that — membership may already be written
+  // and a cancelled success handler would leave the invite breadcrumb stuck (UR-B3).
+  const showDatesRef = useRef(showDates);
+  showDatesRef.current = showDates;
 
   useEffect(() => {
     if (!userId) return;
@@ -74,17 +108,25 @@ export function usePendingPoolJoin(showDates = []) {
         const result = await joinPoolByInviteCode({
           userId,
           inviteCode: code,
-          showDates,
+          showDates: showDatesRef.current,
         });
 
-        if (cancelled) return;
+        const success =
+          result.outcome === 'joined' || result.outcome === 'already-member';
+
+        // Unmount / dep churn: still heal breadcrumb if membership landed.
+        if (cancelled) {
+          if (success) {
+            removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
+            invalidateUserPools();
+            resetPendingPoolJoinStatus();
+          }
+          return;
+        }
 
         // Late completion after timeout: heal membership chrome without fighting Retry.
         if (timedOut) {
-          if (
-            result.outcome === 'joined' ||
-            result.outcome === 'already-member'
-          ) {
+          if (success) {
             removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
             invalidateUserPools();
             resetPendingPoolJoinStatus();
@@ -94,36 +136,13 @@ export function usePendingPoolJoin(showDates = []) {
 
         clearTimeout(timeoutId);
 
-        if (result.outcome === 'joined') {
-          removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
-          invalidateUserPools();
-          setPendingPoolJoinStatus({
-            state: 'succeeded',
-            inviteCode: null,
-            poolId: result.poolId ?? null,
-            errorKind: null,
+        if (result.outcome === 'joined' || result.outcome === 'already-member') {
+          finishSuccessfulJoin({
+            outcome: result.outcome,
+            poolId: result.poolId,
+            navigate,
+            shouldNavigate: true,
           });
-          showSuccessToast('You joined the pool!');
-          const href = result.poolId
-            ? `/dashboard/pool/${result.poolId}`
-            : '/dashboard/pools';
-          navigate(href, { replace: true });
-          return;
-        }
-        if (result.outcome === 'already-member') {
-          removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
-          invalidateUserPools();
-          setPendingPoolJoinStatus({
-            state: 'succeeded',
-            inviteCode: null,
-            poolId: result.poolId ?? null,
-            errorKind: null,
-          });
-          showSuccessToast("You're already in this pool.");
-          const href = result.poolId
-            ? `/dashboard/pool/${result.poolId}`
-            : '/dashboard/pools';
-          navigate(href, { replace: true });
           return;
         }
         if (result.outcome === 'invalid-code') {
@@ -166,5 +185,5 @@ export function usePendingPoolJoin(showDates = []) {
       cancelled = true;
       clearTimeout(timeoutId);
     };
-  }, [userId, navigate, showDates]);
+  }, [userId, navigate]);
 }

--- a/src/features/pool-invite/model/usePendingPoolJoin.js
+++ b/src/features/pool-invite/model/usePendingPoolJoin.js
@@ -10,9 +10,24 @@ import { showErrorToast, showSuccessToast } from '../../../shared/ui/toast';
 import { invalidateUserPools } from '../../pools';
 import { joinPoolByInviteCode } from '../api/joinPool';
 import { POOL_INVITE_STORAGE_KEY } from '../config';
+import {
+  resetPendingPoolJoinStatus,
+  setPendingPoolJoinStatus,
+} from './pendingPoolJoinStatus';
 
 /** Prevents duplicate join attempts when React Strict Mode double-invokes effects. */
 let pendingJoinKeyInFlight = null;
+
+/** Client-side join timeout — keep breadcrumb + allow retry without refresh (#729). */
+export const PENDING_POOL_JOIN_TIMEOUT_MS = 15_000;
+
+/**
+ * Clear in-flight dedupe so a retry (or a fresh mount after timeout) can run.
+ * Exported for timeout/retry paths and tests.
+ */
+export function clearPendingPoolJoinInFlight() {
+  pendingJoinKeyInFlight = null;
+}
 
 /**
  * @param {Array<string | { date?: string }>} showDates Season calendar dates for pick-doc pool snapshot backfill after join.
@@ -31,48 +46,125 @@ export function usePendingPoolJoin(showDates = []) {
     if (pendingJoinKeyInFlight === dedupeKey) return;
     pendingJoinKeyInFlight = dedupeKey;
 
+    let cancelled = false;
+    let timedOut = false;
+
+    setPendingPoolJoinStatus({
+      state: 'joining',
+      inviteCode: code,
+      poolId: null,
+      errorKind: null,
+    });
+
+    const timeoutId = setTimeout(() => {
+      timedOut = true;
+      clearPendingPoolJoinInFlight();
+      // Keep breadcrumb so user can retry from Pools without reopening the link.
+      setPendingPoolJoinStatus({
+        state: 'failed',
+        inviteCode: code,
+        poolId: null,
+        errorKind: 'timeout',
+      });
+      showErrorToast('Still joining — tap Retry on the Pools tab.');
+    }, PENDING_POOL_JOIN_TIMEOUT_MS);
+
     (async () => {
       try {
-        const outcome = await joinPoolByInviteCode({
+        const result = await joinPoolByInviteCode({
           userId,
           inviteCode: code,
           showDates,
         });
 
-        if (outcome === 'joined') {
+        if (cancelled) return;
+
+        // Late completion after timeout: heal membership chrome without fighting Retry.
+        if (timedOut) {
+          if (
+            result.outcome === 'joined' ||
+            result.outcome === 'already-member'
+          ) {
+            removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
+            invalidateUserPools();
+            resetPendingPoolJoinStatus();
+          }
+          return;
+        }
+
+        clearTimeout(timeoutId);
+
+        if (result.outcome === 'joined') {
           removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
           invalidateUserPools();
+          setPendingPoolJoinStatus({
+            state: 'succeeded',
+            inviteCode: null,
+            poolId: result.poolId ?? null,
+            errorKind: null,
+          });
           showSuccessToast('You joined the pool!');
-          navigate('/dashboard/pools', { replace: true });
+          const href = result.poolId
+            ? `/dashboard/pool/${result.poolId}`
+            : '/dashboard/pools';
+          navigate(href, { replace: true });
           return;
         }
-        if (outcome === 'already-member') {
+        if (result.outcome === 'already-member') {
           removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
           invalidateUserPools();
+          setPendingPoolJoinStatus({
+            state: 'succeeded',
+            inviteCode: null,
+            poolId: result.poolId ?? null,
+            errorKind: null,
+          });
           showSuccessToast("You're already in this pool.");
-          navigate('/dashboard/pools', { replace: true });
+          const href = result.poolId
+            ? `/dashboard/pool/${result.poolId}`
+            : '/dashboard/pools';
+          navigate(href, { replace: true });
           return;
         }
-        if (outcome === 'invalid-code') {
+        if (result.outcome === 'invalid-code') {
           removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
+          resetPendingPoolJoinStatus();
           showErrorToast('That invite link is invalid or expired.');
           return;
         }
-        if (outcome === 'pool-full') {
+        if (result.outcome === 'pool-full') {
           removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
+          resetPendingPoolJoinStatus();
           showErrorToast('This pool is full.');
           return;
         }
-        if (outcome === 'pool-archived') {
+        if (result.outcome === 'pool-archived') {
           removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
+          resetPendingPoolJoinStatus();
           showErrorToast('That pool is archived and no longer accepts new members.');
           return;
         }
       } catch {
+        if (cancelled || timedOut) return;
+        clearTimeout(timeoutId);
+        // Keep breadcrumb on generic errors (#723 / #728).
+        setPendingPoolJoinStatus({
+          state: 'failed',
+          inviteCode: code,
+          poolId: null,
+          errorKind: 'generic',
+        });
         showErrorToast('Could not join the pool. Try again from the Pools tab.');
       } finally {
-        pendingJoinKeyInFlight = null;
+        if (!timedOut) {
+          clearPendingPoolJoinInFlight();
+        }
       }
     })();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timeoutId);
+    };
   }, [userId, navigate, showDates]);
 }

--- a/src/features/pool-invite/model/usePendingPoolJoinStatus.js
+++ b/src/features/pool-invite/model/usePendingPoolJoinStatus.js
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+import {
+  getPendingPoolJoinStatus,
+  subscribePendingPoolJoinStatus,
+} from './pendingPoolJoinStatus';
+
+/**
+ * Subscribe to deferred invite-join status for honest pools chrome (#728).
+ */
+export function usePendingPoolJoinStatus() {
+  const [status, setStatus] = useState(getPendingPoolJoinStatus);
+
+  useEffect(() => subscribePendingPoolJoinStatus(setStatus), []);
+
+  return status;
+}

--- a/src/features/pools/api/poolsApi.js
+++ b/src/features/pools/api/poolsApi.js
@@ -134,6 +134,7 @@ export async function joinPool({ userId, inviteCode, showDates }) {
   if (poolData.members?.includes(userId)) {
     const err = new Error('User already in pool.');
     err.code = 'already-in-pool';
+    err.poolId = poolDoc.id;
     throw err;
   }
 
@@ -164,16 +165,15 @@ export async function joinPool({ userId, inviteCode, showDates }) {
       : '';
 
   // Legacy pools only: backfill pick.pools so pre-join graded shows count.
+  // Non-blocking (#729) — membership already committed; do not hold Join UI.
   if (!fromMembership) {
-    try {
-      await arrayUnionPoolOntoUserPickDocs(
-        userId,
-        { id: poolDoc.id, name: poolName },
-        showDates
-      );
-    } catch (e) {
+    void arrayUnionPoolOntoUserPickDocs(
+      userId,
+      { id: poolDoc.id, name: poolName },
+      showDates
+    ).catch((e) => {
       console.error('joinPool: pick snapshot backfill failed:', e);
-    }
+    });
   }
 
   const nextMemberJoinedAt = fromMembership

--- a/src/features/pools/model/useUserPools.js
+++ b/src/features/pools/model/useUserPools.js
@@ -14,7 +14,9 @@ import { subscribeUserPoolsInvalidate } from './userPoolsRefreshBus';
 export default function useUserPools(userId, options = {}) {
   const { showDates = [] } = options;
   const [pools, setPools] = useState([]);
-  const [loading, setLoading] = useState(false);
+  const [listLoading, setListLoading] = useState(false);
+  /** @type {['join' | 'create' | null, import('react').Dispatch<import('react').SetStateAction<'join' | 'create' | null>>]} */
+  const [actionLoading, setActionLoading] = useState(null);
   const [error, setError] = useState(null);
 
   const refreshPools = useCallback(async () => {
@@ -24,7 +26,7 @@ export default function useUserPools(userId, options = {}) {
       return [];
     }
 
-    setLoading(true);
+    setListLoading(true);
     setError(null);
     try {
       const nextPools = await fetchPools(userId);
@@ -34,7 +36,7 @@ export default function useUserPools(userId, options = {}) {
       setError(err);
       throw err;
     } finally {
-      setLoading(false);
+      setListLoading(false);
     }
   }, [userId]);
 
@@ -50,7 +52,7 @@ export default function useUserPools(userId, options = {}) {
 
   const handleCreate = useCallback(
     async (name) => {
-      setLoading(true);
+      setActionLoading('create');
       setError(null);
       try {
         const createdPool = await createPoolApi({ userId, name, showDates });
@@ -60,7 +62,7 @@ export default function useUserPools(userId, options = {}) {
         setError(err);
         throw err;
       } finally {
-        setLoading(false);
+        setActionLoading(null);
       }
     },
     [userId, showDates]
@@ -68,7 +70,7 @@ export default function useUserPools(userId, options = {}) {
 
   const handleJoin = useCallback(
     async (inviteCode) => {
-      setLoading(true);
+      setActionLoading('join');
       setError(null);
       try {
         const joinedPool = await joinPoolApi({ userId, inviteCode, showDates });
@@ -81,7 +83,7 @@ export default function useUserPools(userId, options = {}) {
         setError(err);
         throw err;
       } finally {
-        setLoading(false);
+        setActionLoading(null);
       }
     },
     [userId, showDates]
@@ -89,7 +91,10 @@ export default function useUserPools(userId, options = {}) {
 
   return {
     pools,
-    loading,
+    listLoading,
+    actionLoading,
+    /** @deprecated Prefer `listLoading` / `actionLoading` (#728). True when either is active. */
+    loading: listLoading || actionLoading != null,
     error,
     refreshPools,
     handleCreate,

--- a/src/features/pools/ui/PoolJoinCreateCard.jsx
+++ b/src/features/pools/ui/PoolJoinCreateCard.jsx
@@ -8,11 +8,15 @@ import PoolInviteCodeRow from './PoolInviteCodeRow';
 import PoolInviteShareButton from './PoolInviteShareButton';
 
 export default function PoolJoinCreateCard({
-  loading,
+  actionLoading = null,
+  /** @deprecated Prefer `actionLoading` (#728). */
+  loading = false,
   error,
   onJoin,
   onCreate,
 }) {
+  const joinBusy = actionLoading === 'join' || (actionLoading == null && loading);
+  const createBusy = actionLoading === 'create' || (actionLoading == null && loading);
   const [activeTab, setActiveTab] = useState('join');
   const [joinCode, setJoinCode] = useState('');
   const [createName, setCreateName] = useState('');
@@ -153,8 +157,8 @@ export default function PoolJoinCreateCard({
                 className="text-center font-mono text-xl font-black tracking-widest uppercase"
               />
             </div>
-            <Button variant="primary" type="submit" disabled={loading} className="w-full text-lg uppercase tracking-widest">
-              {loading ? 'Joining...' : 'Join Pool'}
+            <Button variant="primary" type="submit" disabled={joinBusy} className="w-full text-lg uppercase tracking-widest">
+              {joinBusy ? 'Joining...' : 'Join Pool'}
             </Button>
           </form>
         ) : createSuccess ? (
@@ -198,8 +202,8 @@ export default function PoolJoinCreateCard({
                 placeholder="e.g. Denver Crew 2026"
               />
             </div>
-            <Button variant="primary" type="submit" disabled={loading} className="w-full text-lg uppercase tracking-widest">
-              {loading ? 'Creating...' : 'Create pool'}
+            <Button variant="primary" type="submit" disabled={createBusy} className="w-full text-lg uppercase tracking-widest">
+              {createBusy ? 'Creating...' : 'Create pool'}
             </Button>
           </form>
         )}

--- a/src/features/pools/ui/UserPoolsSection.jsx
+++ b/src/features/pools/ui/UserPoolsSection.jsx
@@ -1,22 +1,81 @@
 import React from 'react';
 
+import Button from '../../../shared/ui/Button';
 import PoolCard from './PoolCard';
 
+/**
+ * @param {{
+ *   pools: Array<{ id: string }>,
+ *   hasPicksForNextShow?: boolean,
+ *   picksStatusLoading?: boolean,
+ *   listLoading?: boolean,
+ *   pendingJoinState?: 'idle' | 'joining' | 'succeeded' | 'failed',
+ *   pendingJoinErrorKind?: 'timeout' | 'generic' | 'invalid-code' | 'pool-full' | 'pool-archived' | null,
+ *   onRetryPendingJoin?: (() => void) | null,
+ *   retryPendingJoinLoading?: boolean,
+ * }} props
+ */
 export default function UserPoolsSection({
   pools,
   hasPicksForNextShow = false,
   picksStatusLoading = false,
+  listLoading = false,
+  pendingJoinState = 'idle',
+  pendingJoinErrorKind = null,
+  onRetryPendingJoin = null,
+  retryPendingJoinLoading = false,
 }) {
+  const isJoining = pendingJoinState === 'joining';
+  const isJoinFailed = pendingJoinState === 'failed';
+  const showJoiningChrome = isJoining || isJoinFailed;
+  const showEmpty =
+    !showJoiningChrome && !listLoading && pools.length === 0;
+  const showListLoading = listLoading && pools.length === 0 && !showJoiningChrome;
+
   return (
     <section className="space-y-4">
-      {pools.length === 0 ? (
+      {showJoiningChrome ? (
+        <div className="rounded-3xl border border-dashed border-brand-primary/40 bg-brand-primary/5 p-8 text-center shadow-inset-glass">
+          <p className="font-bold text-brand-primary">
+            {isJoining ? 'Joining your pool…' : "Couldn't finish joining"}
+          </p>
+          <p className="mt-1 text-sm text-content-secondary/90">
+            {isJoining
+              ? 'Hang tight — we’re adding you now.'
+              : pendingJoinErrorKind === 'timeout'
+                ? 'That took too long. Your invite is still saved — retry below.'
+                : 'Your invite is still saved — retry below, or paste the code in Join Pool.'}
+          </p>
+          {isJoinFailed && typeof onRetryPendingJoin === 'function' ? (
+            <Button
+              variant="primary"
+              type="button"
+              className="mt-4 uppercase tracking-widest"
+              disabled={retryPendingJoinLoading}
+              onClick={onRetryPendingJoin}
+            >
+              {retryPendingJoinLoading ? 'Retrying…' : 'Retry join'}
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {showListLoading ? (
+        <div className="rounded-3xl border border-dashed border-border-muted bg-surface-glass p-8 text-center shadow-inset-glass">
+          <p className="font-bold text-content-secondary">Loading your pools…</p>
+        </div>
+      ) : null}
+
+      {showEmpty ? (
         <div className="rounded-3xl border border-dashed border-border-muted bg-surface-glass p-8 text-center shadow-inset-glass">
           <p className="font-bold text-content-secondary">You are not in any pools yet.</p>
           <p className="mt-1 text-sm text-content-secondary/90">
             Join with a code or create a pool below, then lock picks on the Picks tab.
           </p>
         </div>
-      ) : (
+      ) : null}
+
+      {pools.length > 0 ? (
         <div className="flex flex-col gap-4">
           {pools.map((pool) => (
             <PoolCard
@@ -27,7 +86,7 @@ export default function UserPoolsSection({
             />
           ))}
         </div>
-      )}
+      ) : null}
     </section>
   );
 }

--- a/src/pages/auth/ProfileSetupPage.jsx
+++ b/src/pages/auth/ProfileSetupPage.jsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { ProfileSetupForm, useProfileSetup } from '../../features/auth';
+import { POOL_INVITE_STORAGE_KEY } from '../../shared/config/poolInvite';
+import { getLocalStorageItem } from '../../shared/lib/local-storage';
 
 export default function ProfileSetupPage({ user }) {
   const {
@@ -13,6 +15,11 @@ export default function ProfileSetupPage({ user }) {
     saveProfile,
   } = useProfileSetup(user);
 
+  const poolInvitePending = useMemo(
+    () => Boolean(getLocalStorageItem(POOL_INVITE_STORAGE_KEY)?.trim()),
+    [],
+  );
+
   return (
     <div className="flex min-h-screen w-full flex-col items-center justify-center bg-transparent p-6 text-center text-white">
       <div className="w-full max-w-md rounded-[2.5rem] border border-border-subtle bg-surface-panel-strong p-8 shadow-inset-glass ring-1 ring-border-glass/20">
@@ -21,7 +28,9 @@ export default function ProfileSetupPage({ user }) {
         </h2>
 
         <p className="text-slate-400 text-sm font-bold uppercase tracking-widest mb-8">
-          Complete your profile to enter the pool.
+          {poolInvitePending
+            ? 'Complete your profile to enter the pool.'
+            : 'Complete your profile to get started.'}
         </p>
 
         <ProfileSetupForm

--- a/src/pages/pools/PoolsPage.jsx
+++ b/src/pages/pools/PoolsPage.jsx
@@ -1,9 +1,15 @@
-import React, { useId, useState } from 'react';
+import React, { useCallback, useId, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Users } from 'lucide-react';
 
 import { useNextShowPicksStatus } from '../../features/picks';
+import {
+  clearPendingPoolJoinInFlight,
+  resetPendingPoolJoinStatus,
+  setPendingPoolJoinStatus,
+  usePendingPoolJoinStatus,
+} from '../../features/pool-invite';
 import {
   PoolJoinCreateCard,
   PoolsHowItWorksBody,
@@ -13,17 +19,28 @@ import {
   useUserPools,
 } from '../../features/pools';
 import { useShowCalendar } from '../../features/show-calendar';
+import { POOL_INVITE_STORAGE_KEY } from '../../shared/config/poolInvite';
 import { useDashboardMobileChromePortal } from '../../shared/hooks/useDashboardMobileChromePortal';
+import {
+  getLocalStorageItem,
+  removeLocalStorageItem,
+} from '../../shared/lib/local-storage';
 import DashboardActionRow from '../../shared/ui/DashboardActionRow';
 import DashboardRowPill from '../../shared/ui/DashboardRowPill';
+import { showErrorToast, showSuccessToast } from '../../shared/ui/toast';
 import { getNextShow } from '../../shared/utils/timeLogic.js';
-
 export default function Pools({ user }) {
+  const navigate = useNavigate();
   const { showDates } = useShowCalendar();
-  const { pools, loading, error, handleJoin, handleCreate } = useUserPools(
-    user?.uid,
-    { showDates }
-  );
+  const {
+    pools,
+    listLoading,
+    actionLoading,
+    error,
+    handleJoin,
+    handleCreate,
+  } = useUserPools(user?.uid, { showDates });
+  const pendingJoin = usePendingPoolJoinStatus();
   const nextShowDate = getNextShow(showDates).date;
   const {
     hasSubmittedPicksForNextShow,
@@ -38,6 +55,71 @@ export default function Pools({ user }) {
   const mobileChromeRoot = useDashboardMobileChromePortal();
   const howItWorksContentId = useId();
   const [isHowItWorksExpanded, setIsHowItWorksExpanded] = useState(false);
+  const [retryBusy, setRetryBusy] = useState(false);
+
+  const onRetryPendingJoin = useCallback(async () => {
+    const code =
+      pendingJoin.inviteCode?.trim() ||
+      getLocalStorageItem(POOL_INVITE_STORAGE_KEY)?.trim();
+    if (!code) return;
+
+    clearPendingPoolJoinInFlight();
+    setRetryBusy(true);
+    setPendingPoolJoinStatus({
+      state: 'joining',
+      inviteCode: code,
+      poolId: null,
+      errorKind: null,
+    });
+
+    try {
+      const joinedPool = await handleJoin(code);
+      removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
+      resetPendingPoolJoinStatus();
+      showSuccessToast('You joined the pool!');
+      if (joinedPool?.id) {
+        navigate(`/dashboard/pool/${joinedPool.id}`, { replace: true });
+      }
+    } catch (joinError) {
+      if (joinError?.code === 'already-in-pool') {
+        removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
+        resetPendingPoolJoinStatus();
+        showSuccessToast("You're already in this pool.");
+        if (joinError.poolId) {
+          navigate(`/dashboard/pool/${joinError.poolId}`, { replace: true });
+        }
+        return;
+      }
+      // Keep breadcrumb for transient failures.
+      setPendingPoolJoinStatus({
+        state: 'failed',
+        inviteCode: code,
+        poolId: null,
+        errorKind: 'generic',
+      });
+      if (joinError?.code === 'invalid-invite-code') {
+        removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
+        resetPendingPoolJoinStatus();
+        showErrorToast('That invite link is invalid or expired.');
+        return;
+      }
+      if (joinError?.code === 'pool-full') {
+        removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
+        resetPendingPoolJoinStatus();
+        showErrorToast('This pool is full.');
+        return;
+      }
+      if (joinError?.code === 'pool-archived') {
+        removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
+        resetPendingPoolJoinStatus();
+        showErrorToast('That pool is archived and no longer accepts new members.');
+        return;
+      }
+      showErrorToast('Could not join the pool. Try again.');
+    } finally {
+      setRetryBusy(false);
+    }
+  }, [handleJoin, navigate, pendingJoin.inviteCode]);
 
   return (
     <div className="w-full pb-6 md:pb-12">
@@ -77,9 +159,16 @@ export default function Pools({ user }) {
           pools={pools}
           hasPicksForNextShow={isSecured}
           picksStatusLoading={picksStatusLoading}
+          listLoading={listLoading}
+          pendingJoinState={pendingJoin.state}
+          pendingJoinErrorKind={pendingJoin.errorKind}
+          onRetryPendingJoin={
+            pendingJoin.state === 'failed' ? onRetryPendingJoin : null
+          }
+          retryPendingJoinLoading={retryBusy}
         />
         <PoolJoinCreateCard
-          loading={loading}
+          actionLoading={actionLoading}
           error={error}
           onJoin={handleJoin}
           onCreate={handleCreate}

--- a/src/shared/lib/dashboardLastPath.js
+++ b/src/shared/lib/dashboardLastPath.js
@@ -4,12 +4,17 @@
  *
  * Profile cluster is excluded: users often open Profile/Account only to sign out;
  * remembering that route would send them back to Profile after every login.
+ *
+ * Pending pool invite (`phish_pool_pending_invite`) overrides remembered tab so
+ * post-auth lands on Pools for honest joining chrome (#728).
  */
 
 import { isProfileClusterPath } from '../config/dashboardRoutes';
+import { POOL_INVITE_STORAGE_KEY } from '../config/poolInvite';
 import { getLocalStorageItem, setLocalStorageItem } from './local-storage';
 
 export const DASHBOARD_LAST_PATH_STORAGE_KEY = 'setpicks_dash_last_loc_v1';
+export const DASHBOARD_POOLS_HREF = '/dashboard/pools';
 
 /** Query string must be empty or ?key=value&... with safe characters only. */
 function isSafeDashboardSearch(search) {
@@ -65,6 +70,12 @@ export function shouldPersistDashboardPath(pathname, search = '', opts = {}) {
  * @returns {string} path + search for <Navigate to={...} /> or location.assign
  */
 export function getDashboardEntryHref(opts = {}) {
+  // Invite join: skip remembered last-tab so Pools shows "Joining…" instead of
+  // a stale Standings/Picks flash while usePendingPoolJoin runs (#728).
+  if (getLocalStorageItem(POOL_INVITE_STORAGE_KEY)?.trim()) {
+    return DASHBOARD_POOLS_HREF;
+  }
+
   const raw = getLocalStorageItem(DASHBOARD_LAST_PATH_STORAGE_KEY);
   if (!raw) return '/dashboard';
   try {

--- a/src/shared/lib/dashboardLastPath.test.js
+++ b/src/shared/lib/dashboardLastPath.test.js
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DASHBOARD_LAST_PATH_STORAGE_KEY,
+  DASHBOARD_POOLS_HREF,
+  getDashboardEntryHref,
+} from './dashboardLastPath';
+import { POOL_INVITE_STORAGE_KEY } from '../config/poolInvite';
+
+function installMemoryLocalStorage() {
+  const store = new Map();
+  const localStorage = {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => {
+      store.set(String(key), String(value));
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+  vi.stubGlobal('window', { localStorage });
+  return localStorage;
+}
+
+describe('getDashboardEntryHref', () => {
+  /** @type {ReturnType<typeof installMemoryLocalStorage>} */
+  let localStorage;
+
+  beforeEach(() => {
+    localStorage = installMemoryLocalStorage();
+  });
+
+  it('returns /dashboard when nothing is stored', () => {
+    expect(getDashboardEntryHref()).toBe('/dashboard');
+  });
+
+  it('restores a remembered eligible tab', () => {
+    localStorage.setItem(
+      DASHBOARD_LAST_PATH_STORAGE_KEY,
+      JSON.stringify({ pathname: '/dashboard/standings', search: '' }),
+    );
+    expect(getDashboardEntryHref()).toBe('/dashboard/standings');
+  });
+
+  it('overrides remembered tab when a pending pool invite is stored (#728)', () => {
+    localStorage.setItem(
+      DASHBOARD_LAST_PATH_STORAGE_KEY,
+      JSON.stringify({ pathname: '/dashboard/standings', search: '' }),
+    );
+    localStorage.setItem(POOL_INVITE_STORAGE_KEY, 'A7X9K');
+    expect(getDashboardEntryHref()).toBe(DASHBOARD_POOLS_HREF);
+  });
+});


### PR DESCRIPTION
Closes #727
Closes #728
Closes #729

## Summary
- **#727** — AuthProvider sets `loading:true` on guest→sign-in until the first profile snapshot, so returning users never flash Almost There; setup subcopy is pool-framed only when `phish_pool_pending_invite` is present.
- **#728** — Pending-join status machine (`idle|joining|succeeded|failed`) + honest Pools chrome; post-auth with invite breadcrumb lands on `/dashboard/pools`; `listLoading` vs `actionLoading` so Join/Create labels ignore list refresh.
- **#729** — Legacy pick backfill no longer awaits after membership commit; ~15s pending-join timeout keeps breadcrumb + Retry (clears in-flight dedupe).

Epic: #726. Branched from `staging` (predictive train stays parked). PATCH `1.39.3`.

## Test plan
- [x] Signed-out → open `/join/:code` → Sign in as returning user with handle → never see Almost There; land on Pools with “Joining your pool…”
- [x] Same path as brand-new user without handle → still reaches Almost There with pool-enter copy
- [x] Organic `/setup` (no invite breadcrumb) → generic “get started” copy
- [x] Pending join success → toast + pool detail (or pools list if id unknown); list no longer flashes “You are not in any pools”
- [x] Force slow network / legacy pool → Join returns after membership (not after full pick backfill); timeout shows Retry without needing a refresh
- [x] Manual Join/Create button labels only spin for that action, not during list refetch
- [ ] `npm test` + `npm run lint` green


Made with [Cursor](https://cursor.com)