### PR TITLE
fix(dashboard): snap to top on every primary menu click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.39.6] — 2026-07-27
+
+### Fixed
+- **Primary nav scroll-to-top** — sidebar, bottom tabs, brand home, Profile/Standings segmented controls call `scrollAppToTop` on click (including same-tab re-taps). Route changes also key off `search` so Standings view switches reset scroll.
+
+---
+
 ## [1.39.5] — 2026-07-27
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.39.5",
+  "version": "1.39.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/app/ScrollToTop.jsx
+++ b/src/app/ScrollToTop.jsx
@@ -1,23 +1,20 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { DASHBOARD_SCROLLPORT_ID } from '../shared/hooks/useDashboardMobileChromePortal';
+import { scrollAppToTop } from '../shared/lib/scrollAppToTop';
 
 /**
  * Reset window + dashboard `main` scroll on client-side navigation.
  * Dashboard routes scroll inside `#dashboard-scrollport`, not the window —
  * so window-only reset left Standings → Picks (etc.) stuck mid-page.
+ * Primary nav also calls {@link scrollAppToTop} on click for same-tab re-taps.
  */
 export default function ScrollToTop() {
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
 
   useEffect(() => {
-    window.scrollTo(0, 0);
-    const dashboardScrollport = document.getElementById(DASHBOARD_SCROLLPORT_ID);
-    if (dashboardScrollport) {
-      dashboardScrollport.scrollTop = 0;
-    }
-  }, [pathname]);
+    scrollAppToTop();
+  }, [pathname, search]);
 
   return null;
 }

--- a/src/app/layout/DashboardLayout.jsx
+++ b/src/app/layout/DashboardLayout.jsx
@@ -44,6 +44,7 @@ import {
   DashboardNotificationsBell,
 } from '../../features/notifications';
 import { persistDashboardPath } from '../../shared/lib/dashboardLastPath';
