### PR TITLE
fix(comms): label setlist_highlight as Bustout:/Bustouts: (#780)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.40.3] — 2026-08-01
+
+### Changed
+- **Show recap bustout highlight (#780)** — `setlist_highlight` now labels nights as `Bustout: Song - a/an N show gap.` (one) or `Bustouts: …; ….` (two+). Fixes cold-branch email reading like a vague memory line when a single bustout landed (e.g. Fenway Melt the Guns).
+
+---
+
 ## [1.40.2] — 2026-07-31
 
 ### Changed

--- a/docs/API.md
+++ b/docs/API.md
@@ -134,7 +134,7 @@ Server-written night-of narrative artifact for `show_recap` / `tour_rankings_dai
 
 | Field | Type | Notes |
 |-------|------|-------|
-| `setlist_highlight` | string? | One-liner for push / Tonight block |
+| `setlist_highlight` | string? | One-liner for push / Tonight block. Bustout nights: `Bustout: Song - a/an N show gap.` (singular) or `Bustouts: …; ….` (plural, `;`-separated) (#780). |
 | `set_flow_summary` | string? | Short S1/S2/E structure |
 | `bustout_titles` | string[] | From official setlist bustouts |
 | `tour_debut_titles` | string[] | New-to-tour titles tonight |

--- a/docs/COMMS_SHOW_CONTEXT_SCHEMA.md
+++ b/docs/COMMS_SHOW_CONTEXT_SCHEMA.md
@@ -23,7 +23,7 @@ Standalone collection (same rationale as `rollup_audit`): do not nest on
 | `bustout_entries` | `{ title, gap }[]` | Bustouts with Phish.net pre-show gap when rows available |
 | `tour_debut_titles` | string[] | Tonight titles not seen earlier this tour |
 | `set_flow_summary` | string \| null | Short S1/S2/E structure line |
-| `setlist_highlight` | string \| null | One-liner for push / Tonight |
+| `setlist_highlight` | string \| null | One-liner for push / Tonight. Bustouts: `Bustout: Song - a/an N show gap.` or `Bustouts: A - …; B - ….` (#780) |
 | `show_moment_tags` | string[] | e.g. `bustout`, `tour_debut`, `multi_encore` |
 | `set_counts` | map | `{ set1, set2, encore }` lengths |
 | `schemaVersion` | number | `1` |

--- a/docs/comms-triggers/TRIGGER_CATALOG.md
+++ b/docs/comms-triggers/TRIGGER_CATALOG.md
@@ -412,7 +412,7 @@ Up next: {{next_show_venue}} on {{next_show_date}}. Picks open now.
 **Body sections:**
 1. **Your night** *(absorbed from `show_recap`, #451)* — score, rank (global + pool if applicable), correct picks count.
 2. **Pick-by-pick** — opener, closer, encore, wildcard results with song names. Bustout Boost called out if earned.
-3. **Setlist context** — `{{setlist_highlight}}` (e.g., "It was the first time Reba opened a show in 6 years").
+3. **Setlist context** — `{{setlist_highlight}}` (e.g., `Bustout: Melt the Guns - a 2051 show gap.` or `Bustouts: Song A - an 87 show gap; Song B - a 40 show gap.`).
 4. **Your tour position** — rank, points, shows played, rank change vs yesterday.
 5. **Pool standing** — `{{pool_tour_rank}}` in `{{pool_name}}` (if applicable).
 6. **Next show** — {{next_show_venue}}, {{next_show_date}}. Picks are open.

--- a/functions/commsShowContextCore.js
+++ b/functions/commsShowContextCore.js
@@ -219,7 +219,7 @@ function formatBustoutSongGap(entries) {
         ? `${e.title} - ${indefiniteArticleForGap(e.gap)} ${e.gap} show gap`
         : e.title,
     )
-    .join(", ");
+    .join("; ");
 }
 
 /**
@@ -246,7 +246,9 @@ function composeSetlistHighlight({
       : (bustoutTitles || []).map((title) => ({ title, gap: null }));
   const bustoutLine = formatBustoutSongGap(entries);
   if (bustoutLine) {
-    return entries.length === 1 ? bustoutLine : `Bustouts: ${bustoutLine}.`;
+    // Single: "Bustout: Song - a N show gap." Multi: "Bustouts: A - …; B - …." (#780)
+    const label = entries.length === 1 ? "Bustout" : "Bustouts";
+    return `${label}: ${bustoutLine}.`;
   }
   if (tourDebuts.length >= 3) {
     return `${tourDebuts.length} songs new to this tour — including ${tourDebuts[0]}.`;

--- a/functions/commsShowContextCore.test.js
+++ b/functions/commsShowContextCore.test.js
@@ -45,7 +45,7 @@ describe("tourDebutTitles", () => {
 });
 
 describe("composeSetlistHighlight", () => {
-  it("formats bustout as Song - gap", () => {
+  it("labels a single bustout as Bustout: Song - gap.", () => {
     assert.equal(
       composeSetlistHighlight({
         bustoutTitles: ["Curtain With"],
@@ -54,7 +54,23 @@ describe("composeSetlistHighlight", () => {
         openerTitle: "YEM",
         encoreTitle: "Tweeprise",
       }),
-      "Curtain With - a 142 show gap",
+      "Bustout: Curtain With - a 142 show gap.",
+    );
+  });
+
+  it("labels multiple bustouts with Bustouts: and semicolon separators", () => {
+    assert.equal(
+      composeSetlistHighlight({
+        bustoutTitles: ["Curtain With", "Fluffhead"],
+        bustoutEntries: [
+          { title: "Curtain With", gap: 142 },
+          { title: "Fluffhead", gap: 87 },
+        ],
+        tourDebuts: [],
+        openerTitle: "YEM",
+        encoreTitle: "Tweeprise",
+      }),
+      "Bustouts: Curtain With - a 142 show gap; Fluffhead - an 87 show gap.",
     );
   });
 });
@@ -79,7 +95,7 @@ describe("buildCommsShowContext", () => {
         { title: "Slave", gap: 10 },
       ],
     });
-    assert.equal(ctx.setlist_highlight, "Wolfman's - an 87 show gap");
+    assert.equal(ctx.setlist_highlight, "Bustout: Wolfman's - an 87 show gap.");
     assert.match(ctx.set_flow_summary, /Set 1 opened with YEM/);
     assert.ok(ctx.show_moment_tags.includes("bustout"));
     assert.ok(ctx.tour_debut_titles.includes("Wolfman's"));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.40.2",
+  "version": "1.40.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
@@ -409,7 +409,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           pool_rank: 1,
           correct_picks_count: 3,
           total_picks_count: 4,
-          setlist_highlight: "Wolfman's Brother - an 87 show gap",
+          setlist_highlight: "Bustout: Wolfman's Brother - an 87 show gap.",
           narrative_line: "You caught a bustout — Wolfman's Brother - an 87 show gap.",
           narrative_branch: 'bustout_hero',
           bustout_bonus: 20,


### PR DESCRIPTION
Closes #780

## Summary
- Single-bustout `setlist_highlight` is now `Bustout: Song - a/an N show gap.` (trailing period)
- Multi-bustout nights use `Bustouts: Song1 - …; Song2 - ….` (semicolon separators + trailing period)
- Catalog / schema / preview samples aligned; PATCH `1.40.3`

Related: epic #573, narrative QA #779 (Fenway cold-branch unlabeled bustout).

**Note:** Existing `comms_show_context/{showDate}` docs rewrite on next setlist poll / `ensureCommsShowContext`. Fenway 2026-07-31 will pick up the label after context rebuild + functions deploy.

## Test plan
- [x] `cd functions && npm test` (commsShowContextCore single + multi cases)
- [ ] After merge + functions deploy: confirm next morning `tour_rankings_daily` cold/mixed line includes `Bustout:` when one bustout played
- [ ] Spot-check `/comms-preview` show-recap sample highlight label


Made with [Cursor](https://cursor.com)