### PR TITLE
feat(picks): gate Prediction Lab behind VITE_ENABLE_PREDICTION_LAB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,10 @@ VITE_SETLIST_API_SOURCE=phishin
 # Off by default — placements render nothing when unset.
 # VITE_ENABLE_SPONSOR_SLOTS=true
 
+# Optional: set true to show Prediction Lab on the Picks page (#651).
+# Off by default — omit in Production; set true on Preview/local to QA the panel.
+# VITE_ENABLE_PREDICTION_LAB=true
+
 # --- Vercel API Functions ---
 # Firebase Admin SDK service account for server-side Firestore access (issue #128).
 # Required for the /join/:code OG tag function (api/invite/[code].js) to resolve pool names.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.40.0] — 2026-07-28
+
+### Added
+- **`VITE_ENABLE_PREDICTION_LAB`** — build-time gate for Prediction Lab UI and recommendations fetch (same pattern as sponsor slots). Omit in Production to ship the rest of the staging train without launching the lab; set `true` on Preview/local to keep QA access.
+
+---
+
 ## [1.39.8] — 2026-07-28
 
 ### Changed

--- a/docs/API.md
+++ b/docs/API.md
@@ -439,6 +439,7 @@ These `VITE_*` variables are read at build time. Adding or removing one is a MIN
 | `VITE_SONG_CATALOG_URL` | No | CDN URL override for song catalog |
 | `VITE_PICK_RECOMMENDATIONS_URL` | No | CDN URL override for pick recommendations (#650) |
 | `VITE_ENABLE_SPONSOR_SLOTS` | No | `true` renders reserved sponsor/ad placements (`SponsorSlot`); omit to hide (default) |
+| `VITE_ENABLE_PREDICTION_LAB` | No | `true` renders Prediction Lab + loads pick-recommendations artifact on Picks; omit to hide (default). Use on Preview/local for QA; leave unset in Production until launch |
 
 ### 4.1 Cloud Functions runtime env vars
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.39.8",
+  "version": "1.40.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/picks/index.js
+++ b/src/features/picks/index.js
@@ -12,6 +12,7 @@ export { default as usePicksForm } from './model/usePicksForm';
 export { usePicksSelfRecap } from './model/usePicksSelfRecap';
 export { useNextShowPicksStatus } from './model/useNextShowPicksStatus';
 export { usePickRecommendations } from './model/usePickRecommendations';
+export { isPredictionLabEnabled } from './model/isPredictionLabEnabled';
 export {
   hasNonEmptyPicksObject,
   pickEntryHasSubmission,

--- a/src/features/picks/model/isPredictionLabEnabled.js
+++ b/src/features/picks/model/isPredictionLabEnabled.js
@@ -1,0 +1,9 @@
+/**
+ * Build-time gate for Prediction Lab UI + recommendations fetch (#651).
+ * Matches SponsorSlot: only the string `'true'` enables; unset = off.
+ *
+ * @returns {boolean}
+ */
+export function isPredictionLabEnabled() {
+  return import.meta.env.VITE_ENABLE_PREDICTION_LAB === 'true';
+}

--- a/src/features/picks/model/isPredictionLabEnabled.test.js
+++ b/src/features/picks/model/isPredictionLabEnabled.test.js
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('isPredictionLabEnabled', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('is false when unset', async () => {
+    vi.stubEnv('VITE_ENABLE_PREDICTION_LAB', undefined);
+    const { isPredictionLabEnabled } = await import('./isPredictionLabEnabled.js');
+    expect(isPredictionLabEnabled()).toBe(false);
+  });
+
+  it('is false for non-true strings', async () => {
+    vi.stubEnv('VITE_ENABLE_PREDICTION_LAB', 'false');
+    const { isPredictionLabEnabled } = await import('./isPredictionLabEnabled.js');
+    expect(isPredictionLabEnabled()).toBe(false);
+  });
+
+  it('is true only for the string true', async () => {
+    vi.stubEnv('VITE_ENABLE_PREDICTION_LAB', 'true');
+    const { isPredictionLabEnabled } = await import('./isPredictionLabEnabled.js');
+    expect(isPredictionLabEnabled()).toBe(true);
+  });
+});

--- a/src/features/picks/model/usePickRecommendations.js
+++ b/src/features/picks/model/usePickRecommendations.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { resolvePickRecommendationsFetchUrl } from '../api/pickRecommendationsUrl.js';
+import { isPredictionLabEnabled } from './isPredictionLabEnabled.js';
 import {
   PICK_RECOMMENDATIONS_CACHE_KEY,
   PICK_RECOMMENDATIONS_CACHE_MAX_AGE_MS,
@@ -49,6 +50,7 @@ function writeCache(entry) {
 /**
  * Loads versioned pick recommendations from Storage with TTL + stale fallback (#650).
  * Returns null artifact when unavailable (Lab / Predictive Mode stay dark).
+ * No-ops when `VITE_ENABLE_PREDICTION_LAB` is not exactly `'true'` (prod default).
  *
  * @returns {{
  *   artifact: object | null,
@@ -58,12 +60,15 @@ function writeCache(entry) {
  * }}
  */
 export function usePickRecommendations() {
+  const enabled = isPredictionLabEnabled();
   const [artifact, setArtifact] = useState(/** @type {object | null} */ (null));
   const [loadError, setLoadError] = useState(/** @type {Error | null} */ (null));
-  const [resolved, setResolved] = useState(false);
+  const [resolved, setResolved] = useState(!enabled);
   const [loadedFromCache, setLoadedFromCache] = useState(false);
 
   useEffect(() => {
+    if (!enabled) return undefined;
+
     const ac = new AbortController();
     let cancelled = false;
 
@@ -141,7 +146,7 @@ export function usePickRecommendations() {
       cancelled = true;
       ac.abort();
     };
-  }, []);
+  }, [enabled]);
 
   return {
     artifact,

--- a/src/features/picks/ui/PickPredictionPanel.jsx
+++ b/src/features/picks/ui/PickPredictionPanel.jsx
@@ -24,6 +24,8 @@ import {
 
 /**
  * Opt-in Prediction Lab — default-collapsed slot recommendations (#651).
+ * Parent pages should gate with `isPredictionLabEnabled()` / `VITE_ENABLE_PREDICTION_LAB`
+ * (fetch also no-ops in `usePickRecommendations` when the flag is off).
  *
  * @param {object} props
  * @param {string} props.selectedDate

--- a/src/pages/picks/PicksPage.jsx
+++ b/src/pages/picks/PicksPage.jsx
@@ -11,6 +11,7 @@ import {
   PicksMobileFixedChrome,
   PicksSelfRecapSection,
   PicksSubmitButton,
+  isPredictionLabEnabled,
   trackPicksPageInteractive,
   usePickRecommendations,
   usePicksForm,
@@ -43,6 +44,7 @@ export default function PicksPage({ user, selectedDate }) {
   } = usePicksForm({ user, selectedDate, showDates, showDatesByTour });
 
   const picksRecap = usePicksSelfRecap({ user, selectedDate, showDates, formData });
+  const predictionLabEnabled = isPredictionLabEnabled();
   const {
     artifact: pickRecsArtifact,
     isLoading: pickRecsLoading,
@@ -163,7 +165,7 @@ export default function PicksPage({ user, selectedDate }) {
             }
           />
         ) : null}
-        {!isLoadingPicks ? (
+        {predictionLabEnabled && !isLoadingPicks ? (
           <PickPredictionPanel
             selectedDate={selectedDate}
             artifact={pickRecsArtifact}


### PR DESCRIPTION
## Summary
- Adds `VITE_ENABLE_PREDICTION_LAB` (MINOR / 1.40.0): Prediction Lab UI and pick-recommendations fetch only run when the value is exactly `true`.
- Default (unset) = hidden — so Production can promote the full staging train without launching the lab.
- Same pattern as `VITE_ENABLE_SPONSOR_SLOTS`. Documented in `docs/API.md` and `.env.example`.

## Test plan
- [ ] `verify` green
- [ ] On Vercel Preview **without** the var: Picks page has no Prediction Lab / flask panel
- [ ] Locally with `VITE_ENABLE_PREDICTION_LAB=true` in `.env`: panel still appears
- [ ] After merge: leave Production unset; optionally set Preview=`true` if you want lab on hosted staging


Made with [Cursor](https://cursor.com)