### PR TITLE
fix(seo): stop home prerender flash on dashboard hard loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.40.1] — 2026-07-28
+
+### Fixed
+- **SEO prerender flash on app hard loads (#743)** — empty-root SPA shell at `dist/dashboard/index.html` + Vercel rewrites for `/dashboard/*`, `/setup`, `/user/*`, `/privacy`, `/terms`, and related app paths so hard navigations no longer flash home marketing copy. In-app inbox CTAs use React Router `Link` for same-origin destinations (no full reload).
+
+---
+
 ## [1.40.0] — 2026-07-28
 
 ### Added

--- a/api/inviteOgHelpers.mjs
+++ b/api/inviteOgHelpers.mjs
@@ -3,6 +3,10 @@
  * src/shared/lib/inviteKit.js — must not import from src/.
  */
 
+import { stripPrerenderBodyFromSpaShell } from '../scripts/seo-strip-body.mjs';
+
+export { stripPrerenderBodyFromSpaShell };
+
 export const SITE_URL = 'https://www.setlistpickem.com';
 export const SITE_NAME = "Setlist Pick 'Em";
 export const OG_IMAGE_VERSION = '20260711';
@@ -219,18 +223,6 @@ ${buildOgMetaTags(og)}
  * @param {{ title: string, description: string, url: string, image: string }} og
  * @returns {string}
  */
-/**
- * Post-build SEO prerender injects crawler copy into `#root` on `dist/index.html`.
- * Invite landings must not flash that home-page body before React boots.
- */
-export function stripPrerenderBodyFromSpaShell(spaHtml) {
-  if (typeof spaHtml !== 'string' || !spaHtml) return spaHtml;
-  return spaHtml.replace(
-    /<div id="root">[\s\S]*?<\/div>/i,
-    '<div id="root"></div>',
-  );
-}
-
 export function injectOgIntoSpa(spaHtml, og) {
   const dynamicTags = buildOgMetaTags(og);
   const cleanedShell = stripPrerenderBodyFromSpaShell(spaHtml);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.40.0",
+  "version": "1.40.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/prerender-seo.mjs
+++ b/scripts/prerender-seo.mjs
@@ -1,5 +1,6 @@
 /**
  * Post-build: write crawler-visible HTML for public marketing routes (#659).
+ * Also writes an empty-root SPA shell for dashboard / app hard loads (#743).
  * Run after `vite build`. Safe to re-run.
  */
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
@@ -7,9 +8,11 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  APP_BOOT_SHELL_REL_PATH,
   PRERENDER_ROUTES,
   injectPrerenderHtml,
   prerenderOutputRelPath,
+  stripPrerenderBodyFromSpaShell,
 } from './seo-prerender-lib.mjs';
 
 const root = join(fileURLToPath(new URL('.', import.meta.url)), '..');
@@ -32,4 +35,14 @@ for (const route of PRERENDER_ROUTES) {
   console.log(`prerender-seo: wrote dist/${rel} (${Buffer.byteLength(html, 'utf8')} bytes)`);
 }
 
-console.log(`prerender-seo: OK (${PRERENDER_ROUTES.length} routes)`);
+// Empty-root boot shell for /dashboard/* (and other app paths via vercel.json).
+// Use the pre-prerender Vite shell so we never copy home SEO body into it.
+const appBootHtml = stripPrerenderBodyFromSpaShell(shell);
+const appBootPath = join(distDir, APP_BOOT_SHELL_REL_PATH);
+mkdirSync(dirname(appBootPath), { recursive: true });
+writeFileSync(appBootPath, appBootHtml, 'utf8');
+console.log(
+  `prerender-seo: wrote dist/${APP_BOOT_SHELL_REL_PATH} (empty #root boot shell)`,
+);
+
+console.log(`prerender-seo: OK (${PRERENDER_ROUTES.length} routes + app boot shell)`);

--- a/scripts/seo-prerender-lib.mjs
+++ b/scripts/seo-prerender-lib.mjs
@@ -7,8 +7,17 @@ import {
   PRERENDER_ROUTES,
   SEO_FAVICON_VERSION,
 } from '../src/shared/config/seoRoutes.js';
+import {
+  APP_BOOT_SHELL_REL_PATH,
+  stripPrerenderBodyFromSpaShell,
+} from './seo-strip-body.mjs';
 
-export { PRERENDER_ROUTES, SEO_FAVICON_VERSION };
+export {
+  PRERENDER_ROUTES,
+  SEO_FAVICON_VERSION,
+  APP_BOOT_SHELL_REL_PATH,
+  stripPrerenderBodyFromSpaShell,
+};
 
 function escapeHtml(str) {
   return String(str ?? '')

--- a/scripts/seo-strip-body.mjs
+++ b/scripts/seo-strip-body.mjs
@@ -1,0 +1,21 @@
+/**
+ * Pure HTML helper — no src/ imports (safe for Vercel `api/invite` + build scripts).
+ */
+
+/**
+ * Post-build SEO prerender injects crawler copy into `#root` on `dist/index.html`.
+ * App hard loads must not flash that home-page body (#743 / invite landings).
+ *
+ * @param {string} spaHtml
+ * @returns {string}
+ */
+export function stripPrerenderBodyFromSpaShell(spaHtml) {
+  if (typeof spaHtml !== 'string' || !spaHtml) return spaHtml;
+  return spaHtml.replace(
+    /<div id="root">[\s\S]*?<\/div>/i,
+    '<div id="root"></div>',
+  );
+}
+
+/** Dist-relative empty-root SPA shell for authenticated / app hard loads (#743). */
+export const APP_BOOT_SHELL_REL_PATH = 'dashboard/index.html';

--- a/scripts/verify-seo-prerender.mjs
+++ b/scripts/verify-seo-prerender.mjs
@@ -10,6 +10,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  APP_BOOT_SHELL_REL_PATH,
   PRERENDER_ROUTES,
   buildFixtureShellHtml,
   injectPrerenderHtml,
@@ -76,6 +77,24 @@ if (existsSync(distIndex) && existsSync(distHowItWorks)) {
     const html = readFileSync(outPath, 'utf8');
     assertRouteHtml(html, route, `dist ${route.path}`);
   }
+
+  const appBootPath = join(root, 'dist', APP_BOOT_SHELL_REL_PATH);
+  assert(existsSync(appBootPath), `dist missing ${APP_BOOT_SHELL_REL_PATH} — run npm run build`);
+  const appBootHtml = readFileSync(appBootPath, 'utf8');
+  assert(
+    /<div id="root">\s*<\/div>/i.test(appBootHtml),
+    'app boot shell must have empty #root',
+  );
+  assert(
+    !appBootHtml.includes('data-seo-prerender'),
+    'app boot shell must not include SEO prerender body',
+  );
+  assert(
+    existsSync(distIndex) &&
+      readFileSync(distIndex, 'utf8').includes('data-seo-prerender'),
+    'home dist/index.html must still include SEO prerender body',
+  );
+
   console.log('verify:seo-prerender: dist/ checked');
 } else {
   console.log('verify:seo-prerender: fixture-only (dist/ not prerendered)');

--- a/src/features/notifications/ui/commsTemplates/CommsTemplateBody.jsx
+++ b/src/features/notifications/ui/commsTemplates/CommsTemplateBody.jsx
@@ -1,10 +1,17 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { sameOriginAppPath } from './sameOriginAppPath.js';
 
 /**
  * Generic, data-driven in-app message body. Template build functions return a
  * plain structure (eyebrow / title / paragraphs / stats / cta) and this component
  * renders it with the dashboard design tokens — so adding a new trigger template is
  * a copy change, not a new bespoke component.
+ *
+ * Same-origin CTA hrefs use React Router `Link` so inbox clicks soft-navigate
+ * (no full reload / home SEO flash — #743). External hrefs stay normal anchors.
+ * Modifier / middle-click “open in new tab” still works via `Link`.
  *
  * @param {{
  *   icon?: React.ComponentType<{ className?: string }>,
@@ -27,6 +34,10 @@ export default function CommsTemplateBody({
   cta,
   onCtaClick,
 }) {
+  const ctaClassName =
+    'inline-flex items-center justify-center rounded-lg border border-brand-primary/40 bg-brand-primary/10 px-4 py-2 text-xs font-black uppercase tracking-widest text-brand-primary transition-colors hover:border-brand-primary hover:bg-brand-primary/20';
+  const spaPath = cta ? sameOriginAppPath(cta.href) : null;
+
   return (
     <article className="space-y-3 text-sm font-normal leading-relaxed text-content-secondary">
       {(eyebrow || title) && (
@@ -69,13 +80,23 @@ export default function CommsTemplateBody({
 
       {cta ? (
         <div className="pt-2">
-          <a
-            href={cta.href || '#'}
-            onClick={() => onCtaClick?.(cta)}
-            className="inline-flex items-center justify-center rounded-lg border border-brand-primary/40 bg-brand-primary/10 px-4 py-2 text-xs font-black uppercase tracking-widest text-brand-primary transition-colors hover:border-brand-primary hover:bg-brand-primary/20"
-          >
-            {cta.label}
-          </a>
+          {spaPath ? (
+            <Link
+              to={spaPath}
+              onClick={() => onCtaClick?.(cta)}
+              className={ctaClassName}
+            >
+              {cta.label}
+            </Link>
+          ) : (
+            <a
+              href={cta.href || '#'}
+              onClick={() => onCtaClick?.(cta)}
+              className={ctaClassName}
+            >
+              {cta.label}
+            </a>
+          )}
         </div>
       ) : null}
     </article>

--- a/src/features/notifications/ui/commsTemplates/sameOriginAppPath.js
+++ b/src/features/notifications/ui/commsTemplates/sameOriginAppPath.js
@@ -1,0 +1,32 @@
+/**
+ * Resolve same-origin in-app paths for soft navigation (#743).
+ * External / protocol-relative / empty hrefs return null (keep normal <a>).
+ *
+ * @param {string | undefined} href
+ * @param {string} [origin] defaults to window.location.origin when available
+ * @returns {string | null} pathname + search + hash, or null
+ */
+export function sameOriginAppPath(href, origin) {
+  if (typeof href !== 'string') return null;
+  const trimmed = href.trim();
+  if (!trimmed || trimmed === '#') return null;
+
+  const resolvedOrigin =
+    origin ||
+    (typeof window !== 'undefined' && window.location?.origin
+      ? window.location.origin
+      : '');
+
+  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) {
+    return trimmed;
+  }
+
+  try {
+    const base = resolvedOrigin || 'https://www.setlistpickem.com';
+    const url = new URL(trimmed, base);
+    if (resolvedOrigin && url.origin !== resolvedOrigin) return null;
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return null;
+  }
+}

--- a/src/features/notifications/ui/commsTemplates/sameOriginAppPath.test.js
+++ b/src/features/notifications/ui/commsTemplates/sameOriginAppPath.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { sameOriginAppPath } from './sameOriginAppPath.js';
+
+describe('sameOriginAppPath', () => {
+  const origin = 'https://www.setlistpickem.com';
+
+  it('returns relative app paths as-is', () => {
+    expect(sameOriginAppPath('/dashboard/picks', origin)).toBe('/dashboard/picks');
+    expect(sameOriginAppPath('/dashboard/standings#self-recap', origin)).toBe(
+      '/dashboard/standings#self-recap',
+    );
+  });
+
+  it('accepts absolute same-origin URLs', () => {
+    expect(
+      sameOriginAppPath('https://www.setlistpickem.com/dashboard/picks', origin),
+    ).toBe('/dashboard/picks');
+  });
+
+  it('rejects external and empty hrefs', () => {
+    expect(sameOriginAppPath('https://example.com/x', origin)).toBeNull();
+    expect(sameOriginAppPath('//cdn.example/x', origin)).toBeNull();
+    expect(sameOriginAppPath('#', origin)).toBeNull();
+    expect(sameOriginAppPath('', origin)).toBeNull();
+    expect(sameOriginAppPath(undefined, origin)).toBeNull();
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -37,6 +37,42 @@
       "destination": "/api/invite?code=:code"
     },
     {
+      "source": "/dashboard",
+      "destination": "/dashboard/index.html"
+    },
+    {
+      "source": "/dashboard/(.*)",
+      "destination": "/dashboard/index.html"
+    },
+    {
+      "source": "/setup",
+      "destination": "/dashboard/index.html"
+    },
+    {
+      "source": "/user/(.*)",
+      "destination": "/dashboard/index.html"
+    },
+    {
+      "source": "/password-reset-complete",
+      "destination": "/dashboard/index.html"
+    },
+    {
+      "source": "/comms-preview",
+      "destination": "/dashboard/index.html"
+    },
+    {
+      "source": "/privacy",
+      "destination": "/dashboard/index.html"
+    },
+    {
+      "source": "/terms",
+      "destination": "/dashboard/index.html"
+    },
+    {
+      "source": "/join",
+      "destination": "/dashboard/index.html"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
Closes #743

## Summary
- **B — Empty `#root` boot shell:** post-build writes `dist/dashboard/index.html` (no SEO body). Vercel rewrites `/dashboard/*`, `/setup`, `/user/*`, `/password-reset-complete`, `/comms-preview`, `/privacy`, `/terms`, and bare `/join` to that shell before the catch-all home `index.html`.
- **A — Soft inbox CTAs:** `CommsTemplateBody` uses React Router `Link` for same-origin hrefs (e.g. `/dashboard/picks`, `/dashboard/standings#self-recap`) so in-app message CTAs no longer full-reload.
- Shared `stripPrerenderBodyFromSpaShell` lives in `scripts/seo-strip-body.mjs` (invite API + prerender). `verify:seo-prerender` asserts empty dashboard shell + home still has prerender markers.
- PATCH 1.40.0 → 1.40.1

## Test plan
- [ ] Hard refresh `/dashboard/picks` on Preview — no “Setlist Pick 'Em — the free Phish…” flash
- [ ] Inbox CTA to picks/standings soft-navigates (no full document reload)
- [ ] Home `/` and `/how-it-works` still show correct marketing content for browsers/crawlers
- [ ] `/join/:code` invite flow unchanged
- [ ] `verify` + `build` green; `verify:seo-prerender` asserts app boot shell

Made with [Cursor](https://cursor.com)