### PR TITLE
promote: staging → main (v1.41.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,16 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ## [Unreleased]
 
+---
+
+## [1.41.0] — 2026-08-01
+
 ### Added
 - **Comms Optimize L2 kickoff scheduler (#778)** — `docs/comms-triggers/optimize_for.md` goal rotation, `npm run comms:optimize-kickoff`, and `.github/workflows/comms-optimize-schedule.yml` (daily cron posts agent prompts on epic #573; no auto-merge/deploy).
 - **Show-recap narrative QA (#779)** — `npm run comms:show-recap-qa` checklist + branch samples against `comms_show_context` / fixtures; post-show Optimize kickoffs attach the report on #573 (fail → `DRAFT_PR`).
+
+### Fixed
+- **QA cache runner hang (#777)** — `qa:cache` no longer waits on Firestore WebChannel `networkidle` after sign-in.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.32.0  
+**Version:** 1.41.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.40.3",
+  "version": "1.41.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Promote staging to production and release **v1.41.0**.

- SemVer bump for Optimize L2 train (#778/#779) + QA hang fix (#777)
- Carries already-promoted bustout labels (#780 / 1.40.3 changelog)

## Test plan
- [x] #785 CI green (verify + Vercel)
- [ ] Production Vercel deploy after merge
- [ ] Tag/release `v1.41.0` via `npm run release:publish -- --confirm`


Made with [Cursor](https://cursor.com)