### PR TITLE
fix(qa): stop qa:cache hanging on Firestore networkidle

### DIFF
--- a/scripts/qa/_lib/qaAuthSplash.mjs
+++ b/scripts/qa/_lib/qaAuthSplash.mjs
@@ -10,8 +10,10 @@
  */
 export async function signInViaSplashEmailPassword(page, origin, email, password) {
   const base = origin.replace(/\/$/, '');
+  // Avoid `networkidle` — after Auth, Firestore keeps a long-lived WebChannel
+  // open so idle never settles (AGENTS.md / pr-qa traps).
   await page.goto(`${base}/?login=true`, {
-    waitUntil: 'networkidle',
+    waitUntil: 'domcontentloaded',
     timeout: 90_000,
   });
 
@@ -26,5 +28,10 @@ export async function signInViaSplashEmailPassword(page, origin, email, password
   await dialog.locator('button[type="submit"]').click();
 
   await page.waitForURL(/\/dashboard/, { timeout: 60_000 });
-  await page.waitForLoadState('networkidle');
+  // Concrete post-auth chrome — not networkidle (WebChannel stays open).
+  await page
+    .getByRole('navigation')
+    .or(page.getByRole('main'))
+    .first()
+    .waitFor({ state: 'visible', timeout: 30_000 });
 }

--- a/scripts/qa/firestore-cache.mjs
+++ b/scripts/qa/firestore-cache.mjs
@@ -3,9 +3,10 @@
  * QA runner for `.cursor/skills/pr-qa/recipes.md` §B — Firestore read
  * cache verification (issue #251 pilot, #349 auth).
  *
- * What it asserts: navigating away from `/user/<uid>` and back via SPA
- * routing reuses the React Query cache for `useUserSeasonStats`,
- * skipping the Firestore read that initially populated the page.
+ * What it asserts: navigating away from `/user/<uid>` (to `/how-it-works`)
+ * and back via SPA routing reuses the React Query cache for
+ * `useUserSeasonStats`, skipping the Firestore read that initially
+ * populated the page.
  *
  * **Auth:** `firestore.rules` require `signedIn()` for `users/{uid}`,
  * `pools`, `show_calendar`, etc. The runner signs in with
@@ -32,7 +33,8 @@ const BASELINE_MIN_BYTES = 512;
 // landed ~280–600 B; 350 B was still flaky on some accounts; 1 KiB was too strict.
 const SAVED_MIN_BYTES = 250;
 
-const BOUNCE_UID = 'qa-cache-bounce-not-a-real-uid';
+/** Soft-nav away target — marketing route (no Firestore season-stats hook). */
+const BOUNCE_PATH = '/how-it-works';
 
 const NAV_TIMEOUT_MS = 20_000;
 
@@ -58,23 +60,25 @@ async function spaNavigate(page, path) {
  * @param {import('playwright').Page} page
  */
 async function waitForProfileSettled(page) {
+  // Do not wait for `networkidle` — signed-in Firestore WebChannel never idles.
   await page.waitForSelector('text=/Total points/i', { timeout: NAV_TIMEOUT_MS });
   await page.waitForFunction(
     () => !document.querySelector('[aria-label^="Loading "]'),
     null,
     { timeout: NAV_TIMEOUT_MS },
   );
-  await page.waitForLoadState('networkidle');
+  // Brief settle so CDP `loadingFinished` events for the profile read land
+  // before we flip measurement phase — without waiting for full network idle.
+  await page.waitForTimeout(750);
 }
 
 /**
  * @param {import('playwright').Page} page
  */
-async function waitForNotFound(page) {
-  await page.waitForSelector('text=/Player not found/i', {
+async function waitForBounceSettled(page) {
+  await page.waitForSelector('text=/How it works/i', {
     timeout: NAV_TIMEOUT_MS,
   });
-  await page.waitForLoadState('networkidle');
 }
 
 /**
@@ -185,8 +189,8 @@ async function run() {
     }
 
     phase = 'idle';
-    await spaNavigate(page, `/user/${BOUNCE_UID}`);
-    await waitForNotFound(page);
+    await spaNavigate(page, BOUNCE_PATH);
+    await waitForBounceSettled(page);
 
     phase = 'postNav';
     await spaNavigate(page, `/user/${PUBLIC_PROFILE_UID}`);


### PR DESCRIPTION
## Summary
- Replace post-auth / post-nav `networkidle` waits in `qa:cache` with concrete UI readiness (Firestore WebChannel never idles).
- Bounce away via `/how-it-works` instead of a fake `/user/:uid` so the cache assertion measures React Query reuse rather than not-found refetch noise.
- Local: `qa:cache` PASS in ~6s; `qa:chunks` still PASS.

## Test plan
- [x] `npm run qa:cache` → PASS locally
- [x] `npm run qa:chunks` → PASS locally
- [ ] CI `qa-runners` completes (no multi-hour hang) on this PR


Made with [Cursor](https://cursor.com)