### PR TITLE
perf(comms): email CTA cold-boot shell + TTI (#773 Phases 1–2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.42.1] — 2026-08-01
+
+### Changed
+- **Email CTA branded dashboard boot shell (#773 Phase 1)** — `dist/dashboard/index.html` now ships a generic vinyl-mark + muted nav / skeleton-card shell (no SEO body) so hard opens paint branded chrome before React mounts. `verify:seo-prerender` asserts the boot marker and keeps home prerender intact.
+
+---
+
 ## [1.42.0] — 2026-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.42.2] — 2026-08-01
+
+### Changed
+- **Email CTA cold-boot TTI (#773 Phase 2)** — dashboard hard opens warm App Check + kick `DashboardRoute` before paint; boot shell `modulepreload`s the dashboard chunk (splash untouched); Auth paints profile via `getDoc` then `onSnapshot` and shows `DashboardBootSkeleton` instead of bare “Loading…”.
+
+---
+
 ## [1.42.1] — 2026-08-01
 
 ### Changed

--- a/docs/USER_ROUTING_AND_JOURNEYS.md
+++ b/docs/USER_ROUTING_AND_JOURNEYS.md
@@ -28,6 +28,10 @@ Defined in `src/app/App.jsx`.
 - **No user profile doc** (first-time setup) → `Navigate` to `/setup`
 - **Else** → `DashboardLayout`
 
+### Email / push hard opens (`/dashboard/*`)
+
+Cold document loads (email CTAs, push, refresh) are rewritten by Vercel to `dist/dashboard/index.html` — a **branded static skeleton** (#773 Phase 1; empty-root precursor #743) so users see chrome before React + Auth mount. `createRoot` replaces `#root` as usual. Marketing SEO prerender stays on `dist/index.html` only (`verify:seo-prerender`). TTI work (eager dashboard entry, auth polish) is Phase 2 on the same epic.
+
 ### Setup
 
 `src/app/routes/SetupRoute.jsx`:

--- a/docs/USER_ROUTING_AND_JOURNEYS.md
+++ b/docs/USER_ROUTING_AND_JOURNEYS.md
@@ -30,7 +30,9 @@ Defined in `src/app/App.jsx`.
 
 ### Email / push hard opens (`/dashboard/*`)
 
-Cold document loads (email CTAs, push, refresh) are rewritten by Vercel to `dist/dashboard/index.html` — a **branded static skeleton** (#773 Phase 1; empty-root precursor #743) so users see chrome before React + Auth mount. `createRoot` replaces `#root` as usual. Marketing SEO prerender stays on `dist/index.html` only (`verify:seo-prerender`). TTI work (eager dashboard entry, auth polish) is Phase 2 on the same epic.
+Cold document loads (email CTAs, push, refresh) are rewritten by Vercel to `dist/dashboard/index.html` — a **branded static skeleton** (#773 Phase 1; empty-root precursor #743) so users see chrome before React + Auth mount. `createRoot` replaces `#root` as usual. Marketing SEO prerender stays on `dist/index.html` only (`verify:seo-prerender`).
+
+**Phase 2 (TTI):** on `/dashboard/*` (and related warm paths), `main.jsx` calls `ensureAppCheckNow()` and kicks a dynamic `import()` of `DashboardRoute` before first paint; the boot shell also `modulepreload`s the `DashboardRoute` chunk. Auth seeds `auth.currentUser`, paints profile via `getDoc` then `onSnapshot`, and dashboard loading uses `DashboardBootSkeleton` instead of bare “Loading…”. Splash stays lazy + deferred App Check. Phase 2b (WebView redirect sign-in) is still open on #773.
 
 ### Setup
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.42.0",
+  "version": "1.42.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.42.1",
+  "version": "1.42.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/dashboard-boot-shell.mjs
+++ b/scripts/dashboard-boot-shell.mjs
@@ -1,0 +1,278 @@
+/**
+ * Generic branded dashboard boot shell for hard loads (#773 Phase 1).
+ * Pure HTML/CSS — no src/ imports (safe for build scripts).
+ *
+ * Injected into `dist/dashboard/index.html` after Vite build. React
+ * `createRoot` still replaces `#root` once the SPA mounts.
+ */
+
+import { stripPrerenderBodyFromSpaShell } from './seo-strip-body.mjs';
+
+/** Attribute marker asserted by `verify:seo-prerender`. */
+export const DASHBOARD_BOOT_SHELL_MARKER = 'data-dashboard-boot-shell';
+
+const VINYL_MARK_SRC = '/branding/splash-vinyl-mark.webp';
+
+/**
+ * Self-contained critical CSS. Tailwind JIT does not scan this post-build HTML,
+ * so we cannot rely on utility classes that are unused in `src/`. Colors match
+ * `src/index.css` brand tokens (RGB → hex).
+ */
+function bootShellCriticalCss() {
+  return `
+/* Paint brand canvas before the Vite CSS bundle arrives (email hard opens). */
+html, body {
+  margin: 0;
+  min-height: 100%;
+  background: #1e1b4b;
+}
+.dbs-shell {
+  position: relative;
+  display: flex;
+  min-height: 100dvh;
+  width: 100%;
+  overflow: hidden;
+  color: #fff;
+  background: #1e1b4b;
+  font-family: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+}
+.dbs-ambient {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+}
+.dbs-ambient::before,
+.dbs-ambient::after {
+  content: "";
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(100px);
+}
+.dbs-ambient::before {
+  top: -20%;
+  left: 50%;
+  width: min(100vw, 36rem);
+  height: min(100vw, 36rem);
+  transform: translateX(-50%);
+  background: rgb(45 212 191 / 0.12);
+}
+.dbs-ambient::after {
+  bottom: -10%;
+  right: -15%;
+  width: min(85vw, 28rem);
+  height: min(70vh, 32rem);
+  background: rgb(59 130 246 / 0.12);
+}
+.dbs-sidebar {
+  display: none;
+  flex-direction: column;
+  width: 16rem;
+  flex-shrink: 0;
+  padding: 1rem;
+  background: #20283e;
+  border-right: 1px solid rgb(71 85 105 / 0.65);
+  z-index: 10;
+}
+.dbs-sidebar-mark {
+  display: block;
+  width: 7rem;
+  height: 7rem;
+  margin: 0.5rem auto 1.5rem;
+  object-fit: contain;
+}
+.dbs-nav-row {
+  height: 2.75rem;
+  margin-bottom: 0.5rem;
+  border-radius: 0.75rem;
+  background: rgb(26 32 52 / 0.85);
+}
+.dbs-nav-row--active {
+  background: rgb(45 212 191 / 0.12);
+  box-shadow: inset 0 0 0 1px rgb(45 212 191 / 0.25);
+}
+.dbs-mobile-top {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  padding-top: env(safe-area-inset-top, 0px);
+}
+.dbs-brand-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid rgb(51 65 85 / 0.35);
+  background: linear-gradient(to bottom, rgb(15 10 46 / 0.76), rgb(30 27 75 / 0.60));
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow: 0 10px 28px -14px rgba(15, 10, 46, 0.85);
+}
+.dbs-brand-mark {
+  display: block;
+  height: 3.5rem;
+  width: auto;
+  max-width: calc(100vw - 7rem);
+  object-fit: contain;
+}
+.dbs-chip-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+.dbs-chip {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  background: #2a344e;
+  border: 1px solid rgb(51 65 85 / 0.35);
+}
+.dbs-main {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  min-width: 0;
+  padding: calc(env(safe-area-inset-top, 0px) + 5.5rem) 1rem calc(4.5rem + env(safe-area-inset-bottom, 0px));
+}
+.dbs-main-inner {
+  width: 100%;
+  max-width: 36rem;
+  margin: 0 auto;
+}
+.dbs-card {
+  height: 5.5rem;
+  margin-bottom: 0.75rem;
+  border-radius: 1rem;
+  background: #222a3e;
+  border: 1px solid rgb(71 85 105 / 0.35);
+  animation: dbs-pulse 1.4s ease-in-out infinite;
+}
+.dbs-card:nth-child(2) { height: 7rem; animation-delay: 0.12s; }
+.dbs-card:nth-child(3) { height: 4.5rem; animation-delay: 0.24s; }
+.dbs-tabs {
+  position: fixed;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 50;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  align-items: center;
+  height: calc(4rem + env(safe-area-inset-bottom, 0px));
+  padding: 0 0.375rem env(safe-area-inset-bottom, 0px);
+  border-top: 1px solid rgb(51 65 85 / 0.35);
+  background: linear-gradient(to top, rgb(15 10 46 / 0.76), rgb(30 27 75 / 0.60));
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow: 0 -10px 28px -14px rgba(15, 10, 46, 0.85);
+}
+.dbs-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  height: calc(100% - 10px);
+  border-radius: 0.75rem;
+}
+.dbs-tab-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 0.35rem;
+  background: rgb(203 213 225 / 0.35);
+}
+.dbs-tab-label {
+  width: 2.25rem;
+  height: 0.4rem;
+  border-radius: 9999px;
+  background: rgb(203 213 225 / 0.28);
+}
+.dbs-tab--active {
+  background: rgb(45 212 191 / 0.14);
+  box-shadow: inset 0 0 0 1px rgb(45 212 191 / 0.30);
+}
+.dbs-tab--active .dbs-tab-icon,
+.dbs-tab--active .dbs-tab-label {
+  background: rgb(45 212 191 / 0.55);
+}
+@keyframes dbs-pulse {
+  0%, 100% { opacity: 0.72; }
+  50% { opacity: 1; }
+}
+@media (min-width: 768px) {
+  .dbs-sidebar { display: flex; }
+  .dbs-mobile-top,
+  .dbs-tabs { display: none; }
+  .dbs-main {
+    padding: 2rem;
+  }
+  .dbs-main-inner {
+    max-width: 36rem;
+    margin: 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .dbs-card { animation: none; }
+}
+`.trim();
+}
+
+/** Static skeleton markup placed inside `#root`. */
+export function buildDashboardBootShellMarkup() {
+  const tab = (active = false) =>
+    `<div class="dbs-tab${active ? ' dbs-tab--active' : ''}" aria-hidden="true"><div class="dbs-tab-icon"></div><div class="dbs-tab-label"></div></div>`;
+
+  return [
+    `<style id="dashboard-boot-shell-css">${bootShellCriticalCss()}</style>`,
+    `<div ${DASHBOARD_BOOT_SHELL_MARKER}="true" class="dbs-shell" role="status" aria-busy="true" aria-label="Loading Setlist Pick'em">`,
+    `<div class="dbs-ambient" aria-hidden="true"></div>`,
+    `<nav class="dbs-sidebar" aria-hidden="true">`,
+    `<img class="dbs-sidebar-mark" src="${VINYL_MARK_SRC}" alt="" width="112" height="112" decoding="async" fetchpriority="high" />`,
+    `<div class="dbs-nav-row dbs-nav-row--active"></div>`,
+    `<div class="dbs-nav-row"></div>`,
+    `<div class="dbs-nav-row"></div>`,
+    `<div class="dbs-nav-row"></div>`,
+    `</nav>`,
+    `<div class="dbs-mobile-top" aria-hidden="true">`,
+    `<div class="dbs-brand-bar">`,
+    `<img class="dbs-brand-mark" src="${VINYL_MARK_SRC}" alt="" width="64" height="64" decoding="async" fetchpriority="high" />`,
+    `<div class="dbs-chip-row"><div class="dbs-chip"></div><div class="dbs-chip"></div></div>`,
+    `</div>`,
+    `</div>`,
+    `<main class="dbs-main">`,
+    `<div class="dbs-main-inner">`,
+    `<div class="dbs-card" aria-hidden="true"></div>`,
+    `<div class="dbs-card" aria-hidden="true"></div>`,
+    `<div class="dbs-card" aria-hidden="true"></div>`,
+    `</div>`,
+    `</main>`,
+    `<nav class="dbs-tabs" aria-hidden="true">`,
+    tab(true),
+    tab(false),
+    tab(false),
+    tab(false),
+    `</nav>`,
+    `</div>`,
+  ].join('');
+}
+
+/**
+ * Build the branded app boot shell HTML from the pre-prerender Vite SPA shell.
+ * Ensures `#root` has no SEO prerender body, then injects the skeleton.
+ *
+ * @param {string} spaHtml
+ * @returns {string}
+ */
+export function buildDashboardBootShellHtml(spaHtml) {
+  const emptied = stripPrerenderBodyFromSpaShell(spaHtml);
+  if (typeof emptied !== 'string' || !emptied) return emptied;
+  const markup = buildDashboardBootShellMarkup();
+  return emptied.replace(
+    /<div id="root">\s*<\/div>/i,
+    `<div id="root">${markup}</div>`,
+  );
+}

--- a/scripts/dashboard-boot-shell.mjs
+++ b/scripts/dashboard-boot-shell.mjs
@@ -1,10 +1,13 @@
 /**
- * Generic branded dashboard boot shell for hard loads (#773 Phase 1).
+ * Generic branded dashboard boot shell for hard loads (#773 Phase 1–2).
  * Pure HTML/CSS — no src/ imports (safe for build scripts).
  *
  * Injected into `dist/dashboard/index.html` after Vite build. React
  * `createRoot` still replaces `#root` once the SPA mounts.
  */
+
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
 
 import { stripPrerenderBodyFromSpaShell } from './seo-strip-body.mjs';
 
@@ -275,4 +278,54 @@ export function buildDashboardBootShellHtml(spaHtml) {
     /<div id="root">\s*<\/div>/i,
     `<div id="root">${markup}</div>`,
   );
+}
+
+/** Chunk filename prefixes to modulepreload on the dashboard boot shell only (#773). */
+export const DASHBOARD_BOOT_MODULEPRELOAD_PREFIXES = ['DashboardRoute-'];
+
+/**
+ * Resolve hashed asset filenames under `dist/assets` for dashboard boot preloads.
+ *
+ * @param {string} assetsDir
+ * @returns {string[]} absolute hrefs like `/assets/DashboardRoute-….js`
+ */
+export function resolveDashboardBootModulepreloadHrefs(assetsDir) {
+  let names = [];
+  try {
+    names = readdirSync(assetsDir);
+  } catch {
+    return [];
+  }
+  const hrefs = [];
+  for (const prefix of DASHBOARD_BOOT_MODULEPRELOAD_PREFIXES) {
+    const match = names.find(
+      (name) => name.startsWith(prefix) && name.endsWith('.js'),
+    );
+    if (match) hrefs.push(`/assets/${match}`);
+  }
+  return hrefs;
+}
+
+/**
+ * Append `<link rel="modulepreload">` for dashboard-critical chunks into `<head>`.
+ * Idempotent; skips hrefs already present. Does not touch splash `dist/index.html`.
+ *
+ * @param {string} html
+ * @param {string} distDir absolute path to `dist/`
+ * @returns {string}
+ */
+export function injectDashboardBootModulepreloads(html, distDir) {
+  if (typeof html !== 'string' || !html) return html;
+  const hrefs = resolveDashboardBootModulepreloadHrefs(join(distDir, 'assets'));
+  if (!hrefs.length) return html;
+
+  const tags = hrefs
+    .filter((href) => !html.includes(`href="${href}"`))
+    .map(
+      (href) =>
+        `  <link rel="modulepreload" crossorigin href="${href}" data-dashboard-boot-preload="true" />`,
+    );
+  if (!tags.length) return html;
+  if (!/<\/head>/i.test(html)) return html;
+  return html.replace(/<\/head>/i, `${tags.join('\n')}\n</head>`);
 }

--- a/scripts/prerender-seo.mjs
+++ b/scripts/prerender-seo.mjs
@@ -1,6 +1,6 @@
 /**
  * Post-build: write crawler-visible HTML for public marketing routes (#659).
- * Also writes an empty-root SPA shell for dashboard / app hard loads (#743).
+ * Also writes a branded SPA boot shell for dashboard / app hard loads (#743 / #773).
  * Run after `vite build`. Safe to re-run.
  */
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
@@ -10,9 +10,9 @@ import { fileURLToPath } from 'node:url';
 import {
   APP_BOOT_SHELL_REL_PATH,
   PRERENDER_ROUTES,
+  buildDashboardBootShellHtml,
   injectPrerenderHtml,
   prerenderOutputRelPath,
-  stripPrerenderBodyFromSpaShell,
 } from './seo-prerender-lib.mjs';
 
 const root = join(fileURLToPath(new URL('.', import.meta.url)), '..');
@@ -35,14 +35,14 @@ for (const route of PRERENDER_ROUTES) {
   console.log(`prerender-seo: wrote dist/${rel} (${Buffer.byteLength(html, 'utf8')} bytes)`);
 }
 
-// Empty-root boot shell for /dashboard/* (and other app paths via vercel.json).
+// Branded boot shell for /dashboard/* (and other app paths via vercel.json).
 // Use the pre-prerender Vite shell so we never copy home SEO body into it.
-const appBootHtml = stripPrerenderBodyFromSpaShell(shell);
+const appBootHtml = buildDashboardBootShellHtml(shell);
 const appBootPath = join(distDir, APP_BOOT_SHELL_REL_PATH);
 mkdirSync(dirname(appBootPath), { recursive: true });
 writeFileSync(appBootPath, appBootHtml, 'utf8');
 console.log(
-  `prerender-seo: wrote dist/${APP_BOOT_SHELL_REL_PATH} (empty #root boot shell)`,
+  `prerender-seo: wrote dist/${APP_BOOT_SHELL_REL_PATH} (branded #root boot shell)`,
 );
 
 console.log(`prerender-seo: OK (${PRERENDER_ROUTES.length} routes + app boot shell)`);

--- a/scripts/prerender-seo.mjs
+++ b/scripts/prerender-seo.mjs
@@ -11,6 +11,7 @@ import {
   APP_BOOT_SHELL_REL_PATH,
   PRERENDER_ROUTES,
   buildDashboardBootShellHtml,
+  injectDashboardBootModulepreloads,
   injectPrerenderHtml,
   prerenderOutputRelPath,
 } from './seo-prerender-lib.mjs';
@@ -37,12 +38,16 @@ for (const route of PRERENDER_ROUTES) {
 
 // Branded boot shell for /dashboard/* (and other app paths via vercel.json).
 // Use the pre-prerender Vite shell so we never copy home SEO body into it.
-const appBootHtml = buildDashboardBootShellHtml(shell);
+// Phase 2: modulepreload DashboardRoute on this shell only (not splash).
+const appBootHtml = injectDashboardBootModulepreloads(
+  buildDashboardBootShellHtml(shell),
+  distDir,
+);
 const appBootPath = join(distDir, APP_BOOT_SHELL_REL_PATH);
 mkdirSync(dirname(appBootPath), { recursive: true });
 writeFileSync(appBootPath, appBootHtml, 'utf8');
 console.log(
-  `prerender-seo: wrote dist/${APP_BOOT_SHELL_REL_PATH} (branded #root boot shell)`,
+  `prerender-seo: wrote dist/${APP_BOOT_SHELL_REL_PATH} (branded #root boot shell + modulepreload)`,
 );
 
 console.log(`prerender-seo: OK (${PRERENDER_ROUTES.length} routes + app boot shell)`);

--- a/scripts/seo-prerender-lib.mjs
+++ b/scripts/seo-prerender-lib.mjs
@@ -15,6 +15,7 @@ import {
   DASHBOARD_BOOT_SHELL_MARKER,
   buildDashboardBootShellHtml,
   buildDashboardBootShellMarkup,
+  injectDashboardBootModulepreloads,
 } from './dashboard-boot-shell.mjs';
 
 export {
@@ -25,6 +26,7 @@ export {
   DASHBOARD_BOOT_SHELL_MARKER,
   buildDashboardBootShellHtml,
   buildDashboardBootShellMarkup,
+  injectDashboardBootModulepreloads,
 };
 
 function escapeHtml(str) {

--- a/scripts/seo-prerender-lib.mjs
+++ b/scripts/seo-prerender-lib.mjs
@@ -11,12 +11,20 @@ import {
   APP_BOOT_SHELL_REL_PATH,
   stripPrerenderBodyFromSpaShell,
 } from './seo-strip-body.mjs';
+import {
+  DASHBOARD_BOOT_SHELL_MARKER,
+  buildDashboardBootShellHtml,
+  buildDashboardBootShellMarkup,
+} from './dashboard-boot-shell.mjs';
 
 export {
   PRERENDER_ROUTES,
   SEO_FAVICON_VERSION,
   APP_BOOT_SHELL_REL_PATH,
   stripPrerenderBodyFromSpaShell,
+  DASHBOARD_BOOT_SHELL_MARKER,
+  buildDashboardBootShellHtml,
+  buildDashboardBootShellMarkup,
 };
 
 function escapeHtml(str) {

--- a/scripts/seo-strip-body.mjs
+++ b/scripts/seo-strip-body.mjs
@@ -17,5 +17,8 @@ export function stripPrerenderBodyFromSpaShell(spaHtml) {
   );
 }
 
-/** Dist-relative empty-root SPA shell for authenticated / app hard loads (#743). */
+/**
+ * Dist-relative SPA shell for authenticated / app hard loads
+ * (#743 empty root → #773 branded skeleton).
+ */
 export const APP_BOOT_SHELL_REL_PATH = 'dashboard/index.html';

--- a/scripts/verify-seo-prerender.mjs
+++ b/scripts/verify-seo-prerender.mjs
@@ -120,9 +120,18 @@ if (existsSync(distIndex) && existsSync(distHowItWorks)) {
     'app boot shell must not include SEO prerender body',
   );
   assert(
-    existsSync(distIndex) &&
-      readFileSync(distIndex, 'utf8').includes('data-seo-prerender'),
+    appBootHtml.includes('data-dashboard-boot-preload="true"') &&
+      appBootHtml.includes('DashboardRoute-'),
+    'app boot shell must modulepreload DashboardRoute chunk',
+  );
+  const homeHtml = readFileSync(distIndex, 'utf8');
+  assert(
+    homeHtml.includes('data-seo-prerender'),
     'home dist/index.html must still include SEO prerender body',
+  );
+  assert(
+    !homeHtml.includes('data-dashboard-boot-preload'),
+    'home dist/index.html must not gain dashboard boot modulepreloads',
   );
 
   console.log('verify:seo-prerender: dist/ checked');

--- a/scripts/verify-seo-prerender.mjs
+++ b/scripts/verify-seo-prerender.mjs
@@ -11,7 +11,9 @@ import { fileURLToPath } from 'node:url';
 
 import {
   APP_BOOT_SHELL_REL_PATH,
+  DASHBOARD_BOOT_SHELL_MARKER,
   PRERENDER_ROUTES,
+  buildDashboardBootShellHtml,
   buildFixtureShellHtml,
   injectPrerenderHtml,
   prerenderOutputRelPath,
@@ -67,6 +69,26 @@ for (const route of PRERENDER_ROUTES) {
   assertRouteHtml(html, route, `fixture ${route.path}`);
 }
 
+// Fixture: branded dashboard boot shell (#773) — no SEO body, marker present.
+const dirtyShell =
+  '<!DOCTYPE html><html><head><meta charset="UTF-8" /></head><body>' +
+  '<div id="root"><main data-seo-prerender="true"><h1>leak</h1></main></div>' +
+  '</body></html>';
+const fixtureBoot = buildDashboardBootShellHtml(dirtyShell);
+assert(
+  fixtureBoot.includes(`${DASHBOARD_BOOT_SHELL_MARKER}="true"`),
+  'boot shell fixture must include dashboard boot marker',
+);
+assert(
+  fixtureBoot.includes('/branding/splash-vinyl-mark.webp'),
+  'boot shell fixture must include vinyl brand mark',
+);
+assert(
+  !fixtureBoot.includes('data-seo-prerender'),
+  'boot shell fixture must not include SEO prerender body',
+);
+assert(!fixtureBoot.includes('<h1>leak</h1>'), 'boot shell must strip prior #root body');
+
 const distIndex = join(root, 'dist', 'index.html');
 const distHowItWorks = join(root, 'dist', 'how-it-works', 'index.html');
 // Only validate dist when post-build prerender has clearly run (subdir artifact).
@@ -82,8 +104,16 @@ if (existsSync(distIndex) && existsSync(distHowItWorks)) {
   assert(existsSync(appBootPath), `dist missing ${APP_BOOT_SHELL_REL_PATH} — run npm run build`);
   const appBootHtml = readFileSync(appBootPath, 'utf8');
   assert(
-    /<div id="root">\s*<\/div>/i.test(appBootHtml),
-    'app boot shell must have empty #root',
+    appBootHtml.includes(`${DASHBOARD_BOOT_SHELL_MARKER}="true"`),
+    'app boot shell must include branded dashboard skeleton marker',
+  );
+  assert(
+    appBootHtml.includes('/branding/splash-vinyl-mark.webp'),
+    'app boot shell must include vinyl brand mark',
+  );
+  assert(
+    /<div id="root">[\s\S]*?<\/div>/i.test(appBootHtml),
+    'app boot shell must keep a #root mount point',
   );
   assert(
     !appBootHtml.includes('data-seo-prerender'),

--- a/src/app/layout/RootAppShell.jsx
+++ b/src/app/layout/RootAppShell.jsx
@@ -1,11 +1,13 @@
 import React, { Suspense } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 
+import { isDashboardEntryPath } from '../../shared/lib/appBootPath';
 import { useServiceWorkerUpdate } from '../../shared/lib/useServiceWorkerUpdate';
 import AppBackground from '../../shared/ui/AppBackground';
 import RouteSuspenseFallback from '../../shared/ui/RouteSuspenseFallback';
 import UpdateAvailableBanner from '../../shared/ui/UpdateAvailableBanner';
 import { shellTransitionKey } from './model/shellTransitionKey';
+import DashboardBootSkeleton from './ui/DashboardBootSkeleton';
 
 /**
  * Global chrome: ambient background + top-level route outlet with enter animation.
@@ -29,7 +31,15 @@ export default function RootAppShell() {
       <AppBackground />
       <div className="relative z-[1] min-h-screen">
         <div key={transitionKey} className="min-h-screen animate-page-enter">
-          <Suspense fallback={<RouteSuspenseFallback />}>
+          <Suspense
+            fallback={
+              isDashboardEntryPath(pathname) ? (
+                <DashboardBootSkeleton />
+              ) : (
+                <RouteSuspenseFallback />
+              )
+            }
+          >
             <Outlet />
           </Suspense>
         </div>

--- a/src/app/layout/ui/DashboardBootSkeleton.jsx
+++ b/src/app/layout/ui/DashboardBootSkeleton.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+
+import {
+  BRAND_APP_CHROME_MARK_SRC,
+  brandAppChromeMarkImgClassNames,
+  brandWordmarkDashboardMobileBarScaleWrapperClassNames,
+  brandWordmarkDashboardMobileLeadingClassNames,
+  brandWordmarkDashboardSidebarScaleWrapperClassNames,
+} from '../../../shared/config/branding';
+import BrandWordmarkBarRow from '../../../shared/ui/BrandWordmarkBarRow';
+
+/**
+ * React twin of the static `dist/dashboard/index.html` boot shell (#773).
+ * Shown while auth/profile resolve so createRoot does not flash bare "Loading…".
+ */
+export default function DashboardBootSkeleton() {
+  return (
+    <div
+      className="flex h-[100dvh] min-h-0 w-full overflow-hidden bg-transparent text-white"
+      role="status"
+      aria-busy="true"
+      aria-label="Loading Setlist Pick'em"
+      data-dashboard-boot-skeleton="true"
+    >
+      <nav
+        className="z-10 hidden w-64 flex-col border-r border-border-muted/65 bg-surface-chrome p-4 md:flex"
+        aria-hidden="true"
+      >
+        <div className="mb-6 overflow-visible py-2">
+          <div className="w-full overflow-visible text-center leading-none">
+            <span className={brandWordmarkDashboardSidebarScaleWrapperClassNames}>
+              <img
+                src={BRAND_APP_CHROME_MARK_SRC}
+                alt=""
+                width={128}
+                height={128}
+                className={brandAppChromeMarkImgClassNames.dashboardSidebar}
+                decoding="async"
+              />
+            </span>
+          </div>
+        </div>
+        <div className="flex flex-1 flex-col gap-2">
+          <div className="h-11 rounded-xl bg-brand-primary/10 ring-1 ring-inset ring-brand-primary/25" />
+          <div className="h-11 animate-pulse rounded-xl bg-surface-inset" />
+          <div className="h-11 animate-pulse rounded-xl bg-surface-inset" />
+          <div className="h-11 animate-pulse rounded-xl bg-surface-inset" />
+        </div>
+      </nav>
+
+      <div className="fixed left-0 top-0 z-50 w-full pt-[env(safe-area-inset-top,0px)] md:hidden">
+        <div className="border-b border-border-subtle/35 bg-[linear-gradient(to_bottom,rgb(var(--brand-bg-deep)_/_0.76),rgb(var(--brand-bg)_/_0.60))] py-2 shadow-[0_10px_28px_-14px_rgba(15,10,46,0.85)] ring-1 ring-inset ring-white/[0.06] backdrop-blur-xl">
+          <BrandWordmarkBarRow variant="dashboard">
+            <div className={brandWordmarkDashboardMobileLeadingClassNames}>
+              <span className={brandWordmarkDashboardMobileBarScaleWrapperClassNames}>
+                <img
+                  className={brandAppChromeMarkImgClassNames.dashboardMobileBar}
+                  src={BRAND_APP_CHROME_MARK_SRC}
+                  alt=""
+                  aria-hidden="true"
+                  decoding="async"
+                />
+              </span>
+            </div>
+            <div className="flex shrink-0 items-center gap-2" aria-hidden="true">
+              <div className="h-8 w-8 rounded-full border border-border-subtle/35 bg-surface-panel-strong" />
+              <div className="h-8 w-8 rounded-full border border-border-subtle/35 bg-surface-panel-strong" />
+            </div>
+          </BrandWordmarkBarRow>
+        </div>
+      </div>
+
+      <main className="relative min-w-0 flex-1 overflow-y-auto pb-[calc(4rem+env(safe-area-inset-bottom,0px)+0.5rem)] pt-[calc(env(safe-area-inset-top,0px)+5.5rem)] md:p-8 md:pb-8 md:pt-8">
+        <div className="mx-auto w-full max-w-xl min-w-0 space-y-3 px-4 pt-2 md:p-0">
+          <div className="h-20 animate-pulse rounded-2xl bg-surface-panel ring-1 ring-border-muted/35" />
+          <div className="h-28 animate-pulse rounded-2xl bg-surface-panel ring-1 ring-border-muted/35" />
+          <div className="h-16 animate-pulse rounded-2xl bg-surface-panel ring-1 ring-border-muted/35" />
+        </div>
+      </main>
+
+      <nav
+        className="fixed inset-x-0 bottom-0 z-50 w-full border-t border-border-subtle/35 bg-[linear-gradient(to_top,rgb(var(--brand-bg-deep)_/_0.76),rgb(var(--brand-bg)_/_0.60))] pb-[env(safe-area-inset-bottom,0px)] shadow-[inset_0_1px_0_0_rgb(var(--brand-primary)/0.12),0_-10px_28px_-14px_rgba(15,10,46,0.85)] ring-1 ring-inset ring-white/[0.06] backdrop-blur-xl md:hidden"
+        aria-hidden="true"
+      >
+        <div className="grid h-16 grid-cols-4 items-center gap-0.5 px-1.5">
+          <div className="mx-auto h-[calc(100%-10px)] w-full max-w-[4.5rem] rounded-xl bg-brand-primary/[0.14] ring-1 ring-inset ring-brand-primary/30" />
+          <div className="mx-auto h-[calc(100%-10px)] w-full max-w-[4.5rem] animate-pulse rounded-xl bg-surface-inset/80" />
+          <div className="mx-auto h-[calc(100%-10px)] w-full max-w-[4.5rem] animate-pulse rounded-xl bg-surface-inset/80" />
+          <div className="mx-auto h-[calc(100%-10px)] w-full max-w-[4.5rem] animate-pulse rounded-xl bg-surface-inset/80" />
+        </div>
+      </nav>
+    </div>
+  );
+}

--- a/src/app/routes/DashboardRoute.jsx
+++ b/src/app/routes/DashboardRoute.jsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 
 import {
-  AuthLoadingScreen,
   trackAuthPartialProfile,
   useAuth,
 } from '../../features/auth';
@@ -11,6 +10,7 @@ import { ShowCalendarProvider } from '../../features/show-calendar';
 import { ensureAppCheckNow } from '../../shared/lib/firebaseAppCheck';
 import { persistDashboardPath } from '../../shared/lib/dashboardLastPath';
 import DashboardLayout from '../layout/DashboardLayout';
+import DashboardBootSkeleton from '../layout/ui/DashboardBootSkeleton';
 import { decideDashboardRoute } from './profileGuardDecision';
 
 export default function DashboardRoute() {
@@ -18,7 +18,7 @@ export default function DashboardRoute() {
   const { user, userProfile, loading } = useAuth();
   const decision = decideDashboardRoute({ loading, user, userProfile });
 
-  // #535: email deep links need Firestore ASAP — don't wait for idle timeout.
+  // #535 / #773: belt-and-suspenders if soft-nav reached dashboard without boot warm.
   useEffect(() => {
     ensureAppCheckNow();
   }, []);
@@ -45,7 +45,8 @@ export default function DashboardRoute() {
     return <Navigate to="/" replace />;
   }
 
-  if (decision.kind === 'loading') return <AuthLoadingScreen />;
+  // Keep branded chrome while session/profile resolve (#773) — no bare "Loading…".
+  if (decision.kind === 'loading') return <DashboardBootSkeleton />;
   if (decision.kind === 'redirect-setup') {
     return <Navigate to="/setup" replace />;
   }

--- a/src/features/auth/model/AuthContext.jsx
+++ b/src/features/auth/model/AuthContext.jsx
@@ -1,6 +1,9 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
 
+import { auth } from '../../../shared/lib/firebase';
+import { ensureAppCheckNow } from '../../../shared/lib/firebaseAppCheck';
 import {
+  fetchUserProfile,
   resolveIsAdmin,
   subscribeToAuthState,
   subscribeToIdTokenChanges,
@@ -12,9 +15,14 @@ const AuthContext = createContext(null);
 /**
  * Single app-wide auth + profile subscription (#496).
  * Replaces N× `useAuth()` listeners with one provider.
+ *
+ * #773 Phase 2: seed from `auth.currentUser`, warm App Check on session, and
+ * paint profile via `getDoc` before attaching `onSnapshot` (mirror #730).
+ * Guards still keep `loading:true` until the first profile result so
+ * `loading:false + user + profile:null` cannot flash Almost There (#727).
  */
 export function AuthProvider({ children }) {
-  const [user, setUser] = useState(null);
+  const [user, setUser] = useState(() => auth.currentUser ?? null);
   const [userProfile, setUserProfile] = useState(null);
   const [loading, setLoading] = useState(true);
   const [isAdmin, setIsAdmin] = useState(false);
@@ -47,8 +55,11 @@ export function AuthProvider({ children }) {
         return;
       }
 
+      // Persisted / fresh session — start App Check immediately (#730 / #773).
+      ensureAppCheckNow();
+
       // Guest → sign-in (and user switches): keep guards in `loading` until the
-      // first profile snapshot. Otherwise `loading:false + user + profile:null`
+      // first profile result. Otherwise `loading:false + user + profile:null`
       // briefly looks like "needs setup" and dumps returning users onto Almost There (#727).
       setUser(u);
       setUserProfile(null);
@@ -63,12 +74,17 @@ export function AuthProvider({ children }) {
         });
 
       try {
+        // Fast path: single getDoc before live listener (#773 / #730).
+        const initialProfile = await fetchUserProfile(u.uid);
+        if (cancelled) return;
+        setUserProfile(initialProfile);
+        setLoading(false);
+
         const unsub = await subscribeToUserProfile(
           u.uid,
           (profile) => {
             if (cancelled) return;
             setUserProfile(profile);
-            setLoading(false);
           },
           (err) => {
             console.error('AuthProvider profile subscription error:', err);
@@ -89,7 +105,7 @@ export function AuthProvider({ children }) {
 
         detachProfile = unsub;
       } catch (err) {
-        console.error('AuthProvider profile subscribe failed:', err);
+        console.error('AuthProvider profile load failed:', err);
         if (!cancelled) {
           setUserProfile(null);
           setLoading(false);

--- a/src/features/auth/ui/AuthLoadingScreen.jsx
+++ b/src/features/auth/ui/AuthLoadingScreen.jsx
@@ -1,10 +1,28 @@
 import React from 'react';
 
-/** Full-screen placeholder while Firebase auth (and profile fetch) resolves for protected areas. */
+import {
+  BRAND_APP_CHROME_MARK_SRC,
+  brandAppChromeMarkImgClassNames,
+} from '../../../shared/config/branding';
+
+/** Branded auth gate (setup / non-dashboard). Dashboard uses `DashboardBootSkeleton`. */
 export default function AuthLoadingScreen() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-transparent font-bold text-white">
-      Loading...
+    <div
+      className="flex min-h-screen flex-col items-center justify-center gap-4 bg-transparent text-white"
+      role="status"
+      aria-busy="true"
+      aria-label="Loading Setlist Pick'em"
+    >
+      <img
+        src={BRAND_APP_CHROME_MARK_SRC}
+        alt=""
+        width={96}
+        height={96}
+        className={`${brandAppChromeMarkImgClassNames.dashboardMobileBar} h-24 w-auto opacity-90`}
+        decoding="async"
+      />
+      <p className="text-sm font-bold text-content-secondary">Loading…</p>
     </div>
   );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,12 +7,30 @@ import App from './app/App.jsx'
 import Ga4RouteListener from './app/Ga4RouteListener.jsx'
 import ScrollToTop from './app/ScrollToTop.jsx'
 import { AuthProvider } from './features/auth'
+import {
+  isDashboardEntryPath,
+  shouldWarmAppCheckOnBoot,
+} from './shared/lib/appBootPath'
 import { initGa4 } from './shared/lib/ga4'
-import { initializeAppCheckDeferred } from './shared/lib/firebaseAppCheck'
+import {
+  ensureAppCheckNow,
+  initializeAppCheckDeferred,
+} from './shared/lib/firebaseAppCheck'
 import { registerMessagingServiceWorker } from './shared/lib/firebaseMessaging'
 import './index.css'
 
 initGa4()
+
+// #773 Phase 2: email / app hard opens — warm App Check + kick DashboardRoute
+// chunk before first paint. Splash keeps deferred App Check + lazy dashboard.
+const bootPath =
+  typeof window !== 'undefined' ? window.location.pathname : ''
+if (shouldWarmAppCheckOnBoot(bootPath)) {
+  ensureAppCheckNow()
+}
+if (isDashboardEntryPath(bootPath)) {
+  void import('./app/routes/DashboardRoute.jsx')
+}
 
 // Shared client for React Query caches (#243 profile/tour standings, #507
 // show-scoped standings). Defaults tuned for read-heavy dashboard hooks

--- a/src/shared/lib/appBootPath.js
+++ b/src/shared/lib/appBootPath.js
@@ -1,0 +1,27 @@
+/**
+ * Path helpers for cold-boot warming on app / email hard opens (#773 Phase 2).
+ */
+
+/**
+ * @param {string} [pathname]
+ * @returns {boolean}
+ */
+export function isDashboardEntryPath(pathname) {
+  if (typeof pathname !== 'string' || !pathname) return false;
+  return pathname === '/dashboard' || pathname.startsWith('/dashboard/');
+}
+
+/**
+ * Surfaces that need Firestore ASAP on hard open (skip App Check idle deferral).
+ * @param {string} [pathname]
+ * @returns {boolean}
+ */
+export function shouldWarmAppCheckOnBoot(pathname) {
+  if (typeof pathname !== 'string' || !pathname) return false;
+  return (
+    isDashboardEntryPath(pathname) ||
+    pathname === '/setup' ||
+    pathname.startsWith('/join') ||
+    pathname.startsWith('/invite/')
+  );
+}

--- a/src/shared/lib/appBootPath.test.js
+++ b/src/shared/lib/appBootPath.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { isDashboardEntryPath, shouldWarmAppCheckOnBoot } from './appBootPath.js';
+
+describe('isDashboardEntryPath', () => {
+  it('matches /dashboard and nested paths', () => {
+    expect(isDashboardEntryPath('/dashboard')).toBe(true);
+    expect(isDashboardEntryPath('/dashboard/')).toBe(true);
+    expect(isDashboardEntryPath('/dashboard/picks')).toBe(true);
+  });
+
+  it('rejects non-dashboard paths', () => {
+    expect(isDashboardEntryPath('/')).toBe(false);
+    expect(isDashboardEntryPath('/setup')).toBe(false);
+    expect(isDashboardEntryPath('/dashboarding')).toBe(false);
+    expect(isDashboardEntryPath('')).toBe(false);
+    expect(isDashboardEntryPath(undefined)).toBe(false);
+  });
+});
+
+describe('shouldWarmAppCheckOnBoot', () => {
+  it('warms dashboard, setup, join, and invite', () => {
+    expect(shouldWarmAppCheckOnBoot('/dashboard/standings')).toBe(true);
+    expect(shouldWarmAppCheckOnBoot('/setup')).toBe(true);
+    expect(shouldWarmAppCheckOnBoot('/join/ABC')).toBe(true);
+    expect(shouldWarmAppCheckOnBoot('/invite/pat')).toBe(true);
+  });
+
+  it('does not warm splash or marketing', () => {
+    expect(shouldWarmAppCheckOnBoot('/')).toBe(false);
+    expect(shouldWarmAppCheckOnBoot('/how-it-works')).toBe(false);
+    expect(shouldWarmAppCheckOnBoot('/privacy')).toBe(false);
+  });
+});


### PR DESCRIPTION
Refs #773

## Summary
- **Phase 1:** branded static skeleton in `dist/dashboard/index.html` (vinyl + muted chrome / cards; no SEO body)
- **Phase 2:** warm App Check + kick `DashboardRoute` before paint on dashboard/join/invite/setup; `modulepreload` DashboardRoute on the boot shell only; Auth seeds `currentUser`, paints profile via `getDoc` then `onSnapshot`, and shows `DashboardBootSkeleton` instead of bare “Loading…”
- Splash stays lazy + deferred App Check (`qa:chunks` green)
- PATCH train: `1.42.1` (Phase 1) → `1.42.2` (Phase 2)
- **Not in this PR:** Phase 2b WebView redirect / open-in-browser; Phase 3 push SPA handoff

## Test plan
- [x] `npm run build` + `verify:seo-prerender` (boot marker, DashboardRoute preload on dash only, home SEO intact)
- [x] `npm test` (467)
- [x] `npm run lint`
- [x] `npm run qa:chunks` (splash does not pull DashboardRoute)
- [ ] Preview hard-open `/dashboard/picks`: branded shell immediately; no home flash; interactive faster than ~12s baseline
- [ ] Optional: compare stopwatch vs Phase 1-only preview if still available