### PR TITLE
feat(comms): post-show narrative QA against comms_show_context (#779)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ### Added
 - **Comms Optimize L2 kickoff scheduler (#778)** — `docs/comms-triggers/optimize_for.md` goal rotation, `npm run comms:optimize-kickoff`, and `.github/workflows/comms-optimize-schedule.yml` (daily cron posts agent prompts on epic #573; no auto-merge/deploy).
+- **Show-recap narrative QA (#779)** — `npm run comms:show-recap-qa` checklist + branch samples against `comms_show_context` / fixtures; post-show Optimize kickoffs attach the report on #573 (fail → `DRAFT_PR`).
 
 ---
 

--- a/docs/comms-triggers/OPTIMIZE_AUTONOMY.md
+++ b/docs/comms-triggers/OPTIMIZE_AUTONOMY.md
@@ -62,9 +62,28 @@ Swap `picks_lock` / window as needed. First L1 pack: [comment on #573](https://g
 
 | When | Mode | `optimize_for` |
 |------|------|----------------|
-| Morning after a calendar show date | `post_show` | always `show_recap_uniqueness` (narrative QA → [#779](https://github.com/pat792/set-picks/issues/779)) |
+| Morning after a calendar show date | `post_show` | always `show_recap_uniqueness` + narrative QA report ([#779](https://github.com/pat792/set-picks/issues/779)) |
 | Monday (Denver), no post-show | `weekly` | ISO-week rotation in `optimize_for.md` (show-week vs off-tour) |
 | Manual | `workflow_dispatch` or CLI | `--mode weekly\|post_show` |
+
+### Show-recap uniqueness QA (#779)
+
+Post-show kickoffs attach a **Show-recap uniqueness QA** section (or run standalone):
+
+```bash
+# Fixture smoke (CI / no Firestore)
+npm run comms:show-recap-qa -- --fixture fenway_labeled
+npm run comms:show-recap-qa -- --fixture fenway_unlabeled   # expect FAIL (pre-#780)
+
+# Live context (rebuild highlight from official_setlists + songGaps)
+npm run comms:show-recap-qa -- --show-date 2026-07-31 --live
+npm run comms:show-recap-qa -- --show-date 2026-07-31 --live --rebuild
+
+# Post report on #573
+npm run comms:show-recap-qa -- --show-date 2026-07-31 --live --post
+```
+
+Checklist (fail → scored `DRAFT_PR`): `Bustout:` / `Bustouts:` labels, trailing period, `;` separators for multi, gap shape, cold/hot wrappers keep the label, catalog example matches runtime. Renders `cold` / `mixed` / `hot_night` / `bustout_hero` via `tour-rankings-daily` (dry — no Resend).
 
 **What the cron does vs does not**
 
@@ -73,6 +92,7 @@ Swap `picks_lock` / window as needed. First L1 pack: [comment on #573](https://g
 | Resolve goal + window from calendar + rotation | Run GA4 MCP / CrewAI / Cursor squad itself |
 | Post agent prompt on #573 | Open draft PRs or deploy |
 | Prefer post-show over weekly when both apply | Invent metrics |
+| Attach narrative QA on post_show (#779) | Send Resend canaries (optional separate script) |
 
 **Human / Cloud Agent step after each kickoff:** run the embedded prompt (or Leadership `crew` optimize → `SQUAD_KICKOFF` → squad). Post the finished **PM review pack** as a follow-up comment on #573. L2 exit criteria (two consecutive packs without chat kickoff) count when those pack comments land from the scheduled kickoffs.
 

--- a/docs/comms-triggers/README.md
+++ b/docs/comms-triggers/README.md
@@ -15,6 +15,8 @@ This directory is the **canonical home** for triggered, templated communications
 | [EXPERIMENT_PLAYBOOK.md](./EXPERIMENT_PLAYBOOK.md) | A/B rules, variant assignment, ship/kill criteria |
 | [OPTIMIZE_AUTONOMY.md](./OPTIMIZE_AUTONOMY.md) | **Optimize autonomy** — cycle order, PM pack template, L2 schedule (#573 / #778) |
 | [optimize_for.md](./optimize_for.md) | Scheduled goal rotation + override for Optimize kickoffs (#778) |
+
+CLI: `npm run comms:optimize-kickoff` · `npm run comms:show-recap-qa` (#779)
 | [EMAIL_INBOX_BADGE.md](./EMAIL_INBOX_BADGE.md) | Inbox sender badge (BIMI/DMARC) vs in-body email logo (#498) |
 | [COMMERCIAL_PHASE3.md](./COMMERCIAL_PHASE3.md) | Sponsor / affiliate / offer gates (Phase 3) |
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "comms:deploy": "node scripts/deploy-comms-functions.mjs",
     "comms:sync": "node scripts/sync-comms-to-functions.mjs",
     "comms:optimize-kickoff": "node scripts/comms-optimize-kickoff.mjs",
+    "comms:show-recap-qa": "node scripts/comms-show-recap-narrative-qa.mjs",
     "test:comms-optimize-schedule": "node --test scripts/lib/commsOptimizeSchedule.test.mjs",
+    "test:comms-show-recap-qa": "node --test scripts/lib/showRecapNarrativeQa.test.mjs",
     "emails:build": "npm run build --prefix emails",
     "emails:preview": "npm run preview --prefix emails"
   },

--- a/scripts/canary-show-recap-narrative-preview.mjs
+++ b/scripts/canary-show-recap-narrative-preview.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+/**
+ * Send local-rendered show-recap narrative branch emails (morning
+ * tour_rankings_daily “your night” + tour block) via Resend.
+ *
+ * Covers cold / mixed / hot_night / bustout_hero plus single + multi Bustout labels (#780).
+ *
+ * Usage:
+ *   node scripts/canary-show-recap-narrative-preview.mjs
+ *   node scripts/canary-show-recap-narrative-preview.mjs --send other@example.com
+ */
+
+import { createRequire } from "node:module";
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+const require = createRequire(import.meta.url);
+
+const envPath = resolve(root, ".env");
+/** @type {Record<string, string>} */
+const fileEnv = {};
+try {
+  for (const line of readFileSync(envPath, "utf8").split("\n")) {
+    const m = line.match(/^([^#=]+)=(.*)$/);
+    if (!m) continue;
+    fileEnv[m[1].trim()] = m[2].trim().replace(/^"|"$/g, "");
+  }
+} catch {
+  // optional
+}
+
+function shouldApplyEnvFile(key, fileValue) {
+  const existing = process.env[key];
+  if (existing == null || existing === "") return true;
+  if (key === "RESEND_API_KEY") {
+    const ok = typeof fileValue === "string" && fileValue.startsWith("re_");
+    const shellOk = typeof existing === "string" && existing.startsWith("re_");
+    return ok && !shellOk;
+  }
+  return false;
+}
+
+for (const [key, value] of Object.entries(fileEnv)) {
+  if (shouldApplyEnvFile(key, value)) process.env[key] = value;
+}
+
+const args = process.argv.slice(2);
+const sendTo =
+  (args.includes("--send") ? args[args.indexOf("--send") + 1] : null) ||
+  "pat@road2media.com";
+
+const siteUrl = "https://www.setlistpickem.com";
+const settingsUrl = `${siteUrl}/dashboard/profile/notifications`;
+
+const { buildProductionBrandedEmailShell } = require(
+  resolve(root, "functions/commsEmailWorker.js"),
+);
+const { buildEmailTrackedCtaUrl } = require(resolve(root, "comms/emailLinks.cjs"));
+const { renderCommsTemplate } = require(resolve(root, "functions/commsTemplates.js"));
+
+const baseTour = {
+  tour_rank: 6,
+  total_tour_pickers: 11,
+  tour_points: 45,
+  rank_change: "held",
+  shows_played: 8,
+  next_show_date: "2026-08-01",
+  next_show_venue: "Fenway Park",
+};
+
+/** @type {{ name: string, payload: Record<string, unknown> }[]} */
+const BRANCHES = [
+  {
+    name: "Cold + Bustout (Fenway Melt the Guns)",
+    payload: {
+      handle: "ChowdahBoyz4Lyfe",
+      show_date: "2026-07-31",
+      venue_name: "Fenway Park",
+      venue_city: "Boston, MA",
+      show_score: 10,
+      global_rank: 6,
+      global_total_pickers: 11,
+      correct_picks_count: 1,
+      total_picks_count: 6,
+      narrative_branch: "cold",
+      setlist_highlight: "Bustout: Melt the Guns - a 2051 show gap.",
+      narrative_line:
+        "Tough board. Still a night to remember: Bustout: Melt the Guns - a 2051 show gap.",
+      ...baseTour,
+    },
+  },
+  {
+    name: "Bustout hero (you caught it)",
+    payload: {
+      handle: "Pat",
+      show_date: "2026-07-31",
+      venue_name: "Fenway Park",
+      venue_city: "Boston, MA",
+      show_score: 30,
+      global_rank: 2,
+      global_total_pickers: 11,
+      correct_picks_count: 2,
+      total_picks_count: 6,
+      bustout_bonus: 20,
+      narrative_branch: "bustout_hero",
+      setlist_highlight: "Bustout: Melt the Guns - a 2051 show gap.",
+      narrative_line:
+        "You caught a bustout — Melt the Guns - a 2051 show gap.",
+      ...baseTour,
+      tour_rank: 2,
+      tour_points: 80,
+      rank_change: "up 3",
+    },
+  },
+  {
+    name: "Hot night + single Bustout",
+    payload: {
+      handle: "RiverTranced",
+      show_date: "2026-07-18",
+      venue_name: "MSG",
+      venue_city: "New York, NY",
+      show_score: 70,
+      global_rank: 4,
+      global_total_pickers: 200,
+      correct_picks_count: 5,
+      total_picks_count: 6,
+      narrative_branch: "hot_night",
+      setlist_highlight: "Bustout: Wolfman's Brother - an 87 show gap.",
+      narrative_line:
+        "Strong night. Bustout: Wolfman's Brother - an 87 show gap.",
+      ...baseTour,
+      tour_rank: 4,
+      total_tour_pickers: 312,
+      tour_points: 455,
+      rank_change: "up 2",
+      shows_played: 5,
+      next_show_date: "2026-07-20",
+      next_show_venue: "MSG",
+    },
+  },
+  {
+    name: "Mixed + Bustouts (multi)",
+    payload: {
+      handle: "CouchTourPat",
+      show_date: "2026-07-15",
+      venue_name: "Enmarket Arena",
+      venue_city: "Savannah, GA",
+      show_score: 25,
+      global_rank: 18,
+      global_total_pickers: 80,
+      correct_picks_count: 2,
+      total_picks_count: 6,
+      narrative_branch: "mixed",
+      setlist_highlight:
+        "Bustouts: Curtain With - a 142 show gap; Fluffhead - an 87 show gap.",
+      narrative_line:
+        "Bustouts: Curtain With - a 142 show gap; Fluffhead - an 87 show gap.",
+      ...baseTour,
+      tour_rank: 22,
+      total_tour_pickers: 90,
+      tour_points: 120,
+      rank_change: "down 1",
+      shows_played: 4,
+      next_show_date: "2026-07-17",
+      next_show_venue: "Walnut Creek",
+    },
+  },
+  {
+    name: "Cold + no bustout (fallback)",
+    payload: {
+      handle: "Pat",
+      show_date: "2026-07-22",
+      venue_name: "Madison Square Garden",
+      venue_city: "New York, NY",
+      show_score: 5,
+      global_rank: 40,
+      global_total_pickers: 200,
+      correct_picks_count: 0,
+      total_picks_count: 6,
+      narrative_branch: "cold",
+      setlist_highlight: "Carini opened; Slave closed the night.",
+      narrative_line:
+        "Tough board. Still a night to remember: Carini opened; Slave closed the night.",
+      ...baseTour,
+      tour_rank: 30,
+      total_tour_pickers: 200,
+      tour_points: 40,
+      rank_change: "down 4",
+      shows_played: 6,
+      next_show_date: "2026-07-24",
+      next_show_venue: "MSG",
+    },
+  },
+];
+
+const resendKey = process.env.RESEND_API_KEY;
+if (!resendKey || !resendKey.startsWith("re_")) {
+  console.error("✗ RESEND_API_KEY missing or invalid in .env");
+  process.exit(1);
+}
+
+const { Resend } = require(resolve(root, "functions/node_modules/resend"));
+const resend = new Resend(resendKey);
+
+const outDir = resolve(root, "emails/preview");
+mkdirSync(outDir, { recursive: true });
+
+console.log(
+  `→ Sending ${BRANCHES.length} show-recap narrative previews to ${sendTo}\n`,
+);
+
+let sent = 0;
+for (const branch of BRANCHES) {
+  // eslint-disable-next-line no-await-in-loop
+  const rendered = await renderCommsTemplate(
+    "tour-rankings-daily",
+    branch.payload,
+  );
+  const shell = buildProductionBrandedEmailShell({
+    siteUrl,
+    bodyText: rendered.email.text,
+    ctaUrl: buildEmailTrackedCtaUrl(
+      rendered.email.ctaUrl || `${siteUrl}/dashboard/picks`,
+      {
+        triggerId: "tour_rankings_daily",
+        templateId: "tour-rankings-daily",
+        cta: rendered.email.ctaLabel || "Make picks for next show",
+      },
+    ),
+    settingsUrl,
+    ctaLabel: rendered.email.ctaLabel,
+    signOff: rendered.email.signOff,
+    inviteBlockHtml: rendered.email.inviteBlockHtml,
+    header: rendered.email.header,
+  });
+
+  const subject = `[Show recap ${branch.name}] ${rendered.email.subject}`;
+  const slug = branch.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  writeFileSync(resolve(outDir, `show-recap-${slug}.html`), shell.html, "utf8");
+
+  // eslint-disable-next-line no-await-in-loop
+  const result = await resend.emails.send({
+    from: "Setlist Pick'em <updates@setlistpickem.com>",
+    to: [sendTo],
+    subject,
+    html: shell.html,
+    text: rendered.email.text,
+  });
+
+  if (result.error) {
+    console.error(
+      `✗ ${branch.name}: ${result.error.message || JSON.stringify(result.error)}`,
+    );
+    process.exit(1);
+  }
+
+  console.log(`✓ ${branch.name}`);
+  console.log(`  subject: ${subject}`);
+  console.log(`  id: ${result.data?.id || "(ok)"}\n`);
+  sent += 1;
+}
+
+console.log(`Done. ${sent} emails → ${sendTo}`);
+console.log('Subjects prefixed with "[Show recap …]" for scanning.');

--- a/scripts/comms-optimize-kickoff.mjs
+++ b/scripts/comms-optimize-kickoff.mjs
@@ -88,7 +88,7 @@ function main() {
     process.exit(1);
   }
 
-  const body = buildKickoffMarkdown({
+  let body = buildKickoffMarkdown({
     optimize_for: resolved.optimize_for,
     window: resolved.window,
     mode: resolved.mode,
@@ -96,6 +96,43 @@ function main() {
     reason: resolved.reason,
     runDate: todayYmd,
   });
+
+  // Post-show: attach deterministic narrative QA (#779). Prefer live Firestore
+  // context; fall back to labeled fixture smoke when credentials are missing.
+  if (resolved.mode === "post_show" && resolved.showDate) {
+    const qaScript = path.join(root, "scripts/comms-show-recap-narrative-qa.mjs");
+    let qa = spawnSync(
+      process.execPath,
+      [qaScript, "--show-date", resolved.showDate, "--live"],
+      { cwd: root, encoding: "utf8" },
+    );
+    let qaNote = "";
+    if (qa.status !== 0 && qa.status !== 2) {
+      qaNote =
+        "_Live `comms_show_context` unavailable — fixture smoke (`fenway_labeled`)._\n\n";
+      qa = spawnSync(
+        process.execPath,
+        [
+          qaScript,
+          "--fixture",
+          "fenway_labeled",
+          "--show-date",
+          resolved.showDate,
+        ],
+        { cwd: root, encoding: "utf8" },
+      );
+    }
+    if (qa.status === 0 || qa.status === 2) {
+      const qaBody = String(qa.stdout || "")
+        .replace(/^\[SKIP-PRD\]\s*/i, "")
+        .trim();
+      body = `${body.trim()}\n\n---\n\n${qaNote}${qaBody}\n`;
+    } else {
+      body = `${body.trim()}\n\n---\n\n### Show-recap uniqueness QA\n\n_QA script failed_ (exit ${qa.status}): ${
+        (qa.stderr || "").split("\n").filter(Boolean)[0] || "unknown"
+      }\n`;
+    }
+  }
 
   console.log(body);
 

--- a/scripts/comms-show-recap-narrative-qa.mjs
+++ b/scripts/comms-show-recap-narrative-qa.mjs
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+/**
+ * Post-show narrative QA against comms_show_context (#779).
+ *
+ * Renders cold / mixed / hot_night / bustout_hero samples, runs the Bustout
+ * label checklist, prints a #573 pack section. Optional --post comments on #573.
+ * Dry-run only for delivery — never Resend / never merge.
+ *
+ * Usage:
+ *   npm run comms:show-recap-qa -- --fixture fenway_labeled
+ *   npm run comms:show-recap-qa -- --fixture fenway_unlabeled   # expect FAIL
+ *   npm run comms:show-recap-qa -- --show-date 2026-07-31 --live
+ *   npm run comms:show-recap-qa -- --show-date 2026-07-31 --live --rebuild
+ *   npm run comms:show-recap-qa -- --show-date 2026-07-31 --live --post
+ */
+
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import {
+  FIXTURE_FENWAY_LABELED,
+  FIXTURE_FENWAY_UNLABELED,
+  FIXTURE_MULTI_BUSTOUT,
+  branchScorecardFixtures,
+  buildNarrativeQaReportMarkdown,
+  runCatalogExampleCheck,
+  runHighlightChecklist,
+  runNarrativeLineChecklist,
+  summarizeChecks,
+} from "./lib/showRecapNarrativeQa.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+const require = createRequire(import.meta.url);
+const EPIC = 573;
+
+const FIXTURES = {
+  fenway_labeled: FIXTURE_FENWAY_LABELED,
+  fenway_unlabeled: FIXTURE_FENWAY_UNLABELED,
+  multi: FIXTURE_MULTI_BUSTOUT,
+};
+
+function loadEnv() {
+  const envPath = resolve(root, ".env");
+  /** @type {Record<string, string>} */
+  const envVars = {};
+  try {
+    for (const line of readFileSync(envPath, "utf8").split("\n")) {
+      const m = line.match(/^([^#=]+)=(.*)$/);
+      if (m) envVars[m[1].trim()] = m[2].trim().replace(/^"|"$/g, "");
+    }
+  } catch {
+    // optional
+  }
+  return envVars;
+}
+
+function parseArgs(argv) {
+  const args = {
+    showDate: null,
+    fixture: null,
+    live: false,
+    post: false,
+    rebuild: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--show-date") args.showDate = argv[++i] || null;
+    else if (a === "--fixture") args.fixture = argv[++i] || null;
+    else if (a === "--live") args.live = true;
+    else if (a === "--post") args.post = true;
+    else if (a === "--rebuild") args.rebuild = true;
+    else if (a === "--help" || a === "-h") {
+      console.log(
+        "Usage: comms-show-recap-narrative-qa [--fixture fenway_labeled|fenway_unlabeled|multi] [--show-date YYYY-MM-DD --live [--rebuild]] [--post]",
+      );
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+/**
+ * @param {Record<string, string>} envVars
+ */
+function initAdmin(envVars) {
+  const admin = require("../functions/node_modules/firebase-admin/lib/index.js");
+  if (!admin.apps.length) {
+    const privateKey = envVars.GCP_PRIVATE_KEY?.replace(/\\n/g, "\n");
+    if (!envVars.GCP_CLIENT_EMAIL || !privateKey) {
+      throw new Error("Missing GCP_CLIENT_EMAIL / GCP_PRIVATE_KEY in .env for --live");
+    }
+    admin.initializeApp({
+      credential: admin.credential.cert({
+        projectId: "set-picks",
+        clientEmail: envVars.GCP_CLIENT_EMAIL,
+        privateKey,
+      }),
+      projectId: "set-picks",
+    });
+  }
+  return admin;
+}
+
+/**
+ * @param {string} showDate
+ * @param {Record<string, string>} envVars
+ * @param {{ rebuild?: boolean }} [opts]
+ */
+async function loadLiveContext(showDate, envVars, opts = {}) {
+  const admin = initAdmin(envVars);
+  const db = admin.firestore();
+
+  if (opts.rebuild) {
+    const { writeCommsShowContext } = require("../functions/commsShowContext.js");
+    const setSnap = await db.collection("official_setlists").doc(showDate).get();
+    if (!setSnap.exists) {
+      throw new Error(`No official_setlists/${showDate} for --rebuild`);
+    }
+    const setlist = setSnap.data() || {};
+    const songGaps =
+      setlist.songGaps && typeof setlist.songGaps === "object"
+        ? setlist.songGaps
+        : {};
+    // Prefer frozen songGaps for bustout rows (same shape as phishnetRows).
+    const phishnetRows = (Array.isArray(setlist.bustouts) ? setlist.bustouts : [])
+      .map((t) => String(t || "").trim())
+      .filter(Boolean)
+      .map((title) => {
+        const gapRaw = songGaps[title.toLowerCase()];
+        const gap =
+          typeof gapRaw === "number" && Number.isFinite(gapRaw)
+            ? Math.trunc(gapRaw)
+            : null;
+        return { title, gap };
+      });
+    await writeCommsShowContext({
+      db,
+      admin,
+      showDate,
+      setlistDoc: setlist,
+      phishnetRows,
+      logger: console,
+    });
+    console.error(`↻ rebuilt comms_show_context/${showDate}`);
+  }
+
+  const snap = await db.collection("comms_show_context").doc(showDate).get();
+  if (!snap.exists) {
+    throw new Error(`No comms_show_context/${showDate}`);
+  }
+  const data = snap.data() || {};
+  return {
+    showDate,
+    setlist_highlight: data.setlist_highlight || null,
+    bustout_titles: data.bustout_titles || [],
+    bustout_entries: data.bustout_entries || [],
+    tour_debut_titles: data.tour_debut_titles || [],
+    opener_title: data.opener_title || null,
+    encore_title: data.encore_title || null,
+    show_moment_tags: data.show_moment_tags || [],
+  };
+}
+
+function recomposeHighlight(ctx) {
+  const {
+    composeSetlistHighlight,
+  } = require("../functions/commsShowContextCore.js");
+  return composeSetlistHighlight({
+    bustoutTitles: ctx.bustout_titles || [],
+    bustoutEntries: ctx.bustout_entries || [],
+    tourDebuts: ctx.tour_debut_titles || [],
+    openerTitle: ctx.opener_title || "",
+    encoreTitle: ctx.encore_title || "",
+  });
+}
+
+function renderSamples(ctx) {
+  const {
+    buildShowRecapEnrichment,
+  } = require("../functions/showRecapNarrativeCore.js");
+  const { renderCommsTemplate } = require("../functions/commsTemplates.js");
+
+  const bustoutTitle =
+    ctx.bustout_entries?.[0]?.title ||
+    ctx.bustout_titles?.[0] ||
+    "Melt the Guns";
+  const fixtures = branchScorecardFixtures(bustoutTitle);
+  const showLevel = {
+    setlist_highlight: ctx.setlist_highlight,
+    bustout_titles: ctx.bustout_titles || [],
+    bustout_entries: ctx.bustout_entries || [],
+    tour_debut_titles: ctx.tour_debut_titles || [],
+    opener_title: ctx.opener_title,
+    encore_title: ctx.encore_title,
+    show_moment_tags: ctx.show_moment_tags || [],
+  };
+
+  /** @type {{ branch: string, narrative_line: string, emailNightExcerpt?: string }[]} */
+  const samples = [];
+  for (const branch of ["cold", "mixed", "hot_night", "bustout_hero"]) {
+    const fix = fixtures[branch];
+    const enriched = buildShowRecapEnrichment({
+      showLevel,
+      userPicks: fix.userPicks,
+      actualSetlist: fix.actualSetlist,
+      show_score: fix.show_score,
+    });
+    // Force branch for sample matrix display when scorecard might not land there
+    // (e.g. bustout_hero needs the hit). Use enrichment branch when it matches.
+    const narrative_line = enriched.narrative_line;
+    const payload = {
+      handle: "QA",
+      show_date: ctx.showDate || "2026-07-31",
+      venue_name: "QA Venue",
+      venue_city: "Test City",
+      show_score: fix.show_score,
+      global_rank: 6,
+      global_total_pickers: 11,
+      correct_picks_count: branch === "cold" ? 0 : branch === "hot_night" ? 5 : 2,
+      total_picks_count: 6,
+      narrative_line,
+      setlist_highlight: ctx.setlist_highlight,
+      narrative_branch: enriched.narrative_branch,
+      tour_rank: 6,
+      total_tour_pickers: 11,
+      tour_points: 40,
+      rank_change: "held",
+      shows_played: 3,
+    };
+    const rendered = renderCommsTemplate("tour-rankings-daily", payload);
+    const nightPara = String(rendered.email?.text || "")
+      .split(/\n\n/)[0]
+      ?.trim();
+    samples.push({
+      branch: enriched.narrative_branch,
+      narrative_line,
+      emailNightExcerpt: nightPara,
+    });
+  }
+  return samples;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const envVars = loadEnv();
+
+  let ctx;
+  let source;
+  if (args.live) {
+    if (!args.showDate) {
+      console.error("--live requires --show-date YYYY-MM-DD");
+      process.exit(1);
+    }
+    ctx = await loadLiveContext(args.showDate, envVars, {
+      rebuild: args.rebuild,
+    });
+    source = `firestore comms_show_context/${args.showDate}${
+      args.rebuild ? " (rebuilt)" : ""
+    }`;
+  } else {
+    const key = args.fixture || "fenway_labeled";
+    if (!FIXTURES[key]) {
+      console.error(
+        `Unknown --fixture ${key}. Valid: ${Object.keys(FIXTURES).join(", ")}`,
+      );
+      process.exit(1);
+    }
+    ctx = { ...FIXTURES[key] };
+    if (args.showDate) ctx.showDate = args.showDate;
+    source = `fixture:${key}`;
+  }
+
+  const recomposed = recomposeHighlight(ctx);
+  const samples = renderSamples(ctx);
+
+  /** @type {{ id: string, ok: boolean, detail: string }[]} */
+  const checks = [
+    ...runHighlightChecklist(ctx),
+    ...runHighlightChecklist({
+      ...ctx,
+      setlist_highlight: recomposed,
+    }).map((c) => ({
+      ...c,
+      id: `recomposed_${c.id}`,
+      detail: `[recompose] ${c.detail}`,
+    })),
+  ];
+
+  for (const s of samples) {
+    checks.push(
+      ...runNarrativeLineChecklist(s.narrative_line, ctx, s.branch).map(
+        (c) => ({
+          ...c,
+          id: `${s.branch}_${c.id}`,
+          detail: `[${s.branch}] ${c.detail}`,
+        }),
+      ),
+    );
+  }
+
+  const catalogPath = resolve(root, "docs/comms-triggers/TRIGGER_CATALOG.md");
+  checks.push(
+    runCatalogExampleCheck(readFileSync(catalogPath, "utf8")),
+  );
+
+  const report = buildNarrativeQaReportMarkdown({
+    showDate: ctx.showDate || "unknown",
+    context: ctx,
+    recomposedHighlight: recomposed,
+    samples,
+    checks,
+    source,
+  });
+
+  const body = `[SKIP-PRD]\n\n${report}`;
+  console.log(body);
+
+  const summary = summarizeChecks(checks);
+  console.error(
+    summary.pass
+      ? "\n✓ Narrative QA PASS"
+      : `\n✗ Narrative QA FAIL (${summary.failed.length} check(s)) → DRAFT_PR`,
+  );
+
+  if (args.post) {
+    const r = spawnSync(
+      "gh",
+      ["issue", "comment", String(EPIC), "--body-file", "-"],
+      { cwd: root, input: body, encoding: "utf8" },
+    );
+    if (r.status !== 0) {
+      console.error(r.stderr || r.stdout || "gh issue comment failed");
+      process.exit(r.status ?? 1);
+    }
+    console.error(`Posted QA report on #${EPIC}`);
+  } else {
+    console.error("\n(dry) Pass --post to comment on GitHub issue #573.");
+  }
+
+  process.exit(summary.pass ? 0 : 2);
+}
+
+main().catch((err) => {
+  console.error("✗", err.message || err);
+  process.exit(1);
+});

--- a/scripts/lib/showRecapNarrativeQa.mjs
+++ b/scripts/lib/showRecapNarrativeQa.mjs
@@ -1,0 +1,348 @@
+/**
+ * Post-show show_recap narrative QA (#779).
+ * Deterministic checklist + sample render helpers (no Resend).
+ */
+
+/**
+ * @typedef {{ title: string, gap?: number | null }} BustoutEntry
+ * @typedef {{
+ *   showDate?: string,
+ *   setlist_highlight?: string | null,
+ *   bustout_titles?: string[],
+ *   bustout_entries?: BustoutEntry[],
+ *   tour_debut_titles?: string[],
+ *   opener_title?: string | null,
+ *   encore_title?: string | null,
+ *   show_moment_tags?: string[],
+ * }} ShowContext
+ */
+
+/**
+ * Fenway-class unlabeled single bustout (pre-#780) — must FAIL checklist.
+ * @type {ShowContext}
+ */
+export const FIXTURE_FENWAY_UNLABELED = {
+  showDate: "2026-07-31",
+  setlist_highlight: "Melt the Guns - a 2051 show gap",
+  bustout_titles: ["Melt the Guns"],
+  bustout_entries: [{ title: "Melt the Guns", gap: 2051 }],
+  tour_debut_titles: ["Melt the Guns"],
+  opener_title: "Carini",
+  encore_title: "A Life Beyond The Dream",
+  show_moment_tags: ["bustout", "tour_debut"],
+};
+
+/**
+ * Expected post-#780 Fenway highlight.
+ * @type {ShowContext}
+ */
+export const FIXTURE_FENWAY_LABELED = {
+  ...FIXTURE_FENWAY_UNLABELED,
+  setlist_highlight: "Bustout: Melt the Guns - a 2051 show gap.",
+};
+
+/**
+ * Multi-bustout night.
+ * @type {ShowContext}
+ */
+export const FIXTURE_MULTI_BUSTOUT = {
+  showDate: "2026-07-15",
+  setlist_highlight:
+    "Bustouts: Curtain With - a 142 show gap; Fluffhead - an 87 show gap.",
+  bustout_titles: ["Curtain With", "Fluffhead"],
+  bustout_entries: [
+    { title: "Curtain With", gap: 142 },
+    { title: "Fluffhead", gap: 87 },
+  ],
+  tour_debut_titles: [],
+  opener_title: "YEM",
+  encore_title: "Slave",
+  show_moment_tags: ["bustout"],
+};
+
+/**
+ * @param {string} highlight
+ * @returns {boolean}
+ */
+export function looksLikeBustoutHighlight(highlight) {
+  return /^Bustouts?:/i.test(String(highlight || "").trim());
+}
+
+/**
+ * @param {ShowContext} ctx
+ * @returns {{ id: string, ok: boolean, detail: string }[]}
+ */
+export function runHighlightChecklist(ctx) {
+  /** @type {{ id: string, ok: boolean, detail: string }[]} */
+  const checks = [];
+  const highlight = String(ctx.setlist_highlight || "").trim();
+  const entries = Array.isArray(ctx.bustout_entries)
+    ? ctx.bustout_entries.filter((e) => e?.title)
+    : [];
+  const titles = Array.isArray(ctx.bustout_titles)
+    ? ctx.bustout_titles.filter(Boolean)
+    : [];
+  const bustoutCount = entries.length || titles.length;
+
+  if (bustoutCount > 0) {
+    const expectLabel = bustoutCount === 1 ? "Bustout:" : "Bustouts:";
+    const hasLabel = highlight.startsWith(expectLabel);
+    checks.push({
+      id: "bustout_label",
+      ok: hasLabel,
+      detail: hasLabel
+        ? `highlight starts with ${expectLabel}`
+        : `expected "${expectLabel}" prefix; got "${highlight.slice(0, 80)}"`,
+    });
+
+    const endsWithPeriod = highlight.endsWith(".");
+    checks.push({
+      id: "trailing_period",
+      ok: endsWithPeriod,
+      detail: endsWithPeriod
+        ? "highlight ends with period"
+        : "highlight missing trailing period",
+    });
+
+    if (bustoutCount >= 2) {
+      const hasSemi = highlight.includes(";");
+      checks.push({
+        id: "multi_semicolon",
+        ok: hasSemi,
+        detail: hasSemi
+          ? "multi-bustout uses semicolon separators"
+          : "multi-bustout missing ';' separators",
+      });
+    }
+
+    const gapsExpected = entries.filter(
+      (e) => e.gap != null && Number.isFinite(e.gap),
+    );
+    if (gapsExpected.length) {
+      const allPresent = gapsExpected.every((e) =>
+        highlight.includes(String(e.gap)),
+      );
+      const shapeOk = / - (a|an) \d+ show gap/.test(highlight);
+      checks.push({
+        id: "gap_shape",
+        ok: allPresent && shapeOk,
+        detail:
+          allPresent && shapeOk
+            ? "gap numbers present with 'a/an N show gap' shape"
+            : `missing gap shape in "${highlight.slice(0, 100)}"`,
+      });
+    }
+  } else {
+    checks.push({
+      id: "bustout_label",
+      ok: !looksLikeBustoutHighlight(highlight),
+      detail: looksLikeBustoutHighlight(highlight)
+        ? "highlight has Bustout label but context has no bustouts"
+        : "no bustouts — label rule N/A",
+    });
+  }
+
+  // Night-scoped: highlight should not look like a tour essay.
+  const tourEssay =
+    /end of (the )?tour|season recap|tour wrap/i.test(highlight);
+  checks.push({
+    id: "night_vs_tour",
+    ok: !tourEssay,
+    detail: tourEssay
+      ? "highlight looks like tour-length copy (#510 boundary)"
+      : "night-scoped highlight",
+  });
+
+  return checks;
+}
+
+/**
+ * @param {string} narrativeLine
+ * @param {ShowContext} ctx
+ * @param {string} branch
+ * @returns {{ id: string, ok: boolean, detail: string }[]}
+ */
+export function runNarrativeLineChecklist(narrativeLine, ctx, branch) {
+  /** @type {{ id: string, ok: boolean, detail: string }[]} */
+  const checks = [];
+  const line = String(narrativeLine || "").trim();
+  const highlight = String(ctx.setlist_highlight || "").trim();
+  const bustoutCount =
+    (ctx.bustout_entries || []).filter((e) => e?.title).length ||
+    (ctx.bustout_titles || []).filter(Boolean).length;
+
+  if (branch === "bustout_hero") {
+    const ok = /^You caught a bustout/i.test(line);
+    checks.push({
+      id: "bustout_hero_prefix",
+      ok,
+      detail: ok
+        ? "bustout_hero opens with You caught a bustout"
+        : `unexpected bustout_hero line: "${line.slice(0, 80)}"`,
+    });
+  }
+
+  if (bustoutCount > 0 && branch !== "bustout_hero" && highlight) {
+    // Cold/hot/mixed must retain the labeled highlight when present.
+    const retains =
+      line.includes("Bustout:") ||
+      line.includes("Bustouts:") ||
+      (looksLikeBustoutHighlight(highlight) && line.includes(highlight));
+    checks.push({
+      id: "wrapper_keeps_label",
+      ok: retains,
+      detail: retains
+        ? `${branch} retains Bustout label`
+        : `${branch} dropped Bustout label — line="${line.slice(0, 100)}"`,
+    });
+  }
+
+  return checks;
+}
+
+/**
+ * Catalog example must document Bustout:/Bustouts: shape (#780), not freeform lore.
+ * @param {string} catalogMd
+ * @returns {{ id: string, ok: boolean, detail: string }}
+ */
+export function runCatalogExampleCheck(catalogMd) {
+  const hasBustoutExample =
+    /Bustout: .+ show gap/i.test(catalogMd) ||
+    /Bustouts: .+ show gap/i.test(catalogMd);
+  const hasStaleReba = /first time Reba opened/i.test(catalogMd);
+  return {
+    id: "catalog_example",
+    ok: hasBustoutExample && !hasStaleReba,
+    detail: hasStaleReba
+      ? "TRIGGER_CATALOG still has stale freeform Reba example"
+      : hasBustoutExample
+        ? "catalog documents Bustout:/Bustouts: shape"
+        : "catalog missing Bustout: example",
+  };
+}
+
+/**
+ * Scorecard fixtures that force each narrative branch when passed to enrichment.
+ * @returns {Record<string, { show_score: number, userPicks: Record<string, string>, actualSetlist: Record<string, unknown> }>}
+ */
+export function branchScorecardFixtures(bustoutTitle = "Melt the Guns") {
+  const emptyBoard = {
+    s1o: "Wrong One",
+    s1c: "Wrong Two",
+    s2o: "Wrong Three",
+    s2c: "Wrong Four",
+    enc: "Wrong Five",
+    wild: "Wrong Six",
+  };
+  const hotBoard = {
+    s1o: "Carini",
+    s1c: "Harry Hood",
+    s2o: "What's Going Through Your Mind",
+    s2c: "Run Like an Antelope",
+    enc: "A Life Beyond The Dream",
+    wild: "Fuego",
+  };
+  const actual = {
+    s1o: "Carini",
+    s1c: "Harry Hood",
+    s2o: "What's Going Through Your Mind",
+    s2c: "Run Like an Antelope",
+    enc: "A Life Beyond The Dream",
+    officialSetlist: [
+      "Carini",
+      "Harry Hood",
+      "What's Going Through Your Mind",
+      "Fuego",
+      bustoutTitle,
+      "Run Like an Antelope",
+      "A Life Beyond The Dream",
+    ],
+    bustouts: [bustoutTitle],
+  };
+
+  return {
+    cold: { show_score: 10, userPicks: emptyBoard, actualSetlist: actual },
+    mixed: {
+      show_score: 25,
+      userPicks: {
+        ...emptyBoard,
+        s1o: "Carini",
+        s2c: "Run Like an Antelope",
+      },
+      actualSetlist: actual,
+    },
+    hot_night: { show_score: 70, userPicks: hotBoard, actualSetlist: actual },
+    bustout_hero: {
+      show_score: 30,
+      userPicks: { ...emptyBoard, wild: bustoutTitle },
+      actualSetlist: actual,
+    },
+  };
+}
+
+/**
+ * @param {{ id: string, ok: boolean, detail: string }[]} checks
+ * @returns {{ pass: boolean, failed: typeof checks, passed: typeof checks }}
+ */
+export function summarizeChecks(checks) {
+  const failed = checks.filter((c) => !c.ok);
+  const passed = checks.filter((c) => c.ok);
+  return { pass: failed.length === 0, failed, passed };
+}
+
+/**
+ * Build markdown pack section for #573.
+ * @param {{
+ *   showDate: string,
+ *   context: ShowContext,
+ *   recomposedHighlight?: string | null,
+ *   samples: { branch: string, narrative_line: string, emailNightExcerpt?: string }[],
+ *   checks: { id: string, ok: boolean, detail: string }[],
+ *   source: string,
+ * }} input
+ */
+export function buildNarrativeQaReportMarkdown(input) {
+  const summary = summarizeChecks(input.checks);
+  const status = summary.pass ? "PASS" : "FAIL → DRAFT_PR";
+  const checkLines = input.checks
+    .map((c) => `- [${c.ok ? "x" : " "}] \`${c.id}\` — ${c.detail}`)
+    .join("\n");
+
+  const sampleBlocks = input.samples
+    .map(
+      (s) =>
+        `#### \`${s.branch}\`\n\n> ${s.narrative_line}\n${
+          s.emailNightExcerpt
+            ? `\n\`\`\`\n${s.emailNightExcerpt}\n\`\`\`\n`
+            : ""
+        }`,
+    )
+    .join("\n");
+
+  return `## Show-recap uniqueness QA — ${input.showDate}
+
+**Status:** **${status}**  
+**Source:** ${input.source}  
+**Stored highlight:** \`${input.context.setlist_highlight || "(none)"}\`${
+    input.recomposedHighlight != null
+      ? `  
+**Recomposed highlight:** \`${input.recomposedHighlight}\``
+      : ""
+  }  
+**Tags:** ${(input.context.show_moment_tags || []).join(", ") || "—"}
+
+### Checklist
+${checkLines}
+
+### Branch samples
+${sampleBlocks}
+
+### Ask for PM
+- [ ] ${
+    summary.pass
+      ? "No copy change required"
+      : "Open/approve draft PR for mechanical label/copy fix"
+  }
+- [ ] Accept uniqueness samples for the pack
+`;
+}

--- a/scripts/lib/showRecapNarrativeQa.test.mjs
+++ b/scripts/lib/showRecapNarrativeQa.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  FIXTURE_FENWAY_LABELED,
+  FIXTURE_FENWAY_UNLABELED,
+  FIXTURE_MULTI_BUSTOUT,
+  runCatalogExampleCheck,
+  runHighlightChecklist,
+  runNarrativeLineChecklist,
+  summarizeChecks,
+} from "./showRecapNarrativeQa.mjs";
+
+describe("showRecapNarrativeQa", () => {
+  it("fails Fenway-class unlabeled single bustout", () => {
+    const checks = runHighlightChecklist(FIXTURE_FENWAY_UNLABELED);
+    const summary = summarizeChecks(checks);
+    assert.equal(summary.pass, false);
+    assert.ok(summary.failed.some((c) => c.id === "bustout_label"));
+  });
+
+  it("passes labeled Fenway highlight", () => {
+    const checks = runHighlightChecklist(FIXTURE_FENWAY_LABELED);
+    assert.equal(summarizeChecks(checks).pass, true);
+  });
+
+  it("requires semicolons for multi bustouts", () => {
+    const bad = {
+      ...FIXTURE_MULTI_BUSTOUT,
+      setlist_highlight:
+        "Bustouts: Curtain With - a 142 show gap, Fluffhead - an 87 show gap.",
+    };
+    const checks = runHighlightChecklist(bad);
+    assert.ok(checks.some((c) => c.id === "multi_semicolon" && !c.ok));
+
+    const good = runHighlightChecklist(FIXTURE_MULTI_BUSTOUT);
+    assert.equal(summarizeChecks(good).pass, true);
+  });
+
+  it("flags cold wrapper that drops Bustout label", () => {
+    const checks = runNarrativeLineChecklist(
+      "Tough board. Still a night to remember: Melt the Guns - a 2051 show gap",
+      FIXTURE_FENWAY_LABELED,
+      "cold",
+    );
+    assert.ok(checks.some((c) => c.id === "wrapper_keeps_label" && !c.ok));
+  });
+
+  it("accepts cold wrapper that keeps Bustout label", () => {
+    const checks = runNarrativeLineChecklist(
+      "Tough board. Still a night to remember: Bustout: Melt the Guns - a 2051 show gap.",
+      FIXTURE_FENWAY_LABELED,
+      "cold",
+    );
+    assert.equal(summarizeChecks(checks).pass, true);
+  });
+
+  it("rejects stale Reba catalog example", () => {
+    const stale = runCatalogExampleCheck(
+      '3. **Setlist context** — `{{setlist_highlight}}` (e.g., "It was the first time Reba opened a show in 6 years").',
+    );
+    assert.equal(stale.ok, false);
+
+    const good = runCatalogExampleCheck(
+      "3. **Setlist context** — `{{setlist_highlight}}` (e.g., `Bustout: Melt the Guns - a 2051 show gap.`).",
+    );
+    assert.equal(good.ok, true);
+  });
+});


### PR DESCRIPTION
Closes #779

## Summary
- `npm run comms:show-recap-qa` — deterministic Bustout:/Bustouts: checklist + cold/mixed/hot/bustout_hero samples
- Fenway-class unlabeled highlight **FAIL**s; labeled/recompose **PASS**
- Post-show Optimize kickoffs (#778) attach the QA report on #573 (live context, fixture fallback)
- `--live --rebuild` rewrites `comms_show_context` from `official_setlists` + `songGaps` (Fenway 2026-07-31 rebuilt in prod)
- Optional Resend helper: `scripts/canary-show-recap-narrative-preview.mjs`

## Test plan
- [x] `npm run test:comms-show-recap-qa`
- [x] Fixture `fenway_unlabeled` exits 2 (FAIL → DRAFT_PR)
- [x] Fixture `fenway_labeled` exits 0
- [x] Live Fenway before rebuild FAIL; after `--rebuild` PASS
- [ ] After merge: `npm run comms:optimize-kickoff -- --mode post_show --show-date 2026-07-31` embeds QA section


Made with [Cursor](https://cursor.com)