### PR TITLE
feat(comms): scheduled Optimize kickoff runner (#778)

### DIFF
--- a/.github/workflows/comms-optimize-schedule.yml
+++ b/.github/workflows/comms-optimize-schedule.yml
@@ -1,0 +1,59 @@
+# Scheduled Comms Optimize kickoff (#778 / epic #573).
+# Posts a [SKIP-PRD] agent prompt on #573 when:
+#   - yesterday was a show date (post_show → show_recap_uniqueness), or
+#   - today is Monday America/Denver and there was no post-show (weekly rotation).
+#
+# Does NOT run the full Leadership/Cursor squad (needs GA4 MCP + LLM).
+# A Cloud Agent / Cursor Automation / human picks up the kickoff comment.
+# Agents never merge or comms:deploy from this workflow.
+
+name: Comms Optimize schedule
+
+on:
+  schedule:
+    # ~09:00 America/Denver during MDT (15:00 UTC); after tour_rankings_daily 08:00 PT.
+    - cron: "0 15 * * *"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "auto | weekly | post_show"
+        required: true
+        default: "auto"
+        type: choice
+        options:
+          - auto
+          - weekly
+          - post_show
+      show_date:
+        description: "Optional YYYY-MM-DD for post_show"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  kickoff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+
+      - name: Resolve + post kickoff on #573
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'auto' }}
+          SHOW_DATE: ${{ github.event_name == 'workflow_dispatch' && inputs.show_date || '' }}
+        run: |
+          set -euo pipefail
+          ARGS=(--mode "$MODE" --post)
+          if [ -n "${SHOW_DATE}" ]; then
+            ARGS+=(--show-date "$SHOW_DATE")
+          fi
+          node scripts/comms-optimize-kickoff.mjs "${ARGS[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ## [Unreleased]
 
