### PR TITLE
promote: staging → main (v1.40.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,9 +131,9 @@ jobs:
     if: github.event_name == 'schedule' || needs.changes.outputs.deps == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.40.2] — 2026-07-31
+
+### Changed
+- **Picks lock basis** — wall clock moves from doors+(tour avg − safety) to **published ticket/show time + 20 minutes** (Phish.com `Show Time` → `scheduledStartLocal`). Client + Functions + lock-reminder share the same resolver; timing banner / War Room / admin helper copy updated. Fallback remains **7:30 PM** venue-local when show time is unknown.
+
+---
+
 ## [1.40.1] — 2026-07-28
 
 ### Fixed

--- a/docs/API.md
+++ b/docs/API.md
@@ -103,13 +103,13 @@ Tour and show date metadata. Read by `resolveCurrentTour` and `resolveSelectable
 | `venue` | string | Display venue line |
 | `city` | string? | City |
 | `timeZone` | string | IANA venue timezone |
-| `doorsLocal` | string? | Venue-local doors `HH:mm` from first-party Phish.com date page (client/Functions also seed known Summer Tour 2026 dates) |
-| `scheduledStartLocal` | string? | Advertised venue-local show time `HH:mm` from Phish.com; informational, not the picks lock |
+| `doorsLocal` | string? | Venue-local doors `HH:mm` from first-party Phish.com date page (informational; client/Functions also seed known Summer Tour 2026 dates) |
+| `scheduledStartLocal` | string? | Advertised venue-local ticket/show time `HH:mm` from Phish.com; primary input for the picks wall-clock lock |
 | `scheduleSource` | `'phish.com'`? | Timing provenance |
 | `scheduleSourceUrl` | string? | Official date-page URL |
 | `picksLockLocal` | string? | Venue-local picks lock `HH:mm` when materialized/overridden |
 
-**Picks wall-clock lock (#522):** when `doorsLocal` (or a seeded doors time) is known, lock = doors + (tour avg doors→start − safety). Summer Tour 2026 defaults: avg **119** min, safety **34** → **doors + 85 min** (1h25). When doors are unknown, fallback is **19:30** venue-local. Admin `show_lock_state` and (planned) setlist `s1o` still win as earlier signals.
+**Picks wall-clock lock (#522):** when `scheduledStartLocal` (or a seeded advertised show time) is known, lock = **published ticket/show time + 20 minutes**. Same Phish.com date-page source as doors (`Show Time`). When show time is unknown, fallback is **19:30** venue-local. Admin `show_lock_state` and (planned) setlist `s1o` still win as earlier signals.
 
 `scheduledPhishnetShowCalendar` runs daily at 06:00 ET. Phish.net is canonical for dates/tours/venues; the sync then fetches Phish.com upcoming date pages for timing. A Phish.com failure does not fail or erase the calendar: prior timing is preserved.
 
@@ -320,7 +320,7 @@ Automated comms delivery triggered by Firestore writes, post-rollup hooks, live-
 | Live-scoring hook | `score_first_points`, `score_leader` | `recomputeLiveScoresForShow` |
 | `scheduledTourCountdownComms` | `tour_countdown` | Daily 9am PT cron (T-10/T-5/T-3/T-1) |
 | `scheduledTourRankingsDailyComms` | `tour_rankings_daily` | Daily 8am PT cron (morning-after show) |
-| `scheduledPicksLockReminder` | `picks_lock_reminder` | Every 15 min; venue-local show day **T-3h–lock** (window tracks per-show lock from doors+offset or 19:30 fallback); **not** gated by `COMMS_EVENT_ADAPTERS_ENABLED` (v1.19.0+) |
+| `scheduledPicksLockReminder` | `picks_lock_reminder` | Every 15 min; venue-local show day **T-3h–lock** (window tracks per-show lock from ticket-time+20 or 19:30 fallback); **not** gated by `COMMS_EVENT_ADAPTERS_ENABLED` (v1.19.0+) |
 
 Trigger specs and channels: `docs/comms-triggers/catalog.json`. Admin canary/replay: `runCommsTrigger` (§2.2).
 

--- a/docs/PICKS_LOCK_ADMIN_RUNBOOK.md
+++ b/docs/PICKS_LOCK_ADMIN_RUNBOOK.md
@@ -27,7 +27,7 @@ Operational guide for **`lockPicksForShowNow`** — the War Room **Lock picks no
 1. Admin clicks **Lock picks now** in War Room while the show is `NEXT`.
 2. Client calls `lockPicksForShowNow({ showDate })`.
 3. Callable writes `show_lock_state/{showDate}` with `lockReason: admin_override`.
-4. All clients subscribed to that doc treat picks as locked even before the per-show wall clock (doors+1:25 when doors known; else 7:30 PM venue-local).
+4. All clients subscribed to that doc treat picks as locked even before the per-show wall clock (published ticket/show time + 20 min when known; else 7:30 PM venue-local).
 
 Idempotent: re-running on an already-stamped doc returns `{ alreadyLocked: true }` without rewriting timestamps.
 
@@ -126,4 +126,4 @@ gcloud run services add-iam-policy-binding lockpicksforshownow \
 - [`docs/API.md`](./API.md) §1.8 (doors / picksLockLocal), §1.10 (`show_lock_state`), §2.2b (`lockPicksForShowNow`)
 - [`docs/ADMIN_CLAIMS_RUNBOOK.md`](./ADMIN_CLAIMS_RUNBOOK.md) — admin claim bootstrap
 - [`docs/PHISHNET_CALLABLE_RUNBOOK.md`](./PHISHNET_CALLABLE_RUNBOOK.md) — phishnet deploy bundle
-- Issue [#522](https://github.com/pat792/set-picks/issues/522) — doors-based wall clock + remaining setlist poll lock
+- Issue [#522](https://github.com/pat792/set-picks/issues/522) — ticket-time wall clock + remaining setlist poll lock

--- a/docs/comms-triggers/TRIGGER_CATALOG.md
+++ b/docs/comms-triggers/TRIGGER_CATALOG.md
@@ -41,7 +41,7 @@ Every template draws from this shared set. Each trigger declares the subset it u
 | `{{venue_name}}` | `show_calendar` snapshot | — |
 | `{{venue_city}}` | `show_calendar` snapshot | — |
 | `{{time_to_lock}}` | Computed at send time | — |
-| `{{lock_time_local}}` | Computed (doors+1:25 when doors known; else 19:30 venue-local) | `7:30 PM` |
+| `{{lock_time_local}}` | Computed (published ticket/show time + 20 min when known; else 19:30 venue-local) | `7:30 PM` |
 | `{{tour_name}}` | Tour metadata | — |
 | `{{days_remaining}}` | Computed from tour start date | — |
 | `{{first_show_date}}` | Tour first show | — |

--- a/docs/comms-triggers/catalog.json
+++ b/docs/comms-triggers/catalog.json
@@ -53,7 +53,7 @@
         { "name": "first_show_date", "source": "tour first show", "fallback": null },
         { "name": "first_show_venue", "source": "tour first show venue", "fallback": null },
         { "name": "first_show_city", "source": "tour first show city", "fallback": null },
-        { "name": "lock_time_local", "source": "computed (doors+offset or 19:30 venue-local)", "fallback": "7:30 PM" },
+        { "name": "lock_time_local", "source": "computed (ticket/show time + 20 min or 19:30 venue-local)", "fallback": "7:30 PM" },
         { "name": "picks_secured", "source": "picks where showDate=first_show + hasNonEmptyPicksObject", "fallback": false }
       ]
     },
@@ -256,7 +256,7 @@
       "family": "show_calendar",
       "priority": "P0",
       "automation": "automated",
-      "schedule": "every 15min on show days, venue-local T-3h through lock (per-show lock from doors+offset or 19:30 fallback)",
+      "schedule": "every 15min on show days, venue-local T-3h through lock (per-show lock from ticket/show time + 20 min or 19:30 fallback)",
       "audience": "users_no_picks_tonight",
       "channels": ["inApp", "push", "email"],
       "prefKeys": ["reminders"],
@@ -272,7 +272,7 @@
         { "name": "venue_name", "source": "show_calendar", "fallback": null },
         { "name": "venue_city", "source": "show_calendar", "fallback": null },
         { "name": "time_to_lock", "source": "computed at send time", "fallback": null },
-        { "name": "lock_time_local", "source": "computed (doors+offset or 19:30 venue-local)", "fallback": "7:30 PM" },
+        { "name": "lock_time_local", "source": "computed (ticket/show time + 20 min or 19:30 venue-local)", "fallback": "7:30 PM" },
         { "name": "picks_secured", "source": "preview/edge only — production fanout skips users with picks", "fallback": false }
       ]
     },

--- a/functions/phishnetLiveSetlistAutomation.js
+++ b/functions/phishnetLiveSetlistAutomation.js
@@ -219,7 +219,7 @@ function parseShowCalendarSnapshotToShows(snapshotData) {
             ? item.timezone.trim()
             : ""
         : "";
-    /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour_name?: string, tour?: string, doorsLocal?: string, picksLockLocal?: string }} */
+    /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour_name?: string, tour?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string }} */
     const show = { date, timeZone: explicitTz || DEFAULT_SHOW_TIME_ZONE };
     if (item && typeof item === "object") {
       if (typeof item.venue === "string" && item.venue.trim()) {
@@ -236,6 +236,12 @@ function parseShowCalendarSnapshotToShows(snapshotData) {
       }
       if (typeof item.doorsLocal === "string" && item.doorsLocal.trim()) {
         show.doorsLocal = item.doorsLocal.trim();
+      }
+      if (
+        typeof item.scheduledStartLocal === "string" &&
+        item.scheduledStartLocal.trim()
+      ) {
+        show.scheduledStartLocal = item.scheduledStartLocal.trim();
       }
       if (typeof item.picksLockLocal === "string" && item.picksLockLocal.trim()) {
         show.picksLockLocal = item.picksLockLocal.trim();
@@ -304,7 +310,7 @@ function parseShowCalendarSnapshotToShowsByTour(snapshotData) {
           : typeof item.timezone === "string" && item.timezone.trim()
             ? item.timezone.trim()
             : "";
-      /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour?: string, tour_name?: string, doorsLocal?: string, picksLockLocal?: string }} */
+      /** @type {{ date: string, timeZone: string, venue?: string, city?: string, tour?: string, tour_name?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string }} */
       const show = {
         date,
         timeZone: explicitTz || DEFAULT_SHOW_TIME_ZONE,
@@ -319,6 +325,12 @@ function parseShowCalendarSnapshotToShowsByTour(snapshotData) {
       }
       if (typeof item.doorsLocal === "string" && item.doorsLocal.trim()) {
         show.doorsLocal = item.doorsLocal.trim();
+      }
+      if (
+        typeof item.scheduledStartLocal === "string" &&
+        item.scheduledStartLocal.trim()
+      ) {
+        show.scheduledStartLocal = item.scheduledStartLocal.trim();
       }
       if (typeof item.picksLockLocal === "string" && item.picksLockLocal.trim()) {
         show.picksLockLocal = item.picksLockLocal.trim();

--- a/functions/picksLockReminder.js
+++ b/functions/picksLockReminder.js
@@ -54,7 +54,7 @@ function localClockParts(showTimeZone, now) {
 }
 
 /**
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null | undefined} show
+ * @param {{ date?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string } | null | undefined} show
  * @returns {number} minutes from midnight
  */
 function lockMinutesForShow(show) {
@@ -66,7 +66,7 @@ function lockMinutesForShow(show) {
  * @param {string} showYmd
  * @param {string} showTimeZone
  * @param {Date} now
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null} [show]
+ * @param {{ date?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string } | null} [show]
  */
 function isPastPicksLock(showYmd, showTimeZone, now, show = null) {
   const clock = localClockParts(showTimeZone, now);
@@ -81,7 +81,7 @@ function isPastPicksLock(showYmd, showTimeZone, now, show = null) {
  * @param {string} showYmd
  * @param {string} showTimeZone
  * @param {Date} now
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null} [show]
+ * @param {{ date?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string } | null} [show]
  */
 function isWithinReminderWindow(showYmd, showTimeZone, now, show = null) {
   const clock = localClockParts(showTimeZone, now);
@@ -95,7 +95,7 @@ function isWithinReminderWindow(showYmd, showTimeZone, now, show = null) {
  * @param {string} showYmd `YYYY-MM-DD`
  * @param {string} showTimeZone IANA tz
  * @param {Date} now
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null} [show]
+ * @param {{ date?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string } | null} [show]
  * @returns {string}
  */
 function formatTimeToLock(showYmd, showTimeZone, now, show = null) {
@@ -114,7 +114,7 @@ function formatTimeToLock(showYmd, showTimeZone, now, show = null) {
 }
 
 /**
- * @param {Array<{ date: string, timeZone?: string, venue?: string, city?: string, doorsLocal?: string, picksLockLocal?: string }>} calendarShows
+ * @param {Array<{ date: string, timeZone?: string, venue?: string, city?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string }>} calendarShows
  * @param {Date} now
  * @returns {{ showDate: string, timeZone: string, venue_name: string, venue_city: string, lock_time_local: string, show: object } | null}
  */

--- a/functions/picksLockTime.js
+++ b/functions/picksLockTime.js
@@ -6,8 +6,7 @@
  */
 
 const DEFAULT_PICKS_LOCK_HM = Object.freeze({ hour: 19, minute: 30 });
-const TOUR_AVG_DOORS_TO_START_MIN = 119;
-const PICKS_LOCK_SAFETY_MIN = 34;
+const PICKS_LOCK_AFTER_START_MIN = 20;
 
 const SHOW_DOORS_LOCAL_BY_DATE = Object.freeze({
   "2026-07-18": "17:30",
@@ -23,6 +22,22 @@ const SHOW_DOORS_LOCAL_BY_DATE = Object.freeze({
   "2026-09-04": "18:00",
   "2026-09-05": "18:00",
   "2026-09-06": "18:00",
+});
+
+const SHOW_SCHEDULED_START_LOCAL_BY_DATE = Object.freeze({
+  "2026-07-18": "19:00",
+  "2026-07-19": "19:00",
+  "2026-07-21": "19:00",
+  "2026-07-22": "20:00",
+  "2026-07-24": "20:00",
+  "2026-07-25": "20:00",
+  "2026-07-27": "20:00",
+  "2026-07-29": "20:00",
+  "2026-07-31": "19:00",
+  "2026-08-01": "19:00",
+  "2026-09-04": "19:30",
+  "2026-09-05": "19:30",
+  "2026-09-06": "19:30",
 });
 
 /**
@@ -93,75 +108,93 @@ function formatLockTimeLocalLabel(hm) {
 }
 
 /**
- * @param {{ hour: number, minute: number }} doors
- * @param {{ tourAvgDoorsToStartMin?: number, safetyMin?: number }} [opts]
+ * @param {{ hour: number, minute: number }} start
+ * @param {{ afterStartMin?: number }} [opts]
  */
-function lockHmFromDoors(
-  doors,
-  {
-    tourAvgDoorsToStartMin = TOUR_AVG_DOORS_TO_START_MIN,
-    safetyMin = PICKS_LOCK_SAFETY_MIN,
-  } = {}
+function lockHmFromScheduledStart(
+  start,
+  { afterStartMin = PICKS_LOCK_AFTER_START_MIN } = {}
 ) {
-  const offset = Math.max(0, tourAvgDoorsToStartMin - safetyMin);
-  const total = doors.hour * 60 + doors.minute + offset;
+  const offset = Math.max(0, afterStartMin);
+  const total = start.hour * 60 + start.minute + offset;
   const wrapped = ((total % (24 * 60)) + 24 * 60) % (24 * 60);
   return { hour: Math.floor(wrapped / 60), minute: wrapped % 60 };
 }
 
 /**
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null | undefined} show
  * @param {{
+ *   date?: string,
+ *   doorsLocal?: string,
+ *   scheduledStartLocal?: string,
+ *   picksLockLocal?: string,
+ * } | null | undefined} show
+ * @param {{
+ *   startByDate?: Record<string, string>,
  *   doorsByDate?: Record<string, string>,
- *   tourAvgDoorsToStartMin?: number,
- *   safetyMin?: number,
+ *   afterStartMin?: number,
  *   fallback?: { hour: number, minute: number },
  * }} [opts]
  */
 function resolvePicksLockHm(show, opts = {}) {
   const fallback = opts.fallback ?? DEFAULT_PICKS_LOCK_HM;
+  const startByDate = opts.startByDate ?? SHOW_SCHEDULED_START_LOCAL_BY_DATE;
   const doorsByDate = opts.doorsByDate ?? SHOW_DOORS_LOCAL_BY_DATE;
+
+  const date = typeof show?.date === "string" ? show.date.trim() : "";
+  const doorsParsed = parseLocalHm(
+    (typeof show?.doorsLocal === "string" && show.doorsLocal.trim()) ||
+      (date && doorsByDate[date]) ||
+      null
+  );
+  const doorsLocal = doorsParsed ? formatLocalHm24(doorsParsed) : null;
 
   const explicitLock = parseLocalHm(show?.picksLockLocal);
   if (explicitLock) {
+    const start = parseLocalHm(
+      typeof show?.scheduledStartLocal === "string"
+        ? show.scheduledStartLocal.trim()
+        : null
+    );
     return {
       ...explicitLock,
       source: "picksLockLocal",
-      doorsLocal:
-        typeof show?.doorsLocal === "string" ? show.doorsLocal.trim() || null : null,
+      scheduledStartLocal: start ? formatLocalHm24(start) : null,
+      doorsLocal,
     };
   }
 
-  const date = typeof show?.date === "string" ? show.date.trim() : "";
-  const doorsRaw =
-    (typeof show?.doorsLocal === "string" && show.doorsLocal.trim()) ||
-    (date && doorsByDate[date]) ||
-    null;
-  const doors = parseLocalHm(doorsRaw);
-  if (doors) {
-    const lock = lockHmFromDoors(doors, opts);
+  const start = parseLocalHm(
+    (typeof show?.scheduledStartLocal === "string" &&
+      show.scheduledStartLocal.trim()) ||
+      (date && startByDate[date]) ||
+      null
+  );
+  if (start) {
+    const lock = lockHmFromScheduledStart(start, opts);
     return {
       ...lock,
-      source: "doors",
-      doorsLocal: formatLocalHm24(doors),
+      source: "scheduledStart",
+      scheduledStartLocal: formatLocalHm24(start),
+      doorsLocal,
     };
   }
 
   return {
     ...fallback,
     source: "fallback",
-    doorsLocal: null,
+    scheduledStartLocal: null,
+    doorsLocal,
   };
 }
 
 module.exports = {
   DEFAULT_PICKS_LOCK_HM,
-  PICKS_LOCK_SAFETY_MIN,
+  PICKS_LOCK_AFTER_START_MIN,
   SHOW_DOORS_LOCAL_BY_DATE,
-  TOUR_AVG_DOORS_TO_START_MIN,
+  SHOW_SCHEDULED_START_LOCAL_BY_DATE,
   formatLocalHm24,
   formatLockTimeLocalLabel,
-  lockHmFromDoors,
+  lockHmFromScheduledStart,
   parseLocalHm,
   resolvePicksLockHm,
 };

--- a/functions/picksLockTime.test.js
+++ b/functions/picksLockTime.test.js
@@ -4,27 +4,29 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const {
   DEFAULT_PICKS_LOCK_HM,
-  lockHmFromDoors,
+  lockHmFromScheduledStart,
   resolvePicksLockHm,
 } = require("./picksLockTime");
 
-test("lockHmFromDoors uses doors+85 for Summer Tour 2026 defaults", () => {
-  assert.deepEqual(lockHmFromDoors({ hour: 17, minute: 30 }), {
-    hour: 18,
-    minute: 55,
+test("lockHmFromScheduledStart uses start+20", () => {
+  assert.deepEqual(lockHmFromScheduledStart({ hour: 19, minute: 0 }), {
+    hour: 19,
+    minute: 20,
   });
 });
 
 test("resolvePicksLockHm seeds Merriweather and falls back", () => {
   assert.deepEqual(resolvePicksLockHm({ date: "2026-07-18" }), {
-    hour: 18,
-    minute: 55,
-    source: "doors",
+    hour: 19,
+    minute: 20,
+    source: "scheduledStart",
+    scheduledStartLocal: "19:00",
     doorsLocal: "17:30",
   });
   assert.deepEqual(resolvePicksLockHm({ date: "2099-01-01" }), {
     ...DEFAULT_PICKS_LOCK_HM,
     source: "fallback",
+    scheduledStartLocal: null,
     doorsLocal: null,
   });
 });

--- a/functions/showFinalizationGate.js
+++ b/functions/showFinalizationGate.js
@@ -64,6 +64,7 @@ function isPastPicksLock(
           date:
             typeof showOrLockHm.date === "string" ? showOrLockHm.date : showYmd,
           doorsLocal: showOrLockHm.doorsLocal,
+          scheduledStartLocal: showOrLockHm.scheduledStartLocal,
           picksLockLocal: showOrLockHm.picksLockLocal,
         })
       : resolvePicksLockHm({ date: showYmd });

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,10 @@
       "devDependencies": {
         "@firebase/rules-unit-testing": "^3.0.4",
         "@vitejs/plugin-react": "^6.0.4",
-        "autoprefixer": "^10.4.14",
+        "autoprefixer": "^10.5.4",
         "eslint": "^10.8.0",
         "eslint-plugin-import-x": "^4.17.1",
-        "playwright": "^1.59.1",
+        "playwright": "^1.62.0",
         "postcss": "^8.4.27",
         "sharp": "^0.35.3",
         "tailwindcss": "^3.3.3",
@@ -2881,9 +2881,9 @@
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.27",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
-      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+      "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
       "dev": true,
       "funding": [
         {
@@ -2901,8 +2901,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.1",
-        "caniuse-lite": "^1.0.30001774",
+        "browserslist": "^4.28.6",
+        "caniuse-lite": "^1.0.30001806",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -2958,9 +2958,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.10",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
-      "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.6.tgz",
+      "integrity": "sha512-69D/imtToCsIcAl8WBS2YaRwA4jO/j0HhU+hELqMEu9f54MoUtI6+XH5mrKU8rEFNEk/Ui1I2MK4/JkWacclGw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3019,9 +3019,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -3039,11 +3039,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3093,9 +3093,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001780",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
-      "integrity": "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -3461,9 +3461,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.321",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
-      "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
+      "version": "1.5.397",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.397.tgz",
+      "integrity": "sha512-khGTy9U9x02KEtsKM8vx5A62BsRmcOsIgDpWr1ImE32Ax8GxHGPHZf+Eu9H8zOOyHJnB0jTbseyTHbq2XCT8yw==",
       "dev": true,
       "license": "ISC"
     },
@@ -6398,11 +6398,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -6624,35 +6627,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "setlistpickem",
-  "version": "1.39.7",
+  "version": "1.40.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setlistpickem",
-      "version": "1.39.7",
+      "version": "1.40.1",
       "dependencies": {
-        "@tanstack/react-query": "^5.0.0",
+        "@tanstack/react-query": "^5.101.4",
         "firebase": "10.14.1",
         "firebase-admin": "^13.0.0",
-        "lucide-react": "^1.7.0",
+        "lucide-react": "^1.27.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-ga4": "^3.0.1",
@@ -2019,9 +2019,9 @@
       "license": "MIT"
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.94.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.94.5.tgz",
-      "integrity": "sha512-Vx1JJiBURW/wdNGP45afjrqn0LfxYwL7K/bSrQvNRtyLGF1bxQPgUXCpzscG29e+UeFOh9hz1KOVala0N+bZiA==",
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2029,12 +2029,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.94.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.94.5.tgz",
-      "integrity": "sha512-1wmrxKFkor+q8l+ygdHmv0Sq5g84Q3p4xvuJ7AdSIAhQQ7udOt+ZSZ19g1Jea3mHqtlTslLGJsmC4vHFgP0P3A==",
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.94.5"
+        "@tanstack/query-core": "5.101.4"
       },
       "funding": {
         "type": "github",
@@ -5597,9 +5597,9 @@
       "license": "ISC"
     },
     "node_modules/lucide-react": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
-      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.27.0.tgz",
+      "integrity": "sha512-rJicGl/3Fly/E0rOH1YmPZ6e49JCnKknh1ox1vpHnkfjujAkKA6sqUZvH3MTAaXXjgexyUwgNwTJzTtYuAFYJw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.40.1",
+  "version": "1.40.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -62,10 +62,10 @@
   "devDependencies": {
     "@firebase/rules-unit-testing": "^3.0.4",
     "@vitejs/plugin-react": "^6.0.4",
-    "autoprefixer": "^10.4.14",
+    "autoprefixer": "^10.5.4",
     "eslint": "^10.8.0",
     "eslint-plugin-import-x": "^4.17.1",
-    "playwright": "^1.59.1",
+    "playwright": "^1.62.0",
     "postcss": "^8.4.27",
     "sharp": "^0.35.3",
     "tailwindcss": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
     "emails:preview": "npm run preview --prefix emails"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.0.0",
+    "@tanstack/react-query": "^5.101.4",
     "firebase": "10.14.1",
     "firebase-admin": "^13.0.0",
-    "lucide-react": "^1.7.0",
+    "lucide-react": "^1.27.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-ga4": "^3.0.1",

--- a/src/features/admin/ui/AdminForm.jsx
+++ b/src/features/admin/ui/AdminForm.jsx
@@ -114,6 +114,7 @@ export default function AdminForm({ user, selectedDate }) {
         onChange={setWarRoomShowDate}
         disabled={isSaving}
         timeZone={warRoomTimeZone}
+        show={warRoomShow}
       />
       <AdminClaimBootstrap user={user} />
       <Card variant="danger" padding="sm" className="mb-6 mt-4">

--- a/src/features/admin/ui/AdminPicksLockControls.jsx
+++ b/src/features/admin/ui/AdminPicksLockControls.jsx
@@ -15,7 +15,7 @@ export default function AdminPicksLockControls({
   const canLock = showStatus === 'NEXT' && !picksAlreadyLocked && !disabled;
 
   let helperText =
-    'Picks lock at doors + ~1:25 (tour avg start − safety), at fallback 7:30 PM venue-local when doors are unknown, when set 1 starts on Phish.net, or when you lock them here.';
+    'Picks lock 20 minutes after the published ticket/show time (Phish.com), at fallback 7:30 PM venue-local when show time is unknown, when set 1 starts on Phish.net, or when you lock them here.';
   if (showStatus && showStatus !== 'NEXT') {
     helperText = 'Lock picks now is only available while this show is NEXT (before wall-clock lock).';
   } else if (adminLockActive) {

--- a/src/features/admin/ui/AdminWarRoomShowDate.jsx
+++ b/src/features/admin/ui/AdminWarRoomShowDate.jsx
@@ -9,22 +9,29 @@ import {
  * Admin-only: pick the Firestore `official_setlists/{showDate}` key independently of the
  * global dashboard tour picker (which may omit past legs or reset to “next show”).
  *
- * @param {{ value: string, onChange: (ymd: string) => void, disabled?: boolean, timeZone: string }} props
+ * @param {{
+ *   value: string,
+ *   onChange: (ymd: string) => void,
+ *   disabled?: boolean,
+ *   timeZone: string,
+ *   show?: { date?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string } | null,
+ * }} props
  */
 export default function AdminWarRoomShowDate({
   value,
   onChange,
   disabled = false,
   timeZone,
+  show = null,
 }) {
-  const lockHm = resolvePicksLockHm({ date: value });
+  const lockHm = resolvePicksLockHm(show || { date: value });
   const lockTimeLabel = formatLockTimeLocalLabel(lockHm);
   const lockSourceNote =
-    lockHm.source === 'doors'
-      ? `doors ${lockHm.doorsLocal} + tour avg − safety`
+    lockHm.source === 'scheduledStart'
+      ? `published ticket time ${lockHm.scheduledStartLocal} + 20 min`
       : lockHm.source === 'picksLockLocal'
         ? 'explicit picksLockLocal'
-        : 'fallback 7:30 PM (doors unknown)';
+        : 'fallback 7:30 PM (ticket time unknown)';
 
   return (
     <div className="rounded-xl border border-border-subtle bg-[rgb(var(--surface-field)_/_0.35)] px-4 py-3 ring-1 ring-border-glass/20">

--- a/src/features/picks/ui/PicksLockTimingBanner.jsx
+++ b/src/features/picks/ui/PicksLockTimingBanner.jsx
@@ -2,8 +2,7 @@ import React, { useState } from 'react';
 import { Clock3, X } from 'lucide-react';
 
 import {
-  PICKS_LOCK_SAFETY_MIN,
-  TOUR_AVG_DOORS_TO_START_MIN,
+  PICKS_LOCK_AFTER_START_MIN,
   formatLockTimeLocalLabel,
   parseLocalHm,
   resolvePicksLockHm,
@@ -19,21 +18,26 @@ function durationWords(minutes) {
 }
 
 /**
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string, picksLockSource?: string } | null | undefined} show
+ * @param {{
+ *   date?: string,
+ *   doorsLocal?: string,
+ *   scheduledStartLocal?: string,
+ *   picksLockLocal?: string,
+ *   picksLockSource?: string,
+ * } | null | undefined} show
  */
 export function buildPicksLockTimingMessage(show) {
   const lock = resolvePicksLockHm(show);
   const lockLabel = formatLockTimeLocalLabel(lock);
-  const doors = parseLocalHm(lock.doorsLocal);
-  const isDoorsBased =
-    lock.source === 'doors' || show?.picksLockSource === 'doors';
+  const start = parseLocalHm(lock.scheduledStartLocal);
+  const isStartBased =
+    lock.source === 'scheduledStart' ||
+    show?.picksLockSource === 'scheduledStart';
 
-  if (doors && isDoorsBased) {
-    const offsetMinutes =
-      TOUR_AVG_DOORS_TO_START_MIN - PICKS_LOCK_SAFETY_MIN;
+  if (start && isStartBased) {
     return `Picks lock at ${lockLabel} — ${durationWords(
-      offsetMinutes
-    )} after tonight’s published doors time (${formatLockTimeLocalLabel(doors)}).`;
+      PICKS_LOCK_AFTER_START_MIN
+    )} after tonight’s published ticket time (${formatLockTimeLocalLabel(start)}).`;
   }
 
   return `Picks lock at ${lockLabel} venue-local.`;