+import { scrollAppToTop } from '../../shared/lib/scrollAppToTop';
 import {
   BRAND_APP_CHROME_MARK_SRC,
   brandAppChromeMarkImgClassNames,
@@ -177,6 +178,7 @@ export default function DashboardLayout() {
           <h1 className="w-full overflow-visible text-center leading-none">
             <Link
               to="/dashboard"
+              onClick={scrollAppToTop}
               className="block w-full overflow-visible outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm hover:opacity-80 transition-opacity md:flex md:justify-center"
               aria-label="Setlist Pick 'Em — dashboard home"
             >
@@ -225,6 +227,7 @@ export default function DashboardLayout() {
               <Link
                 key={item.name}
                 to={item.path}
+                onClick={scrollAppToTop}
                 {...navPrefetchHandlers(item.path)}
                 className={`flex items-center gap-3 rounded-xl px-4 py-3 font-bold transition-all ${isActive ? 'bg-brand-primary/10 text-brand-primary' : 'text-content-secondary hover:bg-surface-inset hover:text-white'}`}
               >
@@ -447,6 +450,7 @@ export default function DashboardLayout() {
               <Link
                 key={item.name}
                 to={item.path}
+                onClick={scrollAppToTop}
                 {...navPrefetchHandlers(item.path)}
                 className={`flex h-[calc(100%-10px)] min-h-0 w-full flex-col items-center justify-center space-y-1 self-center rounded-xl transition-colors ${
                   isActive

--- a/src/app/layout/ui/DashboardMobileBrandBar.jsx
+++ b/src/app/layout/ui/DashboardMobileBrandBar.jsx
@@ -11,6 +11,7 @@ import {
   brandWordmarkDashboardMobileLeadingClassNames,
 } from '../../../shared/config/branding';
 import { PROFILE_CLUSTER_PATHS } from '../../../shared/config/dashboardRoutes';
+import { scrollAppToTop } from '../../../shared/lib/scrollAppToTop';
 import BrandWordmarkBarRow from '../../../shared/ui/BrandWordmarkBarRow';
 
 function avatarInitial(userProfile, user) {
@@ -31,6 +32,7 @@ export default function DashboardMobileBrandBar({ user }) {
         <h1 className={brandWordmarkDashboardMobileLeadingClassNames}>
           <Link
             to="/dashboard"
+            onClick={scrollAppToTop}
             className="inline-flex max-w-full items-center justify-start overflow-visible text-left outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm hover:opacity-80 transition-opacity"
             aria-label="Setlist Pick 'Em — dashboard home"
           >

--- a/src/app/layout/ui/ProfileClusterLayout.jsx
+++ b/src/app/layout/ui/ProfileClusterLayout.jsx
@@ -8,6 +8,7 @@ import {
   NAV_LABEL_PROFILE,
 } from '../../../shared/config/dashboardVocabulary';
 import { PROFILE_CLUSTER_PATHS } from '../../../shared/config/dashboardRoutes';
+import { scrollAppToTop } from '../../../shared/lib/scrollAppToTop';
 import { useDashboardMobileChromePortal } from '../../../shared/hooks/useDashboardMobileChromePortal';
 import ProfileMobileFixedChrome from './ProfileMobileFixedChrome';
 
@@ -42,6 +43,7 @@ export default function ProfileClusterLayout({ user }) {
             key={to}
             to={to}
             end={end}
+            onClick={scrollAppToTop}
             className={({ isActive }) =>
               [
                 'flex-1 rounded-xl px-2 py-2.5 text-center text-[11px] font-black uppercase tracking-widest transition-colors sm:text-xs',

--- a/src/features/scoring/ui/StandingsViewToggle.jsx
+++ b/src/features/scoring/ui/StandingsViewToggle.jsx
@@ -6,6 +6,7 @@ import {
   useFeatureSpotlight,
 } from '../../feature-discovery';
 import ChromeSegmentedControl from '../../../shared/ui/ChromeSegmentedControl';
+import { scrollAppToTop } from '../../../shared/lib/scrollAppToTop';
 
 const OPTIONS = [
   { id: 'show', label: 'Show', icon: ListOrdered },
@@ -51,6 +52,7 @@ export default function StandingsViewToggle({ view, onChange, className = '' }) 
   const tourStatsSpotlight = useFeatureSpotlight('tour-stats');
 
   const handleChange = (next) => {
+    scrollAppToTop();
     if (next === 'stats' && tourStatsSpotlight.active) {
       tourStatsSpotlight.trackClick();
     }

--- a/src/shared/lib/scrollAppToTop.js
+++ b/src/shared/lib/scrollAppToTop.js
@@ -1,0 +1,13 @@
+import { DASHBOARD_SCROLLPORT_ID } from '../hooks/useDashboardMobileChromePortal';
+
+/**
+ * Reset window scroll and the dashboard `main` overflow scrollport.
+ * Use on route changes and primary nav clicks (including same-tab re-taps).
+ */
+export function scrollAppToTop() {
+  window.scrollTo(0, 0);
+  const dashboardScrollport = document.getElementById(DASHBOARD_SCROLLPORT_ID);
+  if (dashboardScrollport) {
+    dashboardScrollport.scrollTop = 0;
+  }
+}

--- a/src/shared/ui/ChromeSegmentedControl.jsx
+++ b/src/shared/ui/ChromeSegmentedControl.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 
+import { scrollAppToTop } from '../lib/scrollAppToTop';
+
 const trayClass =
   'flex w-full min-w-0 gap-1 rounded-xl border border-border-subtle/60 bg-surface-panel-strong p-1 shadow-inset-glass';
 
@@ -52,6 +54,7 @@ export default function ChromeSegmentedControl({
             key={to}
             to={to}
             end={end}
+            onClick={scrollAppToTop}
             className={({ isActive }) =>
               [segmentBase, isActive ? segmentActive : segmentInactive].join(' ')
             }
@@ -79,7 +82,10 @@ export default function ChromeSegmentedControl({
             type="button"
             role="tab"
             aria-selected={selected}
-            onClick={() => onChange?.(id)}
+            onClick={() => {
+              scrollAppToTop();
+              onChange?.(id);
+            }}
             className={[segmentBase, selected ? segmentActive : segmentInactive].join(' ')}
           >
             {Icon ? <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden /> : null}


### PR DESCRIPTION
## Summary
- Shared `scrollAppToTop` resets window + `#dashboard-scrollport`.
- Wired on sidebar, bottom tabs, brand home, Profile sub-nav, Chrome segmented controls, and Standings view toggle — including same-tab re-taps.
- `ScrollToTop` also keys off `search` for query-driven view switches.

## Test plan
- [ ] Scroll deep on Standings → tap Picks / Pools / Profile / Standings → at top
- [ ] Already on Picks, scroll down → tap Picks again → at top
- [ ] Standings Show → Tour / Stats → at top
- [ ] Profile → Messages / Account → at top


Made with [Cursor](https://cursor.com)