-No unreleased changes.
+### Added
+- **Comms Optimize L2 kickoff scheduler (#778)** — `docs/comms-triggers/optimize_for.md` goal rotation, `npm run comms:optimize-kickoff`, and `.github/workflows/comms-optimize-schedule.yml` (daily cron posts agent prompts on epic #573; no auto-merge/deploy).
 
 ---
 

--- a/docs/GITHUB_AUTOMATION_CONTEXT.md
+++ b/docs/GITHUB_AUTOMATION_CONTEXT.md
@@ -8,6 +8,7 @@
 
 - **GitHub Actions:** Workflows run from the **default branch**’s `.github/workflows/` copy. If `[SKIP-PRD]` handling was added on another branch, merge to **default** before expecting skips to work on newly opened issues.
 - **Body:** If the issue body (after leading whitespace) starts with **`[SKIP-PRD]`**, automation must **not** replace the body (Cursor agent–authored specs). The Action refetches the issue via the REST API and treats the **first non-empty line** as `[SKIP-PRD]` (after stripping a UTF-8 BOM if present).
+- **Comms Optimize schedule (#778):** `.github/workflows/comms-optimize-schedule.yml` posts `[SKIP-PRD]` **comments** on epic #573 (kickoff prompts only — not issue-body rewrites). Same skip-prd discipline; agents never merge/deploy from that workflow.
 - **Labels:** Do not run auto-PRD / do not groom if the issue has any of:
   - **`skip-prd`** — no GitHub Action PRD rewrite on open (use with `[SKIP-PRD]` for belt-and-suspenders).
   - **`cursor-authored`** — treat as human/agent final copy; skip Action and groom rewrites.

--- a/docs/comms-triggers/ECOSYSTEM.md
+++ b/docs/comms-triggers/ECOSYSTEM.md
@@ -8,7 +8,8 @@ message across in‑app, push, and email — fully automated, with **no manual
 It complements the other comms docs:
 
 - [`FRAMEWORK.md`](./FRAMEWORK.md) — the TTDMOM operating model (Trigger → Template → Deliver → Measure → Optimize → Monetize)
-- [`OPTIMIZE_AUTONOMY.md`](./OPTIMIZE_AUTONOMY.md) — Optimize autonomy L0 playbook + PM pack (#573)
+- [`OPTIMIZE_AUTONOMY.md`](./OPTIMIZE_AUTONOMY.md) — Optimize autonomy playbook + L2 schedule (#573 / #778)
+- [`optimize_for.md`](./optimize_for.md) — Scheduled `optimize_for` rotation
 - [`catalog.json`](./catalog.json) / [`TRIGGER_CATALOG.md`](./TRIGGER_CATALOG.md) — the machine + human trigger registry
 - [`MEASUREMENT_PLAN.md`](./MEASUREMENT_PLAN.md) — the GA4 events & funnels
 
@@ -135,7 +136,7 @@ change regardless of which agent (or human) makes it.
 
 ### 3.4 Optimize (feedback loop)
 
-Canonical playbook: **[OPTIMIZE_AUTONOMY.md](./OPTIMIZE_AUTONOMY.md)** (#573 L0).
+Canonical playbook: **[OPTIMIZE_AUTONOMY.md](./OPTIMIZE_AUTONOMY.md)** (#573). L2 kickoff cron: [#778](https://github.com/pat792/set-picks/issues/778).
 
 Cycle order: `comms-analyst` → `comms-triggers` → `comms-drafter` → `comms-architect` → **PM**.
 

--- a/docs/comms-triggers/OPTIMIZE_AUTONOMY.md
+++ b/docs/comms-triggers/OPTIMIZE_AUTONOMY.md
@@ -1,7 +1,7 @@
-# Comms Optimize autonomy (L0 playbook)
+# Comms Optimize autonomy (L0–L2 playbook)
 
 **Epic:** [#573](https://github.com/pat792/set-picks/issues/573)  
-**Status:** L1 — playbook + first on-demand pack proven (2026-07-17, goal `picks_lock`). Scheduled runner (L2) not yet.  
+**Status:** L2 kickoff automation shipped ([#778](https://github.com/pat792/set-picks/issues/778)) — daily GH Action posts a pack kickoff on #573; full Leadership → squad execution still agent-driven from that comment. L1 on-demand packs remain supported.  
 **Does not replace:** automated **delivery** (`deliverCommsTrigger` / epic #441). This doc is the **editorial + measurement + recommendation** loop.
 
 ---
@@ -44,6 +44,45 @@ and never merge or deploy.
 ```
 
 Swap `picks_lock` / window as needed. First L1 pack: [comment on #573](https://github.com/pat792/set-picks/issues/573#issuecomment-5000375612).
+
+---
+
+## Scheduled runner (L2 — #778)
+
+| Piece | Path |
+|-------|------|
+| Goal rotation | [`optimize_for.md`](./optimize_for.md) |
+| Kickoff script | `npm run comms:optimize-kickoff` (`scripts/comms-optimize-kickoff.mjs`) |
+| Cron | `.github/workflows/comms-optimize-schedule.yml` — daily `15:00` UTC (~09:00 America/Denver) |
+| Epic comments | Workflow posts `[SKIP-PRD]` kickoff on **#573** (does not merge/deploy) |
+
+**Note:** GitHub `schedule` workflows run only from the repo **default branch** (`main`). Merge to `staging` first; cron becomes live after promote to `main`. Use `workflow_dispatch` on the workflow file’s branch for earlier dry runs.
+
+**Cadence**
+
+| When | Mode | `optimize_for` |
+|------|------|----------------|
+| Morning after a calendar show date | `post_show` | always `show_recap_uniqueness` (narrative QA → [#779](https://github.com/pat792/set-picks/issues/779)) |
+| Monday (Denver), no post-show | `weekly` | ISO-week rotation in `optimize_for.md` (show-week vs off-tour) |
+| Manual | `workflow_dispatch` or CLI | `--mode weekly\|post_show` |
+
+**What the cron does vs does not**
+
+| Does | Does not |
+|------|----------|
+| Resolve goal + window from calendar + rotation | Run GA4 MCP / CrewAI / Cursor squad itself |
+| Post agent prompt on #573 | Open draft PRs or deploy |
+| Prefer post-show over weekly when both apply | Invent metrics |
+
+**Human / Cloud Agent step after each kickoff:** run the embedded prompt (or Leadership `crew` optimize → `SQUAD_KICKOFF` → squad). Post the finished **PM review pack** as a follow-up comment on #573. L2 exit criteria (two consecutive packs without chat kickoff) count when those pack comments land from the scheduled kickoffs.
+
+```bash
+# Dry-run (prints markdown)
+npm run comms:optimize-kickoff -- --mode auto
+
+# Post to #573 (needs gh auth)
+npm run comms:optimize-kickoff -- --mode weekly --post
+```
 
 ---
 
@@ -152,6 +191,7 @@ Full L0→L4 table lives on [#573](https://github.com/pat792/set-picks/issues/57
 |-------|-------------|
 | **L0** | Done — this playbook + skills (#628) |
 | **L1** | Done — first on-demand pack (2026-07-17, `optimize_for=picks_lock`) |
-| **L2+** | Open — scheduled runner; uniqueness; NBA |
+| **L2** | Kickoff cron shipped (#778) — exit when **two consecutive** packs land from scheduled kickoffs without chat |
+| **L3+** | Open — narrative QA (#779); uniqueness metrics; NBA |
 
 Related Wave 5 siblings: [#510](https://github.com/pat792/set-picks/issues/510) (`tour_recap`), [#512](https://github.com/pat792/set-picks/issues/512) (email open signal), [#513](https://github.com/pat792/set-picks/issues/513) (prefs hub).

--- a/docs/comms-triggers/README.md
+++ b/docs/comms-triggers/README.md
@@ -13,7 +13,8 @@ This directory is the **canonical home** for triggered, templated communications
 | [MEASUREMENT_PLAN.md](./MEASUREMENT_PLAN.md) | GA4 comms events, dimensions, funnels |
 | [CTA_ROUTE_AUDIT.md](./CTA_ROUTE_AUDIT.md) | In-app/email CTA label ↔ destination matrix (#551) |
 | [EXPERIMENT_PLAYBOOK.md](./EXPERIMENT_PLAYBOOK.md) | A/B rules, variant assignment, ship/kill criteria |
-| [OPTIMIZE_AUTONOMY.md](./OPTIMIZE_AUTONOMY.md) | **Optimize autonomy L0** — cycle order, PM pack template, draft-only gate (#573) |
+| [OPTIMIZE_AUTONOMY.md](./OPTIMIZE_AUTONOMY.md) | **Optimize autonomy** — cycle order, PM pack template, L2 schedule (#573 / #778) |
+| [optimize_for.md](./optimize_for.md) | Scheduled goal rotation + override for Optimize kickoffs (#778) |
 | [EMAIL_INBOX_BADGE.md](./EMAIL_INBOX_BADGE.md) | Inbox sender badge (BIMI/DMARC) vs in-body email logo (#498) |
 | [COMMERCIAL_PHASE3.md](./COMMERCIAL_PHASE3.md) | Sponsor / affiliate / offer gates (Phase 3) |
 

--- a/docs/comms-triggers/optimize_for.md
+++ b/docs/comms-triggers/optimize_for.md
@@ -1,0 +1,59 @@
+# Optimize goal rotation (#778 / #573)
+
+**Source of truth** for scheduled Optimize kickoffs. Agents and
+`.github/workflows/comms-optimize-schedule.yml` read this file via
+`scripts/comms-optimize-kickoff.mjs`.
+
+<!-- Machine-readable override (empty = ISO-week rotation). Do not fence this line. -->
+current_override:
+
+## Override (optional)
+
+Set `current_override:` above to a single snake_case goal to force the next
+weekly kickoff. Clear it (leave empty) to resume automatic rotation.
+
+Valid goals: `picks_lock` · `return_14d` · `tour_retention` · `push_opt_in` ·
+`email_open` · `show_recap_uniqueness`
+
+## Automatic rotation
+
+### Post-show (morning after a calendar show date)
+
+Always: **`show_recap_uniqueness`**  
+Window: that show date (GA4 still uses last 7 complete days for funnels).  
+Narrative QA checklist: [#779](https://github.com/pat792/set-picks/issues/779).
+
+### Weekly (Monday, America/Denver) — show week
+
+ISO week number → goal (cycle of 4):
+
+| ISO week mod 4 | `optimize_for` |
+|----------------|----------------|
+| 0 | `picks_lock` |
+| 1 | `email_open` |
+| 2 | `show_recap_uniqueness` |
+| 3 | `tour_retention` |
+
+Show week = at least one `FALLBACK_SHOW_DATES` / calendar date in
+`[today−7d, today+7d]` (script uses committed show-date fallback until
+Firestore is available in Actions).
+
+### Weekly (Monday) — off-tour
+
+| ISO week mod 2 | `optimize_for` |
+|----------------|----------------|
+| 0 | `return_14d` |
+| 1 | `push_opt_in` |
+
+## Priority when Monday follows a show night
+
+1. **Post-show** kickoff (`show_recap_uniqueness`) if yesterday was a show
+2. Else **weekly** kickoff
+
+## Manual kickoff
+
+```bash
+npm run comms:optimize-kickoff -- --mode weekly
+npm run comms:optimize-kickoff -- --mode post_show --show-date 2026-07-31
+npm run comms:optimize-kickoff -- --mode weekly --post   # comment on #573
+```

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "comms:deploy:dry": "node scripts/deploy-comms-functions.mjs --dry-run",
     "comms:deploy": "node scripts/deploy-comms-functions.mjs",
     "comms:sync": "node scripts/sync-comms-to-functions.mjs",
+    "comms:optimize-kickoff": "node scripts/comms-optimize-kickoff.mjs",
+    "test:comms-optimize-schedule": "node --test scripts/lib/commsOptimizeSchedule.test.mjs",
     "emails:build": "npm run build --prefix emails",
     "emails:preview": "npm run preview --prefix emails"
   },

--- a/scripts/comms-optimize-kickoff.mjs
+++ b/scripts/comms-optimize-kickoff.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Scheduled / manual Comms Optimize kickoff (#778).
+ *
+ *   npm run comms:optimize-kickoff
+ *   npm run comms:optimize-kickoff -- --mode weekly --post
+ *   npm run comms:optimize-kickoff -- --mode post_show --show-date 2026-07-31 --post
+ *
+ * --post comments on GitHub issue #573 (requires `gh` auth).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import {
+  buildKickoffMarkdown,
+  calendarDateInTz,
+  parseOverrideFromOptimizeForMd,
+  parseShowDatesFromSource,
+  resolveOptimizeKickoff,
+} from "./lib/commsOptimizeSchedule.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+const EPIC = 573;
+const TZ = "America/Denver";
+
+function parseArgs(argv) {
+  const args = {
+    mode: "auto",
+    post: false,
+    showDate: null,
+    date: null,
+    force: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--mode") args.mode = argv[++i] || "auto";
+    else if (a === "--post") args.post = true;
+    else if (a === "--show-date") args.showDate = argv[++i] || null;
+    else if (a === "--date") args.date = argv[++i] || null;
+    else if (a === "--force") args.force = true;
+    else if (a === "--help" || a === "-h") {
+      console.log(`Usage: comms-optimize-kickoff [--mode auto|weekly|post_show] [--date YYYY-MM-DD] [--show-date YYYY-MM-DD] [--post] [--force]`);
+      process.exit(0);
+    }
+  }
+  if (!["auto", "weekly", "post_show"].includes(args.mode)) {
+    console.error(`Invalid --mode ${args.mode}`);
+    process.exit(1);
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const showDatesPath = path.join(root, "src/shared/data/showDates.js");
+  const optimizeForPath = path.join(
+    root,
+    "docs/comms-triggers/optimize_for.md",
+  );
+  const showDates = parseShowDatesFromSource(
+    fs.readFileSync(showDatesPath, "utf8"),
+  );
+  const override = parseOverrideFromOptimizeForMd(
+    fs.readFileSync(optimizeForPath, "utf8"),
+  );
+
+  const todayYmd =
+    args.date || calendarDateInTz(new Date(), TZ);
+  const resolved = resolveOptimizeKickoff({
+    mode: args.mode,
+    todayYmd,
+    timeZone: TZ,
+    showDates,
+    override,
+    showDate: args.showDate,
+  });
+
+  if (resolved.action === "skip" && !args.force) {
+    console.log(`SKIP: ${resolved.reason}`);
+    process.exit(0);
+  }
+
+  if (resolved.action === "skip" && args.force) {
+    console.error("Nothing to force-kick (resolution skipped). Use --mode weekly|post_show.");
+    process.exit(1);
+  }
+
+  const body = buildKickoffMarkdown({
+    optimize_for: resolved.optimize_for,
+    window: resolved.window,
+    mode: resolved.mode,
+    showDate: resolved.showDate,
+    reason: resolved.reason,
+    runDate: todayYmd,
+  });
+
+  console.log(body);
+
+  if (!args.post) {
+    console.error("\n(dry) Pass --post to comment on GitHub issue #573.");
+    return;
+  }
+
+  const r = spawnSync(
+    "gh",
+    ["issue", "comment", String(EPIC), "--body-file", "-"],
+    {
+      cwd: root,
+      input: body,
+      encoding: "utf8",
+    },
+  );
+  if (r.status !== 0) {
+    console.error(r.stderr || r.stdout || "gh issue comment failed");
+    process.exit(r.status ?? 1);
+  }
+  console.error(`\nPosted kickoff comment on #${EPIC}`);
+  if (r.stdout) console.error(r.stdout.trim());
+}
+
+main();

--- a/scripts/lib/commsOptimizeSchedule.mjs
+++ b/scripts/lib/commsOptimizeSchedule.mjs
@@ -1,0 +1,300 @@
+/**
+ * Pure helpers for scheduled Comms Optimize kickoffs (#778 / #573).
+ */
+
+/** @type {string[]} */
+export const SHOW_WEEK_GOALS = [
+  "picks_lock",
+  "email_open",
+  "show_recap_uniqueness",
+  "tour_retention",
+];
+
+/** @type {string[]} */
+export const OFF_TOUR_GOALS = ["return_14d", "push_opt_in"];
+
+const SHOW_DATE_RE = /date:\s*'(\d{4}-\d{2}-\d{2})'/g;
+
+/**
+ * @param {string} sourceText contents of showDates.js (or similar)
+ * @returns {string[]} YYYY-MM-DD sorted unique
+ */
+export function parseShowDatesFromSource(sourceText) {
+  const out = new Set();
+  for (const m of String(sourceText).matchAll(SHOW_DATE_RE)) {
+    out.add(m[1]);
+  }
+  return [...out].sort();
+}
+
+/**
+ * @param {string} ymd
+ * @param {string} timeZone
+ * @returns {{ y: number, m: number, d: number }}
+ */
+function partsInTz(ymd, timeZone) {
+  // Interpret ymd as a calendar date; format a UTC noon instant in TZ for stable DOW.
+  const [y, m, d] = ymd.split("-").map(Number);
+  const utcNoon = new Date(Date.UTC(y, m - 1, d, 12, 0, 0));
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    weekday: "short",
+  });
+  const map = Object.fromEntries(
+    fmt.formatToParts(utcNoon).map((p) => [p.type, p.value]),
+  );
+  return {
+    y: Number(map.year),
+    m: Number(map.month),
+    d: Number(map.day),
+    weekday: map.weekday,
+  };
+}
+
+/**
+ * @param {Date} now
+ * @param {string} timeZone
+ * @returns {string} YYYY-MM-DD
+ */
+export function calendarDateInTz(now, timeZone) {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  return fmt.format(now);
+}
+
+/**
+ * @param {string} ymd
+ * @param {number} deltaDays
+ * @returns {string}
+ */
+export function addDaysYmd(ymd, deltaDays) {
+  const [y, m, d] = ymd.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + deltaDays);
+  return dt.toISOString().slice(0, 10);
+}
+
+/**
+ * ISO week number (UTC date parts of the calendar ymd).
+ * @param {string} ymd
+ * @returns {number}
+ */
+export function isoWeekNumber(ymd) {
+  const [y, m, d] = ymd.split("-").map(Number);
+  const date = new Date(Date.UTC(y, m - 1, d));
+  // Thursday in current week decides the year.
+  date.setUTCDate(date.getUTCDate() + 4 - (date.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+  return Math.ceil(((date - yearStart) / 86400000 + 1) / 7);
+}
+
+/**
+ * @param {string} todayYmd
+ * @param {string} timeZone
+ * @returns {boolean}
+ */
+export function isMondayInTz(todayYmd, timeZone) {
+  return partsInTz(todayYmd, timeZone).weekday === "Mon";
+}
+
+/**
+ * @param {string} todayYmd
+ * @param {string[]} showDates
+ * @returns {boolean}
+ */
+export function isShowWeek(todayYmd, showDates) {
+  const start = addDaysYmd(todayYmd, -7);
+  const end = addDaysYmd(todayYmd, 7);
+  return showDates.some((d) => d >= start && d <= end);
+}
+
+const VALID_GOALS = new Set([
+  ...SHOW_WEEK_GOALS,
+  ...OFF_TOUR_GOALS,
+]);
+
+/**
+ * Machine line (not inside a fenced example): `current_override: picks_lock`
+ * Empty / missing → null (use ISO-week rotation).
+ * @param {string} md
+ * @returns {string | null}
+ */
+export function parseOverrideFromOptimizeForMd(md) {
+  for (const line of String(md).split(/\n/)) {
+    const m = line.match(/^current_override:\s*(\S+)?\s*$/);
+    if (!m) continue;
+    const v = (m[1] || "").trim();
+    if (!v) return null;
+    if (!VALID_GOALS.has(v)) {
+      throw new Error(
+        `Invalid current_override "${v}". Valid: ${[...VALID_GOALS].join(", ")}`,
+      );
+    }
+    return v;
+  }
+  return null;
+}
+
+/**
+ * @param {{
+ *   mode: 'auto' | 'weekly' | 'post_show',
+ *   todayYmd: string,
+ *   timeZone?: string,
+ *   showDates: string[],
+ *   override?: string | null,
+ *   showDate?: string | null,
+ * }} input
+ * @returns {{
+ *   action: 'kickoff' | 'skip',
+ *   mode: 'weekly' | 'post_show' | null,
+ *   optimize_for: string | null,
+ *   window: string,
+ *   showDate: string | null,
+ *   reason: string,
+ * }}
+ */
+export function resolveOptimizeKickoff({
+  mode,
+  todayYmd,
+  timeZone = "America/Denver",
+  showDates,
+  override = null,
+  showDate = null,
+}) {
+  const yesterday = addDaysYmd(todayYmd, -1);
+  const yesterdayWasShow = showDates.includes(yesterday);
+
+  if (mode === "post_show" || (mode === "auto" && yesterdayWasShow)) {
+    const night = showDate || yesterday;
+    if (!showDates.includes(night) && mode === "post_show" && showDate) {
+      // Allow explicit --show-date even if not in fallback list.
+    } else if (mode === "auto" && !yesterdayWasShow) {
+      return {
+        action: "skip",
+        mode: null,
+        optimize_for: null,
+        window: "last_7_days",
+        showDate: null,
+        reason: "auto: yesterday was not a show date",
+      };
+    }
+    return {
+      action: "kickoff",
+      mode: "post_show",
+      optimize_for: "show_recap_uniqueness",
+      window: "last_7_days",
+      showDate: night,
+      reason: `post_show after ${night}`,
+    };
+  }
+
+  if (mode === "weekly" || mode === "auto") {
+    if (mode === "auto" && !isMondayInTz(todayYmd, timeZone)) {
+      return {
+        action: "skip",
+        mode: null,
+        optimize_for: null,
+        window: "last_7_days",
+        showDate: null,
+        reason: "auto: not Monday and no post-show",
+      };
+    }
+
+    if (override) {
+      return {
+        action: "kickoff",
+        mode: "weekly",
+        optimize_for: override,
+        window: "last_7_days",
+        showDate: null,
+        reason: `weekly override=${override}`,
+      };
+    }
+
+    const week = isoWeekNumber(todayYmd);
+    const onTour = isShowWeek(todayYmd, showDates);
+    const optimize_for = onTour
+      ? SHOW_WEEK_GOALS[week % SHOW_WEEK_GOALS.length]
+      : OFF_TOUR_GOALS[week % OFF_TOUR_GOALS.length];
+
+    return {
+      action: "kickoff",
+      mode: "weekly",
+      optimize_for,
+      window: "last_7_days",
+      showDate: null,
+      reason: onTour
+        ? `weekly show-week isoWeek=${week} → ${optimize_for}`
+        : `weekly off-tour isoWeek=${week} → ${optimize_for}`,
+    };
+  }
+
+  return {
+    action: "skip",
+    mode: null,
+    optimize_for: null,
+    window: "last_7_days",
+    showDate: null,
+    reason: `unknown mode ${mode}`,
+  };
+}
+
+/**
+ * @param {{
+ *   optimize_for: string,
+ *   window: string,
+ *   mode: string,
+ *   showDate?: string | null,
+ *   reason: string,
+ *   runDate: string,
+ * }} p
+ */
+export function buildKickoffMarkdown(p) {
+  const showLine = p.showDate
+    ? `\n**Show date (narrative QA):** \`${p.showDate}\` — follow [#779](https://github.com/pat792/set-picks/issues/779) sample-render checklist when available.`
+    : "";
+
+  const agentPrompt = `Using docs/comms-triggers/OPTIMIZE_AUTONOMY.md, docs/comms-triggers/optimize_for.md, and the comms squad skills (comms-orchestration-lead → analyst → triggers → drafter → architect),
+run Optimize for goal ${p.optimize_for} covering ${p.window} (GA4 property 527619709)${
+    p.showDate ? ` with night context for show ${p.showDate}` : ""
+  }.
+Produce the PM review pack template, post it on GitHub issue #573 with [SKIP-PRD],
+open a draft PR to staging only if a low-risk copy/catalog change is justified,
+and never merge or deploy.`;
+
+  return `[SKIP-PRD]
+
+## Scheduled Optimize kickoff — ${p.runDate}
+
+**Epic:** #573 · **Scheduler:** #778  
+**Mode:** \`${p.mode}\`  
+**optimize_for:** \`${p.optimize_for}\`  
+**Window:** \`${p.window}\`  
+**Reason:** ${p.reason}${showLine}
+
+### Agent prompt (Cloud Agent / Cursor)
+
+\`\`\`text
+${agentPrompt}
+\`\`\`
+
+### Pipeline reminder
+
+1. GA4 snapshot (recipe \`crew/knowledge/optimize_snapshot_recipe.md\` §§A–C)
+2. Leadership \`crew\` optimize → \`SQUAD_KICKOFF\`
+3. Cursor squad: analyst → triggers → drafter → architect
+4. Pack comment on this epic; draft PR only when justified
+5. Never merge / never \`comms:deploy\`
+
+### Scored next action (fill after run)
+
+- [ ] \`DRAFT_PR\` / \`WAIT_EVIDENCE\` / \`CATALOG_HOLD\` / \`MEASUREMENT_ONLY\`
+`;
+}

--- a/scripts/lib/commsOptimizeSchedule.test.mjs
+++ b/scripts/lib/commsOptimizeSchedule.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  addDaysYmd,
+  isoWeekNumber,
+  isShowWeek,
+  parseOverrideFromOptimizeForMd,
+  parseShowDatesFromSource,
+  resolveOptimizeKickoff,
+  SHOW_WEEK_GOALS,
+} from "./commsOptimizeSchedule.mjs";
+
+describe("commsOptimizeSchedule", () => {
+  it("parses show dates from source", () => {
+    const dates = parseShowDatesFromSource(`
+      { date: '2026-07-31', venue: 'Fenway' },
+      { date: '2026-08-01', venue: 'Fenway' },
+    `);
+    assert.deepEqual(dates, ["2026-07-31", "2026-08-01"]);
+  });
+
+  it("parses current_override (ignores fenced examples)", () => {
+    assert.equal(parseOverrideFromOptimizeForMd("current_override:\n"), null);
+    assert.equal(
+      parseOverrideFromOptimizeForMd("current_override: picks_lock\n"),
+      "picks_lock",
+    );
+    assert.equal(
+      parseOverrideFromOptimizeForMd("```text\noverride: picks_lock\n```\n"),
+      null,
+    );
+  });
+
+  it("post_show after Fenway night", () => {
+    const r = resolveOptimizeKickoff({
+      mode: "auto",
+      todayYmd: "2026-08-01",
+      showDates: ["2026-07-31", "2026-08-01"],
+    });
+    assert.equal(r.action, "kickoff");
+    assert.equal(r.mode, "post_show");
+    assert.equal(r.optimize_for, "show_recap_uniqueness");
+    assert.equal(r.showDate, "2026-07-31");
+  });
+
+  it("weekly Monday show-week rotates by ISO week", () => {
+    // 2026-08-03 is a Monday; Fenway week still in ±7d window from Aug 1.
+    const today = "2026-08-03";
+    assert.equal(isShowWeek(today, ["2026-07-31", "2026-08-01"]), true);
+    const week = isoWeekNumber(today);
+    const r = resolveOptimizeKickoff({
+      mode: "weekly",
+      todayYmd: today,
+      showDates: ["2026-07-31", "2026-08-01"],
+    });
+    assert.equal(r.action, "kickoff");
+    assert.equal(r.optimize_for, SHOW_WEEK_GOALS[week % SHOW_WEEK_GOALS.length]);
+  });
+
+  it("auto skips mid-week with no prior show", () => {
+    const r = resolveOptimizeKickoff({
+      mode: "auto",
+      todayYmd: "2026-08-05",
+      showDates: ["2026-07-31"],
+    });
+    assert.equal(r.action, "skip");
+  });
+
+  it("addDaysYmd crosses months", () => {
+    assert.equal(addDaysYmd("2026-07-31", 1), "2026-08-01");
+  });
+});


### PR DESCRIPTION
Closes #778

## Summary
- L2 Optimize **kickoff** automation: daily cron posts `[SKIP-PRD]` prompts on epic #573
- Goal rotation in `docs/comms-triggers/optimize_for.md` (post-show → `show_recap_uniqueness`; Monday ISO-week cycle)
- `npm run comms:optimize-kickoff` + unit tests; docs updated in `OPTIMIZE_AUTONOMY.md`
- Does **not** auto-run Crew/Cursor squad, merge, or `comms:deploy` — agents pick up the kickoff comment

**Note:** GitHub `schedule` only runs from **default branch (`main`)**. Cron goes live after promote; use `workflow_dispatch` sooner.

## Test plan
- [x] `npm run test:comms-optimize-schedule`
- [x] Dry-run post_show for 2026-08-01 → Fenway night
- [x] Dry-run weekly Monday → `picks_lock` (isoWeek 32)
- [ ] After merge: Actions → “Comms Optimize schedule” → `workflow_dispatch` mode `weekly` (confirm #573 comment)
- [ ] After promote to main: confirm daily cron posts on a show morning


Made with [Cursor](https://cursor.com)