@@ -65,7 +69,13 @@ function rememberDismissal(showDate) {
  * Small pre-lock timing notice shared by Picks and Standings.
  *
  * @param {{
- *   show: { date?: string, doorsLocal?: string, picksLockLocal?: string, picksLockSource?: string } | null | undefined,
+ *   show: {
+ *     date?: string,
+ *     doorsLocal?: string,
+ *     scheduledStartLocal?: string,
+ *     picksLockLocal?: string,
+ *     picksLockSource?: string,
+ *   } | null | undefined,
  *   showStatus: string | null | undefined
  * }} props
  */

--- a/src/features/picks/ui/PicksLockTimingBanner.test.js
+++ b/src/features/picks/ui/PicksLockTimingBanner.test.js
@@ -3,20 +3,21 @@ import { describe, expect, it } from 'vitest';
 import { buildPicksLockTimingMessage } from './PicksLockTimingBanner';
 
 describe('buildPicksLockTimingMessage', () => {
-  it('explains the doors-based lock for tonight', () => {
+  it('explains the ticket-time-based lock for tonight', () => {
     expect(
       buildPicksLockTimingMessage({
         date: '2026-07-18',
         doorsLocal: '17:30',
-        picksLockLocal: '18:55',
-        picksLockSource: 'doors',
+        scheduledStartLocal: '19:00',
+        picksLockLocal: '19:20',
+        picksLockSource: 'scheduledStart',
       })
     ).toBe(
-      'Picks lock at 6:55 PM — 1 hour 25 minutes after tonight’s published doors time (5:30 PM).'
+      'Picks lock at 7:20 PM — 20 minutes after tonight’s published ticket time (7:00 PM).'
     );
   });
 
-  it('shows only the venue-local fallback when doors are unknown', () => {
+  it('shows only the venue-local fallback when show time is unknown', () => {
     expect(buildPicksLockTimingMessage({ date: '2099-01-01' })).toBe(
       'Picks lock at 7:30 PM venue-local.'
     );

--- a/src/features/show-calendar/model/normalizeShowCalendarDoc.js
+++ b/src/features/show-calendar/model/normalizeShowCalendarDoc.js
@@ -3,14 +3,14 @@ import { resolveShowTimeZone } from '../../../shared/utils/showTimeZone';
 
 /**
  * @param {Record<string, unknown>} s
- * @returns {{ date: string, venue: string, timeZone: string, doorsLocal?: string, picksLockLocal?: string, picksLockSource?: string } | null}
+ * @returns {{ date: string, venue: string, timeZone: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string, picksLockSource?: string } | null}
  */
 function normalizeShowRow(s) {
   if (!s || typeof s !== 'object') return null;
   const date = typeof s.date === 'string' ? s.date.trim() : '';
   const venue = typeof s.venue === 'string' ? s.venue.trim() : '';
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || !venue) return null;
-  /** @type {{ date: string, venue: string, timeZone: string, doorsLocal?: string, picksLockLocal?: string }} */
+  /** @type {{ date: string, venue: string, timeZone: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string }} */
   const base = {
     date,
     venue,
@@ -21,6 +21,9 @@ function normalizeShowRow(s) {
   if (typeof s.doorsLocal === 'string' && s.doorsLocal.trim()) {
     base.doorsLocal = s.doorsLocal.trim();
   }
+  if (typeof s.scheduledStartLocal === 'string' && s.scheduledStartLocal.trim()) {
+    base.scheduledStartLocal = s.scheduledStartLocal.trim();
+  }
   if (typeof s.picksLockLocal === 'string' && s.picksLockLocal.trim()) {
     base.picksLockLocal = s.picksLockLocal.trim();
   }
@@ -29,9 +32,9 @@ function normalizeShowRow(s) {
 
 /**
  * Validates Firestore `show_calendar/snapshot` written by Cloud Functions (issue #160).
- * Enriches each show with `doorsLocal` / `picksLockLocal` (#522 doors-based lock).
+ * Enriches each show with `scheduledStartLocal` / `picksLockLocal` (#522 ticket-time lock).
  * @param {import('firebase/firestore').DocumentData | null | undefined} data
- * @returns {{ showDatesByTour: { tour: string, shows: { date: string, venue: string, timeZone: string, doorsLocal?: string, picksLockLocal?: string }[] }[], showDates: { date: string, venue: string, timeZone: string, doorsLocal?: string, picksLockLocal?: string }[], syncError?: string | null } | null}
+ * @returns {{ showDatesByTour: { tour: string, shows: { date: string, venue: string, timeZone: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string }[] }[], showDates: { date: string, venue: string, timeZone: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string }[], syncError?: string | null } | null}
  */
 export function normalizeShowCalendarDoc(data) {
   if (!data || typeof data !== 'object') return null;

--- a/src/shared/utils/picksLockTime.js
+++ b/src/shared/utils/picksLockTime.js
@@ -1,9 +1,9 @@
 /**
  * Per-show picks wall-clock lock (#522).
  *
- * When doors are known: lock = doors + (tourAvgDoorsToStart − safety).
- * Summer Tour 2026 setlist.fm avg doors→start is 1h59m (119); safety 34 → doors+85 (1h25).
- * Fallback when doors unknown: 19:30 venue-local.
+ * When advertised ticket/show time is known (Phish.com `Show Time` →
+ * `scheduledStartLocal`): lock = start + PICKS_LOCK_AFTER_START_MIN.
+ * Fallback when show time unknown: 19:30 venue-local.
  */
 
 /** @type {{ hour: number, minute: number }} */
@@ -13,16 +13,12 @@ export const DEFAULT_PICKS_LOCK_HM = Object.freeze({ hour: 19, minute: 30 });
 export const SHOW_PICKS_LOCK_HOUR_LOCAL = DEFAULT_PICKS_LOCK_HM.hour;
 export const SHOW_PICKS_LOCK_MINUTE_LOCAL = DEFAULT_PICKS_LOCK_HM.minute;
 
-/** setlist.fm Summer Tour 2026 “Avg start time after doors”. */
-export const TOUR_AVG_DOORS_TO_START_MIN = 119;
-
-/** Minutes before average start to lock picks (doors+85 when avg is 119). */
-export const PICKS_LOCK_SAFETY_MIN = 34;
+/** Minutes after published ticket/show time to lock picks. */
+export const PICKS_LOCK_AFTER_START_MIN = 20;
 
 /**
- * Known doors times (venue-local 24h `HH:mm`) from setlist.fm / tickets.
- * Ops: extend as future dates publish. Calendar fields `doorsLocal` /
- * `picksLockLocal` override this seed when present.
+ * Known doors times (venue-local 24h `HH:mm`) from Phish.com / tickets.
+ * Informational + War Room context; no longer drives the lock formula.
  *
  * @type {Readonly<Record<string, string>>}
  */
@@ -40,6 +36,29 @@ export const SHOW_DOORS_LOCAL_BY_DATE = Object.freeze({
   '2026-09-04': '18:00', // Dick's
   '2026-09-05': '18:00',
   '2026-09-06': '18:00',
+});
+
+/**
+ * Known advertised show/ticket times (venue-local 24h `HH:mm`) from Phish.com.
+ * Calendar field `scheduledStartLocal` overrides this seed when present.
+ * Ops: extend as future dates publish.
+ *
+ * @type {Readonly<Record<string, string>>}
+ */
+export const SHOW_SCHEDULED_START_LOCAL_BY_DATE = Object.freeze({
+  '2026-07-18': '19:00', // Merriweather
+  '2026-07-19': '19:00',
+  '2026-07-21': '19:00', // Syracuse
+  '2026-07-22': '20:00', // MSG
+  '2026-07-24': '20:00',
+  '2026-07-25': '20:00',
+  '2026-07-27': '20:00',
+  '2026-07-29': '20:00',
+  '2026-07-31': '19:00', // Fenway
+  '2026-08-01': '19:00',
+  '2026-09-04': '19:30', // Dick's
+  '2026-09-05': '19:30',
+  '2026-09-06': '19:30',
 });
 
 /**
@@ -110,19 +129,16 @@ export function formatLockTimeLocalLabel(hm) {
 }
 
 /**
- * @param {{ hour: number, minute: number }} doors
- * @param {{ tourAvgDoorsToStartMin?: number, safetyMin?: number }} [opts]
+ * @param {{ hour: number, minute: number }} start
+ * @param {{ afterStartMin?: number }} [opts]
  * @returns {{ hour: number, minute: number }}
  */
-export function lockHmFromDoors(
-  doors,
-  {
-    tourAvgDoorsToStartMin = TOUR_AVG_DOORS_TO_START_MIN,
-    safetyMin = PICKS_LOCK_SAFETY_MIN,
-  } = {}
+export function lockHmFromScheduledStart(
+  start,
+  { afterStartMin = PICKS_LOCK_AFTER_START_MIN } = {}
 ) {
-  const offset = Math.max(0, tourAvgDoorsToStartMin - safetyMin);
-  const total = doors.hour * 60 + doors.minute + offset;
+  const offset = Math.max(0, afterStartMin);
+  const total = start.hour * 60 + start.minute + offset;
   const wrapped = ((total % (24 * 60)) + 24 * 60) % (24 * 60);
   return { hour: Math.floor(wrapped / 60), minute: wrapped % 60 };
 }
@@ -132,61 +148,100 @@ export function lockHmFromDoors(
  *
  * Priority:
  * 1. `show.picksLockLocal` (materialized / override)
- * 2. `show.doorsLocal` or seeded doors for `show.date` → doors + (avg − safety)
+ * 2. `show.scheduledStartLocal` or seeded show time for `show.date` → start + 20
  * 3. Default 19:30
  *
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | null | undefined} show
  * @param {{
+ *   date?: string,
+ *   doorsLocal?: string,
+ *   scheduledStartLocal?: string,
+ *   picksLockLocal?: string,
+ * } | null | undefined} show
+ * @param {{
+ *   startByDate?: Record<string, string>,
  *   doorsByDate?: Record<string, string>,
- *   tourAvgDoorsToStartMin?: number,
- *   safetyMin?: number,
+ *   afterStartMin?: number,
  *   fallback?: { hour: number, minute: number },
  * }} [opts]
- * @returns {{ hour: number, minute: number, source: 'picksLockLocal' | 'doors' | 'fallback', doorsLocal: string | null }}
+ * @returns {{
+ *   hour: number,
+ *   minute: number,
+ *   source: 'picksLockLocal' | 'scheduledStart' | 'fallback',
+ *   scheduledStartLocal: string | null,
+ *   doorsLocal: string | null,
+ * }}
  */
 export function resolvePicksLockHm(show, opts = {}) {
   const fallback = opts.fallback ?? DEFAULT_PICKS_LOCK_HM;
+  const startByDate = opts.startByDate ?? SHOW_SCHEDULED_START_LOCAL_BY_DATE;
   const doorsByDate = opts.doorsByDate ?? SHOW_DOORS_LOCAL_BY_DATE;
+
+  const date = typeof show?.date === 'string' ? show.date.trim() : '';
+  const doorsParsed = parseLocalHm(
+    (typeof show?.doorsLocal === 'string' && show.doorsLocal.trim()) ||
+      (date && doorsByDate[date]) ||
+      null
+  );
+  const doorsLocal = doorsParsed ? formatLocalHm24(doorsParsed) : null;
 
   const explicitLock = parseLocalHm(show?.picksLockLocal);
   if (explicitLock) {
+    const start = parseLocalHm(
+      typeof show?.scheduledStartLocal === 'string'
+        ? show.scheduledStartLocal.trim()
+        : null
+    );
     return {
       ...explicitLock,
       source: 'picksLockLocal',
-      doorsLocal: typeof show?.doorsLocal === 'string' ? show.doorsLocal.trim() || null : null,
+      scheduledStartLocal: start ? formatLocalHm24(start) : null,
+      doorsLocal,
     };
   }
 
-  const date = typeof show?.date === 'string' ? show.date.trim() : '';
-  const doorsRaw =
-    (typeof show?.doorsLocal === 'string' && show.doorsLocal.trim()) ||
-    (date && doorsByDate[date]) ||
-    null;
-  const doors = parseLocalHm(doorsRaw);
-  if (doors) {
-    const lock = lockHmFromDoors(doors, opts);
+  const start = parseLocalHm(
+    (typeof show?.scheduledStartLocal === 'string' &&
+      show.scheduledStartLocal.trim()) ||
+      (date && startByDate[date]) ||
+      null
+  );
+  if (start) {
+    const lock = lockHmFromScheduledStart(start, opts);
     return {
       ...lock,
-      source: 'doors',
-      doorsLocal: formatLocalHm24(doors),
+      source: 'scheduledStart',
+      scheduledStartLocal: formatLocalHm24(start),
+      doorsLocal,
     };
   }
 
   return {
     ...fallback,
     source: 'fallback',
-    doorsLocal: null,
+    scheduledStartLocal: null,
+    doorsLocal,
   };
 }
 
 /**
  * Enrich a show row with resolved lock fields (idempotent).
- * @param {{ date: string, venue?: string, timeZone?: string, doorsLocal?: string, picksLockLocal?: string }} show
+ * @param {{
+ *   date: string,
+ *   venue?: string,
+ *   timeZone?: string,
+ *   doorsLocal?: string,
+ *   scheduledStartLocal?: string,
+ *   picksLockLocal?: string,
+ * }} show
  */
 export function enrichShowWithPicksLock(show) {
   if (!show || typeof show !== 'object') return show;
   const resolved = resolvePicksLockHm(show);
-  if (resolved.source === 'fallback') return { ...show };
+  if (resolved.source === 'fallback') {
+    const out = { ...show };
+    if (resolved.doorsLocal && !out.doorsLocal) out.doorsLocal = resolved.doorsLocal;
+    return out;
+  }
 
   const enriched = {
     ...show,
@@ -195,5 +250,8 @@ export function enrichShowWithPicksLock(show) {
   };
   const doorsLocal = show.doorsLocal || resolved.doorsLocal;
   if (doorsLocal) enriched.doorsLocal = doorsLocal;
+  const scheduledStartLocal =
+    show.scheduledStartLocal || resolved.scheduledStartLocal;
+  if (scheduledStartLocal) enriched.scheduledStartLocal = scheduledStartLocal;
   return enriched;
 }

--- a/src/shared/utils/picksLockTime.test.js
+++ b/src/shared/utils/picksLockTime.test.js
@@ -4,7 +4,7 @@ import {
   DEFAULT_PICKS_LOCK_HM,
   formatLockTimeLocalLabel,
   formatLocalHm24,
-  lockHmFromDoors,
+  lockHmFromScheduledStart,
   parseLocalHm,
   resolvePicksLockHm,
 } from './picksLockTime';
@@ -18,57 +18,75 @@ describe('parseLocalHm', () => {
   });
 });
 
-describe('lockHmFromDoors', () => {
-  it('locks doors+85 when avg=119 and safety=34', () => {
-    expect(lockHmFromDoors({ hour: 17, minute: 30 })).toEqual({ hour: 18, minute: 55 });
-    expect(lockHmFromDoors({ hour: 18, minute: 30 })).toEqual({ hour: 19, minute: 55 });
-    expect(lockHmFromDoors({ hour: 17, minute: 0 })).toEqual({ hour: 18, minute: 25 });
+describe('lockHmFromScheduledStart', () => {
+  it('locks start+20 by default', () => {
+    expect(lockHmFromScheduledStart({ hour: 19, minute: 0 })).toEqual({
+      hour: 19,
+      minute: 20,
+    });
+    expect(lockHmFromScheduledStart({ hour: 20, minute: 0 })).toEqual({
+      hour: 20,
+      minute: 20,
+    });
+    expect(lockHmFromScheduledStart({ hour: 19, minute: 30 })).toEqual({
+      hour: 19,
+      minute: 50,
+    });
   });
 });
 
 describe('resolvePicksLockHm (#522)', () => {
-  it('uses seeded doors for Merriweather / MSG / Fenway', () => {
+  it('uses seeded ticket/show time for Merriweather / MSG / Fenway', () => {
     expect(resolvePicksLockHm({ date: '2026-07-18' })).toMatchObject({
-      hour: 18,
-      minute: 55,
-      source: 'doors',
+      hour: 19,
+      minute: 20,
+      source: 'scheduledStart',
+      scheduledStartLocal: '19:00',
       doorsLocal: '17:30',
     });
     expect(resolvePicksLockHm({ date: '2026-07-22' })).toMatchObject({
-      hour: 19,
-      minute: 55,
-      source: 'doors',
+      hour: 20,
+      minute: 20,
+      source: 'scheduledStart',
+      scheduledStartLocal: '20:00',
     });
     expect(resolvePicksLockHm({ date: '2026-07-31' })).toMatchObject({
-      hour: 18,
-      minute: 25,
-      source: 'doors',
+      hour: 19,
+      minute: 20,
+      source: 'scheduledStart',
+      scheduledStartLocal: '19:00',
     });
   });
 
-  it('falls back to 19:30 when doors unknown', () => {
+  it('falls back to 19:30 when show time unknown', () => {
     expect(resolvePicksLockHm({ date: '2099-01-01' })).toEqual({
       ...DEFAULT_PICKS_LOCK_HM,
       source: 'fallback',
+      scheduledStartLocal: null,
       doorsLocal: null,
     });
   });
 
-  it('prefers picksLockLocal then doorsLocal on the show', () => {
+  it('prefers picksLockLocal then scheduledStartLocal on the show', () => {
     expect(
       resolvePicksLockHm({
         date: '2026-07-18',
         picksLockLocal: '19:40',
-        doorsLocal: '17:30',
+        scheduledStartLocal: '19:00',
       })
     ).toMatchObject({ hour: 19, minute: 40, source: 'picksLockLocal' });
 
     expect(
       resolvePicksLockHm({
         date: '2099-01-01',
-        doorsLocal: '18:00',
+        scheduledStartLocal: '19:30',
       })
-    ).toMatchObject({ hour: 19, minute: 25, source: 'doors', doorsLocal: '18:00' });
+    ).toMatchObject({
+      hour: 19,
+      minute: 50,
+      source: 'scheduledStart',
+      scheduledStartLocal: '19:30',
+    });
   });
 
   it('formats labels', () => {

--- a/src/shared/utils/timeLogic.js
+++ b/src/shared/utils/timeLogic.js
@@ -58,7 +58,7 @@ function showClockOnShowYmd(showYmd, showTimeZone, now = new Date()) {
  * @param {string} showYmd
  * @param {string} [showTimeZone]
  * @param {Date} [now]
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | { hour: number, minute: number } | null} [showOrLockHm]
+ * @param {{ date?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string } | { hour: number, minute: number } | null} [showOrLockHm]
  *   Show row (preferred) or explicit `{ hour, minute }` lock. Defaults to 19:30.
  */
 export function isPastPicksLock(
@@ -77,7 +77,7 @@ export function isPastPicksLock(
 
 /**
  * @param {string} showYmd
- * @param {{ date?: string, doorsLocal?: string, picksLockLocal?: string } | { hour: number, minute: number } | null | undefined} showOrLockHm
+ * @param {{ date?: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string } | { hour: number, minute: number } | null | undefined} showOrLockHm
  */
 function coercePicksLockHm(showYmd, showOrLockHm) {
   if (
@@ -87,6 +87,7 @@ function coercePicksLockHm(showYmd, showOrLockHm) {
     Number.isInteger(showOrLockHm.minute) &&
     showOrLockHm.date === undefined &&
     showOrLockHm.doorsLocal === undefined &&
+    showOrLockHm.scheduledStartLocal === undefined &&
     showOrLockHm.picksLockLocal === undefined
   ) {
     return { hour: showOrLockHm.hour, minute: showOrLockHm.minute };
@@ -95,6 +96,7 @@ function coercePicksLockHm(showYmd, showOrLockHm) {
     return resolvePicksLockHm({
       date: typeof showOrLockHm.date === 'string' ? showOrLockHm.date : showYmd,
       doorsLocal: showOrLockHm.doorsLocal,
+      scheduledStartLocal: showOrLockHm.scheduledStartLocal,
       picksLockLocal: showOrLockHm.picksLockLocal,
     });
   }
@@ -141,7 +143,7 @@ export function getShowBeforeDate(ymd, showDates) {
 
 /**
  * @param {string} selectedDate — YYYY-MM-DD
- * @param {{ date: string, doorsLocal?: string, picksLockLocal?: string }[]} showDates
+ * @param {{ date: string, doorsLocal?: string, scheduledStartLocal?: string, picksLockLocal?: string }[]} showDates
  */
 export const getShowStatus = (selectedDate, showDates) => {
   const nextShow = getNextShow(showDates);

--- a/src/shared/utils/timeLogic.test.js
+++ b/src/shared/utils/timeLogic.test.js
@@ -67,10 +67,10 @@ describe('venue-local lock + status (#278)', () => {
     expect(getShowStatus('2099-06-15', shows)).toBe('LIVE');
   });
 
-  it('locks Merriweather at doors+85 (6:55 PM ET) before fallback 7:30', () => {
+  it('locks Merriweather at ticket+20 (7:20 PM ET) after published show time', () => {
     vi.useFakeTimers();
-    // 2026-07-18 23:00Z = 7:00 PM ET → past 6:55 lock, before 7:30 fallback.
-    vi.setSystemTime(new Date('2026-07-18T23:00:00.000Z'));
+    // 2026-07-18 23:25Z = 7:25 PM ET → past 7:20 lock (seeded show 7:00 + 20).
+    vi.setSystemTime(new Date('2026-07-18T23:25:00.000Z'));
 
     const shows = [
       {
@@ -83,9 +83,9 @@ describe('venue-local lock + status (#278)', () => {
     expect(getShowStatus('2026-07-18', shows)).toBe('LIVE');
   });
 
-  it('keeps Merriweather NEXT at 6:45 PM ET (before doors+85 lock)', () => {
+  it('keeps Merriweather NEXT at 7:10 PM ET (before ticket+20 lock)', () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-07-18T22:45:00.000Z'));
+    vi.setSystemTime(new Date('2026-07-18T23:10:00.000Z'));
 
     const shows = [
       {


### PR DESCRIPTION
## Summary
Promote staging to production and release **v1.40.2**.

- **Picks lock hotfix (#774)** — wall clock moves from doors+(avg−safety) to **published Phish.com ticket/show time + 20 minutes**. Client + Functions + lock-reminder share the same resolver; timing banner / War Room copy updated. Fallback remains 7:30 PM venue-local.
- Staging also carries recent safe Dependabot bumps already merged to staging after v1.40.1.

## Test plan
- [x] Agent QA on #774: lint/test/dashboard-meta/dashboard-ui, functions lock tests, `npm run build`, local `qa:chunks` PASS
- [x] CI required checks on #774: `verify` + Vercel PASS (`functions` + `build` PASS)
- [ ] Note: CI `qa-runners` hung on `qa:cache` (WebChannel/`networkidle` — unrelated to lock formula); cancelled after local `qa:chunks` green
- [ ] Production Vercel deploy after merge
- [ ] Deploy Functions: `npm run deploy:functions:phishnet` so reminder fanout matches client lock
- [ ] Tag/release `v1.40.2` via `release:publish --confirm`


Made with [Cursor](https://cursor.com)