### PR TITLE
fix(picks): lock at ticket time + 20 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.40.2] — 2026-07-31
+
+### Changed
+- **Picks lock basis** — wall clock moves from doors+(tour avg − safety) to **published ticket/show time + 20 minutes** (Phish.com `Show Time` → `scheduledStartLocal`). Client + Functions + lock-reminder share the same resolver; timing banner / War Room / admin helper copy updated. Fallback remains **7:30 PM** venue-local when show time is unknown.
+
+---
+
 ## [1.40.1] — 2026-07-28
 
 ### Fixed

--- a/docs/API.md
+++ b/docs/API.md
@@ -103,13 +103,13 @@ Tour and show date metadata. Read by `resolveCurrentTour` and `resolveSelectable
 | `venue` | string | Display venue line |
 | `city` | string? | City |
 | `timeZone` | string | IANA venue timezone |
-| `doorsLocal` | string? | Venue-local doors `HH:mm` from first-party Phish.com date page (client/Functions also seed known Summer Tour 2026 dates) |
-| `scheduledStartLocal` | string? | Advertised venue-local show time `HH:mm` from Phish.com; informational, not the picks lock |
+| `doorsLocal` | string? | Venue-local doors `HH:mm` from first-party Phish.com date page (informational; client/Functions also seed known Summer Tour 2026 dates) |
+| `scheduledStartLocal` | string? | Advertised venue-local ticket/show time `HH:mm` from Phish.com; primary input for the picks wall-clock lock |
 | `scheduleSource` | `'phish.com'`? | Timing provenance |
 | `scheduleSourceUrl` | string? | Official date-page URL |
 | `picksLockLocal` | string? | Venue-local picks lock `HH:mm` when materialized/overridden |
 
-**Picks wall-clock lock (#522):** when `doorsLocal` (or a seeded doors time) is known, lock = doors + (tour avg doors→start − safety). Summer Tour 2026 defaults: avg **119** min, safety **34** → **doors + 85 min** (1h25). When doors are unknown, fallback is **19:30** venue-local. Admin `show_lock_state` and (planned) setlist `s1o` still win as earlier signals.
+**Picks wall-clock lock (#522):** when `scheduledStartLocal` (or a seeded advertised show time) is known, lock = **published ticket/show time + 20 minutes**. Same Phish.com date-page source as doors (`Show Time`). When show time is unknown, fallback is **19:30** venue-local. Admin `show_lock_state` and (planned) setlist `s1o` still win as earlier signals.
 
 `scheduledPhishnetShowCalendar` runs daily at 06:00 ET. Phish.net is canonical for dates/tours/venues; the sync then fetches Phish.com upcoming date pages for timing. A Phish.com failure does not fail or erase the calendar: prior timing is preserved.
 
@@ -320,7 +320,7 @@ Automated comms delivery triggered by Firestore writes, post-rollup hooks, live-
 | Live-scoring hook | `score_first_points`, `score_leader` | `recomputeLiveScoresForShow` |
 | `scheduledTourCountdownComms` | `tour_countdown` | Daily 9am PT cron (T-10/T-5/T-3/T-1) |
 | `scheduledTourRankingsDailyComms` | `tour_rankings_daily` | Daily 8am PT cron (morning-after show) |
-| `scheduledPicksLockReminder` | `picks_lock_reminder` | Every 15 min; venue-local show day **T-3h–lock** (window tracks per-show lock from doors+offset or 19:30 fallback); **not** gated by `COMMS_EVENT_ADAPTERS_ENABLED` (v1.19.0+) |
+| `scheduledPicksLockReminder` | `picks_lock_reminder` | Every 15 min; venue-local show day **T-3h–lock** (window tracks per-show lock from ticket-time+20 or 19:30 fallback); **not** gated by `COMMS_EVENT_ADAPTERS_ENABLED` (v1.19.0+) |
 
 Trigger specs and channels: `docs/comms-triggers/catalog.json`. Admin canary/replay: `runCommsTrigger` (§2.2).
 

--- a/docs/PICKS_LOCK_ADMIN_RUNBOOK.md
+++ b/docs/PICKS_LOCK_ADMIN_RUNBOOK.md
@@ -27,7 +27,7 @@ Operational guide for **`lockPicksForShowNow`** — the War Room **Lock picks no
 1. Admin clicks **Lock picks now** in War Room while the show is `NEXT`.
 2. Client calls `lockPicksForShowNow({ showDate })`.
 3. Callable writes `show_lock_state/{showDate}` with `lockReason: admin_override`.
-4. All clients subscribed to that doc treat picks as locked even before the per-show wall clock (doors+1:25 when doors known; else 7:30 PM venue-local).
+4. All clients subscribed to that doc treat picks as locked even before the per-show wall clock (published ticket/show time + 20 min when known; else 7:30 PM venue-local).
 
 Idempotent: re-running on an already-stamped doc returns `{ alreadyLocked: true }` without rewriting timestamps.
 
@@ -126,4 +126,4 @@ gcloud run services add-iam-policy-binding lockpicksforshownow \
 - [`docs/API.md`](./API.md) §1.8 (doors / picksLockLocal), §1.10 (`show_lock_state`), §2.2b (`lockPicksForShowNow`)
 - [`docs/ADMIN_CLAIMS_RUNBOOK.md`](./ADMIN_CLAIMS_RUNBOOK.md) — admin claim bootstrap
 - [`docs/PHISHNET_CALLABLE_RUNBOOK.md`](./PHISHNET_CALLABLE_RUNBOOK.md) — phishnet deploy bundle
-- Issue [#522](https://github.com/pat792/set-picks/issues/522) — doors-based wall clock + remaining setlist poll lock
+- Issue [#522](https://github.com/pat792/set-picks/issues/522) — ticket-time wall clock + remaining setlist poll lock

--- a/docs/comms-triggers/TRIGGER_CATALOG.md
+++ b/docs/comms-triggers/TRIGGER_CATALOG.md
@@ -41,7 +41,7 @@ Every template draws from this shared set. Each trigger declares the subset it u
 | `{{venue_name}}` | `show_calendar` snapshot | — |
 | `{{venue_city}}` | `show_calendar` snapshot | — |
 | `{{time_to_lock}}` | Computed at send time | — |
-| `{{lock_time_local}}` | Computed (doors+1:25 when doors known; else 19:30 venue-local) | `7:30 PM` |
+| `{{lock_time_local}}` | Computed (published ticket/show time + 20 min when known; else 19:30 venue-local) | `7:30 PM` |
 | `{{tour_name}}` | Tour metadata | — |
 | `{{days_remaining}}` | Computed from tour start date | — |
 | `{{first_show_date}}` | Tour first show | — |

--- a/docs/comms-triggers/catalog.json
+++ b/docs/comms-triggers/catalog.json
@@ -53,7 +53,7 @@
         { "name": "first_show_date", "source": "tour first show", "fallback": null },
         { "name": "first_show_venue", "source": "tour first show venue", "fallback": null },
         { "name": "first_show_city", "source": "tour first show city", "fallback": null },
-        { "name": "lock_time_local", "source": "computed (doors+offset or 19:30 venue-local)", "fallback": "7:30 PM" },
+        { "name": "lock_time_local", "source": "computed (ticket/show time + 20 min or 19:30 venue-local)", "fallback": "7:30 PM" },
         { "name": "picks_secured", "source": "picks where showDate=first_show + hasNonEmptyPicksObject", "fallback": false }
       ]
     },
@@ -256,7 +256,7 @@
       "family": "show_calendar",
       "priority": "P0",
       "automation": "automated",
-      "schedule": "every 15min on show days, venue-local T-3h through lock (per-show lock from doors+offset or 19:30 fallback)",
+      "schedule": "every 15min on show days, venue-local T-3h through lock (per-show lock from ticket/show time + 20 min or 19:30 fallback)",
       "audience": "users_no_picks_tonight",
       "channels": ["inApp", "push", "email"],
       "prefKeys": ["reminders"],
@@ -272,7 +272,7 @@
         { "name": "venue_name", "source": "show_calendar", "fallback": null },
         { "name": "venue_city", "source": "show_calendar", "fallback": null },
         { "name": "time_to_lock", "source": "computed at send time", "fallback": null },
-        { "name": "lock_time_local", "source": "computed (doors+offset or 19:30 venue-local)", "fallback": "7:30 PM" },
+        { "name": "lock_time_local", "source": "computed (ticket/show time + 20 min or 19:30 venue-local)", "fallback": "7:30 PM" },
         { "name": "picks_secured", "source": "preview/edge only — production fanout skips users with picks", "fallback": false }
       ]
     },

--- a/functions/phishnetLiveSetlistAutomation.js
+++ b/functions/phishnetLiveSetlistAutomation.js
@@ -219,7 +219,7 @@ function parseShowCalendarSnapshotToShows(snapshotData) {
             ? item.timezone.trim()
             : ""
         : "";
-    /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour_name?: string, tour?: string, doorsLocal?: string, picksLockLocal?: string }} */
+    /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour_name?: string, tour?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string }} */
     const show = { date, timeZone: explicitTz || DEFAULT_SHOW_TIME_ZONE };
     if (item && typeof item === "object") {
       if (typeof item.venue === "string" && item.venue.trim()) {
@@ -236,6 +236,12 @@ function parseShowCalendarSnapshotToShows(snapshotData) {
       }
       if (typeof item.doorsLocal === "string" && item.doorsLocal.trim()) {
         show.doorsLocal = item.doorsLocal.trim();
+      }
+      if (
+        typeof item.scheduledStartLocal === "string" &&
+        item.scheduledStartLocal.trim()
+      ) {
+        show.scheduledStartLocal = item.scheduledStartLocal.trim();
       }
       if (typeof item.picksLockLocal === "string" && item.picksLockLocal.trim()) {
         show.picksLockLocal = item.picksLockLocal.trim();
@@ -304,7 +310,7 @@ function parseShowCalendarSnapshotToShowsByTour(snapshotData) {
           : typeof item.timezone === "string" && item.timezone.trim()
             ? item.timezone.trim()
             : "";
-      /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour?: string, tour_name?: string, doorsLocal?: string, picksLockLocal?: string }} */
+      /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour?: string, tour_name?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string }} */
       const show = {
         date,
         timeZone: explicitTz || DEFAULT_SHOW_TIME_ZONE,
@@ -319,6 +325,12 @@ function parseShowCalendarSnapshotToShowsByTour(snapshotData) {
       }
       if (typeof item.doorsLocal === "string" && item.doorsLocal.trim()) {
         show.doorsLocal = item.doorsLocal.trim();
+      }
+      if (
+        typeof item.scheduledStartLocal === "string" &&
+        item.scheduledStartLocal.trim()
+      ) {
+        show.scheduledStartLocal = item.scheduledStartLocal.trim();
       }
       if (typeof item.picksLockLocal === "string" && item.picksLockLocal.trim()) {
         show.picksLockLocal = item.picksLockLocal.trim();

--- a/functions/picksLockReminder.js
+++ b/functions/picksLockReminder.js
@@ -54,7 +54,7 @@ function localClockParts(showTimeZone, now) {
 }
 
 /**
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null | undefined} show
+ * @param {{ date?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string } | null | undefined} show
  * @returns {number} minutes from midnight
  */
 function lockMinutesForShow(show) {
@@ -66,7 +66,7 @@ function lockMinutesForShow(show) {
  * @param {string} showYmd
  * @param {string} showTimeZone
  * @param {Date} now
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null} [show]
+ * @param {{ date?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string } | null} [show]
  */
 function isPastPicksLock(showYmd, showTimeZone, now, show = null) {
   const clock = localClockParts(showTimeZone, now);
@@ -81,7 +81,7 @@ function isPastPicksLock(showYmd, showTimeZone, now, show = null) {
  * @param {string} showYmd
  * @param {string} showTimeZone
  * @param {Date} now
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null} [show]
+ * @param {{ date?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string } | null} [show]
  */
 function isWithinReminderWindow(showYmd, showTimeZone, now, show = null) {
   const clock = localClockParts(showTimeZone, now);
@@ -95,7 +95,7 @@ function isWithinReminderWindow(showYmd, showTimeZone, now, show = null) {
  * @param {string} showYmd `YYYY-MM-DD`
  * @param {string} showTimeZone IANA tz
  * @param {Date} now
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null} [show]
+ * @param {{ date?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string } | null} [show]
  * @returns {string}
  */
 function formatTimeToLock(showYmd, showTimeZone, now, show = null) {
@@ -114,7 +114,7 @@ function formatTimeToLock(showYmd, showTimeZone, now, show = null) {
 }
 
 /**
- * @param {Array<{ date: string, timeZone?: string, venue?: string, city?: string, doorsLocal?: string, picksLockLocal?: string }>} calendarShows
+ * @param {Array<{ date: string, timeZone?: string, venue?: string, city?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string }>} calendarShows
  * @param {Date} now
  * @returns {{ showDate: string, timeZone: string, venue_name: string, venue_city: string, lock_time_local: string, show: object } | null}
  */

--- a/functions/picksLockTime.js
+++ b/functions/picksLockTime.js
@@ -6,8 +6,7 @@
  */
 
 const DEFAULT_PICKS_LOCK_HM = Object.freeze({ hour: 19, minute: 30 });
-const TOUR_AVG_DOORS_TO_START_MIN = 119;
-const PICKS_LOCK_SAFETY_MIN = 34;
+const PICKS_LOCK_AFTER_START_MIN = 20;
 
 const SHOW_DOORS_LOCAL_BY_DATE = Object.freeze({
   "2026-07-18": "17:30",
@@ -23,6 +22,22 @@ const SHOW_DOORS_LOCAL_BY_DATE = Object.freeze({
   "2026-09-04": "18:00",
   "2026-09-05": "18:00",
   "2026-09-06": "18:00",
+});
+
+const SHOW_SCHEDULED_START_LOCAL_BY_DATE = Object.freeze({
+  "2026-07-18": "19:00",
+  "2026-07-19": "19:00",
+  "2026-07-21": "19:00",
+  "2026-07-22": "20:00",
+  "2026-07-24": "20:00",
+  "2026-07-25": "20:00",
+  "2026-07-27": "20:00",
+  "2026-07-29": "20:00",
+  "2026-07-31": "19:00",
+  "2026-08-01": "19:00",
+  "2026-09-04": "19:30",
+  "2026-09-05": "19:30",
+  "2026-09-06": "19:30",
 });
 
 /**
@@ -93,75 +108,93 @@ function formatLockTimeLocalLabel(hm) {
 }
 
 /**
- * @param {{ hour: number, minute: number }} doors
- * @param {{ tourAvgDoorsToStartMin?: number, safetyMin?: number }} [opts]
+ * @param {{ hour: number, minute: number }} start
+ * @param {{ afterStartMin?: number }} [opts]
  */
-function lockHmFromDoors(
-  doors,
-  {
-    tourAvgDoorsToStartMin = TOUR_AVG_DOORS_TO_START_MIN,
-    safetyMin = PICKS_LOCK_SAFETY_MIN,
-  } = {}
+function lockHmFromScheduledStart(
+  start,
+  { afterStartMin = PICKS_LOCK_AFTER_START_MIN } = {}
 ) {
-  const offset = Math.max(0, tourAvgDoorsToStartMin - safetyMin);
-  const total = doors.hour * 60 + doors.minute + offset;
+  const offset = Math.max(0, afterStartMin);
+  const total = start.hour * 60 + start.minute + offset;
   const wrapped = ((total % (24 * 60)) + 24 * 60) % (24 * 60);
   return { hour: Math.floor(wrapped / 60), minute: wrapped % 60 };
 }
 
 /**
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null | undefined} show
  * @param {{
+ *   date?: string,
+ *   doorsLocal?: string,
+ *   scheduledStartLocal?: string,
+ *   picksLockLocal?: string,
+ * } | null | undefined} show
+ * @param {{
+ *   startByDate?: Record<string, string>,
  *   doorsByDate?: Record<string, string>,
- *   tourAvgDoorsToStartMin?: number,
- *   safetyMin?: number,
+ *   afterStartMin?: number,
  *   fallback?: { hour: number, minute: number },
  * }} [opts]
  */
 function resolvePicksLockHm(show, opts = {}) {
   const fallback = opts.fallback ?? DEFAULT_PICKS_LOCK_HM;
+  const startByDate = opts.startByDate ?? SHOW_SCHEDULED_START_LOCAL_BY_DATE;
   const doorsByDate = opts.doorsByDate ?? SHOW_DOORS_LOCAL_BY_DATE;
+
+  const date = typeof show?.date === "string" ? show.date.trim() : "";
+  const doorsParsed = parseLocalHm(
+    (typeof show?.doorsLocal === "string" && show.doorsLocal.trim()) ||
+      (date && doorsByDate[date]) ||
+      null
+  );
+  const doorsLocal = doorsParsed ? formatLocalHm24(doorsParsed) : null;
 
   const explicitLock = parseLocalHm(show?.picksLockLocal);
   if (explicitLock) {
+    const start = parseLocalHm(
+      typeof show?.scheduledStartLocal === "string"
+        ? show.scheduledStartLocal.trim()
+        : null
+    );
     return {
       ...explicitLock,
       source: "picksLockLocal",
-      doorsLocal:
-        typeof show?.doorsLocal === "string" ? show.doorsLocal.trim() || null : null,
+      scheduledStartLocal: start ? formatLocalHm24(start) : null,
+      doorsLocal,
     };
   }
 
-  const date = typeof show?.date === "string" ? show.date.trim() : "";
-  const doorsRaw =
-    (typeof show?.doorsLocal === "string" && show.doorsLocal.trim()) ||
-    (date && doorsByDate[date]) ||
-    null;
-  const doors = parseLocalHm(doorsRaw);
-  if (doors) {
-    const lock = lockHmFromDoors(doors, opts);
+  const start = parseLocalHm(
+    (typeof show?.scheduledStartLocal === "string" &&
+      show.scheduledStartLocal.trim()) ||
+      (date && startByDate[date]) ||
+      null
+  );
+  if (start) {
+    const lock = lockHmFromScheduledStart(start, opts);
     return {
       ...lock,
-      source: "doors",
-      doorsLocal: formatLocalHm24(doors),
+      source: "scheduledStart",
+      scheduledStartLocal: formatLocalHm24(start),
+      doorsLocal,
     };
   }
 
   return {
     ...fallback,
     source: "fallback",
-    doorsLocal: null,
+    scheduledStartLocal: null,
+    doorsLocal,
   };
 }
 
 module.exports = {
   DEFAULT_PICKS_LOCK_HM,
-  PICKS_LOCK_SAFETY_MIN,
+  PICKS_LOCK_AFTER_START_MIN,
   SHOW_DOORS_LOCAL_BY_DATE,
-  TOUR_AVG_DOORS_TO_START_MIN,
+  SHOW_SCHEDULED_START_LOCAL_BY_DATE,
   formatLocalHm24,
   formatLockTimeLocalLabel,
-  lockHmFromDoors,
+  lockHmFromScheduledStart,
   parseLocalHm,
   resolvePicksLockHm,
 };

--- a/functions/picksLockTime.test.js
+++ b/functions/picksLockTime.test.js
@@ -4,27 +4,29 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const {
   DEFAULT_PICKS_LOCK_HM,
-  lockHmFromDoors,
+  lockHmFromScheduledStart,
   resolvePicksLockHm,
 } = require("./picksLockTime");
 
-test("lockHmFromDoors uses doors+85 for Summer Tour 2026 defaults", () => {
-  assert.deepEqual(lockHmFromDoors({ hour: 17, minute: 30 }), {
-    hour: 18,
-    minute: 55,
+test("lockHmFromScheduledStart uses start+20", () => {
+  assert.deepEqual(lockHmFromScheduledStart({ hour: 19, minute: 0 }), {
+    hour: 19,
+    minute: 20,
   });
 });
 
 test("resolvePicksLockHm seeds Merriweather and falls back", () => {
   assert.deepEqual(resolvePicksLockHm({ date: "2026-07-18" }), {
-    hour: 18,
-    minute: 55,
-    source: "doors",
+    hour: 19,
+    minute: 20,
+    source: "scheduledStart",
+    scheduledStartLocal: "19:00",
     doorsLocal: "17:30",
   });
   assert.deepEqual(resolvePicksLockHm({ date: "2099-01-01" }), {
     ...DEFAULT_PICKS_LOCK_HM,
     source: "fallback",
+    scheduledStartLocal: null,
     doorsLocal: null,
   });
 });

--- a/functions/showFinalizationGate.js
+++ b/functions/showFinalizationGate.js
@@ -64,6 +64,7 @@ function isPastPicksLock(
           date:
             typeof showOrLockHm.date === "string" ? showOrLockHm.date : showYmd,
           doorsLocal: showOrLockHm.doorsLocal,
+          scheduledStartLocal: showOrLockHm.scheduledStartLocal,
           picksLockLocal: showOrLockHm.picksLockLocal,
         })
       : resolvePicksLockHm({ date: showYmd });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.40.1",
+  "version": "1.40.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/admin/ui/AdminForm.jsx
+++ b/src/features/admin/ui/AdminForm.jsx
@@ -114,6 +114,7 @@ export default function AdminForm({ user, selectedDate }) {
         onChange={setWarRoomShowDate}
         disabled={isSaving}
         timeZone={warRoomTimeZone}
+        show={warRoomShow}
       />
       <AdminClaimBootstrap user={user} />
       <Card variant="danger" padding="sm" className="mb-6 mt-4">

--- a/src/features/admin/ui/AdminPicksLockControls.jsx
+++ b/src/features/admin/ui/AdminPicksLockControls.jsx
@@ -15,7 +15,7 @@ export default function AdminPicksLockControls({
   const canLock = showStatus === 'NEXT' && !picksAlreadyLocked && !disabled;
 
   let helperText =
-    'Picks lock at doors + ~1:25 (tour avg start − safety), at fallback 7:30 PM venue-local when doors are unknown, when set 1 starts on Phish.net, or when you lock them here.';
+    'Picks lock 20 minutes after the published ticket/show time (Phish.com), at fallback 7:30 PM venue-local when show time is unknown, when set 1 starts on Phish.net, or when you lock them here.';
   if (showStatus && showStatus !== 'NEXT') {
     helperText = 'Lock picks now is only available while this show is NEXT (before wall-clock lock).';
   } else if (adminLockActive) {

--- a/src/features/admin/ui/AdminWarRoomShowDate.jsx
+++ b/src/features/admin/ui/AdminWarRoomShowDate.jsx
@@ -9,22 +9,29 @@ import {
  * Admin-only: pick the Firestore `official_setlists/{showDate}` key independently of the
  * global dashboard tour picker (which may omit past legs or reset to “next show”).
  *
- * @param {{ value: string, onChange: (ymd: string) => void, disabled?: boolean, timeZone: string }} props
+ * @param {{
+ *   value: string,
+ *   onChange: (ymd: string) => void,
+ *   disabled?: boolean,
+ *   timeZone: string,
+ *   show?: { date?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string } | null,
+ * }} props
  */
 export default function AdminWarRoomShowDate({
   value,
   onChange,
   disabled = false,
   timeZone,
+  show = null,
 }) {
-  const lockHm = resolvePicksLockHm({ date: value });
+  const lockHm = resolvePicksLockHm(show || { date: value });
   const lockTimeLabel = formatLockTimeLocalLabel(lockHm);
   const lockSourceNote =
-    lockHm.source === 'doors'
-      ? `doors ${lockHm.doorsLocal} + tour avg − safety`
+    lockHm.source === 'scheduledStart'
+      ? `published ticket time ${lockHm.scheduledStartLocal} + 20 min`
       : lockHm.source === 'picksLockLocal'
         ? 'explicit picksLockLocal'
-        : 'fallback 7:30 PM (doors unknown)';
+        : 'fallback 7:30 PM (ticket time unknown)';
 
   return (
     <div className="rounded-xl border border-border-subtle bg-[rgb(var(--surface-field)_/_0.35)] px-4 py-3 ring-1 ring-border-glass/20">

--- a/src/features/picks/ui/PicksLockTimingBanner.jsx
+++ b/src/features/picks/ui/PicksLockTimingBanner.jsx
@@ -2,8 +2,7 @@ import React, { useState } from 'react';
 import { Clock3, X } from 'lucide-react';
 
 import {
-  PICKS_LOCK_SAFETY_MIN,
-  TOUR_AVG_DOORS_TO_START_MIN,
+  PICKS_LOCK_AFTER_START_MIN,
   formatLockTimeLocalLabel,
   parseLocalHm,
   resolvePicksLockHm,
@@ -19,21 +18,26 @@ function durationWords(minutes) {
 }
 
 /**
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string, picksLockSource?: string } | null | undefined} show
+ * @param {{
+ *   date?: string,
+ *   doorsLocal?: string,
+ *   scheduledStartLocal?: string,
+ *   picksLockLocal?: string,
+ *   picksLockSource?: string,
+ * } | null | undefined} show
  */
 export function buildPicksLockTimingMessage(show) {
   const lock = resolvePicksLockHm(show);
   const lockLabel = formatLockTimeLocalLabel(lock);
-  const doors = parseLocalHm(lock.doorsLocal);
-  const isDoorsBased =
-    lock.source === 'doors' || show?.picksLockSource === 'doors';
+  const start = parseLocalHm(lock.scheduledStartLocal);
+  const isStartBased =
+    lock.source === 'scheduledStart' ||
+    show?.picksLockSource === 'scheduledStart';
 
-  if (doors && isDoorsBased) {
-    const offsetMinutes =
-      TOUR_AVG_DOORS_TO_START_MIN - PICKS_LOCK_SAFETY_MIN;
+  if (start && isStartBased) {
     return `Picks lock at ${lockLabel} — ${durationWords(
-      offsetMinutes
-    )} after tonight’s published doors time (${formatLockTimeLocalLabel(doors)}).`;
+      PICKS_LOCK_AFTER_START_MIN
+    )} after tonight’s published ticket time (${formatLockTimeLocalLabel(start)}).`;
   }
 
   return `Picks lock at ${lockLabel} venue-local.`;
