### PR TITLE
chore(deps): split majors out of Dependabot groups + build check for dep PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,10 @@
 # PRs target `staging` (repo PR base), not `main`.
 #
 # Re-enabled 2026-07-05 (Sprint 6 wrap, #504) after v1.18 enablement-wave ops reset.
-# Triage: docs/DEPENDABOT_OPERATIONS.md — max 1–2 merges/week; never batch-rebase all PRs.
+# Reworked 2026-07-28 (#744): groups contain ONLY minor/patch ("safe") updates so
+# they stay green and mergeable. Major versions arrive as individual PRs and get
+# dedicated migration work — see docs/DEPENDABOT_OPERATIONS.md "Major upgrades".
+# Triage: max 1–2 merges/week; never batch-rebase all PRs.
 version: 2
 updates:
   - package-ecosystem: npm
@@ -17,10 +20,12 @@ updates:
       - dependencies
       - skip-version-bump
     groups:
-      root-production:
+      root-production-safe:
         dependency-type: production
-      root-development:
+        update-types: ["minor", "patch"]
+      root-development-safe:
         dependency-type: development
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: npm
     directory: "/functions"
@@ -32,11 +37,19 @@ updates:
     labels:
       - dependencies
       - skip-version-bump
+    ignore:
+      # firebase-functions-test (even latest) peer-supports firebase-admin <=13,
+      # so admin 14 PRs always fail `npm ci` with ERESOLVE (#624, #744).
+      # Remove once firebase-functions-test allows firebase-admin ^14.
+      - dependency-name: "firebase-admin"
+        update-types: ["version-update:semver-major"]
     groups:
-      functions-production:
+      functions-production-safe:
         dependency-type: production
-      functions-development:
+        update-types: ["minor", "patch"]
+      functions-development-safe:
         dependency-type: development
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       functions: ${{ steps.filter.outputs.functions }}
       rules: ${{ steps.filter.outputs.rules }}
       qa_risk: ${{ steps.filter.outputs.qa_risk }}
+      deps: ${{ steps.filter.outputs.deps }}
     steps:
       - uses: actions/checkout@v4
       - id: filter
@@ -31,6 +32,12 @@ jobs:
               - 'firestore.indexes.json'
               - 'firestore.rules.test.cjs'
               - 'firestore.rules.test.*'
+            deps:
+              - 'package.json'
+              - 'package-lock.json'
+              - 'vite.config.*'
+              - 'postcss.config.*'
+              - 'tailwind.config.*'
             qa_risk:
               - 'src/app/**'
               - 'src/pages/**'
@@ -114,6 +121,29 @@ jobs:
             exit 1
           fi
           echo "✓ version $CURRENT is ahead of last release $TAGGED"
+
+  # Dep-only PRs don't touch src/, so `verify` (lint + vitest, no build) and
+  # qa-runners both stay silent while a toolchain bump can still break the
+  # production bundle (#519 Tailwind 4 / #744). Run the real build whenever
+  # the root manifest, lockfile, or build config changes.
+  build:
+    needs: changes
+    if: github.event_name == 'schedule' || needs.changes.outputs.deps == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Production build (vite + SEO prerender)
+        run: npm run build
 
   functions:
     needs: changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Core local commands:
 ### Dependabot / npm audit (#414)
 
 - **Runbook:** **`docs/DEPENDABOT_OPERATIONS.md`** — first-enable timeline, ops-reset procedure, re-enable steps. Read before touching `dependabot.yml` or triaging dep PRs.
