### PR TITLE
chore(release): bump to 1.41.0 (Optimize L2 train)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,16 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ## [Unreleased]
 
+---
+
+## [1.41.0] — 2026-08-01
+
 ### Added
 - **Comms Optimize L2 kickoff scheduler (#778)** — `docs/comms-triggers/optimize_for.md` goal rotation, `npm run comms:optimize-kickoff`, and `.github/workflows/comms-optimize-schedule.yml` (daily cron posts agent prompts on epic #573; no auto-merge/deploy).
 - **Show-recap narrative QA (#779)** — `npm run comms:show-recap-qa` checklist + branch samples against `comms_show_context` / fixtures; post-show Optimize kickoffs attach the report on #573 (fail → `DRAFT_PR`).
+
+### Fixed
+- **QA cache runner hang (#777)** — `qa:cache` no longer waits on Firestore WebChannel `networkidle` after sign-in.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.32.0  
+**Version:** 1.41.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.40.3",
+  "version": "1.41.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bump `package.json` to **1.41.0**
- Fold Unreleased Optimize L2 items (#778/#779) + QA hang fix (#777) into CHANGELOG
- Align `docs/API.md` version header (no declared surface change beyond header)

Prerequisite for tagging prod at current Optimize train (`v1.40.3` was never tagged; this ships the full train as MINOR).

## Test plan
- [x] `npm run release:gate` locally after merge path
- [ ] CI verify green
- [ ] Promote staging → main
- [ ] `npm run release:publish -- --confirm` → `v1.41.0`


Made with [Cursor](https://cursor.com)