@@ -65,7 +69,13 @@ function rememberDismissal(showDate) {
  * Small pre-lock timing notice shared by Picks and Standings.
  *
  * @param {{
- *   show: { date?: string, doorsLocal?: string, picksLockLocal?: string, picksLockSource?: string } | null | undefined,
+ *   show: {
+ *     date?: string,
+ *     doorsLocal?: string,
+ *     scheduledStartLocal?: string,
+ *     picksLockLocal?: string,
+ *     picksLockSource?: string,
+ *   } | null | undefined,
  *   showStatus: string | null | undefined
  * }} props
  */

--- a/src/features/picks/ui/PicksLockTimingBanner.test.js
+++ b/src/features/picks/ui/PicksLockTimingBanner.test.js
@@ -3,20 +3,21 @@ import { describe, expect, it } from 'vitest';
 import { buildPicksLockTimingMessage } from './PicksLockTimingBanner';
 
 describe('buildPicksLockTimingMessage', () => {
-  it('explains the doors-based lock for tonight', () => {
+  it('explains the ticket-time-based lock for tonight', () => {
     expect(
       buildPicksLockTimingMessage({
         date: '2026-07-18',
         doorsLocal: '17:30',
-        picksLockLocal: '18:55',
-        picksLockSource: 'doors',
+        scheduledStartLocal: '19:00',
+        picksLockLocal: '19:20',
+        picksLockSource: 'scheduledStart',
       })
     ).toBe(
-      'Picks lock at 6:55 PM — 1 hour 25 minutes after tonight’s published doors time (5:30 PM).'
+      'Picks lock at 7:20 PM — 20 minutes after tonight’s published ticket time (7:00 PM).'
     );
   });
 
-  it('shows only the venue-local fallback when doors are unknown', () => {
+  it('shows only the venue-local fallback when show time is unknown', () => {
     expect(buildPicksLockTimingMessage({ date: '2099-01-01' })).toBe(
       'Picks lock at 7:30 PM venue-local.'
     );

--- a/src/features/show-calendar/model/normalizeShowCalendarDoc.js
+++ b/src/features/show-calendar/model/normalizeShowCalendarDoc.js
@@ -3,14 +3,14 @@ import { resolveShowTimeZone } from '../../../shared/utils/showTimeZone';
 
 /**
  * @param {Record<string, unknown>} s
- * @returns {{ date: string, venue: string, timeZone: string, doorsLocal?: string, picksLockLocal?: string, picksLockSource?: string } | null}
+ * @returns {{ date: string, venue: string, timeZone: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string, picksLockSource?: string } | null}
  */
 function normalizeShowRow(s) {
   if (!s || typeof s !== 'object') return null;
   const date = typeof s.date === 'string' ? s.date.trim() : '';
   const venue = typeof s.venue === 'string' ? s.venue.trim() : '';
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || !venue) return null;
-  /** @type {{ date: string, venue: string, timeZone: string, doorsLocal?: string, picksLockLocal?: string }} */
+  /** @type {{ date: string, venue: string, timeZone: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string }} */
   const base = {
     date,
     venue,
@@ -21,6 +21,9 @@ function normalizeShowRow(s) {
   if (typeof s.doorsLocal === 'string' && s.doorsLocal.trim()) {
     base.doorsLocal = s.doorsLocal.trim();
   }
+  if (typeof s.scheduledStartLocal === 'string' && s.scheduledStartLocal.trim()) {
+    base.scheduledStartLocal = s.scheduledStartLocal.trim();
+  }
   if (typeof s.picksLockLocal === 'string' && s.picksLockLocal.trim()) {
     base.picksLockLocal = s.picksLockLocal.trim();
   }
@@ -29,9 +32,9 @@ function normalizeShowRow(s) {
 
 /**
  * Validates Firestore `show_calendar/snapshot` written by Cloud Functions (issue #160).
- * Enriches each show with `doorsLocal` / `picksLockLocal` (#522 doors-based lock).
+ * Enriches each show with `scheduledStartLocal` / `picksLockLocal` (#522 ticket-time lock).
  * @param {import('firebase/firestore').DocumentData | null | undefined} data
- * @returns {{ showDatesByTour: { tour: string, shows: { date: string, venue: string, timeZone: string, doorsLocal?: string, picksLockLocal?: string }[] }[], showDates: { date: string, venue: string, timeZone: string, doorsLocal?: string, picksLockLocal?: string }[], syncError?: string | null } | null}
+ * @returns {{ showDatesByTour: { tour: string, shows: { date: string, venue: string, timeZone: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string }[] }[], showDates: { date: string, venue: string, timeZone: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string }[], syncError?: string | null } | null}
  */
 export function normalizeShowCalendarDoc(data) {
   if (!data || typeof data !== 'object') return null;

--- a/src/shared/utils/picksLockTime.js
+++ b/src/shared/utils/picksLockTime.js
@@ -1,9 +1,9 @@
 /**
  * Per-show picks wall-clock lock (#522).
  *
- * When doors are known: lock = doors + (tourAvgDoorsToStart − safety).
- * Summer Tour 2026 setlist.fm avg doors→start is 1h59m (119); safety 34 → doors+85 (1h25).
- * Fallback when doors unknown: 19:30 venue-local.
+ * When advertised ticket/show time is known (Phish.com `Show Time` →
+ * `scheduledStartLocal`): lock = start + PICKS_LOCK_AFTER_START_MIN.
+ * Fallback when show time unknown: 19:30 venue-local.
  */
 
 /** @type {{ hour: number, minute: number }} */
@@ -13,16 +13,12 @@ export const DEFAULT_PICKS_LOCK_HM = Object.freeze({ hour: 19, minute: 30 });
 export const SHOW_PICKS_LOCK_HOUR_LOCAL = DEFAULT_PICKS_LOCK_HM.hour;
 export const SHOW_PICKS_LOCK_MINUTE_LOCAL = DEFAULT_PICKS_LOCK_HM.minute;
 
-/** setlist.fm Summer Tour 2026 “Avg start time after doors”. */
-export const TOUR_AVG_DOORS_TO_START_MIN = 119;
-
-/** Minutes before average start to lock picks (doors+85 when avg is 119). */
-export const PICKS_LOCK_SAFETY_MIN = 34;
+/** Minutes after published ticket/show time to lock picks. */
+export const PICKS_LOCK_AFTER_START_MIN = 20;
 
 /**
- * Known doors times (venue-local 24h `HH:mm`) from setlist.fm / tickets.
- * Ops: extend as future dates publish. Calendar fields `doorsLocal` /
- * `picksLockLocal` override this seed when present.
+ * Known doors times (venue-local 24h `HH:mm`) from Phish.com / tickets.
+ * Informational + War Room context; no longer drives the lock formula.
  *
  * @type {Readonly<Record<string, string>>}
  */
@@ -40,6 +36,29 @@ export const SHOW_DOORS_LOCAL_BY_DATE = Object.freeze({
   '2026-09-04': '18:00', // Dick's
   '2026-09-05': '18:00',
   '2026-09-06': '18:00',
+});
+
+/**
+ * Known advertised show/ticket times (venue-local 24h `HH:mm`) from Phish.com.
+ * Calendar field `scheduledStartLocal` overrides this seed when present.
+ * Ops: extend as future dates publish.
+ *
+ * @type {Readonly<Record<string, string>>}
+ */
+export const SHOW_SCHEDULED_START_LOCAL_BY_DATE = Object.freeze({
+  '2026-07-18': '19:00', // Merriweather
+  '2026-07-19': '19:00',
+  '2026-07-21': '19:00', // Syracuse
+  '2026-07-22': '20:00', // MSG
+  '2026-07-24': '20:00',
+  '2026-07-25': '20:00',
+  '2026-07-27': '20:00',
+  '2026-07-29': '20:00',
+  '2026-07-31': '19:00', // Fenway
+  '2026-08-01': '19:00',
+  '2026-09-04': '19:30', // Dick's
+  '2026-09-05': '19:30',
+  '2026-09-06': '19:30',
 });
 
 /**
@@ -110,19 +129,16 @@ export function formatLockTimeLocalLabel(hm) {
 }
 
 /**
- * @param {{ hour: number, minute: number }} doors
- * @param {{ tourAvgDoorsToStartMin?: number, safetyMin?: number }} [opts]
+ * @param {{ hour: number, minute: number }} start
+ * @param {{ afterStartMin?: number }} [opts]
  * @returns {{ hour: number, minute: number }}
  */
-export function lockHmFromDoors(
-  doors,
-  {
-    tourAvgDoorsToStartMin = TOUR_AVG_DOORS_TO_START_MIN,
-    safetyMin = PICKS_LOCK_SAFETY_MIN,
-  } = {}
+export function lockHmFromScheduledStart(
+  start,
+  { afterStartMin = PICKS_LOCK_AFTER_START_MIN } = {}
 ) {
-  const offset = Math.max(0, tourAvgDoorsToStartMin - safetyMin);
-  const total = doors.hour * 60 + doors.minute + offset;
+  const offset = Math.max(0, afterStartMin);
+  const total = start.hour * 60 + start.minute + offset;
   const wrapped = ((total % (24 * 60)) + 24 * 60) % (24 * 60);
   return { hour: Math.floor(wrapped / 60), minute: wrapped % 60 };
 }
@@ -132,61 +148,100 @@ export function lockHmFromDoors(
  *
  * Priority:
  * 1. `show.picksLockLocal` (materialized / override)
- * 2. `show.doorsLocal` or seeded doors for `show.date` → doors + (avg − safety)
+ * 2. `show.scheduledStartLocal` or seeded show time for `show.date` → start + 20
  * 3. Default 19:30
  *
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null | undefined} show
  * @param {{
+ *   date?: string,
+ *   doorsLocal?: string,
+ *   scheduledStartLocal?: string,
+ *   picksLockLocal?: string,
+ * } | null | undefined} show
+ * @param {{
+ *   startByDate?: Record<string, string>,
  *   doorsByDate?: Record<string, string>,
- *   tourAvgDoorsToStartMin?: number,
- *   safetyMin?: number,
+ *   afterStartMin?: number,
  *   fallback?: { hour: number, minute: number },
  * }} [opts]
- * @returns {{ hour: number, minute: number, source: 'picksLockLocal' | 'doors' | 'fallback', doorsLocal: string | null }}
+ * @returns {{
+ *   hour: number,
+ *   minute: number,
+ *   source: 'picksLockLocal' | 'scheduledStart' | 'fallback',
+ *   scheduledStartLocal: string | null,
+ *   doorsLocal: string | null,
+ * }}
  */
 export function resolvePicksLockHm(show, opts = {}) {
   const fallback = opts.fallback ?? DEFAULT_PICKS_LOCK_HM;
+  const startByDate = opts.startByDate ?? SHOW_SCHEDULED_START_LOCAL_BY_DATE;
   const doorsByDate = opts.doorsByDate ?? SHOW_DOORS_LOCAL_BY_DATE;
+
+  const date = typeof show?.date === 'string' ? show.date.trim() : '';
+  const doorsParsed = parseLocalHm(
+    (typeof show?.doorsLocal === 'string' && show.doorsLocal.trim()) ||
+      (date && doorsByDate[date]) ||
+      null
+  );
+  const doorsLocal = doorsParsed ? formatLocalHm24(doorsParsed) : null;
 
   const explicitLock = parseLocalHm(show?.picksLockLocal);
   if (explicitLock) {
+    const start = parseLocalHm(
+      typeof show?.scheduledStartLocal === 'string'
+        ? show.scheduledStartLocal.trim()
+        : null
+    );
     return {
       ...explicitLock,
       source: 'picksLockLocal',
-      doorsLocal: typeof show?.doorsLocal === 'string' ? show.doorsLocal.trim() || null : null,
+      scheduledStartLocal: start ? formatLocalHm24(start) : null,
+      doorsLocal,
     };
   }
 
-  const date = typeof show?.date === 'string' ? show.date.trim() : '';
-  const doorsRaw =
-    (typeof show?.doorsLocal === 'string' && show.doorsLocal.trim()) ||
-    (date && doorsByDate[date]) ||
-    null;
-  const doors = parseLocalHm(doorsRaw);
-  if (doors) {
-    const lock = lockHmFromDoors(doors, opts);
+  const start = parseLocalHm(
+    (typeof show?.scheduledStartLocal === 'string' &&
+      show.scheduledStartLocal.trim()) ||
+      (date && startByDate[date]) ||
+      null
+  );
+  if (start) {
+    const lock = lockHmFromScheduledStart(start, opts);
     return {
       ...lock,
-      source: 'doors',
-      doorsLocal: formatLocalHm24(doors),
+      source: 'scheduledStart',
+      scheduledStartLocal: formatLocalHm24(start),
+      doorsLocal,
     };
   }
 
   return {
     ...fallback,
     source: 'fallback',
-    doorsLocal: null,
+    scheduledStartLocal: null,
+    doorsLocal,
   };
 }
 
 /**
  * Enrich a show row with resolved lock fields (idempotent).
- * @param {{ date: string, venue?: string, timeZone?: string, doorsLocal?: string, picksLockLocal?: string }} show
+ * @param {{
+ *   date: string,
+ *   venue?: string,
+ *   timeZone?: string,
+ *   doorsLocal?: string,
+ *   scheduledStartLocal?: string,
+ *   picksLockLocal?: string,
+ * }} show
  */
 export function enrichShowWithPicksLock(show) {
   if (!show || typeof show !== 'object') return show;
   const resolved = resolvePicksLockHm(show);
-  if (resolved.source === 'fallback') return { ...show };
+  if (resolved.source === 'fallback') {
+    const out = { ...show };
+    if (resolved.doorsLocal && !out.doorsLocal) out.doorsLocal = resolved.doorsLocal;
+    return out;
+  }
 
   const enriched = {
     ...show,
@@ -195,5 +250,8 @@ export function enrichShowWithPicksLock(show) {
   };
   const doorsLocal = show.doorsLocal || resolved.doorsLocal;
   if (doorsLocal) enriched.doorsLocal = doorsLocal;
+  const scheduledStartLocal =
+    show.scheduledStartLocal || resolved.scheduledStartLocal;
+  if (scheduledStartLocal) enriched.scheduledStartLocal = scheduledStartLocal;
   return enriched;
 }

--- a/src/shared/utils/picksLockTime.test.js
+++ b/src/shared/utils/picksLockTime.test.js
@@ -4,7 +4,7 @@ import {
   DEFAULT_PICKS_LOCK_HM,
   formatLockTimeLocalLabel,
   formatLocalHm24,
-  lockHmFromDoors,
+  lockHmFromScheduledStart,
   parseLocalHm,
   resolvePicksLockHm,
 } from './picksLockTime';
@@ -18,57 +18,75 @@ describe('parseLocalHm', () => {
   });
 });
 
-describe('lockHmFromDoors', () => {
-  it('locks doors+85 when avg=119 and safety=34', () => {
-    expect(lockHmFromDoors({ hour: 17, minute: 30 })).toEqual({ hour: 18, minute: 55 });
-    expect(lockHmFromDoors({ hour: 18, minute: 30 })).toEqual({ hour: 19, minute: 55 });
-    expect(lockHmFromDoors({ hour: 17, minute: 0 })).toEqual({ hour: 18, minute: 25 });
+describe('lockHmFromScheduledStart', () => {
+  it('locks start+20 by default', () => {
+    expect(lockHmFromScheduledStart({ hour: 19, minute: 0 })).toEqual({
+      hour: 19,
+      minute: 20,
+    });
+    expect(lockHmFromScheduledStart({ hour: 20, minute: 0 })).toEqual({
+      hour: 20,
+      minute: 20,
+    });
+    expect(lockHmFromScheduledStart({ hour: 19, minute: 30 })).toEqual({
+      hour: 19,
+      minute: 50,
+    });
   });
 });
 
 describe('resolvePicksLockHm (#522)', () => {
-  it('uses seeded doors for Merriweather / MSG / Fenway', () => {
+  it('uses seeded ticket/show time for Merriweather / MSG / Fenway', () => {
     expect(resolvePicksLockHm({ date: '2026-07-18' })).toMatchObject({
-      hour: 18,
-      minute: 55,
-      source: 'doors',
+      hour: 19,
+      minute: 20,
+      source: 'scheduledStart',
+      scheduledStartLocal: '19:00',
       doorsLocal: '17:30',
     });
     expect(resolvePicksLockHm({ date: '2026-07-22' })).toMatchObject({
-      hour: 19,
-      minute: 55,
-      source: 'doors',
+      hour: 20,
+      minute: 20,
+      source: 'scheduledStart',
+      scheduledStartLocal: '20:00',
     });
     expect(resolvePicksLockHm({ date: '2026-07-31' })).toMatchObject({
-      hour: 18,
-      minute: 25,
-      source: 'doors',
+      hour: 19,
+      minute: 20,
+      source: 'scheduledStart',
+      scheduledStartLocal: '19:00',
     });
   });
 
-  it('falls back to 19:30 when doors unknown', () => {
+  it('falls back to 19:30 when show time unknown', () => {
     expect(resolvePicksLockHm({ date: '2099-01-01' })).toEqual({
       ...DEFAULT_PICKS_LOCK_HM,
       source: 'fallback',
+      scheduledStartLocal: null,
       doorsLocal: null,
     });
   });
 
-  it('prefers picksLockLocal then doorsLocal on the show', () => {
+  it('prefers picksLockLocal then scheduledStartLocal on the show', () => {
     expect(
       resolvePicksLockHm({
         date: '2026-07-18',
         picksLockLocal: '19:40',
-        doorsLocal: '17:30',
+        scheduledStartLocal: '19:00',
       })
     ).toMatchObject({ hour: 19, minute: 40, source: 'picksLockLocal' });
 
     expect(
       resolvePicksLockHm({
         date: '2099-01-01',
-        doorsLocal: '18:00',
+        scheduledStartLocal: '19:30',
       })
-    ).toMatchObject({ hour: 19, minute: 25, source: 'doors', doorsLocal: '18:00' });
+    ).toMatchObject({
+      hour: 19,
+      minute: 50,
+      source: 'scheduledStart',
+      scheduledStartLocal: '19:30',
+    });
   });
 
   it('formats labels', () => {

--- a/src/shared/utils/timeLogic.js
+++ b/src/shared/utils/timeLogic.js
@@ -58,7 +58,7 @@ function showClockOnShowYmd(showYmd, showTimeZone, now = new Date()) {
  * @param {string} showYmd
  * @param {string} [showTimeZone]
  * @param {Date} [now]
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | { hour: number, minute: number } | null} [showOrLockHm]
+ * @param {{ date?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string } | { hour: number, minute: number } | null} [showOrLockHm]
  *   Show row (preferred) or explicit `{ hour, minute }` lock. Defaults to 19:30.
  */
 export function isPastPicksLock(
@@ -77,7 +77,7 @@ export function isPastPicksLock(
 
 /**
  * @param {string} showYmd
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | { hour: number, minute: number } | null | undefined} showOrLockHm
+ * @param {{ date?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string } | { hour: number, minute: number } | null | undefined} showOrLockHm
  */
 function coercePicksLockHm(showYmd, showOrLockHm) {
   if (
@@ -87,6 +87,7 @@ function coercePicksLockHm(showYmd, showOrLockHm) {
     Number.isInteger(showOrLockHm.minute) &&
     showOrLockHm.date === undefined &&
     showOrLockHm.doorsLocal === undefined &&
+    showOrLockHm.scheduledStartLocal === undefined &&
     showOrLockHm.picksLockLocal === undefined
   ) {
     return { hour: showOrLockHm.hour, minute: showOrLockHm.minute };
@@ -95,6 +96,7 @@ function coercePicksLockHm(showYmd, showOrLockHm) {
     return resolvePicksLockHm({
       date: typeof showOrLockHm.date === 'string' ? showOrLockHm.date : showYmd,
       doorsLocal: showOrLockHm.doorsLocal,
+      scheduledStartLocal: showOrLockHm.scheduledStartLocal,
       picksLockLocal: showOrLockHm.picksLockLocal,
     });
   }
@@ -141,7 +143,7 @@ export function getShowBeforeDate(ymd, showDates) {
 
 /**
  * @param {string} selectedDate — YYYY-MM-DD
- * @param {{ date: string, doorsLocal?: string, picksLockLocal?: string }[]} showDates
+ * @param {{ date: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string }[]} showDates
  */
 export const getShowStatus = (selectedDate, showDates) => {
   const nextShow = getNextShow(showDates);

--- a/src/shared/utils/timeLogic.test.js
+++ b/src/shared/utils/timeLogic.test.js
@@ -67,10 +67,10 @@ describe('venue-local lock + status (#278)', () => {
     expect(getShowStatus('2099-06-15', shows)).toBe('LIVE');
   });
 
-  it('locks Merriweather at doors+85 (6:55 PM ET) before fallback 7:30', () => {
+  it('locks Merriweather at ticket+20 (7:20 PM ET) after published show time', () => {
     vi.useFakeTimers();
-    // 2026-07-18 23:00Z = 7:00 PM ET → past 6:55 lock, before 7:30 fallback.
-    vi.setSystemTime(new Date('2026-07-18T23:00:00.000Z'));
+    // 2026-07-18 23:25Z = 7:25 PM ET → past 7:20 lock (seeded show 7:00 + 20).
+    vi.setSystemTime(new Date('2026-07-18T23:25:00.000Z'));
 
     const shows = [
       {
@@ -83,9 +83,9 @@ describe('venue-local lock + status (#278)', () => {
     expect(getShowStatus('2026-07-18', shows)).toBe('LIVE');
   });
 
-  it('keeps Merriweather NEXT at 6:45 PM ET (before doors+85 lock)', () => {
+  it('keeps Merriweather NEXT at 7:10 PM ET (before ticket+20 lock)', () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-07-18T22:45:00.000Z'));
+    vi.setSystemTime(new Date('2026-07-18T23:10:00.000Z'));
 
     const shows = [
       {


### PR DESCRIPTION
## Summary
- Change picks wall-clock lock from doors+(tour avg − safety) to **published Phish.com ticket/show time + 20 minutes** (`scheduledStartLocal`).
- Keep client + Functions resolvers, lock-reminder window, and timing banner / War Room / admin helper copy aligned.
- PATCH **1.40.2** — update `docs/API.md`, comms catalog, and runbook wording. Fallback remains 7:30 PM venue-local when show time is unknown.

## Test plan
- [ ] Confirm Fenway N1 is complete before merging/deploying (hotfix after tonight).
- [ ] Unit: `npm test -- src/shared/utils/picksLockTime.test.js src/shared/utils/timeLogic.test.js src/features/picks/ui/PicksLockTimingBanner.test.js`
- [ ] Functions: `cd functions && node --test picksLockTime.test.js picksLockReminder.test.js`
- [ ] On preview: open Picks for a show with `scheduledStartLocal` and verify banner says “20 minutes after tonight’s published ticket time”.
- [ ] Deploy Functions with `npm run deploy:functions:phishnet` so reminder fanout matches the client lock.
- [ ] War Room show date shows `published ticket time HH:mm + 20 min` source note.


Made with [Cursor](https://cursor.com)