### PR TITLE
promote: staging → main (v1.40.3)

### DIFF
--- a/.github/workflows/comms-optimize-schedule.yml
+++ b/.github/workflows/comms-optimize-schedule.yml
@@ -1,0 +1,59 @@
+# Scheduled Comms Optimize kickoff (#778 / epic #573).
+# Posts a [SKIP-PRD] agent prompt on #573 when:
+#   - yesterday was a show date (post_show → show_recap_uniqueness), or
+#   - today is Monday America/Denver and there was no post-show (weekly rotation).
+#
+# Does NOT run the full Leadership/Cursor squad (needs GA4 MCP + LLM).
+# A Cloud Agent / Cursor Automation / human picks up the kickoff comment.
+# Agents never merge or comms:deploy from this workflow.
+
+name: Comms Optimize schedule
+
+on:
+  schedule:
+    # ~09:00 America/Denver during MDT (15:00 UTC); after tour_rankings_daily 08:00 PT.
+    - cron: "0 15 * * *"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "auto | weekly | post_show"
+        required: true
+        default: "auto"
+        type: choice
+        options:
+          - auto
+          - weekly
+          - post_show
+      show_date:
+        description: "Optional YYYY-MM-DD for post_show"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  kickoff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+
+      - name: Resolve + post kickoff on #573
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'auto' }}
+          SHOW_DATE: ${{ github.event_name == 'workflow_dispatch' && inputs.show_date || '' }}
+        run: |
+          set -euo pipefail
+          ARGS=(--mode "$MODE" --post)
+          if [ -n "${SHOW_DATE}" ]; then
+            ARGS+=(--show-date "$SHOW_DATE")
+          fi
+          node scripts/comms-optimize-kickoff.mjs "${ARGS[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ### Added
 - **Comms Optimize L2 kickoff scheduler (#778)** — `docs/comms-triggers/optimize_for.md` goal rotation, `npm run comms:optimize-kickoff`, and `.github/workflows/comms-optimize-schedule.yml` (daily cron posts agent prompts on epic #573; no auto-merge/deploy).
+- **Show-recap narrative QA (#779)** — `npm run comms:show-recap-qa` checklist + branch samples against `comms_show_context` / fixtures; post-show Optimize kickoffs attach the report on #573 (fail → `DRAFT_PR`).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ## [Unreleased]
 
-No unreleased changes.
+### Added
+- **Comms Optimize L2 kickoff scheduler (#778)** — `docs/comms-triggers/optimize_for.md` goal rotation, `npm run comms:optimize-kickoff`, and `.github/workflows/comms-optimize-schedule.yml` (daily cron posts agent prompts on epic #573; no auto-merge/deploy).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ No unreleased changes.
 
 ---
 
+## [1.40.3] — 2026-08-01
+
+### Changed
+- **Show recap bustout highlight (#780)** — `setlist_highlight` now labels nights as `Bustout: Song - a/an N show gap.` (one) or `Bustouts: …; ….` (two+). Fixes cold-branch email reading like a vague memory line when a single bustout landed (e.g. Fenway Melt the Guns).
+
+---
+
 ## [1.40.2] — 2026-07-31
 
 ### Changed

--- a/docs/API.md
+++ b/docs/API.md
@@ -134,7 +134,7 @@ Server-written night-of narrative artifact for `show_recap` / `tour_rankings_dai
 
 | Field | Type | Notes |
 |-------|------|-------|
-| `setlist_highlight` | string? | One-liner for push / Tonight block |
+| `setlist_highlight` | string? | One-liner for push / Tonight block. Bustout nights: `Bustout: Song - a/an N show gap.` (singular) or `Bustouts: …; ….` (plural, `;`-separated) (#780). |
 | `set_flow_summary` | string? | Short S1/S2/E structure |
 | `bustout_titles` | string[] | From official setlist bustouts |
 | `tour_debut_titles` | string[] | New-to-tour titles tonight |

--- a/docs/COMMS_SHOW_CONTEXT_SCHEMA.md
+++ b/docs/COMMS_SHOW_CONTEXT_SCHEMA.md
@@ -23,7 +23,7 @@ Standalone collection (same rationale as `rollup_audit`): do not nest on
 | `bustout_entries` | `{ title, gap }[]` | Bustouts with Phish.net pre-show gap when rows available |
 | `tour_debut_titles` | string[] | Tonight titles not seen earlier this tour |
 | `set_flow_summary` | string \| null | Short S1/S2/E structure line |
-| `setlist_highlight` | string \| null | One-liner for push / Tonight |
+| `setlist_highlight` | string \| null | One-liner for push / Tonight. Bustouts: `Bustout: Song - a/an N show gap.` or `Bustouts: A - …; B - ….` (#780) |
 | `show_moment_tags` | string[] | e.g. `bustout`, `tour_debut`, `multi_encore` |
 | `set_counts` | map | `{ set1, set2, encore }` lengths |
 | `schemaVersion` | number | `1` |

--- a/docs/GITHUB_AUTOMATION_CONTEXT.md
+++ b/docs/GITHUB_AUTOMATION_CONTEXT.md
@@ -8,6 +8,7 @@
 
 - **GitHub Actions:** Workflows run from the **default branch**’s `.github/workflows/` copy. If `[SKIP-PRD]` handling was added on another branch, merge to **default** before expecting skips to work on newly opened issues.
 - **Body:** If the issue body (after leading whitespace) starts with **`[SKIP-PRD]`**, automation must **not** replace the body (Cursor agent–authored specs). The Action refetches the issue via the REST API and treats the **first non-empty line** as `[SKIP-PRD]` (after stripping a UTF-8 BOM if present).
+- **Comms Optimize schedule (#778):** `.github/workflows/comms-optimize-schedule.yml` posts `[SKIP-PRD]` **comments** on epic #573 (kickoff prompts only — not issue-body rewrites). Same skip-prd discipline; agents never merge/deploy from that workflow.
 - **Labels:** Do not run auto-PRD / do not groom if the issue has any of:
   - **`skip-prd`** — no GitHub Action PRD rewrite on open (use with `[SKIP-PRD]` for belt-and-suspenders).
   - **`cursor-authored`** — treat as human/agent final copy; skip Action and groom rewrites.

--- a/docs/comms-triggers/ECOSYSTEM.md
+++ b/docs/comms-triggers/ECOSYSTEM.md
@@ -8,7 +8,8 @@ message across in‑app, push, and email — fully automated, with **no manual
 It complements the other comms docs:
 
 - [`FRAMEWORK.md`](./FRAMEWORK.md) — the TTDMOM operating model (Trigger → Template → Deliver → Measure → Optimize → Monetize)
-- [`OPTIMIZE_AUTONOMY.md`](./OPTIMIZE_AUTONOMY.md) — Optimize autonomy L0 playbook + PM pack (#573)
+- [`OPTIMIZE_AUTONOMY.md`](./OPTIMIZE_AUTONOMY.md) — Optimize autonomy playbook + L2 schedule (#573 / #778)
+- [`optimize_for.md`](./optimize_for.md) — Scheduled `optimize_for` rotation
 - [`catalog.json`](./catalog.json) / [`TRIGGER_CATALOG.md`](./TRIGGER_CATALOG.md) — the machine + human trigger registry
 - [`MEASUREMENT_PLAN.md`](./MEASUREMENT_PLAN.md) — the GA4 events & funnels
 
@@ -135,7 +136,7 @@ change regardless of which agent (or human) makes it.
 
 ### 3.4 Optimize (feedback loop)
 
-Canonical playbook: **[OPTIMIZE_AUTONOMY.md](./OPTIMIZE_AUTONOMY.md)** (#573 L0).
+Canonical playbook: **[OPTIMIZE_AUTONOMY.md](./OPTIMIZE_AUTONOMY.md)** (#573). L2 kickoff cron: [#778](https://github.com/pat792/set-picks/issues/778).
 
 Cycle order: `comms-analyst` → `comms-triggers` → `comms-drafter` → `comms-architect` → **PM**.
 

--- a/docs/comms-triggers/OPTIMIZE_AUTONOMY.md
+++ b/docs/comms-triggers/OPTIMIZE_AUTONOMY.md
@@ -1,7 +1,7 @@
-# Comms Optimize autonomy (L0 playbook)
+# Comms Optimize autonomy (L0–L2 playbook)
 
 **Epic:** [#573](https://github.com/pat792/set-picks/issues/573)  
-**Status:** L1 — playbook + first on-demand pack proven (2026-07-17, goal `picks_lock`). Scheduled runner (L2) not yet.  
+**Status:** L2 kickoff automation shipped ([#778](https://github.com/pat792/set-picks/issues/778)) — daily GH Action posts a pack kickoff on #573; full Leadership → squad execution still agent-driven from that comment. L1 on-demand packs remain supported.  
 **Does not replace:** automated **delivery** (`deliverCommsTrigger` / epic #441). This doc is the **editorial + measurement + recommendation** loop.
 
 ---
@@ -44,6 +44,45 @@ and never merge or deploy.
 ```
 
 Swap `picks_lock` / window as needed. First L1 pack: [comment on #573](https://github.com/pat792/set-picks/issues/573#issuecomment-5000375612).
+
+---
+
+## Scheduled runner (L2 — #778)
+
+| Piece | Path |
+|-------|------|
+| Goal rotation | [`optimize_for.md`](./optimize_for.md) |
+| Kickoff script | `npm run comms:optimize-kickoff` (`scripts/comms-optimize-kickoff.mjs`) |
+| Cron | `.github/workflows/comms-optimize-schedule.yml` — daily `15:00` UTC (~09:00 America/Denver) |
+| Epic comments | Workflow posts `[SKIP-PRD]` kickoff on **#573** (does not merge/deploy) |
+
+**Note:** GitHub `schedule` workflows run only from the repo **default branch** (`main`). Merge to `staging` first; cron becomes live after promote to `main`. Use `workflow_dispatch` on the workflow file’s branch for earlier dry runs.
+
+**Cadence**
+
+| When | Mode | `optimize_for` |
+|------|------|----------------|
+| Morning after a calendar show date | `post_show` | always `show_recap_uniqueness` (narrative QA → [#779](https://github.com/pat792/set-picks/issues/779)) |
+| Monday (Denver), no post-show | `weekly` | ISO-week rotation in `optimize_for.md` (show-week vs off-tour) |
+| Manual | `workflow_dispatch` or CLI | `--mode weekly\|post_show` |
+
+**What the cron does vs does not**
+
+| Does | Does not |
+|------|----------|
+| Resolve goal + window from calendar + rotation | Run GA4 MCP / CrewAI / Cursor squad itself |
+| Post agent prompt on #573 | Open draft PRs or deploy |
+| Prefer post-show over weekly when both apply | Invent metrics |
+
+**Human / Cloud Agent step after each kickoff:** run the embedded prompt (or Leadership `crew` optimize → `SQUAD_KICKOFF` → squad). Post the finished **PM review pack** as a follow-up comment on #573. L2 exit criteria (two consecutive packs without chat kickoff) count when those pack comments land from the scheduled kickoffs.
+
+```bash
+# Dry-run (prints markdown)
+npm run comms:optimize-kickoff -- --mode auto
+
+# Post to #573 (needs gh auth)
+npm run comms:optimize-kickoff -- --mode weekly --post
+```
 
 ---
 
@@ -152,6 +191,7 @@ Full L0→L4 table lives on [#573](https://github.com/pat792/set-picks/issues/57
 |-------|-------------|
 | **L0** | Done — this playbook + skills (#628) |
 | **L1** | Done — first on-demand pack (2026-07-17, `optimize_for=picks_lock`) |
-| **L2+** | Open — scheduled runner; uniqueness; NBA |
+| **L2** | Kickoff cron shipped (#778) — exit when **two consecutive** packs land from scheduled kickoffs without chat |
+| **L3+** | Open — narrative QA (#779); uniqueness metrics; NBA |
 
 Related Wave 5 siblings: [#510](https://github.com/pat792/set-picks/issues/510) (`tour_recap`), [#512](https://github.com/pat792/set-picks/issues/512) (email open signal), [#513](https://github.com/pat792/set-picks/issues/513) (prefs hub).

--- a/docs/comms-triggers/OPTIMIZE_AUTONOMY.md
+++ b/docs/comms-triggers/OPTIMIZE_AUTONOMY.md
@@ -62,9 +62,28 @@ Swap `picks_lock` / window as needed. First L1 pack: [comment on #573](https://g
 
 | When | Mode | `optimize_for` |
 |------|------|----------------|
-| Morning after a calendar show date | `post_show` | always `show_recap_uniqueness` (narrative QA → [#779](https://github.com/pat792/set-picks/issues/779)) |
+| Morning after a calendar show date | `post_show` | always `show_recap_uniqueness` + narrative QA report ([#779](https://github.com/pat792/set-picks/issues/779)) |
 | Monday (Denver), no post-show | `weekly` | ISO-week rotation in `optimize_for.md` (show-week vs off-tour) |
 | Manual | `workflow_dispatch` or CLI | `--mode weekly\|post_show` |
+
+### Show-recap uniqueness QA (#779)
+
+Post-show kickoffs attach a **Show-recap uniqueness QA** section (or run standalone):
+
+```bash
+# Fixture smoke (CI / no Firestore)
+npm run comms:show-recap-qa -- --fixture fenway_labeled
+npm run comms:show-recap-qa -- --fixture fenway_unlabeled   # expect FAIL (pre-#780)
+
+# Live context (rebuild highlight from official_setlists + songGaps)
+npm run comms:show-recap-qa -- --show-date 2026-07-31 --live
+npm run comms:show-recap-qa -- --show-date 2026-07-31 --live --rebuild
+
+# Post report on #573
+npm run comms:show-recap-qa -- --show-date 2026-07-31 --live --post
+```
+
+Checklist (fail → scored `DRAFT_PR`): `Bustout:` / `Bustouts:` labels, trailing period, `;` separators for multi, gap shape, cold/hot wrappers keep the label, catalog example matches runtime. Renders `cold` / `mixed` / `hot_night` / `bustout_hero` via `tour-rankings-daily` (dry — no Resend).
 
 **What the cron does vs does not**
 
@@ -73,6 +92,7 @@ Swap `picks_lock` / window as needed. First L1 pack: [comment on #573](https://g
 | Resolve goal + window from calendar + rotation | Run GA4 MCP / CrewAI / Cursor squad itself |
 | Post agent prompt on #573 | Open draft PRs or deploy |
 | Prefer post-show over weekly when both apply | Invent metrics |
+| Attach narrative QA on post_show (#779) | Send Resend canaries (optional separate script) |
 
 **Human / Cloud Agent step after each kickoff:** run the embedded prompt (or Leadership `crew` optimize → `SQUAD_KICKOFF` → squad). Post the finished **PM review pack** as a follow-up comment on #573. L2 exit criteria (two consecutive packs without chat kickoff) count when those pack comments land from the scheduled kickoffs.
 

--- a/docs/comms-triggers/README.md
+++ b/docs/comms-triggers/README.md
@@ -15,6 +15,8 @@ This directory is the **canonical home** for triggered, templated communications
 | [EXPERIMENT_PLAYBOOK.md](./EXPERIMENT_PLAYBOOK.md) | A/B rules, variant assignment, ship/kill criteria |
 | [OPTIMIZE_AUTONOMY.md](./OPTIMIZE_AUTONOMY.md) | **Optimize autonomy** — cycle order, PM pack template, L2 schedule (#573 / #778) |
 | [optimize_for.md](./optimize_for.md) | Scheduled goal rotation + override for Optimize kickoffs (#778) |
+
+CLI: `npm run comms:optimize-kickoff` · `npm run comms:show-recap-qa` (#779)
 | [EMAIL_INBOX_BADGE.md](./EMAIL_INBOX_BADGE.md) | Inbox sender badge (BIMI/DMARC) vs in-body email logo (#498) |
 | [COMMERCIAL_PHASE3.md](./COMMERCIAL_PHASE3.md) | Sponsor / affiliate / offer gates (Phase 3) |
 

--- a/docs/comms-triggers/README.md
+++ b/docs/comms-triggers/README.md
@@ -13,7 +13,8 @@ This directory is the **canonical home** for triggered, templated communications
 | [MEASUREMENT_PLAN.md](./MEASUREMENT_PLAN.md) | GA4 comms events, dimensions, funnels |
 | [CTA_ROUTE_AUDIT.md](./CTA_ROUTE_AUDIT.md) | In-app/email CTA label ↔ destination matrix (#551) |
 | [EXPERIMENT_PLAYBOOK.md](./EXPERIMENT_PLAYBOOK.md) | A/B rules, variant assignment, ship/kill criteria |
-| [OPTIMIZE_AUTONOMY.md](./OPTIMIZE_AUTONOMY.md) | **Optimize autonomy L0** — cycle order, PM pack template, draft-only gate (#573) |
+| [OPTIMIZE_AUTONOMY.md](./OPTIMIZE_AUTONOMY.md) | **Optimize autonomy** — cycle order, PM pack template, L2 schedule (#573 / #778) |
+| [optimize_for.md](./optimize_for.md) | Scheduled goal rotation + override for Optimize kickoffs (#778) |
 | [EMAIL_INBOX_BADGE.md](./EMAIL_INBOX_BADGE.md) | Inbox sender badge (BIMI/DMARC) vs in-body email logo (#498) |
 | [COMMERCIAL_PHASE3.md](./COMMERCIAL_PHASE3.md) | Sponsor / affiliate / offer gates (Phase 3) |
 

--- a/docs/comms-triggers/TRIGGER_CATALOG.md
+++ b/docs/comms-triggers/TRIGGER_CATALOG.md
@@ -412,7 +412,7 @@ Up next: {{next_show_venue}} on {{next_show_date}}. Picks open now.
 **Body sections:**
 1. **Your night** *(absorbed from `show_recap`, #451)* — score, rank (global + pool if applicable), correct picks count.
 2. **Pick-by-pick** — opener, closer, encore, wildcard results with song names. Bustout Boost called out if earned.
-3. **Setlist context** — `{{setlist_highlight}}` (e.g., "It was the first time Reba opened a show in 6 years").
+3. **Setlist context** — `{{setlist_highlight}}` (e.g., `Bustout: Melt the Guns - a 2051 show gap.` or `Bustouts: Song A - an 87 show gap; Song B - a 40 show gap.`).
 4. **Your tour position** — rank, points, shows played, rank change vs yesterday.
 5. **Pool standing** — `{{pool_tour_rank}}` in `{{pool_name}}` (if applicable).
 6. **Next show** — {{next_show_venue}}, {{next_show_date}}. Picks are open.

--- a/docs/comms-triggers/optimize_for.md
+++ b/docs/comms-triggers/optimize_for.md
@@ -1,0 +1,59 @@
+# Optimize goal rotation (#778 / #573)
+
+**Source of truth** for scheduled Optimize kickoffs. Agents and
+`.github/workflows/comms-optimize-schedule.yml` read this file via
+`scripts/comms-optimize-kickoff.mjs`.
+
+<!-- Machine-readable override (empty = ISO-week rotation). Do not fence this line. -->
+current_override:
+
+## Override (optional)
+
+Set `current_override:` above to a single snake_case goal to force the next
+weekly kickoff. Clear it (leave empty) to resume automatic rotation.
+
+Valid goals: `picks_lock` · `return_14d` · `tour_retention` · `push_opt_in` ·
+`email_open` · `show_recap_uniqueness`
+
+## Automatic rotation
+
+### Post-show (morning after a calendar show date)
+
+Always: **`show_recap_uniqueness`**  
+Window: that show date (GA4 still uses last 7 complete days for funnels).  
+Narrative QA checklist: [#779](https://github.com/pat792/set-picks/issues/779).
+
+### Weekly (Monday, America/Denver) — show week
+
+ISO week number → goal (cycle of 4):
+
+| ISO week mod 4 | `optimize_for` |
+|----------------|----------------|
+| 0 | `picks_lock` |
+| 1 | `email_open` |
+| 2 | `show_recap_uniqueness` |
+| 3 | `tour_retention` |
+
+Show week = at least one `FALLBACK_SHOW_DATES` / calendar date in
+`[today−7d, today+7d]` (script uses committed show-date fallback until
+Firestore is available in Actions).
+
+### Weekly (Monday) — off-tour
+
+| ISO week mod 2 | `optimize_for` |
+|----------------|----------------|
+| 0 | `return_14d` |
+| 1 | `push_opt_in` |
+
+## Priority when Monday follows a show night
+
+1. **Post-show** kickoff (`show_recap_uniqueness`) if yesterday was a show
+2. Else **weekly** kickoff
+
+## Manual kickoff
+
+```bash
+npm run comms:optimize-kickoff -- --mode weekly
+npm run comms:optimize-kickoff -- --mode post_show --show-date 2026-07-31
+npm run comms:optimize-kickoff -- --mode weekly --post   # comment on #573
+```

--- a/functions/commsShowContextCore.js
+++ b/functions/commsShowContextCore.js
@@ -219,7 +219,7 @@ function formatBustoutSongGap(entries) {
         ? `${e.title} - ${indefiniteArticleForGap(e.gap)} ${e.gap} show gap`
         : e.title,
     )
-    .join(", ");
+    .join("; ");
 }
 
 /**
@@ -246,7 +246,9 @@ function composeSetlistHighlight({
       : (bustoutTitles || []).map((title) => ({ title, gap: null }));
   const bustoutLine = formatBustoutSongGap(entries);
   if (bustoutLine) {
-    return entries.length === 1 ? bustoutLine : `Bustouts: ${bustoutLine}.`;
+    // Single: "Bustout: Song - a N show gap." Multi: "Bustouts: A - …; B - …." (#780)
+    const label = entries.length === 1 ? "Bustout" : "Bustouts";
+    return `${label}: ${bustoutLine}.`;
   }
   if (tourDebuts.length >= 3) {
     return `${tourDebuts.length} songs new to this tour — including ${tourDebuts[0]}.`;

--- a/functions/commsShowContextCore.test.js
+++ b/functions/commsShowContextCore.test.js
@@ -45,7 +45,7 @@ describe("tourDebutTitles", () => {
 });
 
 describe("composeSetlistHighlight", () => {
-  it("formats bustout as Song - gap", () => {
+  it("labels a single bustout as Bustout: Song - gap.", () => {
     assert.equal(
       composeSetlistHighlight({
         bustoutTitles: ["Curtain With"],
@@ -54,7 +54,23 @@ describe("composeSetlistHighlight", () => {
         openerTitle: "YEM",
         encoreTitle: "Tweeprise",
       }),
-      "Curtain With - a 142 show gap",
+      "Bustout: Curtain With - a 142 show gap.",
+    );
+  });
+
+  it("labels multiple bustouts with Bustouts: and semicolon separators", () => {
+    assert.equal(
+      composeSetlistHighlight({
+        bustoutTitles: ["Curtain With", "Fluffhead"],
+        bustoutEntries: [
+          { title: "Curtain With", gap: 142 },
+          { title: "Fluffhead", gap: 87 },
+        ],
+        tourDebuts: [],
+        openerTitle: "YEM",
+        encoreTitle: "Tweeprise",
+      }),
+      "Bustouts: Curtain With - a 142 show gap; Fluffhead - an 87 show gap.",
     );
   });
 });
@@ -79,7 +95,7 @@ describe("buildCommsShowContext", () => {
         { title: "Slave", gap: 10 },
       ],
     });
-    assert.equal(ctx.setlist_highlight, "Wolfman's - an 87 show gap");
+    assert.equal(ctx.setlist_highlight, "Bustout: Wolfman's - an 87 show gap.");
     assert.match(ctx.set_flow_summary, /Set 1 opened with YEM/);
     assert.ok(ctx.show_moment_tags.includes("bustout"));
     assert.ok(ctx.tour_debut_titles.includes("Wolfman's"));

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "comms:deploy": "node scripts/deploy-comms-functions.mjs",
     "comms:sync": "node scripts/sync-comms-to-functions.mjs",
     "comms:optimize-kickoff": "node scripts/comms-optimize-kickoff.mjs",
+    "comms:show-recap-qa": "node scripts/comms-show-recap-narrative-qa.mjs",
     "test:comms-optimize-schedule": "node --test scripts/lib/commsOptimizeSchedule.test.mjs",
+    "test:comms-show-recap-qa": "node --test scripts/lib/showRecapNarrativeQa.test.mjs",
     "emails:build": "npm run build --prefix emails",
     "emails:preview": "npm run preview --prefix emails"
   },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "comms:deploy:dry": "node scripts/deploy-comms-functions.mjs --dry-run",
     "comms:deploy": "node scripts/deploy-comms-functions.mjs",
     "comms:sync": "node scripts/sync-comms-to-functions.mjs",
+    "comms:optimize-kickoff": "node scripts/comms-optimize-kickoff.mjs",
+    "test:comms-optimize-schedule": "node --test scripts/lib/commsOptimizeSchedule.test.mjs",
     "emails:build": "npm run build --prefix emails",
     "emails:preview": "npm run preview --prefix emails"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.40.2",
+  "version": "1.40.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/canary-show-recap-narrative-preview.mjs
+++ b/scripts/canary-show-recap-narrative-preview.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+/**
+ * Send local-rendered show-recap narrative branch emails (morning
+ * tour_rankings_daily “your night” + tour block) via Resend.
+ *
+ * Covers cold / mixed / hot_night / bustout_hero plus single + multi Bustout labels (#780).
+ *
+ * Usage:
+ *   node scripts/canary-show-recap-narrative-preview.mjs
+ *   node scripts/canary-show-recap-narrative-preview.mjs --send other@example.com
+ */
+
+import { createRequire } from "node:module";
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+const require = createRequire(import.meta.url);
+
+const envPath = resolve(root, ".env");
+/** @type {Record<string, string>} */
+const fileEnv = {};
+try {
+  for (const line of readFileSync(envPath, "utf8").split("\n")) {
+    const m = line.match(/^([^#=]+)=(.*)$/);
+    if (!m) continue;
+    fileEnv[m[1].trim()] = m[2].trim().replace(/^"|"$/g, "");
+  }
+} catch {
+  // optional
+}
+
+function shouldApplyEnvFile(key, fileValue) {
+  const existing = process.env[key];
+  if (existing == null || existing === "") return true;
+  if (key === "RESEND_API_KEY") {
+    const ok = typeof fileValue === "string" && fileValue.startsWith("re_");
+    const shellOk = typeof existing === "string" && existing.startsWith("re_");
+    return ok && !shellOk;
+  }
+  return false;
+}
+
+for (const [key, value] of Object.entries(fileEnv)) {
+  if (shouldApplyEnvFile(key, value)) process.env[key] = value;
+}
+
+const args = process.argv.slice(2);
+const sendTo =
+  (args.includes("--send") ? args[args.indexOf("--send") + 1] : null) ||
+  "pat@road2media.com";
+
+const siteUrl = "https://www.setlistpickem.com";
+const settingsUrl = `${siteUrl}/dashboard/profile/notifications`;
+
+const { buildProductionBrandedEmailShell } = require(
+  resolve(root, "functions/commsEmailWorker.js"),
+);
+const { buildEmailTrackedCtaUrl } = require(resolve(root, "comms/emailLinks.cjs"));
+const { renderCommsTemplate } = require(resolve(root, "functions/commsTemplates.js"));
+
+const baseTour = {
+  tour_rank: 6,
+  total_tour_pickers: 11,
+  tour_points: 45,
+  rank_change: "held",
+  shows_played: 8,
+  next_show_date: "2026-08-01",
+  next_show_venue: "Fenway Park",
+};
+
+/** @type {{ name: string, payload: Record<string, unknown> }[]} */
+const BRANCHES = [
+  {
+    name: "Cold + Bustout (Fenway Melt the Guns)",
+    payload: {
+      handle: "ChowdahBoyz4Lyfe",
+      show_date: "2026-07-31",
+      venue_name: "Fenway Park",
+      venue_city: "Boston, MA",
+      show_score: 10,
+      global_rank: 6,
+      global_total_pickers: 11,
+      correct_picks_count: 1,
+      total_picks_count: 6,
+      narrative_branch: "cold",
+      setlist_highlight: "Bustout: Melt the Guns - a 2051 show gap.",
+      narrative_line:
+        "Tough board. Still a night to remember: Bustout: Melt the Guns - a 2051 show gap.",
+      ...baseTour,
+    },
+  },
+  {
+    name: "Bustout hero (you caught it)",
+    payload: {
+      handle: "Pat",
+      show_date: "2026-07-31",
+      venue_name: "Fenway Park",
+      venue_city: "Boston, MA",
+      show_score: 30,
+      global_rank: 2,
+      global_total_pickers: 11,
+      correct_picks_count: 2,
+      total_picks_count: 6,
+      bustout_bonus: 20,
+      narrative_branch: "bustout_hero",
+      setlist_highlight: "Bustout: Melt the Guns - a 2051 show gap.",
+      narrative_line:
+        "You caught a bustout — Melt the Guns - a 2051 show gap.",
+      ...baseTour,
+      tour_rank: 2,
+      tour_points: 80,
+      rank_change: "up 3",
+    },
+  },
+  {
+    name: "Hot night + single Bustout",
+    payload: {
+      handle: "RiverTranced",
+      show_date: "2026-07-18",
+      venue_name: "MSG",
+      venue_city: "New York, NY",
+      show_score: 70,
+      global_rank: 4,
+      global_total_pickers: 200,
+      correct_picks_count: 5,
+      total_picks_count: 6,
+      narrative_branch: "hot_night",
+      setlist_highlight: "Bustout: Wolfman's Brother - an 87 show gap.",
+      narrative_line:
+        "Strong night. Bustout: Wolfman's Brother - an 87 show gap.",
+      ...baseTour,
+      tour_rank: 4,
+      total_tour_pickers: 312,
+      tour_points: 455,
+      rank_change: "up 2",
+      shows_played: 5,
+      next_show_date: "2026-07-20",
+      next_show_venue: "MSG",
+    },
+  },
+  {
+    name: "Mixed + Bustouts (multi)",
+    payload: {
+      handle: "CouchTourPat",
+      show_date: "2026-07-15",
+      venue_name: "Enmarket Arena",
+      venue_city: "Savannah, GA",
+      show_score: 25,
+      global_rank: 18,
+      global_total_pickers: 80,
+      correct_picks_count: 2,
+      total_picks_count: 6,
+      narrative_branch: "mixed",
+      setlist_highlight:
+        "Bustouts: Curtain With - a 142 show gap; Fluffhead - an 87 show gap.",
+      narrative_line:
+        "Bustouts: Curtain With - a 142 show gap; Fluffhead - an 87 show gap.",
+      ...baseTour,
+      tour_rank: 22,
+      total_tour_pickers: 90,
+      tour_points: 120,
+      rank_change: "down 1",
+      shows_played: 4,
+      next_show_date: "2026-07-17",
+      next_show_venue: "Walnut Creek",
+    },
+  },
+  {
+    name: "Cold + no bustout (fallback)",
+    payload: {
+      handle: "Pat",
+      show_date: "2026-07-22",
+      venue_name: "Madison Square Garden",
+      venue_city: "New York, NY",
+      show_score: 5,
+      global_rank: 40,
+      global_total_pickers: 200,
+      correct_picks_count: 0,
+      total_picks_count: 6,
+      narrative_branch: "cold",
+      setlist_highlight: "Carini opened; Slave closed the night.",
+      narrative_line:
+        "Tough board. Still a night to remember: Carini opened; Slave closed the night.",
+      ...baseTour,
+      tour_rank: 30,
+      total_tour_pickers: 200,
+      tour_points: 40,
+      rank_change: "down 4",
+      shows_played: 6,
+      next_show_date: "2026-07-24",
+      next_show_venue: "MSG",
+    },
+  },
+];
+
+const resendKey = process.env.RESEND_API_KEY;
+if (!resendKey || !resendKey.startsWith("re_")) {
+  console.error("✗ RESEND_API_KEY missing or invalid in .env");
+  process.exit(1);
+}
+
+const { Resend } = require(resolve(root, "functions/node_modules/resend"));
+const resend = new Resend(resendKey);
+
+const outDir = resolve(root, "emails/preview");
+mkdirSync(outDir, { recursive: true });
+
+console.log(
+  `→ Sending ${BRANCHES.length} show-recap narrative previews to ${sendTo}\n`,
+);
+
+let sent = 0;
+for (const branch of BRANCHES) {
+  // eslint-disable-next-line no-await-in-loop
+  const rendered = await renderCommsTemplate(
+    "tour-rankings-daily",
+    branch.payload,
+  );
+  const shell = buildProductionBrandedEmailShell({
+    siteUrl,
+    bodyText: rendered.email.text,
+    ctaUrl: buildEmailTrackedCtaUrl(
+      rendered.email.ctaUrl || `${siteUrl}/dashboard/picks`,
+      {
+        triggerId: "tour_rankings_daily",
+        templateId: "tour-rankings-daily",
+        cta: rendered.email.ctaLabel || "Make picks for next show",
+      },
+    ),
+    settingsUrl,
+    ctaLabel: rendered.email.ctaLabel,
+    signOff: rendered.email.signOff,
+    inviteBlockHtml: rendered.email.inviteBlockHtml,
+    header: rendered.email.header,
+  });
+
+  const subject = `[Show recap ${branch.name}] ${rendered.email.subject}`;
+  const slug = branch.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  writeFileSync(resolve(outDir, `show-recap-${slug}.html`), shell.html, "utf8");
+
+  // eslint-disable-next-line no-await-in-loop
+  const result = await resend.emails.send({
+    from: "Setlist Pick'em <updates@setlistpickem.com>",
+    to: [sendTo],
+    subject,
+    html: shell.html,
+    text: rendered.email.text,
+  });
+
+  if (result.error) {
+    console.error(
+      `✗ ${branch.name}: ${result.error.message || JSON.stringify(result.error)}`,
+    );
+    process.exit(1);
+  }
+
+  console.log(`✓ ${branch.name}`);
+  console.log(`  subject: ${subject}`);
+  console.log(`  id: ${result.data?.id || "(ok)"}\n`);
+  sent += 1;
+}
+
+console.log(`Done. ${sent} emails → ${sendTo}`);
+console.log('Subjects prefixed with "[Show recap …]" for scanning.');

--- a/scripts/comms-optimize-kickoff.mjs
+++ b/scripts/comms-optimize-kickoff.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Scheduled / manual Comms Optimize kickoff (#778).
+ *
+ *   npm run comms:optimize-kickoff
+ *   npm run comms:optimize-kickoff -- --mode weekly --post
+ *   npm run comms:optimize-kickoff -- --mode post_show --show-date 2026-07-31 --post
+ *
+ * --post comments on GitHub issue #573 (requires `gh` auth).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import {
+  buildKickoffMarkdown,
+  calendarDateInTz,
+  parseOverrideFromOptimizeForMd,
+  parseShowDatesFromSource,
+  resolveOptimizeKickoff,
+} from "./lib/commsOptimizeSchedule.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+const EPIC = 573;
+const TZ = "America/Denver";
+
+function parseArgs(argv) {
+  const args = {
+    mode: "auto",
+    post: false,
+    showDate: null,
+    date: null,
+    force: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--mode") args.mode = argv[++i] || "auto";
+    else if (a === "--post") args.post = true;
+    else if (a === "--show-date") args.showDate = argv[++i] || null;
+    else if (a === "--date") args.date = argv[++i] || null;
+    else if (a === "--force") args.force = true;
+    else if (a === "--help" || a === "-h") {
+      console.log(`Usage: comms-optimize-kickoff [--mode auto|weekly|post_show] [--date YYYY-MM-DD] [--show-date YYYY-MM-DD] [--post] [--force]`);
+      process.exit(0);
+    }
+  }
+  if (!["auto", "weekly", "post_show"].includes(args.mode)) {
+    console.error(`Invalid --mode ${args.mode}`);
+    process.exit(1);
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const showDatesPath = path.join(root, "src/shared/data/showDates.js");
+  const optimizeForPath = path.join(
+    root,
+    "docs/comms-triggers/optimize_for.md",
+  );
+  const showDates = parseShowDatesFromSource(
+    fs.readFileSync(showDatesPath, "utf8"),
+  );
+  const override = parseOverrideFromOptimizeForMd(
+    fs.readFileSync(optimizeForPath, "utf8"),
+  );
+
+  const todayYmd =
+    args.date || calendarDateInTz(new Date(), TZ);
+  const resolved = resolveOptimizeKickoff({
+    mode: args.mode,
+    todayYmd,
+    timeZone: TZ,
+    showDates,
+    override,
+    showDate: args.showDate,
+  });
+
+  if (resolved.action === "skip" && !args.force) {
+    console.log(`SKIP: ${resolved.reason}`);
+    process.exit(0);
+  }
+
+  if (resolved.action === "skip" && args.force) {
+    console.error("Nothing to force-kick (resolution skipped). Use --mode weekly|post_show.");
+    process.exit(1);
+  }
+
+  const body = buildKickoffMarkdown({
+    optimize_for: resolved.optimize_for,
+    window: resolved.window,
+    mode: resolved.mode,
+    showDate: resolved.showDate,
+    reason: resolved.reason,
+    runDate: todayYmd,
+  });
+
+  console.log(body);
+
+  if (!args.post) {
+    console.error("\n(dry) Pass --post to comment on GitHub issue #573.");
+    return;
+  }
+
+  const r = spawnSync(
+    "gh",
+    ["issue", "comment", String(EPIC), "--body-file", "-"],
+    {
+      cwd: root,
+      input: body,
+      encoding: "utf8",
+    },
+  );
+  if (r.status !== 0) {
+    console.error(r.stderr || r.stdout || "gh issue comment failed");
+    process.exit(r.status ?? 1);
+  }
+  console.error(`\nPosted kickoff comment on #${EPIC}`);
+  if (r.stdout) console.error(r.stdout.trim());
+}
+
+main();

--- a/scripts/comms-optimize-kickoff.mjs
+++ b/scripts/comms-optimize-kickoff.mjs
@@ -88,7 +88,7 @@ function main() {
     process.exit(1);
   }
 
-  const body = buildKickoffMarkdown({
+  let body = buildKickoffMarkdown({
     optimize_for: resolved.optimize_for,
     window: resolved.window,
     mode: resolved.mode,
@@ -96,6 +96,43 @@ function main() {
     reason: resolved.reason,
     runDate: todayYmd,
   });
+
+  // Post-show: attach deterministic narrative QA (#779). Prefer live Firestore
+  // context; fall back to labeled fixture smoke when credentials are missing.
+  if (resolved.mode === "post_show" && resolved.showDate) {
+    const qaScript = path.join(root, "scripts/comms-show-recap-narrative-qa.mjs");
+    let qa = spawnSync(
+      process.execPath,
+      [qaScript, "--show-date", resolved.showDate, "--live"],
+      { cwd: root, encoding: "utf8" },
+    );
+    let qaNote = "";
+    if (qa.status !== 0 && qa.status !== 2) {
+      qaNote =
+        "_Live `comms_show_context` unavailable — fixture smoke (`fenway_labeled`)._\n\n";
+      qa = spawnSync(
+        process.execPath,
+        [
+          qaScript,
+          "--fixture",
+          "fenway_labeled",
+          "--show-date",
+          resolved.showDate,
+        ],
+        { cwd: root, encoding: "utf8" },
+      );
+    }
+    if (qa.status === 0 || qa.status === 2) {
+      const qaBody = String(qa.stdout || "")
+        .replace(/^\[SKIP-PRD\]\s*/i, "")
+        .trim();
+      body = `${body.trim()}\n\n---\n\n${qaNote}${qaBody}\n`;
+    } else {
+      body = `${body.trim()}\n\n---\n\n### Show-recap uniqueness QA\n\n_QA script failed_ (exit ${qa.status}): ${
+        (qa.stderr || "").split("\n").filter(Boolean)[0] || "unknown"
+      }\n`;
+    }
+  }
 
   console.log(body);
 

--- a/scripts/comms-show-recap-narrative-qa.mjs
+++ b/scripts/comms-show-recap-narrative-qa.mjs
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+/**
+ * Post-show narrative QA against comms_show_context (#779).
+ *
+ * Renders cold / mixed / hot_night / bustout_hero samples, runs the Bustout
+ * label checklist, prints a #573 pack section. Optional --post comments on #573.
+ * Dry-run only for delivery — never Resend / never merge.
+ *
+ * Usage:
+ *   npm run comms:show-recap-qa -- --fixture fenway_labeled
+ *   npm run comms:show-recap-qa -- --fixture fenway_unlabeled   # expect FAIL
+ *   npm run comms:show-recap-qa -- --show-date 2026-07-31 --live
+ *   npm run comms:show-recap-qa -- --show-date 2026-07-31 --live --rebuild
+ *   npm run comms:show-recap-qa -- --show-date 2026-07-31 --live --post
+ */
+
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import {
+  FIXTURE_FENWAY_LABELED,
+  FIXTURE_FENWAY_UNLABELED,
+  FIXTURE_MULTI_BUSTOUT,
+  branchScorecardFixtures,
+  buildNarrativeQaReportMarkdown,
+  runCatalogExampleCheck,
+  runHighlightChecklist,
+  runNarrativeLineChecklist,
+  summarizeChecks,
+} from "./lib/showRecapNarrativeQa.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+const require = createRequire(import.meta.url);
+const EPIC = 573;
+
+const FIXTURES = {
+  fenway_labeled: FIXTURE_FENWAY_LABELED,
+  fenway_unlabeled: FIXTURE_FENWAY_UNLABELED,
+  multi: FIXTURE_MULTI_BUSTOUT,
+};
+
+function loadEnv() {
+  const envPath = resolve(root, ".env");
+  /** @type {Record<string, string>} */
+  const envVars = {};
+  try {
+    for (const line of readFileSync(envPath, "utf8").split("\n")) {
+      const m = line.match(/^([^#=]+)=(.*)$/);
+      if (m) envVars[m[1].trim()] = m[2].trim().replace(/^"|"$/g, "");
+    }
+  } catch {
+    // optional
+  }
+  return envVars;
+}
+
+function parseArgs(argv) {
+  const args = {
+    showDate: null,
+    fixture: null,
+    live: false,
+    post: false,
+    rebuild: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--show-date") args.showDate = argv[++i] || null;
+    else if (a === "--fixture") args.fixture = argv[++i] || null;
+    else if (a === "--live") args.live = true;
+    else if (a === "--post") args.post = true;
+    else if (a === "--rebuild") args.rebuild = true;
+    else if (a === "--help" || a === "-h") {
+      console.log(
+        "Usage: comms-show-recap-narrative-qa [--fixture fenway_labeled|fenway_unlabeled|multi] [--show-date YYYY-MM-DD --live [--rebuild]] [--post]",
+      );
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+/**
+ * @param {Record<string, string>} envVars
+ */
+function initAdmin(envVars) {
+  const admin = require("../functions/node_modules/firebase-admin/lib/index.js");
+  if (!admin.apps.length) {
+    const privateKey = envVars.GCP_PRIVATE_KEY?.replace(/\\n/g, "\n");
+    if (!envVars.GCP_CLIENT_EMAIL || !privateKey) {
+      throw new Error("Missing GCP_CLIENT_EMAIL / GCP_PRIVATE_KEY in .env for --live");
+    }
+    admin.initializeApp({
+      credential: admin.credential.cert({
+        projectId: "set-picks",
+        clientEmail: envVars.GCP_CLIENT_EMAIL,
+        privateKey,
+      }),
+      projectId: "set-picks",
+    });
+  }
+  return admin;
+}
+
+/**
+ * @param {string} showDate
+ * @param {Record<string, string>} envVars
+ * @param {{ rebuild?: boolean }} [opts]
+ */
+async function loadLiveContext(showDate, envVars, opts = {}) {
+  const admin = initAdmin(envVars);
+  const db = admin.firestore();
+
+  if (opts.rebuild) {
+    const { writeCommsShowContext } = require("../functions/commsShowContext.js");
+    const setSnap = await db.collection("official_setlists").doc(showDate).get();
+    if (!setSnap.exists) {
+      throw new Error(`No official_setlists/${showDate} for --rebuild`);
+    }
+    const setlist = setSnap.data() || {};
+    const songGaps =
+      setlist.songGaps && typeof setlist.songGaps === "object"
+        ? setlist.songGaps
+        : {};
+    // Prefer frozen songGaps for bustout rows (same shape as phishnetRows).
+    const phishnetRows = (Array.isArray(setlist.bustouts) ? setlist.bustouts : [])
+      .map((t) => String(t || "").trim())
+      .filter(Boolean)
+      .map((title) => {
+        const gapRaw = songGaps[title.toLowerCase()];
+        const gap =
+          typeof gapRaw === "number" && Number.isFinite(gapRaw)
+            ? Math.trunc(gapRaw)
+            : null;
+        return { title, gap };
+      });
+    await writeCommsShowContext({
+      db,
+      admin,
+      showDate,
+      setlistDoc: setlist,
+      phishnetRows,
+      logger: console,
+    });
+    console.error(`↻ rebuilt comms_show_context/${showDate}`);
+  }
+
+  const snap = await db.collection("comms_show_context").doc(showDate).get();
+  if (!snap.exists) {
+    throw new Error(`No comms_show_context/${showDate}`);
+  }
+  const data = snap.data() || {};
+  return {
+    showDate,
+    setlist_highlight: data.setlist_highlight || null,
+    bustout_titles: data.bustout_titles || [],
+    bustout_entries: data.bustout_entries || [],
+    tour_debut_titles: data.tour_debut_titles || [],
+    opener_title: data.opener_title || null,
+    encore_title: data.encore_title || null,
+    show_moment_tags: data.show_moment_tags || [],
+  };
+}
+
+function recomposeHighlight(ctx) {
+  const {
+    composeSetlistHighlight,
+  } = require("../functions/commsShowContextCore.js");
+  return composeSetlistHighlight({
+    bustoutTitles: ctx.bustout_titles || [],
+    bustoutEntries: ctx.bustout_entries || [],
+    tourDebuts: ctx.tour_debut_titles || [],
+    openerTitle: ctx.opener_title || "",
+    encoreTitle: ctx.encore_title || "",
+  });
+}
+
+function renderSamples(ctx) {
+  const {
+    buildShowRecapEnrichment,
+  } = require("../functions/showRecapNarrativeCore.js");
+  const { renderCommsTemplate } = require("../functions/commsTemplates.js");
+
+  const bustoutTitle =
+    ctx.bustout_entries?.[0]?.title ||
+    ctx.bustout_titles?.[0] ||
+    "Melt the Guns";
+  const fixtures = branchScorecardFixtures(bustoutTitle);
+  const showLevel = {
+    setlist_highlight: ctx.setlist_highlight,
+    bustout_titles: ctx.bustout_titles || [],
+    bustout_entries: ctx.bustout_entries || [],
+    tour_debut_titles: ctx.tour_debut_titles || [],
+    opener_title: ctx.opener_title,
+    encore_title: ctx.encore_title,
+    show_moment_tags: ctx.show_moment_tags || [],
+  };
+
+  /** @type {{ branch: string, narrative_line: string, emailNightExcerpt?: string }[]} */
+  const samples = [];
+  for (const branch of ["cold", "mixed", "hot_night", "bustout_hero"]) {
+    const fix = fixtures[branch];
+    const enriched = buildShowRecapEnrichment({
+      showLevel,
+      userPicks: fix.userPicks,
+      actualSetlist: fix.actualSetlist,
+      show_score: fix.show_score,
+    });
+    // Force branch for sample matrix display when scorecard might not land there
+    // (e.g. bustout_hero needs the hit). Use enrichment branch when it matches.
+    const narrative_line = enriched.narrative_line;
+    const payload = {
+      handle: "QA",
+      show_date: ctx.showDate || "2026-07-31",
+      venue_name: "QA Venue",
+      venue_city: "Test City",
+      show_score: fix.show_score,
+      global_rank: 6,
+      global_total_pickers: 11,
+      correct_picks_count: branch === "cold" ? 0 : branch === "hot_night" ? 5 : 2,
+      total_picks_count: 6,
+      narrative_line,
+      setlist_highlight: ctx.setlist_highlight,
+      narrative_branch: enriched.narrative_branch,
+      tour_rank: 6,
+      total_tour_pickers: 11,
+      tour_points: 40,
+      rank_change: "held",
+      shows_played: 3,
+    };
+    const rendered = renderCommsTemplate("tour-rankings-daily", payload);
+    const nightPara = String(rendered.email?.text || "")
+      .split(/\n\n/)[0]
+      ?.trim();
+    samples.push({
+      branch: enriched.narrative_branch,
+      narrative_line,
+      emailNightExcerpt: nightPara,
+    });
+  }
+  return samples;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const envVars = loadEnv();
+
+  let ctx;
+  let source;
+  if (args.live) {
+    if (!args.showDate) {
+      console.error("--live requires --show-date YYYY-MM-DD");
+      process.exit(1);
+    }
+    ctx = await loadLiveContext(args.showDate, envVars, {
+      rebuild: args.rebuild,
+    });
+    source = `firestore comms_show_context/${args.showDate}${
+      args.rebuild ? " (rebuilt)" : ""
+    }`;
+  } else {
+    const key = args.fixture || "fenway_labeled";
+    if (!FIXTURES[key]) {
+      console.error(
+        `Unknown --fixture ${key}. Valid: ${Object.keys(FIXTURES).join(", ")}`,
+      );
+      process.exit(1);
+    }
+    ctx = { ...FIXTURES[key] };
+    if (args.showDate) ctx.showDate = args.showDate;
+    source = `fixture:${key}`;
+  }
+
+  const recomposed = recomposeHighlight(ctx);
+  const samples = renderSamples(ctx);
+
+  /** @type {{ id: string, ok: boolean, detail: string }[]} */
+  const checks = [
+    ...runHighlightChecklist(ctx),
+    ...runHighlightChecklist({
+      ...ctx,
+      setlist_highlight: recomposed,
+    }).map((c) => ({
+      ...c,
+      id: `recomposed_${c.id}`,
+      detail: `[recompose] ${c.detail}`,
+    })),
+  ];
+
+  for (const s of samples) {
+    checks.push(
+      ...runNarrativeLineChecklist(s.narrative_line, ctx, s.branch).map(
+        (c) => ({
+          ...c,
+          id: `${s.branch}_${c.id}`,
+          detail: `[${s.branch}] ${c.detail}`,
+        }),
+      ),
+    );
+  }
+
+  const catalogPath = resolve(root, "docs/comms-triggers/TRIGGER_CATALOG.md");
+  checks.push(
+    runCatalogExampleCheck(readFileSync(catalogPath, "utf8")),
+  );
+
+  const report = buildNarrativeQaReportMarkdown({
+    showDate: ctx.showDate || "unknown",
+    context: ctx,
+    recomposedHighlight: recomposed,
+    samples,
+    checks,
+    source,
+  });
+
+  const body = `[SKIP-PRD]\n\n${report}`;
+  console.log(body);
+
+  const summary = summarizeChecks(checks);
+  console.error(
+    summary.pass
+      ? "\n✓ Narrative QA PASS"
+      : `\n✗ Narrative QA FAIL (${summary.failed.length} check(s)) → DRAFT_PR`,
+  );
+
+  if (args.post) {
+    const r = spawnSync(
+      "gh",
+      ["issue", "comment", String(EPIC), "--body-file", "-"],
+      { cwd: root, input: body, encoding: "utf8" },
+    );
+    if (r.status !== 0) {
+      console.error(r.stderr || r.stdout || "gh issue comment failed");
+      process.exit(r.status ?? 1);
+    }
+    console.error(`Posted QA report on #${EPIC}`);
+  } else {
+    console.error("\n(dry) Pass --post to comment on GitHub issue #573.");
+  }
+
+  process.exit(summary.pass ? 0 : 2);
+}
+
+main().catch((err) => {
+  console.error("✗", err.message || err);
+  process.exit(1);
+});

--- a/scripts/lib/commsOptimizeSchedule.mjs
+++ b/scripts/lib/commsOptimizeSchedule.mjs
@@ -1,0 +1,300 @@
+/**
+ * Pure helpers for scheduled Comms Optimize kickoffs (#778 / #573).
+ */
+
+/** @type {string[]} */
+export const SHOW_WEEK_GOALS = [
+  "picks_lock",
+  "email_open",
+  "show_recap_uniqueness",
+  "tour_retention",
+];
+
+/** @type {string[]} */
+export const OFF_TOUR_GOALS = ["return_14d", "push_opt_in"];
+
+const SHOW_DATE_RE = /date:\s*'(\d{4}-\d{2}-\d{2})'/g;
+
+/**
+ * @param {string} sourceText contents of showDates.js (or similar)
+ * @returns {string[]} YYYY-MM-DD sorted unique
+ */
+export function parseShowDatesFromSource(sourceText) {
+  const out = new Set();
+  for (const m of String(sourceText).matchAll(SHOW_DATE_RE)) {
+    out.add(m[1]);
+  }
+  return [...out].sort();
+}
+
+/**
+ * @param {string} ymd
+ * @param {string} timeZone
+ * @returns {{ y: number, m: number, d: number }}
+ */
+function partsInTz(ymd, timeZone) {
+  // Interpret ymd as a calendar date; format a UTC noon instant in TZ for stable DOW.
+  const [y, m, d] = ymd.split("-").map(Number);
+  const utcNoon = new Date(Date.UTC(y, m - 1, d, 12, 0, 0));
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    weekday: "short",
+  });
+  const map = Object.fromEntries(
+    fmt.formatToParts(utcNoon).map((p) => [p.type, p.value]),
+  );
+  return {
+    y: Number(map.year),
+    m: Number(map.month),
+    d: Number(map.day),
+    weekday: map.weekday,
+  };
+}
+
+/**
+ * @param {Date} now
+ * @param {string} timeZone
+ * @returns {string} YYYY-MM-DD
+ */
+export function calendarDateInTz(now, timeZone) {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  return fmt.format(now);
+}
+
+/**
+ * @param {string} ymd
+ * @param {number} deltaDays
+ * @returns {string}
+ */
+export function addDaysYmd(ymd, deltaDays) {
+  const [y, m, d] = ymd.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + deltaDays);
+  return dt.toISOString().slice(0, 10);
+}
+
+/**
+ * ISO week number (UTC date parts of the calendar ymd).
+ * @param {string} ymd
+ * @returns {number}
+ */
+export function isoWeekNumber(ymd) {
+  const [y, m, d] = ymd.split("-").map(Number);
+  const date = new Date(Date.UTC(y, m - 1, d));
+  // Thursday in current week decides the year.
+  date.setUTCDate(date.getUTCDate() + 4 - (date.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+  return Math.ceil(((date - yearStart) / 86400000 + 1) / 7);
+}
+
+/**
+ * @param {string} todayYmd
+ * @param {string} timeZone
+ * @returns {boolean}
+ */
+export function isMondayInTz(todayYmd, timeZone) {
+  return partsInTz(todayYmd, timeZone).weekday === "Mon";
+}
+
+/**
+ * @param {string} todayYmd
+ * @param {string[]} showDates
+ * @returns {boolean}
+ */
+export function isShowWeek(todayYmd, showDates) {
+  const start = addDaysYmd(todayYmd, -7);
+  const end = addDaysYmd(todayYmd, 7);
+  return showDates.some((d) => d >= start && d <= end);
+}
+
+const VALID_GOALS = new Set([
+  ...SHOW_WEEK_GOALS,
+  ...OFF_TOUR_GOALS,
+]);
+
+/**
+ * Machine line (not inside a fenced example): `current_override: picks_lock`
+ * Empty / missing → null (use ISO-week rotation).
+ * @param {string} md
+ * @returns {string | null}
+ */
+export function parseOverrideFromOptimizeForMd(md) {
+  for (const line of String(md).split(/\n/)) {
+    const m = line.match(/^current_override:\s*(\S+)?\s*$/);
+    if (!m) continue;
+    const v = (m[1] || "").trim();
+    if (!v) return null;
+    if (!VALID_GOALS.has(v)) {
+      throw new Error(
+        `Invalid current_override "${v}". Valid: ${[...VALID_GOALS].join(", ")}`,
+      );
+    }
+    return v;
+  }
+  return null;
+}
+
+/**
+ * @param {{
+ *   mode: 'auto' | 'weekly' | 'post_show',
+ *   todayYmd: string,
+ *   timeZone?: string,
+ *   showDates: string[],
+ *   override?: string | null,
+ *   showDate?: string | null,
+ * }} input
+ * @returns {{
+ *   action: 'kickoff' | 'skip',
+ *   mode: 'weekly' | 'post_show' | null,
+ *   optimize_for: string | null,
+ *   window: string,
+ *   showDate: string | null,
+ *   reason: string,
+ * }}
+ */
+export function resolveOptimizeKickoff({
+  mode,
+  todayYmd,
+  timeZone = "America/Denver",
+  showDates,
+  override = null,
+  showDate = null,
+}) {
+  const yesterday = addDaysYmd(todayYmd, -1);
+  const yesterdayWasShow = showDates.includes(yesterday);
+
+  if (mode === "post_show" || (mode === "auto" && yesterdayWasShow)) {
+    const night = showDate || yesterday;
+    if (!showDates.includes(night) && mode === "post_show" && showDate) {
+      // Allow explicit --show-date even if not in fallback list.
+    } else if (mode === "auto" && !yesterdayWasShow) {
+      return {
+        action: "skip",
+        mode: null,
+        optimize_for: null,
+        window: "last_7_days",
+        showDate: null,
+        reason: "auto: yesterday was not a show date",
+      };
+    }
+    return {
+      action: "kickoff",
+      mode: "post_show",
+      optimize_for: "show_recap_uniqueness",
+      window: "last_7_days",
+      showDate: night,
+      reason: `post_show after ${night}`,
+    };
+  }
+
+  if (mode === "weekly" || mode === "auto") {
+    if (mode === "auto" && !isMondayInTz(todayYmd, timeZone)) {
+      return {
+        action: "skip",
+        mode: null,
+        optimize_for: null,
+        window: "last_7_days",
+        showDate: null,
+        reason: "auto: not Monday and no post-show",
+      };
+    }
+
+    if (override) {
+      return {
+        action: "kickoff",
+        mode: "weekly",
+        optimize_for: override,
+        window: "last_7_days",
+        showDate: null,
+        reason: `weekly override=${override}`,
+      };
+    }
+
+    const week = isoWeekNumber(todayYmd);
+    const onTour = isShowWeek(todayYmd, showDates);
+    const optimize_for = onTour
+      ? SHOW_WEEK_GOALS[week % SHOW_WEEK_GOALS.length]
+      : OFF_TOUR_GOALS[week % OFF_TOUR_GOALS.length];
+
+    return {
+      action: "kickoff",
+      mode: "weekly",
+      optimize_for,
+      window: "last_7_days",
+      showDate: null,
+      reason: onTour
+        ? `weekly show-week isoWeek=${week} → ${optimize_for}`
+        : `weekly off-tour isoWeek=${week} → ${optimize_for}`,
+    };
+  }
+
+  return {
+    action: "skip",
+    mode: null,
+    optimize_for: null,
+    window: "last_7_days",
+    showDate: null,
+    reason: `unknown mode ${mode}`,
+  };
+}
+
+/**
+ * @param {{
+ *   optimize_for: string,
+ *   window: string,
+ *   mode: string,
+ *   showDate?: string | null,
+ *   reason: string,
+ *   runDate: string,
+ * }} p
+ */
+export function buildKickoffMarkdown(p) {
+  const showLine = p.showDate
+    ? `\n**Show date (narrative QA):** \`${p.showDate}\` — follow [#779](https://github.com/pat792/set-picks/issues/779) sample-render checklist when available.`
+    : "";
+
+  const agentPrompt = `Using docs/comms-triggers/OPTIMIZE_AUTONOMY.md, docs/comms-triggers/optimize_for.md, and the comms squad skills (comms-orchestration-lead → analyst → triggers → drafter → architect),
+run Optimize for goal ${p.optimize_for} covering ${p.window} (GA4 property 527619709)${
+    p.showDate ? ` with night context for show ${p.showDate}` : ""
+  }.
+Produce the PM review pack template, post it on GitHub issue #573 with [SKIP-PRD],
+open a draft PR to staging only if a low-risk copy/catalog change is justified,
+and never merge or deploy.`;
+
+  return `[SKIP-PRD]
+
+## Scheduled Optimize kickoff — ${p.runDate}
+
+**Epic:** #573 · **Scheduler:** #778  
+**Mode:** \`${p.mode}\`  
+**optimize_for:** \`${p.optimize_for}\`  
+**Window:** \`${p.window}\`  
+**Reason:** ${p.reason}${showLine}
+
+### Agent prompt (Cloud Agent / Cursor)
+
+\`\`\`text
+${agentPrompt}
+\`\`\`
+
+### Pipeline reminder
+
+1. GA4 snapshot (recipe \`crew/knowledge/optimize_snapshot_recipe.md\` §§A–C)
+2. Leadership \`crew\` optimize → \`SQUAD_KICKOFF\`
+3. Cursor squad: analyst → triggers → drafter → architect
+4. Pack comment on this epic; draft PR only when justified
+5. Never merge / never \`comms:deploy\`
+
+### Scored next action (fill after run)
+
+- [ ] \`DRAFT_PR\` / \`WAIT_EVIDENCE\` / \`CATALOG_HOLD\` / \`MEASUREMENT_ONLY\`
+`;
+}

--- a/scripts/lib/commsOptimizeSchedule.test.mjs
+++ b/scripts/lib/commsOptimizeSchedule.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  addDaysYmd,
+  isoWeekNumber,
+  isShowWeek,
+  parseOverrideFromOptimizeForMd,
+  parseShowDatesFromSource,
+  resolveOptimizeKickoff,
+  SHOW_WEEK_GOALS,
+} from "./commsOptimizeSchedule.mjs";
+
+describe("commsOptimizeSchedule", () => {
+  it("parses show dates from source", () => {
+    const dates = parseShowDatesFromSource(`
+      { date: '2026-07-31', venue: 'Fenway' },
+      { date: '2026-08-01', venue: 'Fenway' },
+    `);
+    assert.deepEqual(dates, ["2026-07-31", "2026-08-01"]);
+  });
+
+  it("parses current_override (ignores fenced examples)", () => {
+    assert.equal(parseOverrideFromOptimizeForMd("current_override:\n"), null);
+    assert.equal(
+      parseOverrideFromOptimizeForMd("current_override: picks_lock\n"),
+      "picks_lock",
+    );
+    assert.equal(
+      parseOverrideFromOptimizeForMd("```text\noverride: picks_lock\n```\n"),
+      null,
+    );
+  });
+
+  it("post_show after Fenway night", () => {
+    const r = resolveOptimizeKickoff({
+      mode: "auto",
+      todayYmd: "2026-08-01",
+      showDates: ["2026-07-31", "2026-08-01"],
+    });
+    assert.equal(r.action, "kickoff");
+    assert.equal(r.mode, "post_show");
+    assert.equal(r.optimize_for, "show_recap_uniqueness");
+    assert.equal(r.showDate, "2026-07-31");
+  });
+
+  it("weekly Monday show-week rotates by ISO week", () => {
+    // 2026-08-03 is a Monday; Fenway week still in ±7d window from Aug 1.
+    const today = "2026-08-03";
+    assert.equal(isShowWeek(today, ["2026-07-31", "2026-08-01"]), true);
+    const week = isoWeekNumber(today);
+    const r = resolveOptimizeKickoff({
+      mode: "weekly",
+      todayYmd: today,
+      showDates: ["2026-07-31", "2026-08-01"],
+    });
+    assert.equal(r.action, "kickoff");
+    assert.equal(r.optimize_for, SHOW_WEEK_GOALS[week % SHOW_WEEK_GOALS.length]);
+  });
+
+  it("auto skips mid-week with no prior show", () => {
+    const r = resolveOptimizeKickoff({
+      mode: "auto",
+      todayYmd: "2026-08-05",
+      showDates: ["2026-07-31"],
+    });
+    assert.equal(r.action, "skip");
+  });
+
+  it("addDaysYmd crosses months", () => {
+    assert.equal(addDaysYmd("2026-07-31", 1), "2026-08-01");
+  });
+});

--- a/scripts/lib/showRecapNarrativeQa.mjs
+++ b/scripts/lib/showRecapNarrativeQa.mjs
@@ -1,0 +1,348 @@
+/**
+ * Post-show show_recap narrative QA (#779).
+ * Deterministic checklist + sample render helpers (no Resend).
+ */
+
+/**
+ * @typedef {{ title: string, gap?: number | null }} BustoutEntry
+ * @typedef {{
+ *   showDate?: string,
+ *   setlist_highlight?: string | null,
+ *   bustout_titles?: string[],
+ *   bustout_entries?: BustoutEntry[],
+ *   tour_debut_titles?: string[],
+ *   opener_title?: string | null,
+ *   encore_title?: string | null,
+ *   show_moment_tags?: string[],
+ * }} ShowContext
+ */
+
+/**
+ * Fenway-class unlabeled single bustout (pre-#780) — must FAIL checklist.
+ * @type {ShowContext}
+ */
+export const FIXTURE_FENWAY_UNLABELED = {
+  showDate: "2026-07-31",
+  setlist_highlight: "Melt the Guns - a 2051 show gap",
+  bustout_titles: ["Melt the Guns"],
+  bustout_entries: [{ title: "Melt the Guns", gap: 2051 }],
+  tour_debut_titles: ["Melt the Guns"],
+  opener_title: "Carini",
+  encore_title: "A Life Beyond The Dream",
+  show_moment_tags: ["bustout", "tour_debut"],
+};
+
+/**
+ * Expected post-#780 Fenway highlight.
+ * @type {ShowContext}
+ */
+export const FIXTURE_FENWAY_LABELED = {
+  ...FIXTURE_FENWAY_UNLABELED,
+  setlist_highlight: "Bustout: Melt the Guns - a 2051 show gap.",
+};
+
+/**
+ * Multi-bustout night.
+ * @type {ShowContext}
+ */
+export const FIXTURE_MULTI_BUSTOUT = {
+  showDate: "2026-07-15",
+  setlist_highlight:
+    "Bustouts: Curtain With - a 142 show gap; Fluffhead - an 87 show gap.",
+  bustout_titles: ["Curtain With", "Fluffhead"],
+  bustout_entries: [
+    { title: "Curtain With", gap: 142 },
+    { title: "Fluffhead", gap: 87 },
+  ],
+  tour_debut_titles: [],
+  opener_title: "YEM",
+  encore_title: "Slave",
+  show_moment_tags: ["bustout"],
+};
+
+/**
+ * @param {string} highlight
+ * @returns {boolean}
+ */
+export function looksLikeBustoutHighlight(highlight) {
+  return /^Bustouts?:/i.test(String(highlight || "").trim());
+}
+
+/**
+ * @param {ShowContext} ctx
+ * @returns {{ id: string, ok: boolean, detail: string }[]}
+ */
+export function runHighlightChecklist(ctx) {
+  /** @type {{ id: string, ok: boolean, detail: string }[]} */
+  const checks = [];
+  const highlight = String(ctx.setlist_highlight || "").trim();
+  const entries = Array.isArray(ctx.bustout_entries)
+    ? ctx.bustout_entries.filter((e) => e?.title)
+    : [];
+  const titles = Array.isArray(ctx.bustout_titles)
+    ? ctx.bustout_titles.filter(Boolean)
+    : [];
+  const bustoutCount = entries.length || titles.length;
+
+  if (bustoutCount > 0) {
+    const expectLabel = bustoutCount === 1 ? "Bustout:" : "Bustouts:";
+    const hasLabel = highlight.startsWith(expectLabel);
+    checks.push({
+      id: "bustout_label",
+      ok: hasLabel,
+      detail: hasLabel
+        ? `highlight starts with ${expectLabel}`
+        : `expected "${expectLabel}" prefix; got "${highlight.slice(0, 80)}"`,
+    });
+
+    const endsWithPeriod = highlight.endsWith(".");
+    checks.push({
+      id: "trailing_period",
+      ok: endsWithPeriod,
+      detail: endsWithPeriod
+        ? "highlight ends with period"
+        : "highlight missing trailing period",
+    });
+
+    if (bustoutCount >= 2) {
+      const hasSemi = highlight.includes(";");
+      checks.push({
+        id: "multi_semicolon",
+        ok: hasSemi,
+        detail: hasSemi
+          ? "multi-bustout uses semicolon separators"
+          : "multi-bustout missing ';' separators",
+      });
+    }
+
+    const gapsExpected = entries.filter(
+      (e) => e.gap != null && Number.isFinite(e.gap),
+    );
+    if (gapsExpected.length) {
+      const allPresent = gapsExpected.every((e) =>
+        highlight.includes(String(e.gap)),
+      );
+      const shapeOk = / - (a|an) \d+ show gap/.test(highlight);
+      checks.push({
+        id: "gap_shape",
+        ok: allPresent && shapeOk,
+        detail:
+          allPresent && shapeOk
+            ? "gap numbers present with 'a/an N show gap' shape"
+            : `missing gap shape in "${highlight.slice(0, 100)}"`,
+      });
+    }
+  } else {
+    checks.push({
+      id: "bustout_label",
+      ok: !looksLikeBustoutHighlight(highlight),
+      detail: looksLikeBustoutHighlight(highlight)
+        ? "highlight has Bustout label but context has no bustouts"
+        : "no bustouts — label rule N/A",
+    });
+  }
+
+  // Night-scoped: highlight should not look like a tour essay.
+  const tourEssay =
+    /end of (the )?tour|season recap|tour wrap/i.test(highlight);
+  checks.push({
+    id: "night_vs_tour",
+    ok: !tourEssay,
+    detail: tourEssay
+      ? "highlight looks like tour-length copy (#510 boundary)"
+      : "night-scoped highlight",
+  });
+
+  return checks;
+}
+
+/**
+ * @param {string} narrativeLine
+ * @param {ShowContext} ctx
+ * @param {string} branch
+ * @returns {{ id: string, ok: boolean, detail: string }[]}
+ */
+export function runNarrativeLineChecklist(narrativeLine, ctx, branch) {
+  /** @type {{ id: string, ok: boolean, detail: string }[]} */
+  const checks = [];
+  const line = String(narrativeLine || "").trim();
+  const highlight = String(ctx.setlist_highlight || "").trim();
+  const bustoutCount =
+    (ctx.bustout_entries || []).filter((e) => e?.title).length ||
+    (ctx.bustout_titles || []).filter(Boolean).length;
+
+  if (branch === "bustout_hero") {
+    const ok = /^You caught a bustout/i.test(line);
+    checks.push({
+      id: "bustout_hero_prefix",
+      ok,
+      detail: ok
+        ? "bustout_hero opens with You caught a bustout"
+        : `unexpected bustout_hero line: "${line.slice(0, 80)}"`,
+    });
+  }
+
+  if (bustoutCount > 0 && branch !== "bustout_hero" && highlight) {
+    // Cold/hot/mixed must retain the labeled highlight when present.
+    const retains =
+      line.includes("Bustout:") ||
+      line.includes("Bustouts:") ||
+      (looksLikeBustoutHighlight(highlight) && line.includes(highlight));
+    checks.push({
+      id: "wrapper_keeps_label",
+      ok: retains,
+      detail: retains
+        ? `${branch} retains Bustout label`
+        : `${branch} dropped Bustout label — line="${line.slice(0, 100)}"`,
+    });
+  }
+
+  return checks;
+}
+
+/**
+ * Catalog example must document Bustout:/Bustouts: shape (#780), not freeform lore.
+ * @param {string} catalogMd
+ * @returns {{ id: string, ok: boolean, detail: string }}
+ */
+export function runCatalogExampleCheck(catalogMd) {
+  const hasBustoutExample =
+    /Bustout: .+ show gap/i.test(catalogMd) ||
+    /Bustouts: .+ show gap/i.test(catalogMd);
+  const hasStaleReba = /first time Reba opened/i.test(catalogMd);
+  return {
+    id: "catalog_example",
+    ok: hasBustoutExample && !hasStaleReba,
+    detail: hasStaleReba
+      ? "TRIGGER_CATALOG still has stale freeform Reba example"
+      : hasBustoutExample
+        ? "catalog documents Bustout:/Bustouts: shape"
+        : "catalog missing Bustout: example",
+  };
+}
+
+/**
+ * Scorecard fixtures that force each narrative branch when passed to enrichment.
+ * @returns {Record<string, { show_score: number, userPicks: Record<string, string>, actualSetlist: Record<string, unknown> }>}
+ */
+export function branchScorecardFixtures(bustoutTitle = "Melt the Guns") {
+  const emptyBoard = {
+    s1o: "Wrong One",
+    s1c: "Wrong Two",
+    s2o: "Wrong Three",
+    s2c: "Wrong Four",
+    enc: "Wrong Five",
+    wild: "Wrong Six",
+  };
+  const hotBoard = {
+    s1o: "Carini",
+    s1c: "Harry Hood",
+    s2o: "What's Going Through Your Mind",
+    s2c: "Run Like an Antelope",
+    enc: "A Life Beyond The Dream",
+    wild: "Fuego",
+  };
+  const actual = {
+    s1o: "Carini",
+    s1c: "Harry Hood",
+    s2o: "What's Going Through Your Mind",
+    s2c: "Run Like an Antelope",
+    enc: "A Life Beyond The Dream",
+    officialSetlist: [
+      "Carini",
+      "Harry Hood",
+      "What's Going Through Your Mind",
+      "Fuego",
+      bustoutTitle,
+      "Run Like an Antelope",
+      "A Life Beyond The Dream",
+    ],
+    bustouts: [bustoutTitle],
+  };
+
+  return {
+    cold: { show_score: 10, userPicks: emptyBoard, actualSetlist: actual },
+    mixed: {
+      show_score: 25,
+      userPicks: {
+        ...emptyBoard,
+        s1o: "Carini",
+        s2c: "Run Like an Antelope",
+      },
+      actualSetlist: actual,
+    },
+    hot_night: { show_score: 70, userPicks: hotBoard, actualSetlist: actual },
+    bustout_hero: {
+      show_score: 30,
+      userPicks: { ...emptyBoard, wild: bustoutTitle },
+      actualSetlist: actual,
+    },
+  };
+}
+
+/**
+ * @param {{ id: string, ok: boolean, detail: string }[]} checks
+ * @returns {{ pass: boolean, failed: typeof checks, passed: typeof checks }}
+ */
+export function summarizeChecks(checks) {
+  const failed = checks.filter((c) => !c.ok);
+  const passed = checks.filter((c) => c.ok);
+  return { pass: failed.length === 0, failed, passed };
+}
+
+/**
+ * Build markdown pack section for #573.
+ * @param {{
+ *   showDate: string,
+ *   context: ShowContext,
+ *   recomposedHighlight?: string | null,
+ *   samples: { branch: string, narrative_line: string, emailNightExcerpt?: string }[],
+ *   checks: { id: string, ok: boolean, detail: string }[],
+ *   source: string,
+ * }} input
+ */
+export function buildNarrativeQaReportMarkdown(input) {
+  const summary = summarizeChecks(input.checks);
+  const status = summary.pass ? "PASS" : "FAIL → DRAFT_PR";
+  const checkLines = input.checks
+    .map((c) => `- [${c.ok ? "x" : " "}] \`${c.id}\` — ${c.detail}`)
+    .join("\n");
+
+  const sampleBlocks = input.samples
+    .map(
+      (s) =>
+        `#### \`${s.branch}\`\n\n> ${s.narrative_line}\n${
+          s.emailNightExcerpt
+            ? `\n\`\`\`\n${s.emailNightExcerpt}\n\`\`\`\n`
+            : ""
+        }`,
+    )
+    .join("\n");
+
+  return `## Show-recap uniqueness QA — ${input.showDate}
+
+**Status:** **${status}**  
+**Source:** ${input.source}  
+**Stored highlight:** \`${input.context.setlist_highlight || "(none)"}\`${
+    input.recomposedHighlight != null
+      ? `  
+**Recomposed highlight:** \`${input.recomposedHighlight}\``
+      : ""
+  }  
+**Tags:** ${(input.context.show_moment_tags || []).join(", ") || "—"}
+
+### Checklist
+${checkLines}
+
+### Branch samples
+${sampleBlocks}
+
+### Ask for PM
+- [ ] ${
+    summary.pass
+      ? "No copy change required"
+      : "Open/approve draft PR for mechanical label/copy fix"
+  }
+- [ ] Accept uniqueness samples for the pack
+`;
+}

--- a/scripts/lib/showRecapNarrativeQa.test.mjs
+++ b/scripts/lib/showRecapNarrativeQa.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  FIXTURE_FENWAY_LABELED,
+  FIXTURE_FENWAY_UNLABELED,
+  FIXTURE_MULTI_BUSTOUT,
+  runCatalogExampleCheck,
+  runHighlightChecklist,
+  runNarrativeLineChecklist,
+  summarizeChecks,
+} from "./showRecapNarrativeQa.mjs";
+
+describe("showRecapNarrativeQa", () => {
+  it("fails Fenway-class unlabeled single bustout", () => {
+    const checks = runHighlightChecklist(FIXTURE_FENWAY_UNLABELED);
+    const summary = summarizeChecks(checks);
+    assert.equal(summary.pass, false);
+    assert.ok(summary.failed.some((c) => c.id === "bustout_label"));
+  });
+
+  it("passes labeled Fenway highlight", () => {
+    const checks = runHighlightChecklist(FIXTURE_FENWAY_LABELED);
+    assert.equal(summarizeChecks(checks).pass, true);
+  });
+
+  it("requires semicolons for multi bustouts", () => {
+    const bad = {
+      ...FIXTURE_MULTI_BUSTOUT,
+      setlist_highlight:
+        "Bustouts: Curtain With - a 142 show gap, Fluffhead - an 87 show gap.",
+    };
+    const checks = runHighlightChecklist(bad);
+    assert.ok(checks.some((c) => c.id === "multi_semicolon" && !c.ok));
+
+    const good = runHighlightChecklist(FIXTURE_MULTI_BUSTOUT);
+    assert.equal(summarizeChecks(good).pass, true);
+  });
+
+  it("flags cold wrapper that drops Bustout label", () => {
+    const checks = runNarrativeLineChecklist(
+      "Tough board. Still a night to remember: Melt the Guns - a 2051 show gap",
+      FIXTURE_FENWAY_LABELED,
+      "cold",
+    );
+    assert.ok(checks.some((c) => c.id === "wrapper_keeps_label" && !c.ok));
+  });
+
+  it("accepts cold wrapper that keeps Bustout label", () => {
+    const checks = runNarrativeLineChecklist(
+      "Tough board. Still a night to remember: Bustout: Melt the Guns - a 2051 show gap.",
+      FIXTURE_FENWAY_LABELED,
+      "cold",
+    );
+    assert.equal(summarizeChecks(checks).pass, true);
+  });
+
+  it("rejects stale Reba catalog example", () => {
+    const stale = runCatalogExampleCheck(
+      '3. **Setlist context** — `{{setlist_highlight}}` (e.g., "It was the first time Reba opened a show in 6 years").',
+    );
+    assert.equal(stale.ok, false);
+
+    const good = runCatalogExampleCheck(
+      "3. **Setlist context** — `{{setlist_highlight}}` (e.g., `Bustout: Melt the Guns - a 2051 show gap.`).",
+    );
+    assert.equal(good.ok, true);
+  });
+});

--- a/scripts/qa/_lib/qaAuthSplash.mjs
+++ b/scripts/qa/_lib/qaAuthSplash.mjs
@@ -10,8 +10,10 @@
  */
 export async function signInViaSplashEmailPassword(page, origin, email, password) {
   const base = origin.replace(/\/$/, '');
+  // Avoid `networkidle` — after Auth, Firestore keeps a long-lived WebChannel
+  // open so idle never settles (AGENTS.md / pr-qa traps).
   await page.goto(`${base}/?login=true`, {
-    waitUntil: 'networkidle',
+    waitUntil: 'domcontentloaded',
     timeout: 90_000,
   });
 
@@ -26,5 +28,10 @@ export async function signInViaSplashEmailPassword(page, origin, email, password
   await dialog.locator('button[type="submit"]').click();
 
   await page.waitForURL(/\/dashboard/, { timeout: 60_000 });
-  await page.waitForLoadState('networkidle');
+  // Concrete post-auth chrome — not networkidle (WebChannel stays open).
+  await page
+    .getByRole('navigation')
+    .or(page.getByRole('main'))
+    .first()
+    .waitFor({ state: 'visible', timeout: 30_000 });
 }

--- a/scripts/qa/firestore-cache.mjs
+++ b/scripts/qa/firestore-cache.mjs
@@ -3,9 +3,10 @@
  * QA runner for `.cursor/skills/pr-qa/recipes.md` §B — Firestore read
  * cache verification (issue #251 pilot, #349 auth).
  *
- * What it asserts: navigating away from `/user/<uid>` and back via SPA
- * routing reuses the React Query cache for `useUserSeasonStats`,
- * skipping the Firestore read that initially populated the page.
+ * What it asserts: navigating away from `/user/<uid>` (to `/how-it-works`)
+ * and back via SPA routing reuses the React Query cache for
+ * `useUserSeasonStats`, skipping the Firestore read that initially
+ * populated the page.
  *
  * **Auth:** `firestore.rules` require `signedIn()` for `users/{uid}`,
  * `pools`, `show_calendar`, etc. The runner signs in with
@@ -32,7 +33,8 @@ const BASELINE_MIN_BYTES = 512;
 // landed ~280–600 B; 350 B was still flaky on some accounts; 1 KiB was too strict.
 const SAVED_MIN_BYTES = 250;
 
-const BOUNCE_UID = 'qa-cache-bounce-not-a-real-uid';
+/** Soft-nav away target — marketing route (no Firestore season-stats hook). */
+const BOUNCE_PATH = '/how-it-works';
 
 const NAV_TIMEOUT_MS = 20_000;
 
@@ -58,23 +60,25 @@ async function spaNavigate(page, path) {
  * @param {import('playwright').Page} page
  */
 async function waitForProfileSettled(page) {
+  // Do not wait for `networkidle` — signed-in Firestore WebChannel never idles.
   await page.waitForSelector('text=/Total points/i', { timeout: NAV_TIMEOUT_MS });
   await page.waitForFunction(
     () => !document.querySelector('[aria-label^="Loading "]'),
     null,
     { timeout: NAV_TIMEOUT_MS },
   );
-  await page.waitForLoadState('networkidle');
+  // Brief settle so CDP `loadingFinished` events for the profile read land
+  // before we flip measurement phase — without waiting for full network idle.
+  await page.waitForTimeout(750);
 }
 
 /**
  * @param {import('playwright').Page} page
  */
-async function waitForNotFound(page) {
-  await page.waitForSelector('text=/Player not found/i', {
+async function waitForBounceSettled(page) {
+  await page.waitForSelector('text=/How it works/i', {
     timeout: NAV_TIMEOUT_MS,
   });
-  await page.waitForLoadState('networkidle');
 }
 
 /**
@@ -185,8 +189,8 @@ async function run() {
     }
 
     phase = 'idle';
-    await spaNavigate(page, `/user/${BOUNCE_UID}`);
-    await waitForNotFound(page);
+    await spaNavigate(page, BOUNCE_PATH);
+    await waitForBounceSettled(page);
 
     phase = 'postNav';
     await spaNavigate(page, `/user/${PUBLIC_PROFILE_UID}`);

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
@@ -409,7 +409,7 @@ export const COMMS_TEMPLATE_REGISTRY = {
           pool_rank: 1,
           correct_picks_count: 3,
           total_picks_count: 4,
-          setlist_highlight: "Wolfman's Brother - an 87 show gap",
+          setlist_highlight: "Bustout: Wolfman's Brother - an 87 show gap.",
           narrative_line: "You caught a bustout — Wolfman's Brother - an 87 show gap.",
           narrative_branch: 'bustout_hero',
           bustout_bonus: 20,


### PR DESCRIPTION
## Summary
Promote staging to production (**v1.40.3** + Optimize L2 train).

- **Show recap bustout labels (#780 / #781)** — `setlist_highlight` uses `Bustout:` / `Bustouts:` with song-gap shape (PATCH in CHANGELOG).
- **Optimize L2 kickoff scheduler (#778 / #782)** — daily cron + `npm run comms:optimize-kickoff` posts agent prompts on epic #573 (cron live only after this promote; `workflow_dispatch` available sooner).
- **Show-recap narrative QA (#779 / #783)** — `npm run comms:show-recap-qa`; post-show kickoffs attach QA on #573.
- **QA runner fix (#777)** — `qa:cache` no longer hangs on Firestore `networkidle`.

**Note:** #778/#779 CHANGELOG entries are still under `[Unreleased]` on staging (code shipped; fold into next SemVer bump or tag hygiene). Cron for Optimize kickoffs requires default-branch merge.

## Test plan
- [x] #781/#782/#783 merged to staging; issues #778/#779/#780 closed manually (Closes does not fire on non-default base)
- [x] CI green on #783 (verify + Vercel)
- [ ] Production Vercel deploy after merge
- [ ] Deploy Functions if bustout compose path not yet live: confirm Fenway / next show `comms_show_context` has labeled highlight
- [ ] Actions → “Comms Optimize schedule” → `workflow_dispatch` (weekly + post_show) → two packs on #573 (L2 exit)
- [ ] Tag/release when ready via `release:publish --confirm` (after Unreleased fold if desired)


Made with [Cursor](https://cursor.com)