### PR TITLE
fix(prod): dashboard scrollport reset on tab change (#738 → main, 1.35.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.35.8] — 2026-07-27
+
+### Fixed
+- **Dashboard route scroll (#738)** — navigating between dashboard tabs (e.g. Standings → Picks) resets the `main` scrollport to the top, not only `window` scroll.
+
+---
+
 ## [1.35.7] — 2026-07-27
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.35.7",
+  "version": "1.35.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/app/ScrollToTop.jsx
+++ b/src/app/ScrollToTop.jsx
@@ -1,15 +1,22 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
+import { DASHBOARD_SCROLLPORT_ID } from '../shared/hooks/useDashboardMobileChromePortal';
+
 /**
- * Reset window scroll on client-side navigation so deep-linked legal pages and
- * other routes always open at the top (React Router does not do this by default).
+ * Reset window + dashboard `main` scroll on client-side navigation.
+ * Dashboard routes scroll inside `#dashboard-scrollport`, not the window —
+ * so window-only reset left Standings → Picks (etc.) stuck mid-page.
  */
 export default function ScrollToTop() {
   const { pathname } = useLocation();
 
   useEffect(() => {
     window.scrollTo(0, 0);
+    const dashboardScrollport = document.getElementById(DASHBOARD_SCROLLPORT_ID);
+    if (dashboardScrollport) {
+      dashboardScrollport.scrollTop = 0;
+    }
   }, [pathname]);
 
   return null;

--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -55,7 +55,10 @@ import DashboardMobileBrandBar from './ui/DashboardMobileBrandBar';
 import DashboardMobileContextBar from './ui/DashboardMobileContextBar';
 import DashboardPageHeading from './ui/DashboardPageHeading';
 import DashboardTourDateScope from './ui/DashboardTourDateScope';
-import { DASHBOARD_MOBILE_FIXED_CHROME_ROOT_ID } from '../../shared/hooks/useDashboardMobileChromePortal';
+import {
+  DASHBOARD_MOBILE_FIXED_CHROME_ROOT_ID,
+  DASHBOARD_SCROLLPORT_ID,
+} from '../../shared/hooks/useDashboardMobileChromePortal';
 
 import { ListMusic, Users, Medal, User as UserIcon, Settings } from 'lucide-react';
 
@@ -275,6 +278,7 @@ export default function DashboardLayout() {
 
       {/* MAIN CONTENT — routes with fixed chrome get extra top pad for the pills row */}
       <main
+        id={DASHBOARD_SCROLLPORT_ID}
         className={[
           'flex-1 min-w-0 overflow-y-auto relative',
           'pb-[calc(4rem+env(safe-area-inset-bottom,0px)+0.5rem)] md:pt-8 md:pb-8',

--- a/src/shared/hooks/useDashboardMobileChromePortal.js
+++ b/src/shared/hooks/useDashboardMobileChromePortal.js
@@ -4,6 +4,9 @@ import { useEffect, useState } from 'react';
 export const DASHBOARD_MOBILE_FIXED_CHROME_ROOT_ID =
   'dashboard-mobile-fixed-chrome-root';
 
+/** Dashboard `main` overflow scrollport — reset on route change (see ScrollToTop). */
+export const DASHBOARD_SCROLLPORT_ID = 'dashboard-scrollport';
+
 /** Trailing slot in the mobile context bar (e.g. Standings Scoring rules). */
 export const DASHBOARD_MOBILE_CONTEXT_TRAILING_ROOT_ID =
   'dashboard-mobile-context-trailing-root';


### PR DESCRIPTION
## Summary
- Hotfix of [#738](https://github.com/pat792/set-picks/pull/738) onto `main` only (**1.35.8**).
- Resets `#dashboard-scrollport` on route change so Standings → Picks opens at the top.
- Does not promote other staging-only work.

## Test plan
- [ ] Prod preview: scroll Standings → open Picks → at top
- [ ] Other dashboard tab switches reset similarly


Made with [Cursor](https://cursor.com)