### PR TITLE
perf(push): SPA soft-nav on notification click (#773 Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.42.4] — 2026-08-01
+
+### Changed
+- **Push SPA soft-nav (#773 Phase 3)** — notification clicks on an already-open same-origin tab `postMessage` a `NAVIGATE` path into the SPA (no `client.navigate` full reload); cold open still uses `openWindow`.
+
+---
+
 ## [1.42.3] — 2026-08-01
 
 ### Changed

--- a/docs/USER_ROUTING_AND_JOURNEYS.md
+++ b/docs/USER_ROUTING_AND_JOURNEYS.md
@@ -36,6 +36,8 @@ Cold document loads (email CTAs, push, refresh) are rewritten by Vercel to `dist
 
 **Phase 2b (signed-out / WebView):** email in-app browsers get an “Open in browser” banner plus Google **redirect** auth (`signInWithRedirect` / `getRedirectResult`) instead of popup. Intended dashboard path is still preserved via `persistDashboardPath` (#535) before the home bounce. Normal browsers keep popup Google sign-in.
 
+**Phase 3 (push SPA handoff):** when a push notification is tapped and a same-origin tab already exists, `firebase-messaging-sw.js` `postMessage`s `{ type: 'NAVIGATE', path }` and focuses that tab (React Router soft-nav via `usePushNavigationBridge`). No existing tab → `clients.openWindow` hard open as before.
+
 ### Setup
 
 `src/app/routes/SetupRoute.jsx`:

--- a/docs/comms-triggers/MEASUREMENT_PLAN.md
+++ b/docs/comms-triggers/MEASUREMENT_PLAN.md
@@ -84,7 +84,7 @@ Primary metric: **pick submission rate before lock** among reminded users vs hol
 |---------|------------------|--------------|-------|
 | **inApp** | `comms_opened` | `comms_cta_click` | Default GA “open cliff” lens |
 | **email** | Resend opens ([#512](https://github.com/pat792/set-picks/issues/512)) — missing in GA until landed | Session UTM `source=email` / `medium=comms` (+ `utm_content` / campaign ≈ template) · `comms_email_landed` | **If `comms_cta_click` is 0 for an email-heavy trigger, query UTM sessions before concluding no engagement** |
-| **push** | `comms_push_tap` / open instrumentation | deep link | Sparse volume; verify wiring before judgment |
+| **push** | `comms_push_tap` / open instrumentation | deep link | Sparse volume; verify wiring before judgment. When a tab is already open, soft-nav via SW `postMessage` (#773 Phase 3) — do not treat tap→interactive TTI like a cold document load |
 
 **Optimize / analyst rule (2026-07-20):** For `picks_lock_reminder`, always report (1) trigger×channel `comms_*` counts **and** (2) UTM email-session `picks_page_interactive` / `submit_picks`. Snapshot recipe: `crew/knowledge/optimize_snapshot_recipe.md`.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.42.3",
+  "version": "1.42.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -18,6 +18,26 @@ const messaging = firebase.messaging();
 
 const DEFAULT_CLICK_URL = '/dashboard/profile/notifications';
 
+/**
+ * Same-origin path for SPA soft-nav (#773 Phase 3).
+ * Duplicated here (SW cannot import app modules).
+ * @param {string} absoluteOrRelativeUrl
+ * @returns {string | null}
+ */
+function appPathFromPushTargetUrl(absoluteOrRelativeUrl) {
+  try {
+    const url = new URL(absoluteOrRelativeUrl, self.location.origin);
+    if (url.origin !== self.location.origin) return null;
+    const path = `${url.pathname}${url.search}${url.hash}`;
+    if (!path.startsWith('/') || path.startsWith('//') || path.includes('://')) {
+      return null;
+    }
+    return path;
+  } catch {
+    return null;
+  }
+}
+
 // Registering `onBackgroundMessage` takes over notification display from the
 // FCM SDK's own default handler, which means its automatic `fcmOptions.link`
 // click-to-open behavior no longer applies either — we have to wire our own
@@ -35,13 +55,14 @@ messaging.onBackgroundMessage((payload) => {
   self.registration.showNotification(title, options);
 });
 
-// Focus an existing Setlist Pick'em tab (navigating it to the target URL) or
-// open a new one — without this, tapping/clicking a notification just closes
-// it with no navigation.
+// Focus an existing Setlist Pick'em tab and soft-navigate via postMessage, or
+// open a new window when none exists (#773 Phase 3). Avoid `client.navigate()`
+// on an open SPA tab — that forces a full document reload.
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
   const targetUrl = event.notification?.data?.url || DEFAULT_CLICK_URL;
   const targetHref = new URL(targetUrl, self.location.origin).href;
+  const appPath = appPathFromPushTargetUrl(targetHref) || DEFAULT_CLICK_URL;
 
   event.waitUntil(
     (async () => {
@@ -51,12 +72,10 @@ self.addEventListener('notificationclick', (event) => {
       });
       for (const client of windowClients) {
         if (client.url.startsWith(self.location.origin) && 'focus' in client) {
-          if ('navigate' in client) {
-            try {
-              await client.navigate(targetHref);
-            } catch {
-              // Cross-origin or unsupported navigate — fall back to focus only.
-            }
+          try {
+            client.postMessage({ type: 'NAVIGATE', path: appPath });
+          } catch {
+            // Older clients without a listener — focus only; user can navigate.
           }
           return client.focus();
         }

--- a/src/app/layout/RootAppShell.jsx
+++ b/src/app/layout/RootAppShell.jsx
@@ -2,6 +2,7 @@ import React, { Suspense } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 
 import { isDashboardEntryPath } from '../../shared/lib/appBootPath';
+import { usePushNavigationBridge } from '../../shared/lib/usePushNavigationBridge';
 import { useServiceWorkerUpdate } from '../../shared/lib/useServiceWorkerUpdate';
 import AppBackground from '../../shared/ui/AppBackground';
 import RouteSuspenseFallback from '../../shared/ui/RouteSuspenseFallback';
@@ -25,6 +26,7 @@ export default function RootAppShell() {
   const { pathname } = useLocation();
   const transitionKey = shellTransitionKey(pathname);
   const { updateAvailable, applyUpdate } = useServiceWorkerUpdate();
+  usePushNavigationBridge();
 
   return (
     <>

--- a/src/shared/lib/pushNavigationPath.js
+++ b/src/shared/lib/pushNavigationPath.js
@@ -1,0 +1,41 @@
+/**
+ * Sanitize SW → SPA navigation paths for push soft-nav (#773 Phase 3).
+ *
+ * @param {unknown} path
+ * @returns {string | null} same-origin app path (`/…`) or null if unsafe
+ */
+export function sanitizePushNavigationPath(path) {
+  if (typeof path !== 'string') return null;
+  const trimmed = path.trim();
+  if (!trimmed.startsWith('/') || trimmed.startsWith('//')) return null;
+  if (trimmed.includes('://')) return null;
+  // Block backslash tricks / control chars.
+  if (/[\u0000-\u001F\\]/.test(trimmed)) return null;
+  return trimmed;
+}
+
+/**
+ * @param {string} absoluteOrRelativeUrl
+ * @param {string} [origin]
+ * @returns {string | null}
+ */
+export function appPathFromPushTargetUrl(absoluteOrRelativeUrl, origin) {
+  const base =
+    typeof origin === 'string' && origin
+      ? origin
+      : typeof self !== 'undefined' && self.location?.origin
+        ? self.location.origin
+        : '';
+  if (!base) return null;
+  try {
+    const url = new URL(absoluteOrRelativeUrl, base);
+    if (url.origin !== base) return null;
+    return sanitizePushNavigationPath(
+      `${url.pathname}${url.search}${url.hash}`,
+    );
+  } catch {
+    return null;
+  }
+}
+
+export const PUSH_NAVIGATE_MESSAGE_TYPE = 'NAVIGATE';

--- a/src/shared/lib/pushNavigationPath.test.js
+++ b/src/shared/lib/pushNavigationPath.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  appPathFromPushTargetUrl,
+  sanitizePushNavigationPath,
+} from './pushNavigationPath.js';
+
+describe('sanitizePushNavigationPath', () => {
+  it('accepts app-relative paths', () => {
+    expect(sanitizePushNavigationPath('/dashboard/picks')).toBe(
+      '/dashboard/picks',
+    );
+    expect(sanitizePushNavigationPath('/dashboard/standings?showDate=2026-08-01')).toBe(
+      '/dashboard/standings?showDate=2026-08-01',
+    );
+  });
+
+  it('rejects open redirects and non-paths', () => {
+    expect(sanitizePushNavigationPath('https://evil.example/')).toBe(null);
+    expect(sanitizePushNavigationPath('//evil.example')).toBe(null);
+    expect(sanitizePushNavigationPath('dashboard/picks')).toBe(null);
+    expect(sanitizePushNavigationPath('')).toBe(null);
+  });
+});
+
+describe('appPathFromPushTargetUrl', () => {
+  const origin = 'https://www.setlistpickem.com';
+
+  it('keeps same-origin absolute URLs as paths', () => {
+    expect(
+      appPathFromPushTargetUrl(
+        'https://www.setlistpickem.com/dashboard/picks?x=1',
+        origin,
+      ),
+    ).toBe('/dashboard/picks?x=1');
+  });
+
+  it('rejects cross-origin targets', () => {
+    expect(
+      appPathFromPushTargetUrl('https://evil.example/dashboard', origin),
+    ).toBe(null);
+  });
+});

--- a/src/shared/lib/usePushNavigationBridge.js
+++ b/src/shared/lib/usePushNavigationBridge.js
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import {
+  PUSH_NAVIGATE_MESSAGE_TYPE,
+  sanitizePushNavigationPath,
+} from './pushNavigationPath';
+
+/**
+ * Soft-navigate when the FCM service worker asks an existing tab to move
+ * (#773 Phase 3). Replaces `client.navigate()` full reloads for open tabs.
+ */
+export function usePushNavigationBridge() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+      return undefined;
+    }
+
+    function onMessage(event) {
+      const data = event?.data;
+      if (!data || data.type !== PUSH_NAVIGATE_MESSAGE_TYPE) return;
+      const path = sanitizePushNavigationPath(data.path);
+      if (!path) return;
+      navigate(path);
+    }
+
+    navigator.serviceWorker.addEventListener('message', onMessage);
+    return () => {
+      navigator.serviceWorker.removeEventListener('message', onMessage);
+    };
+  }, [navigate]);
+}


### PR DESCRIPTION
Refs #773

## Summary
- FCM `notificationclick`: existing same-origin tab gets `postMessage({ type: 'NAVIGATE', path })` + focus (no `client.navigate` reload)
- `usePushNavigationBridge` in `RootAppShell` soft-navigates via React Router
- No open tab → `clients.openWindow` unchanged
- PATCH `1.42.4` — closes the #773 train stack (Phases 1–3 + 2b) pending human stopwatch sign-off

## Test plan
- [x] `npm test` (480) + `npm run lint`
- [ ] Device: app open on `/dashboard/picks`, tap a push deep-linking to standings/notifications — tab focuses and soft-navs without full reload
- [ ] Cold: no tab open — notification still opens a new window to the target URL
- [ ] After deploy: hard-refresh once (or Update banner) so the new SW activates


Made with [Cursor](https://cursor.com)