-- **Dependabot** (`.github/dependabot.yml`) — **paused** (`open-pull-requests-limit: 0`) after 2026-07-04 enablement-wave reset. When active: weekly grouped npm PRs + monthly Actions; base `staging`; auto `skip-version-bump`; CI exempts `dependabot/*`. Agents must **not** bump `package.json` on Dependabot PRs.
+- **Dependabot** (`.github/dependabot.yml`) — **active** (re-enabled 2026-07-05, reworked 2026-07-28 #744): weekly npm groups contain **minor/patch only** (`*-safe` groups); **majors arrive as individual PRs** and require dedicated migration work (never merge on green alone — see `docs/DEPENDABOT_OPERATIONS.md` "Major upgrades"). Monthly Actions group; base `staging`; auto `skip-version-bump`; CI exempts `dependabot/*` and runs a `build` job on any dep/lockfile diff. Agents must **not** bump `package.json` on Dependabot PRs. `firebase-admin` majors ignored in `/functions` until `firebase-functions-test` supports admin 14.
 - **Vercel:** `ignoreCommand` → `scripts/vercel-should-build.sh` skips previews for Actions/functions-only dep PRs.
 - **CI `npm audit`** on the `verify` job is **informational** (`continue-on-error: true`). It does not block merge.
 - **Triage:** Critical/high in **production** deps → fix or upgrade in a normal PR. Dev-only / low noise → defer or group into a maintenance PR. Do not mass-upgrade without running `npm test` and `cd functions && npm test`.

--- a/docs/DEPENDABOT_OPERATIONS.md
+++ b/docs/DEPENDABOT_OPERATIONS.md
@@ -20,13 +20,47 @@ This is **not** recurring weekly noise — it was a **one-time enablement avalan
 
 ---
 
-## Current policy (post ops-reset 2026-07-04)
+## Current policy (reworked 2026-07-28, #744)
 
 | Setting | Value | Why |
 |---------|-------|-----|
+| Groups | **minor/patch only** (`*-safe` groups) | One breaking major must never block a week of safe updates (July 2026 wave: #518/#519/#624 sat open ~3 weeks) |
+| Majors | **Individual PRs**, one dependency each | Each major gets its own migration + QA; see "Major upgrades" below |
+| `firebase-admin` majors in `/functions` | **Ignored** | `firebase-functions-test` peer-supports admin ≤13; admin 14 PRs always fail `npm ci` (#624). Remove the ignore when upstream catches up |
+| CI `build` job | Runs on any PR touching `package.json` / `package-lock.json` / build config | `verify` doesn't run the production build and qa-runners skip lockfile-only diffs, so Tailwind-4-class breaks were only visible on Vercel (#519) |
 | `open-pull-requests-limit` | **5** root/functions, **3** actions (re-enabled 2026-07-05, #504) | Was **0** during ops reset; triage max 1–2 merges/week |
 | SemVer gate | Skips `dependabot/*` + `skip-version-bump` label | Deps PRs never bump `package.json` |
 | Vercel | `ignoreCommand` → `scripts/vercel-should-build.sh` | No SPA preview for Actions/functions-only bumps |
+
+### Merge policy by PR class
+
+| PR class | Policy |
+|----------|--------|
+| `*-safe` group (minor/patch) | Mergeable on green checks (`verify` + `build` + Vercel + `functions` when it runs). Human says "merge"; no extra QA needed |
+| Actions group | Mergeable on green `verify`; CI-only impact |
+| Individual **major** PR | **Never merge on green alone.** Open a dedicated migration issue/PR, apply `ci/qa` (and `ci/full` for toolchain), follow "Major upgrades" below |
+
+### Major upgrades (dedicated migration work)
+
+Green CI is *necessary but not sufficient* for majors — dep-only diffs skip the
+Playwright behavioral suite. Treat each as a feature PR:
+
+1. Branch `feat/<issue#>-<dep>-<major>`; apply the bump, run codemods/migration guides.
+2. Label `ci/qa` (forces qa-runners) and `ci/full` for build-toolchain deps.
+3. Browser-verify on the Vercel preview per `.cursor/skills/pr-qa/SKILL.md`.
+
+Known pending majors (from the closed July 2026 group PRs — tracked in #744):
+
+| Dependency | Risk | Notes |
+|------------|------|-------|
+| eslint 10, sharp 0.35 | Low | Do first, quick wins |
+| vite 8 + @vitejs/plugin-react 6 + vitest 4 | High | Move as one unit (rolldown-based); re-check `qa:chunks` manual-chunk strategy |
+| tailwindcss 4 | High | PostCSS plugin moved to `@tailwindcss/postcss`; CSS-first config; visual QA (border/ring defaults changed) |
+| react 19 + react-router-dom 7 | High | Dedicated migration, full `ci/qa` |
+| firebase 12 | High | QA WebChannel + App Check flows (see pr-qa traps.md) |
+| @firebase/rules-unit-testing 5 | Medium | Pair with `npm run test:rules` |
+| resend 6 (`/functions`) | Medium | Comms email worker QA + `functions` job |
+| firebase-admin 14 (`/functions`) | **Blocked** | Wait for firebase-functions-test peer support; ignore rule in `dependabot.yml` |
 
 ### Re-enabling Dependabot (human step)
 
@@ -50,10 +84,9 @@ This is **not** recurring weekly noise — it was a **one-time enablement avalan
 | PR type | Agent action |
 |---------|----------------|
 | `dependabot/github_actions/*` | Triage together; merge only if `verify` green; never bump version |
-| Root production group | Run `npm test`; merge if patch/minor only |
-| Root **development** group | **Defer** if vite/eslint/tailwind major jumps bundled |
-| `functions/*` production | Run `cd functions && npm test`; merge individually |
-| `functions/*` development | Low priority; merge when functions CI green |
+| `*-safe` npm groups (minor/patch) | Confirm green (`verify` + `build` + Vercel; `functions` job for `/functions` groups); report ready-to-merge |
+| Individual **major** PR | Do NOT merge on green; route through "Major upgrades" above |
+| Stale/red group PR | If lockfile desync (EUSAGE): regenerate with `npm install` in the affected dir and push to the PR branch (#521 pattern). If ERESOLVE peer conflict: check upstream peer ranges before assuming it's fixable (#624 pattern) |
 
 ### Never
 
@@ -81,10 +114,10 @@ Set `open-pull-requests-limit: 0` in `dependabot.yml` until re-enable.
 | PR class | Merge? | Notes |
 |----------|--------|-------|
 | Actions only (#486-class) | Optional batch | CI-only; Vercel skip |
-| Root prod patch bumps | Yes, one PR/week | `npm test` |
-| Root dev (vite 8, tailwind 4) | **No** | Dedicated upgrade issue |
-| Functions prod | Case-by-case | `functions` job must pass |
-| Functions dev | Low priority | Test-only dep |
+| `*-safe` groups (minor/patch) | Yes, when green | `build` job now covers the bundle |
+| Individual majors | **No — migration flow** | See "Major upgrades"; `ci/qa` label mandatory |
+| Functions prod safe group | Case-by-case | `functions` job must pass |
+| Functions dev safe group | Low priority | Test-only dep |
 
 ---
 


### PR DESCRIPTION
Closes #744

## Summary
- **Dependabot groups now contain only minor/patch updates** (`*-safe` groups for root + functions). Major versions arrive as individual PRs so one breaking dep (Tailwind 4, firebase-admin 14) can never block a week of safe updates, as happened with #518/#519/#624.
- **New CI `build` job** runs the production build (`vite build` + SEO prerender) whenever `package.json`, `package-lock.json`, or build config changes. Closes the gap where `verify` (no build step) and `qa-runners` (path filter misses lockfiles) both stayed green while the bundle was broken — only the Vercel preview caught #519.
- **`firebase-admin` majors ignored in `/functions`** until `firebase-functions-test` peer-supports admin 14 (its ceiling is ≤13 even at latest 3.5.0, so those PRs can never pass `npm ci`).
- Updated `docs/DEPENDABOT_OPERATIONS.md` (merge policy per PR class + "Major upgrades" playbook with the pending majors from the closed July PRs) and the stale `AGENTS.md` Dependabot bullet.

No version bump: CI workflow YAML + docs only (per versioning rules); staging (1.39.6) is already ahead of the last release (v1.35.9).

## Test plan
- [x] `js-yaml` parses `dependabot.yml` and `ci.yml` cleanly
- [x] `npm run build` succeeds locally with no `.env` (validates the new `build` job needs no secrets)
- [ ] `changes` job on this PR shows `deps: false` (no lockfile touched) and `build` is skipped
- [ ] After merge: next Monday's Dependabot wave opens `*-safe` group PRs (minor/patch only) and individual major PRs

Made with [Cursor](https://cursor.com)