### PR TITLE
feat(auth): WebView Google redirect + open-in-browser (#773 Phase 2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.42.3] — 2026-08-01
+
+### Changed
+- **Email WebView auth path (#773 Phase 2b)** — in-app browsers prefer Google `signInWithRedirect` (with splash intent restore) and show an Open-in-browser banner; popup Google remains the default elsewhere. Return URL via `persistDashboardPath` unchanged.
+
+---
+
 ## [1.42.2] — 2026-08-01
 
 ### Changed

--- a/docs/USER_ROUTING_AND_JOURNEYS.md
+++ b/docs/USER_ROUTING_AND_JOURNEYS.md
@@ -32,7 +32,9 @@ Defined in `src/app/App.jsx`.
 
 Cold document loads (email CTAs, push, refresh) are rewritten by Vercel to `dist/dashboard/index.html` — a **branded static skeleton** (#773 Phase 1; empty-root precursor #743) so users see chrome before React + Auth mount. `createRoot` replaces `#root` as usual. Marketing SEO prerender stays on `dist/index.html` only (`verify:seo-prerender`).
 
-**Phase 2 (TTI):** on `/dashboard/*` (and related warm paths), `main.jsx` calls `ensureAppCheckNow()` and kicks a dynamic `import()` of `DashboardRoute` before first paint; the boot shell also `modulepreload`s the `DashboardRoute` chunk. Auth seeds `auth.currentUser`, paints profile via `getDoc` then `onSnapshot`, and dashboard loading uses `DashboardBootSkeleton` instead of bare “Loading…”. Splash stays lazy + deferred App Check. Phase 2b (WebView redirect sign-in) is still open on #773.
+**Phase 2 (TTI):** on `/dashboard/*` (and related warm paths), `main.jsx` calls `ensureAppCheckNow()` and kicks a dynamic `import()` of `DashboardRoute` before first paint; the boot shell also `modulepreload`s the `DashboardRoute` chunk. Auth seeds `auth.currentUser`, paints profile via `getDoc` then `onSnapshot`, and dashboard loading uses `DashboardBootSkeleton` instead of bare “Loading…”. Splash stays lazy + deferred App Check.
+
+**Phase 2b (signed-out / WebView):** email in-app browsers get an “Open in browser” banner plus Google **redirect** auth (`signInWithRedirect` / `getRedirectResult`) instead of popup. Intended dashboard path is still preserved via `persistDashboardPath` (#535) before the home bounce. Normal browsers keep popup Google sign-in.
 
 ### Setup
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.42.2",
+  "version": "1.42.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/auth/api/splashAuthApi.js
+++ b/src/features/auth/api/splashAuthApi.js
@@ -2,10 +2,12 @@ import {
   createUserWithEmailAndPassword,
   deleteUser,
   getAdditionalUserInfo,
+  getRedirectResult,
   GoogleAuthProvider,
   sendPasswordResetEmail,
   signInWithEmailAndPassword,
   signInWithPopup,
+  signInWithRedirect,
 } from 'firebase/auth';
 
 import { getPasswordResetActionCodeSettings } from '../utils/passwordResetActionSettings';
@@ -33,6 +35,33 @@ function getGoogleProvider() {
  */
 export async function signInWithGoogle(auth) {
   const cred = await signInWithPopup(auth, getGoogleProvider());
+  const extra = getAdditionalUserInfo(cred);
+  return { isNewUser: Boolean(extra?.isNewUser) };
+}
+
+/**
+ * Full-page Google redirect — preferred in email / in-app WebViews where
+ * popups are blocked or flaky (#773 Phase 2b / #576 / #412).
+ *
+ * Does not resolve with a credential; the page navigates away. Call
+ * {@link consumeGoogleRedirectResult} on the next load.
+ *
+ * @param {import('firebase/auth').Auth} auth
+ * @returns {Promise<void>}
+ */
+export function startGoogleSignInRedirect(auth) {
+  return signInWithRedirect(auth, getGoogleProvider());
+}
+
+/**
+ * Complete a pending Google redirect, if any.
+ *
+ * @param {import('firebase/auth').Auth} auth
+ * @returns {Promise<{ isNewUser: boolean } | null>}
+ */
+export async function consumeGoogleRedirectResult(auth) {
+  const cred = await getRedirectResult(auth);
+  if (!cred) return null;
   const extra = getAdditionalUserInfo(cred);
   return { isNewUser: Boolean(extra?.isNewUser) };
 }

--- a/src/features/auth/index.js
+++ b/src/features/auth/index.js
@@ -1,4 +1,5 @@
 export { default as AuthLoadingScreen } from './ui/AuthLoadingScreen';
+export { default as OpenInBrowserBanner } from './ui/OpenInBrowserBanner';
 export { default as SplashAuthEntryCard } from './ui/SplashAuthEntryCard';
 export { default as SplashAuthModalShell } from './ui/SplashAuthModalShell';
 export { default as SplashSignInModal } from './ui/SplashSignInModal';
@@ -7,6 +8,7 @@ export { default as PasswordResetForm } from './ui/PasswordResetForm';
 export { default as ProfileSetupForm } from './ui/ProfileSetupForm';
 export { AuthProvider, useAuth } from './model/AuthContext.jsx';
 export { useAuthSession } from './model/useAuthSession';
+export { useGoogleRedirectCompletion } from './model/useGoogleRedirectCompletion';
 export { trackAuthPartialProfile } from './model/authAnalytics';
 export { usePasswordReset } from './model/usePasswordReset';
 export { usePasswordResetCompleteState } from './model/usePasswordResetCompleteState';

--- a/src/features/auth/model/authAnalytics.js
+++ b/src/features/auth/model/authAnalytics.js
@@ -10,12 +10,13 @@ function mirrorAuthTelemetry(event, params) {
 
 /**
  * @param {string} method
- * @param {{ surface?: AuthModalSurface }} [opts]
+ * @param {{ surface?: AuthModalSurface, auth_flow?: 'popup' | 'redirect' }} [opts]
  */
 export function trackAuthSignUp(method, opts = {}) {
   const params = {
     method,
     ...(opts.surface ? { surface: opts.surface } : {}),
+    ...(opts.auth_flow ? { auth_flow: opts.auth_flow } : {}),
   };
   mirrorAuthTelemetry('sign_up', params);
   ga4Event('sign_up', params);
@@ -23,25 +24,32 @@ export function trackAuthSignUp(method, opts = {}) {
 
 /**
  * @param {string} method
- * @param {{ surface?: AuthModalSurface }} [opts]
+ * @param {{ surface?: AuthModalSurface, auth_flow?: 'popup' | 'redirect' }} [opts]
  */
 export function trackAuthLogin(method, opts = {}) {
   const params = {
     method,
     ...(opts.surface ? { surface: opts.surface } : {}),
+    ...(opts.auth_flow ? { auth_flow: opts.auth_flow } : {}),
   };
   mirrorAuthTelemetry('login', params);
   ga4Event('login', params);
 }
 
 /**
- * @param {{ method: string, error_code?: string, surface?: AuthModalSurface }} payload
+ * @param {{
+ *   method: string,
+ *   error_code?: string,
+ *   surface?: AuthModalSurface,
+ *   auth_flow?: 'popup' | 'redirect',
+ * }} payload
  */
 export function trackAuthError(payload) {
   const params = {
     method: payload.method,
     error_code: payload.error_code ?? 'unknown',
     ...(payload.surface ? { surface: payload.surface } : {}),
+    ...(payload.auth_flow ? { auth_flow: payload.auth_flow } : {}),
   };
   mirrorAuthTelemetry('auth_error', params);
   ga4Event('auth_error', params);

--- a/src/features/auth/model/completeGoogleSplashAuth.js
+++ b/src/features/auth/model/completeGoogleSplashAuth.js
@@ -1,0 +1,89 @@
+import { auth } from '../../../shared/lib/firebase';
+import { signOutUser } from '../api/authApi';
+import { recordTermsPrivacyConsent } from '../api/legalConsentApi';
+import { deleteAuthUserIfPresent } from '../api/splashAuthApi';
+import {
+  trackAuthError,
+  trackAuthLogin,
+  trackAuthRollback,
+  trackAuthRollbackFailed,
+  trackAuthSignUp,
+} from './authAnalytics';
+import { decideSignInModalGoogleAction } from './signInModalGuard';
+
+/**
+ * Finish Google splash auth after popup or redirect (#773 Phase 2b).
+ *
+ * @param {{
+ *   intent: 'signin' | 'signup',
+ *   isNewUser: boolean,
+ *   flow?: 'popup' | 'redirect',
+ * }} params
+ * @returns {Promise<
+ *   | { kind: 'success' }
+ *   | { kind: 'error', message: string }
+ * >}
+ */
+export async function completeGoogleSplashAuth({
+  intent,
+  isNewUser,
+  flow = 'popup',
+}) {
+  const flowOpts = { auth_flow: flow };
+
+  if (intent === 'signin') {
+    const action = decideSignInModalGoogleAction(isNewUser);
+    if (action.kind === 'block-new-user') {
+      await deleteAuthUserIfPresent(auth.currentUser);
+      try {
+        await signOutUser();
+      } catch (signOutErr) {
+        console.error('signOut after sign-in modal block:', signOutErr);
+      }
+      trackAuthError({
+        method: 'google',
+        error_code: action.telemetryErrorCode,
+        surface: 'sign_in',
+        ...flowOpts,
+      });
+      return { kind: 'error', message: action.errorMessage };
+    }
+    trackAuthLogin('google', { surface: 'sign_in', ...flowOpts });
+    return { kind: 'success' };
+  }
+
+  // signup
+  if (isNewUser) {
+    try {
+      await recordTermsPrivacyConsent(auth.currentUser.uid);
+    } catch (consentErr) {
+      console.error('Consent write after Google sign-up:', consentErr);
+      trackAuthRollback({ method: 'google', stage: 'consent_write' });
+      const rollback = await deleteAuthUserIfPresent(auth.currentUser);
+      if (!rollback.deleted) {
+        trackAuthRollbackFailed({
+          method: 'google',
+          error_code: rollback.errorCode || 'unknown',
+        });
+        console.error(
+          'Auth rollback delete failed after Google sign-up:',
+          rollback.errorCode,
+        );
+      }
+      try {
+        await signOutUser();
+      } catch {
+        // best-effort
+      }
+      return {
+        kind: 'error',
+        message: 'Could not finish creating your account. Please try again.',
+      };
+    }
+    trackAuthSignUp('google', { surface: 'create_account', ...flowOpts });
+    return { kind: 'success' };
+  }
+
+  trackAuthLogin('google', { surface: 'create_account', ...flowOpts });
+  return { kind: 'success' };
+}

--- a/src/features/auth/model/completeGoogleSplashAuth.test.js
+++ b/src/features/auth/model/completeGoogleSplashAuth.test.js
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../shared/lib/firebase', () => ({
+  auth: { currentUser: { uid: 'u1' } },
+}));
+
+const signOutUser = vi.fn(async () => {});
+const deleteAuthUserIfPresent = vi.fn(async () => ({ deleted: true }));
+const recordTermsPrivacyConsent = vi.fn(async () => {});
+
+vi.mock('../api/authApi', () => ({
+  signOutUser: (...args) => signOutUser(...args),
+}));
+vi.mock('../api/splashAuthApi', () => ({
+  deleteAuthUserIfPresent: (...args) => deleteAuthUserIfPresent(...args),
+}));
+vi.mock('../api/legalConsentApi', () => ({
+  recordTermsPrivacyConsent: (...args) => recordTermsPrivacyConsent(...args),
+}));
+
+const trackAuthError = vi.fn();
+const trackAuthLogin = vi.fn();
+const trackAuthSignUp = vi.fn();
+
+vi.mock('./authAnalytics', () => ({
+  trackAuthError: (...args) => trackAuthError(...args),
+  trackAuthLogin: (...args) => trackAuthLogin(...args),
+  trackAuthSignUp: (...args) => trackAuthSignUp(...args),
+  trackAuthRollback: vi.fn(),
+  trackAuthRollbackFailed: vi.fn(),
+}));
+
+import { completeGoogleSplashAuth } from './completeGoogleSplashAuth.js';
+
+describe('completeGoogleSplashAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('blocks new Google users on sign-in modal and rolls back', async () => {
+    const out = await completeGoogleSplashAuth({
+      intent: 'signin',
+      isNewUser: true,
+      flow: 'redirect',
+    });
+    expect(out.kind).toBe('error');
+    expect(deleteAuthUserIfPresent).toHaveBeenCalled();
+    expect(signOutUser).toHaveBeenCalled();
+    expect(trackAuthError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error_code: 'signin_modal_new_user_blocked',
+        auth_flow: 'redirect',
+      }),
+    );
+  });
+
+  it('allows returning Google users on sign-in', async () => {
+    const out = await completeGoogleSplashAuth({
+      intent: 'signin',
+      isNewUser: false,
+      flow: 'popup',
+    });
+    expect(out).toEqual({ kind: 'success' });
+    expect(trackAuthLogin).toHaveBeenCalledWith(
+      'google',
+      expect.objectContaining({ surface: 'sign_in', auth_flow: 'popup' }),
+    );
+  });
+
+  it('records consent for new Google sign-up', async () => {
+    const out = await completeGoogleSplashAuth({
+      intent: 'signup',
+      isNewUser: true,
+      flow: 'redirect',
+    });
+    expect(out).toEqual({ kind: 'success' });
+    expect(recordTermsPrivacyConsent).toHaveBeenCalledWith('u1');
+    expect(trackAuthSignUp).toHaveBeenCalled();
+  });
+});

--- a/src/features/auth/model/useGoogleRedirectCompletion.js
+++ b/src/features/auth/model/useGoogleRedirectCompletion.js
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from 'react';
+
+import { auth } from '../../../shared/lib/firebase';
+import { consumeGoogleRedirectResult } from '../api/splashAuthApi';
+import {
+  clearSplashGoogleModalInflight,
+  setSplashGoogleModalInflight,
+} from '../utils/splashGoogleModalInflight';
+import { consumeGoogleRedirectIntent } from '../utils/googleRedirectIntent';
+import { getFirebaseAuthErrorMessage } from '../utils/firebaseAuthMessages';
+import { trackAuthError } from './authAnalytics';
+import { completeGoogleSplashAuth } from './completeGoogleSplashAuth';
+
+/**
+ * Completes a pending Google `signInWithRedirect` on splash / invite landings.
+ *
+ * @param {{
+ *   onOpenSignIn?: () => void,
+ *   onOpenSignUp?: () => void,
+ *   onError?: (message: string, intent: 'signin' | 'signup' | null) => void,
+ * }} [opts]
+ */
+export function useGoogleRedirectCompletion({
+  onOpenSignIn,
+  onOpenSignUp,
+  onError,
+} = {}) {
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    if (ranRef.current) return;
+    ranRef.current = true;
+
+    let cancelled = false;
+
+    (async () => {
+      let result;
+      try {
+        result = await consumeGoogleRedirectResult(auth);
+      } catch (err) {
+        console.error('Google redirect result:', err);
+        const intent = consumeGoogleRedirectIntent();
+        trackAuthError({
+          method: 'google',
+          error_code: err?.code || 'redirect_result_failed',
+          surface: intent === 'signup' ? 'create_account' : 'sign_in',
+          auth_flow: 'redirect',
+        });
+        onError?.(getFirebaseAuthErrorMessage(err?.code), intent);
+        if (intent === 'signup') onOpenSignUp?.();
+        else if (intent === 'signin') onOpenSignIn?.();
+        return;
+      }
+
+      if (cancelled || !result) {
+        // Clear a stale intent if Firebase returned nothing (user cancelled).
+        if (!result) consumeGoogleRedirectIntent();
+        return;
+      }
+
+      const intent = consumeGoogleRedirectIntent() || 'signin';
+      setSplashGoogleModalInflight();
+      try {
+        const outcome = await completeGoogleSplashAuth({
+          intent,
+          isNewUser: result.isNewUser,
+          flow: 'redirect',
+        });
+        if (cancelled) return;
+        if (outcome.kind === 'error') {
+          onError?.(outcome.message, intent);
+          if (intent === 'signup') onOpenSignUp?.();
+          else onOpenSignIn?.();
+        }
+        // success: AuthContext + HomeRoute Navigate handle post-login routing
+      } finally {
+        clearSplashGoogleModalInflight();
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [onError, onOpenSignIn, onOpenSignUp]);
+}

--- a/src/features/auth/model/useSplashSignIn.js
+++ b/src/features/auth/model/useSplashSignIn.js
@@ -1,27 +1,33 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { isLikelyInAppBrowser } from '../../../shared/lib/inAppBrowser';
 import { auth } from '../../../shared/lib/firebase';
-import { signOutUser } from '../api/authApi';
 import { getFirebaseAuthErrorMessage } from '../utils/firebaseAuthMessages';
 import {
-  deleteAuthUserIfPresent,
   sendResetEmail,
   signInWithEmail,
   signInWithGoogle,
+  startGoogleSignInRedirect,
 } from '../api/splashAuthApi';
 import {
   clearSplashGoogleModalInflight,
   setSplashGoogleModalInflight,
 } from '../utils/splashGoogleModalInflight';
+import { stashGoogleRedirectIntent } from '../utils/googleRedirectIntent';
 import { trackAuthError, trackAuthLogin } from './authAnalytics';
-import { decideSignInModalGoogleAction } from './signInModalGuard';
+import { completeGoogleSplashAuth } from './completeGoogleSplashAuth';
 
-export function useSplashSignIn(isOpen, onClose) {
+export function useSplashSignIn(isOpen, onClose, { seedError = '' } = {}) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
   const [resetLinkNotice, setResetLinkNotice] = useState({ text: '', type: '' });
+  const inAppBrowser = isLikelyInAppBrowser();
+
+  useEffect(() => {
+    if (isOpen && seedError) setError(seedError);
+  }, [isOpen, seedError]);
 
   const resetForm = useCallback(() => {
     setEmail('');
@@ -57,30 +63,23 @@ export function useSplashSignIn(isOpen, onClose) {
     setBusy(true);
     setSplashGoogleModalInflight();
     try {
-      const { isNewUser } = await signInWithGoogle(auth);
-      const action = decideSignInModalGoogleAction(isNewUser);
-      if (action.kind === 'block-new-user') {
-        // Sign-in modal is for returning users only — it never presented
-        // the Terms/Privacy clickwrap. Roll back the auth account
-        // (best-effort) and force a sign-out so a partially-rolled-back
-        // account can't sit in a signed-in but unconsented state. Route
-        // them to the Create Account modal where the consent checkbox is
-        // enforced.
-        await deleteAuthUserIfPresent(auth.currentUser);
-        try {
-          await signOutUser();
-        } catch (signOutErr) {
-          console.error('signOut after sign-in modal block:', signOutErr);
-        }
-        trackAuthError({
-          method: 'google',
-          error_code: action.telemetryErrorCode,
-          surface: 'sign_in',
-        });
-        setError(action.errorMessage);
+      if (inAppBrowser) {
+        stashGoogleRedirectIntent('signin');
+        await startGoogleSignInRedirect(auth);
+        // Navigates away — leave busy/inflight set until unload.
         return;
       }
-      trackAuthLogin('google', { surface: 'sign_in' });
+
+      const { isNewUser } = await signInWithGoogle(auth);
+      const outcome = await completeGoogleSplashAuth({
+        intent: 'signin',
+        isNewUser,
+        flow: 'popup',
+      });
+      if (outcome.kind === 'error') {
+        setError(outcome.message);
+        return;
+      }
       closeModal();
     } catch (err) {
       console.error('Google sign-in:', err);
@@ -88,13 +87,16 @@ export function useSplashSignIn(isOpen, onClose) {
         method: 'google',
         error_code: err.code,
         surface: 'sign_in',
+        auth_flow: inAppBrowser ? 'redirect' : 'popup',
       });
       setError(getFirebaseAuthErrorMessage(err.code));
     } finally {
-      clearSplashGoogleModalInflight();
-      setBusy(false);
+      if (!inAppBrowser) {
+        clearSplashGoogleModalInflight();
+        setBusy(false);
+      }
     }
-  }, [closeModal]);
+  }, [closeModal, inAppBrowser]);
 
   const handleEmailSignIn = useCallback(
     async (e) => {
@@ -117,7 +119,7 @@ export function useSplashSignIn(isOpen, onClose) {
         setBusy(false);
       }
     },
-    [closeModal, email, password]
+    [closeModal, email, password],
   );
 
   const handleSendPasswordResetEmail = useCallback(async () => {
@@ -161,5 +163,6 @@ export function useSplashSignIn(isOpen, onClose) {
     handleGoogle,
     handleEmailSignIn,
     handleSendPasswordResetEmail,
+    inAppBrowser,
   };
 }

--- a/src/features/auth/model/useSplashSignUp.js
+++ b/src/features/auth/model/useSplashSignUp.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { isLikelyInAppBrowser } from '../../../shared/lib/inAppBrowser';
 import { auth } from '../../../shared/lib/firebase';
 import { recordTermsPrivacyConsent } from '../api/legalConsentApi';
 import { getFirebaseAuthErrorMessage } from '../utils/firebaseAuthMessages';
@@ -7,26 +8,33 @@ import {
   deleteAuthUserIfPresent,
   registerWithEmail,
   signInWithGoogle,
+  startGoogleSignInRedirect,
 } from '../api/splashAuthApi';
 import {
   clearSplashGoogleModalInflight,
   setSplashGoogleModalInflight,
 } from '../utils/splashGoogleModalInflight';
+import { stashGoogleRedirectIntent } from '../utils/googleRedirectIntent';
 import {
   trackAuthError,
-  trackAuthLogin,
   trackAuthRollback,
   trackAuthRollbackFailed,
   trackAuthSignUp,
 } from './authAnalytics';
+import { completeGoogleSplashAuth } from './completeGoogleSplashAuth';
 
-export function useSplashSignUp(isOpen, onClose) {
+export function useSplashSignUp(isOpen, onClose, { seedError = '' } = {}) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [legalAccepted, setLegalAccepted] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
+  const inAppBrowser = isLikelyInAppBrowser();
+
+  useEffect(() => {
+    if (isOpen && seedError) setError(seedError);
+  }, [isOpen, seedError]);
 
   const resetForm = useCallback(() => {
     setEmail('');
@@ -67,32 +75,21 @@ export function useSplashSignUp(isOpen, onClose) {
     setBusy(true);
     setSplashGoogleModalInflight();
     try {
+      if (inAppBrowser) {
+        stashGoogleRedirectIntent('signup');
+        await startGoogleSignInRedirect(auth);
+        return;
+      }
+
       const { isNewUser } = await signInWithGoogle(auth);
-      if (isNewUser) {
-        try {
-          await recordTermsPrivacyConsent(auth.currentUser.uid);
-        } catch (consentErr) {
-          console.error('Consent write after Google sign-up:', consentErr);
-          trackAuthRollback({ method: 'google', stage: 'consent_write' });
-          const rollback = await deleteAuthUserIfPresent(auth.currentUser);
-          if (!rollback.deleted) {
-            trackAuthRollbackFailed({
-              method: 'google',
-              error_code: rollback.errorCode || 'unknown',
-            });
-            console.error(
-              'Auth rollback delete failed after Google sign-up:',
-              rollback.errorCode
-            );
-          }
-          setError('Could not finish creating your account. Please try again.');
-          return;
-        }
-        trackAuthSignUp('google', { surface: 'create_account' });
-      } else {
-        // Existing Google account used Create account — treat as login, not a
-        // blocked sign-up. Surface tag lets GA4 separate this from Sign-in.
-        trackAuthLogin('google', { surface: 'create_account' });
+      const outcome = await completeGoogleSplashAuth({
+        intent: 'signup',
+        isNewUser,
+        flow: 'popup',
+      });
+      if (outcome.kind === 'error') {
+        setError(outcome.message);
+        return;
       }
       closeModal();
     } catch (err) {
@@ -101,13 +98,16 @@ export function useSplashSignUp(isOpen, onClose) {
         method: 'google',
         error_code: err.code,
         surface: 'create_account',
+        auth_flow: inAppBrowser ? 'redirect' : 'popup',
       });
       setError(getFirebaseAuthErrorMessage(err.code));
     } finally {
-      clearSplashGoogleModalInflight();
-      setBusy(false);
+      if (!inAppBrowser) {
+        clearSplashGoogleModalInflight();
+        setBusy(false);
+      }
     }
-  }, [closeModal, legalAccepted]);
+  }, [closeModal, inAppBrowser, legalAccepted]);
 
   const handleEmailSignUp = useCallback(
     async (e) => {
@@ -178,5 +178,6 @@ export function useSplashSignUp(isOpen, onClose) {
     closeModal,
     handleGoogle,
     handleEmailSignUp,
+    inAppBrowser,
   };
 }

--- a/src/features/auth/ui/OpenInBrowserBanner.jsx
+++ b/src/features/auth/ui/OpenInBrowserBanner.jsx
@@ -1,0 +1,65 @@
+import React, { useCallback, useMemo, useState } from 'react';
+
+import {
+  isLikelyInAppBrowser,
+  preferredExternalBrowserLabel,
+} from '../../../shared/lib/inAppBrowser';
+import Button from '../../../shared/ui/Button';
+
+/**
+ * Instructional banner for email / in-app WebViews (#773 Phase 2b).
+ * Browsers cannot force a handoff to Safari/Chrome; we guide the user.
+ */
+export default function OpenInBrowserBanner({ className = '' }) {
+  const [dismissed, setDismissed] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const show = useMemo(() => isLikelyInAppBrowser(), []);
+  const browserLabel = useMemo(() => preferredExternalBrowserLabel(), []);
+
+  const handleCopy = useCallback(async () => {
+    const href = `${window.location.origin}${window.location.pathname}${window.location.search}`;
+    try {
+      await navigator.clipboard.writeText(href);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback: select via prompt so user can still copy manually.
+      window.prompt('Copy this link and open it in your browser:', href);
+    }
+  }, []);
+
+  if (!show || dismissed) return null;
+
+  return (
+    <div
+      className={`border-b border-brand-primary/25 bg-brand-primary/10 px-4 py-3 text-sm text-white ${className}`}
+      role="status"
+      data-open-in-browser-banner="true"
+    >
+      <div className="mx-auto flex max-w-xl flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p className="font-semibold leading-snug text-content-secondary">
+          Signing in works more reliably in {browserLabel}. Use your browser menu
+          → Open in {browserLabel}, or copy the link below.
+        </p>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            variant="text"
+            type="button"
+            onClick={handleCopy}
+            className="rounded-lg bg-brand-primary/20 px-3 py-1.5 text-xs font-bold text-brand-primary ring-1 ring-inset ring-brand-primary/35 hover:bg-brand-primary/30"
+          >
+            {copied ? 'Copied' : 'Copy link'}
+          </Button>
+          <Button
+            variant="text"
+            type="button"
+            onClick={() => setDismissed(true)}
+            className="px-2 py-1 text-xs font-bold text-slate-400 hover:text-white"
+          >
+            Dismiss
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/auth/ui/SplashSignInModal.jsx
+++ b/src/features/auth/ui/SplashSignInModal.jsx
@@ -11,6 +11,7 @@ export default function SplashSignInModal({
   onClose,
   onSwitchToSignUp,
   poolInvitePending = false,
+  seedError = '',
 }) {
   const [showPassword, setShowPassword] = useState(false);
 
@@ -26,7 +27,8 @@ export default function SplashSignInModal({
     handleGoogle,
     handleEmailSignIn,
     handleSendPasswordResetEmail,
-  } = useSplashSignIn(isOpen, onClose);
+    inAppBrowser,
+  } = useSplashSignIn(isOpen, onClose, { seedError });
 
   const prependContent =
     poolInvitePending || error ? (
@@ -52,6 +54,11 @@ export default function SplashSignInModal({
       handleGoogle={handleGoogle}
       busy={busy}
       prependContent={prependContent}
+      googleFootnote={
+        inAppBrowser
+          ? 'Continues with a full-page Google sign-in (more reliable in this browser).'
+          : undefined
+      }
       closeOnBackdropClick={false}
     >
         <form onSubmit={handleEmailSignIn} className="space-y-4 text-left">

--- a/src/features/auth/ui/SplashSignUpModal.jsx
+++ b/src/features/auth/ui/SplashSignUpModal.jsx
@@ -13,6 +13,7 @@ export default function SplashSignUpModal({
   onClose,
   onSwitchToSignIn,
   poolInvitePending = false,
+  seedError = '',
 }) {
   const {
     email,
@@ -28,7 +29,8 @@ export default function SplashSignUpModal({
     closeModal,
     handleGoogle,
     handleEmailSignUp,
-  } = useSplashSignUp(isOpen, onClose);
+    inAppBrowser,
+  } = useSplashSignUp(isOpen, onClose, { seedError });
 
   const consentBlock = (
     <label className="flex cursor-pointer items-start gap-3 rounded-2xl border border-border-subtle bg-surface-field/80 p-4 text-left text-sm font-semibold leading-snug text-slate-200">
@@ -89,7 +91,11 @@ export default function SplashSignUpModal({
       busy={busy}
       googleDisabled={busy || !legalAccepted}
       prependContent={prependContent}
-      googleFootnote="You'll set your username/handle on the next page. Your email address is never shared or visible to other users."
+      googleFootnote={
+        inAppBrowser
+          ? "Continues with a full-page Google sign-in. You'll set your username/handle next. Your email is never shared with other users."
+          : "You'll set your username/handle on the next page. Your email address is never shared or visible to other users."
+      }
       closeOnBackdropClick={false}
     >
         <form onSubmit={handleEmailSignUp} className="space-y-4 text-left">

--- a/src/features/auth/utils/googleRedirectIntent.js
+++ b/src/features/auth/utils/googleRedirectIntent.js
@@ -1,0 +1,41 @@
+const STORAGE_KEY = 'setpicks_google_redirect_intent_v1';
+
+/**
+ * Stash which splash modal started a Google redirect (#773 Phase 2b).
+ * @param {'signin' | 'signup'} intent
+ */
+export function stashGoogleRedirectIntent(intent) {
+  if (intent !== 'signin' && intent !== 'signup') return;
+  try {
+    sessionStorage.setItem(STORAGE_KEY, intent);
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+/**
+ * @returns {'signin' | 'signup' | null}
+ */
+export function consumeGoogleRedirectIntent() {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    sessionStorage.removeItem(STORAGE_KEY);
+    if (raw === 'signin' || raw === 'signup') return raw;
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+/**
+ * @returns {'signin' | 'signup' | null}
+ */
+export function peekGoogleRedirectIntent() {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (raw === 'signin' || raw === 'signup') return raw;
+  } catch {
+    // ignore
+  }
+  return null;
+}

--- a/src/features/auth/utils/googleRedirectIntent.test.js
+++ b/src/features/auth/utils/googleRedirectIntent.test.js
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  consumeGoogleRedirectIntent,
+  peekGoogleRedirectIntent,
+  stashGoogleRedirectIntent,
+} from './googleRedirectIntent.js';
+
+const store = new Map();
+
+beforeEach(() => {
+  store.clear();
+  vi.stubGlobal('sessionStorage', {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => {
+      store.set(k, String(v));
+    },
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('googleRedirectIntent', () => {
+  it('stashes and consumes signin/signup once', () => {
+    stashGoogleRedirectIntent('signin');
+    expect(peekGoogleRedirectIntent()).toBe('signin');
+    expect(consumeGoogleRedirectIntent()).toBe('signin');
+    expect(consumeGoogleRedirectIntent()).toBe(null);
+  });
+
+  it('ignores invalid intents', () => {
+    stashGoogleRedirectIntent('nope');
+    expect(consumeGoogleRedirectIntent()).toBe(null);
+  });
+});

--- a/src/features/invite/model/useInviteLanding.js
+++ b/src/features/invite/model/useInviteLanding.js
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   isSplashGoogleModalInflight,
   useAuth,
+  useGoogleRedirectCompletion,
 } from '../../auth';
 import { normalizeInviteHandle } from '../../../shared/lib/inviteKit';
 import { getDashboardEntryHref } from '../../../shared/lib/dashboardLastPath';
@@ -19,12 +20,23 @@ export function useInviteLanding({ inviteKind, handle: rawHandle }) {
   const handle = normalizeInviteHandle(rawHandle);
   const { user, isAdmin: isAdminUser } = useAuth();
   const [authModal, setAuthModal] = useState(null);
+  const [redirectAuthError, setRedirectAuthError] = useState('');
   const [inviter, setInviter] = useState(null);
   const [resolveState, setResolveState] = useState(handle ? 'loading' : 'idle');
 
   const closeModal = useCallback(() => setAuthModal(null), []);
   const openSignUpModal = useCallback(() => setAuthModal('signup'), []);
   const openSignInModal = useCallback(() => setAuthModal('signin'), []);
+  const onRedirectError = useCallback((message, intent) => {
+    setRedirectAuthError(message || '');
+    if (intent === 'signup') setAuthModal('signup');
+    else setAuthModal('signin');
+  }, []);
+  useGoogleRedirectCompletion({
+    onOpenSignIn: openSignInModal,
+    onOpenSignUp: openSignUpModal,
+    onError: onRedirectError,
+  });
 
   useEffect(() => {
     if (!handle) {
@@ -74,6 +86,8 @@ export function useInviteLanding({ inviteKind, handle: rawHandle }) {
     closeModal,
     openSignUpModal,
     openSignInModal,
+    redirectAuthError,
+    clearRedirectAuthError: () => setRedirectAuthError(''),
     redirectTo,
   };
 }

--- a/src/features/invite/ui/InviteVipLanding.jsx
+++ b/src/features/invite/ui/InviteVipLanding.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useLocation } from 'react-router-dom';
 
+import { OpenInBrowserBanner } from '../../auth';
 import { MarketingPageShell, SplashAuthModals } from '../../landing';
 import { SEO_CONFIG } from '../../../shared/config/seo';
 import Button from '../../../shared/ui/Button';
@@ -19,6 +20,8 @@ export default function InviteVipLanding({
   closeModal,
   openSignUpModal,
   openSignInModal,
+  redirectAuthError = '',
+  clearRedirectAuthError,
 }) {
   const { pathname, search } = useLocation();
   const pageTitle = `${headline} | Setlist Pick'Em`;
@@ -40,6 +43,7 @@ export default function InviteVipLanding({
         <meta name="twitter:image" content={SEO_CONFIG.ogImageUrl} />
         <link rel="canonical" href={canonicalUrl} />
       </Helmet>
+      <OpenInBrowserBanner />
       <MarketingPageShell>
         <section className="mx-auto flex min-h-[calc(100vh-5.35rem)] max-w-2xl flex-col items-center justify-center px-4 py-16 text-center sm:px-6 lg:px-8">
           {resolveState === 'loading' ? (
@@ -83,6 +87,8 @@ export default function InviteVipLanding({
         onSwitchToSignIn={openSignInModal}
         onSwitchToSignUp={openSignUpModal}
         poolInvitePending={poolInvitePending}
+        redirectAuthError={redirectAuthError}
+        onClearRedirectAuthError={clearRedirectAuthError}
       />
     </>
   );

--- a/src/features/landing/ui/SplashAuthModals.jsx
+++ b/src/features/landing/ui/SplashAuthModals.jsx
@@ -8,20 +8,29 @@ export default function SplashAuthModals({
   onSwitchToSignIn,
   onSwitchToSignUp,
   poolInvitePending = false,
+  redirectAuthError = '',
+  onClearRedirectAuthError,
 }) {
+  const handleClose = () => {
+    onClearRedirectAuthError?.();
+    closeModal();
+  };
+
   return (
     <>
       <SplashSignUpModal
         isOpen={authModal === 'signup'}
-        onClose={closeModal}
+        onClose={handleClose}
         onSwitchToSignIn={onSwitchToSignIn}
         poolInvitePending={poolInvitePending}
+        seedError={authModal === 'signup' ? redirectAuthError : ''}
       />
       <SplashSignInModal
         isOpen={authModal === 'signin'}
-        onClose={closeModal}
+        onClose={handleClose}
         onSwitchToSignUp={onSwitchToSignUp}
         poolInvitePending={poolInvitePending}
+        seedError={authModal === 'signin' ? redirectAuthError : ''}
       />
     </>
   );

--- a/src/pages/landing/SplashPage.jsx
+++ b/src/pages/landing/SplashPage.jsx
@@ -1,7 +1,11 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
-import { consumeSplashResumeAuthModal } from '../../features/auth';
+import {
+  OpenInBrowserBanner,
+  consumeSplashResumeAuthModal,
+  useGoogleRedirectCompletion,
+} from '../../features/auth';
 import {
   SplashAuthModals,
   SplashPageShell,
@@ -16,9 +20,20 @@ let lastDeferredPoolInvitePromptAt = 0;
 
 export default function Splash() {
   const [authModal, setAuthModal] = useState(null);
+  const [redirectAuthError, setRedirectAuthError] = useState('');
   const closeModal = useCallback(() => setAuthModal(null), []);
   const openSignUpModal = useCallback(() => setAuthModal('signup'), []);
   const openSignInModal = useCallback(() => setAuthModal('signin'), []);
+  const onRedirectError = useCallback((message, intent) => {
+    setRedirectAuthError(message || '');
+    if (intent === 'signup') setAuthModal('signup');
+    else setAuthModal('signin');
+  }, []);
+  useGoogleRedirectCompletion({
+    onOpenSignIn: openSignInModal,
+    onOpenSignUp: openSignUpModal,
+    onError: onRedirectError,
+  });
   /** Invite is stored before splash mounts; seed once for modal join-context copy. */
   const [poolInvitePending] = useState(
     () => Boolean(getLocalStorageItem(POOL_INVITE_STORAGE_KEY)?.trim()),
@@ -75,6 +90,7 @@ export default function Splash() {
 
   return (
     <ScoringRulesModalProvider>
+      <OpenInBrowserBanner />
       <SplashPageShell
         howItWorksSectionRef={howItWorksSectionRef}
         howItWorksHeadingRef={howItWorksHeadingRef}
@@ -93,6 +109,8 @@ export default function Splash() {
         onSwitchToSignIn={openSignInModal}
         onSwitchToSignUp={openSignUpModal}
         poolInvitePending={poolInvitePending}
+        redirectAuthError={redirectAuthError}
+        onClearRedirectAuthError={() => setRedirectAuthError('')}
       />
     </ScoringRulesModalProvider>
   );

--- a/src/shared/lib/inAppBrowser.js
+++ b/src/shared/lib/inAppBrowser.js
@@ -1,0 +1,57 @@
+/**
+ * Best-effort detection of email / social in-app browsers (#773 Phase 2b).
+ * Used to prefer redirect Google auth and surface “Open in browser” copy.
+ * Not perfect — especially some iOS Mail SFSafariViewController cases.
+ */
+
+/**
+ * @param {string} [userAgent]
+ * @returns {boolean}
+ */
+export function isLikelyInAppBrowser(userAgent) {
+  const ua =
+    typeof userAgent === 'string'
+      ? userAgent
+      : typeof navigator !== 'undefined'
+        ? navigator.userAgent || ''
+        : '';
+  if (!ua) return false;
+
+  // Android WebView and common in-app shells.
+  if (/; wv\)/i.test(ua)) return true;
+  if (
+    /FBAN|FBAV|FB_IAB|Instagram|Line\/|LinkedInApp|Twitter|GSA\/|Snapchat|BytedanceWebview|musical_ly/i.test(
+      ua,
+    )
+  ) {
+    return true;
+  }
+
+  // iOS WKWebView often omits the Safari token that real Safari / CriOS include.
+  const isIOS = /iPhone|iPad|iPod/i.test(ua);
+  if (isIOS) {
+    const isWebKit = /AppleWebKit/i.test(ua);
+    const hasSafari = /Safari/i.test(ua);
+    const isNamedBrowser = /CriOS|FxiOS|OPiOS|EdgiOS/i.test(ua);
+    if (isWebKit && !hasSafari && !isNamedBrowser) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Human-facing browser name hint for instructional copy.
+ * @param {string} [userAgent]
+ * @returns {'Safari' | 'Chrome' | 'your browser'}
+ */
+export function preferredExternalBrowserLabel(userAgent) {
+  const ua =
+    typeof userAgent === 'string'
+      ? userAgent
+      : typeof navigator !== 'undefined'
+        ? navigator.userAgent || ''
+        : '';
+  if (/Android/i.test(ua)) return 'Chrome';
+  if (/iPhone|iPad|iPod/i.test(ua)) return 'Safari';
+  return 'your browser';
+}

--- a/src/shared/lib/inAppBrowser.test.js
+++ b/src/shared/lib/inAppBrowser.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isLikelyInAppBrowser,
+  preferredExternalBrowserLabel,
+} from './inAppBrowser.js';
+
+describe('isLikelyInAppBrowser', () => {
+  it('detects Android WebView and Gmail/GSA shells', () => {
+    expect(
+      isLikelyInAppBrowser(
+        'Mozilla/5.0 (Linux; Android 14; Pixel 8 Build/UQ1A; wv) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile Safari/537.36',
+      ),
+    ).toBe(true);
+    expect(
+      isLikelyInAppBrowser(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 GSA/300.0 Mobile/15E148',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not flag desktop Chrome or iOS Safari / CriOS', () => {
+    expect(
+      isLikelyInAppBrowser(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      ),
+    ).toBe(false);
+    expect(
+      isLikelyInAppBrowser(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      ),
+    ).toBe(false);
+    expect(
+      isLikelyInAppBrowser(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.0.0 Mobile/15E148 Safari/604.1',
+      ),
+    ).toBe(false);
+  });
+
+  it('detects iOS WKWebView without Safari token', () => {
+    expect(
+      isLikelyInAppBrowser(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('preferredExternalBrowserLabel', () => {
+  it('returns Safari on iOS and Chrome on Android', () => {
+    expect(preferredExternalBrowserLabel('iPhone OS 17_0')).toBe('Safari');
+    expect(preferredExternalBrowserLabel('Linux; Android 14')).toBe('Chrome');
+  });
+});


### PR DESCRIPTION
Refs #773

## Summary
- Detect email/social in-app browsers; use Google `signInWithRedirect` + `getRedirectResult` there (popup elsewhere)
- Splash/invite restore sign-in vs create-account intent after redirect; same new-user block / consent rules as popup
- “Open in browser” banner with copy-link affordance on splash + invite landings
- Return URL via `persistDashboardPath` unchanged (#535)
- PATCH `1.42.3`

## Test plan
- [x] `npm test` (476) + `npm run lint`
- [ ] Desktop Chrome: Google popup sign-in unchanged
- [ ] iPhone Gmail (or Android WebView): banner shows; Continue with Google uses full-page redirect; post-login lands on remembered `/dashboard/*` when bounced from email CTA
- [ ] Sign-in modal still blocks brand-new Google accounts (redirect + popup)


Made with [Cursor](https://cursor.com)