### PR TITLE
chore(release): promote staging to main — Sprint 11 (#773 cold-boot train)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.42.4] — 2026-08-01
+
+### Changed
+- **Push SPA soft-nav (#773 Phase 3)** — notification clicks on an already-open same-origin tab `postMessage` a `NAVIGATE` path into the SPA (no `client.navigate` full reload); cold open still uses `openWindow`.
+
+---
+
 ## [1.42.3] — 2026-08-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.42.1] — 2026-08-01
+
+### Changed
+- **Email CTA branded dashboard boot shell (#773 Phase 1)** — `dist/dashboard/index.html` now ships a generic vinyl-mark + muted nav / skeleton-card shell (no SEO body) so hard opens paint branded chrome before React mounts. `verify:seo-prerender` asserts the boot marker and keeps home prerender intact.
+
+---
+
 ## [1.42.0] — 2026-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.42.3] — 2026-08-01
+
+### Changed
+- **Email WebView auth path (#773 Phase 2b)** — in-app browsers prefer Google `signInWithRedirect` (with splash intent restore) and show an Open-in-browser banner; popup Google remains the default elsewhere. Return URL via `persistDashboardPath` unchanged.
+
+---
+
 ## [1.42.2] — 2026-08-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.42.2] — 2026-08-01
+
+### Changed
+- **Email CTA cold-boot TTI (#773 Phase 2)** — dashboard hard opens warm App Check + kick `DashboardRoute` before paint; boot shell `modulepreload`s the dashboard chunk (splash untouched); Auth paints profile via `getDoc` then `onSnapshot` and shows `DashboardBootSkeleton` instead of bare “Loading…”.
+
+---
+
 ## [1.42.1] — 2026-08-01
 
 ### Changed

--- a/docs/USER_ROUTING_AND_JOURNEYS.md
+++ b/docs/USER_ROUTING_AND_JOURNEYS.md
@@ -28,6 +28,10 @@ Defined in `src/app/App.jsx`.
 - **No user profile doc** (first-time setup) → `Navigate` to `/setup`
 - **Else** → `DashboardLayout`
 
+### Email / push hard opens (`/dashboard/*`)
+
+Cold document loads (email CTAs, push, refresh) are rewritten by Vercel to `dist/dashboard/index.html` — a **branded static skeleton** (#773 Phase 1; empty-root precursor #743) so users see chrome before React + Auth mount. `createRoot` replaces `#root` as usual. Marketing SEO prerender stays on `dist/index.html` only (`verify:seo-prerender`). TTI work (eager dashboard entry, auth polish) is Phase 2 on the same epic.
+
 ### Setup
 
 `src/app/routes/SetupRoute.jsx`:

--- a/docs/USER_ROUTING_AND_JOURNEYS.md
+++ b/docs/USER_ROUTING_AND_JOURNEYS.md
@@ -32,7 +32,9 @@ Defined in `src/app/App.jsx`.
 
 Cold document loads (email CTAs, push, refresh) are rewritten by Vercel to `dist/dashboard/index.html` — a **branded static skeleton** (#773 Phase 1; empty-root precursor #743) so users see chrome before React + Auth mount. `createRoot` replaces `#root` as usual. Marketing SEO prerender stays on `dist/index.html` only (`verify:seo-prerender`).
 
-**Phase 2 (TTI):** on `/dashboard/*` (and related warm paths), `main.jsx` calls `ensureAppCheckNow()` and kicks a dynamic `import()` of `DashboardRoute` before first paint; the boot shell also `modulepreload`s the `DashboardRoute` chunk. Auth seeds `auth.currentUser`, paints profile via `getDoc` then `onSnapshot`, and dashboard loading uses `DashboardBootSkeleton` instead of bare “Loading…”. Splash stays lazy + deferred App Check. Phase 2b (WebView redirect sign-in) is still open on #773.
+**Phase 2 (TTI):** on `/dashboard/*` (and related warm paths), `main.jsx` calls `ensureAppCheckNow()` and kicks a dynamic `import()` of `DashboardRoute` before first paint; the boot shell also `modulepreload`s the `DashboardRoute` chunk. Auth seeds `auth.currentUser`, paints profile via `getDoc` then `onSnapshot`, and dashboard loading uses `DashboardBootSkeleton` instead of bare “Loading…”. Splash stays lazy + deferred App Check.
+
+**Phase 2b (signed-out / WebView):** email in-app browsers get an “Open in browser” banner plus Google **redirect** auth (`signInWithRedirect` / `getRedirectResult`) instead of popup. Intended dashboard path is still preserved via `persistDashboardPath` (#535) before the home bounce. Normal browsers keep popup Google sign-in.
 
 ### Setup
 

--- a/docs/USER_ROUTING_AND_JOURNEYS.md
+++ b/docs/USER_ROUTING_AND_JOURNEYS.md
@@ -30,7 +30,9 @@ Defined in `src/app/App.jsx`.
 
 ### Email / push hard opens (`/dashboard/*`)
 
-Cold document loads (email CTAs, push, refresh) are rewritten by Vercel to `dist/dashboard/index.html` — a **branded static skeleton** (#773 Phase 1; empty-root precursor #743) so users see chrome before React + Auth mount. `createRoot` replaces `#root` as usual. Marketing SEO prerender stays on `dist/index.html` only (`verify:seo-prerender`). TTI work (eager dashboard entry, auth polish) is Phase 2 on the same epic.
+Cold document loads (email CTAs, push, refresh) are rewritten by Vercel to `dist/dashboard/index.html` — a **branded static skeleton** (#773 Phase 1; empty-root precursor #743) so users see chrome before React + Auth mount. `createRoot` replaces `#root` as usual. Marketing SEO prerender stays on `dist/index.html` only (`verify:seo-prerender`).
+
+**Phase 2 (TTI):** on `/dashboard/*` (and related warm paths), `main.jsx` calls `ensureAppCheckNow()` and kicks a dynamic `import()` of `DashboardRoute` before first paint; the boot shell also `modulepreload`s the `DashboardRoute` chunk. Auth seeds `auth.currentUser`, paints profile via `getDoc` then `onSnapshot`, and dashboard loading uses `DashboardBootSkeleton` instead of bare “Loading…”. Splash stays lazy + deferred App Check. Phase 2b (WebView redirect sign-in) is still open on #773.
 
 ### Setup
 

--- a/docs/USER_ROUTING_AND_JOURNEYS.md
+++ b/docs/USER_ROUTING_AND_JOURNEYS.md
@@ -36,6 +36,8 @@ Cold document loads (email CTAs, push, refresh) are rewritten by Vercel to `dist
 
 **Phase 2b (signed-out / WebView):** email in-app browsers get an “Open in browser” banner plus Google **redirect** auth (`signInWithRedirect` / `getRedirectResult`) instead of popup. Intended dashboard path is still preserved via `persistDashboardPath` (#535) before the home bounce. Normal browsers keep popup Google sign-in.
 
+**Phase 3 (push SPA handoff):** when a push notification is tapped and a same-origin tab already exists, `firebase-messaging-sw.js` `postMessage`s `{ type: 'NAVIGATE', path }` and focuses that tab (React Router soft-nav via `usePushNavigationBridge`). No existing tab → `clients.openWindow` hard open as before.
+
 ### Setup
 
 `src/app/routes/SetupRoute.jsx`:

--- a/docs/comms-triggers/MEASUREMENT_PLAN.md
+++ b/docs/comms-triggers/MEASUREMENT_PLAN.md
@@ -84,7 +84,7 @@ Primary metric: **pick submission rate before lock** among reminded users vs hol
 |---------|------------------|--------------|-------|
 | **inApp** | `comms_opened` | `comms_cta_click` | Default GA “open cliff” lens |
 | **email** | Resend opens ([#512](https://github.com/pat792/set-picks/issues/512)) — missing in GA until landed | Session UTM `source=email` / `medium=comms` (+ `utm_content` / campaign ≈ template) · `comms_email_landed` | **If `comms_cta_click` is 0 for an email-heavy trigger, query UTM sessions before concluding no engagement** |
-| **push** | `comms_push_tap` / open instrumentation | deep link | Sparse volume; verify wiring before judgment |
+| **push** | `comms_push_tap` / open instrumentation | deep link | Sparse volume; verify wiring before judgment. When a tab is already open, soft-nav via SW `postMessage` (#773 Phase 3) — do not treat tap→interactive TTI like a cold document load |
 
 **Optimize / analyst rule (2026-07-20):** For `picks_lock_reminder`, always report (1) trigger×channel `comms_*` counts **and** (2) UTM email-session `picks_page_interactive` / `submit_picks`. Snapshot recipe: `crew/knowledge/optimize_snapshot_recipe.md`.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.42.3",
+  "version": "1.42.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.42.0",
+  "version": "1.42.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.42.1",
+  "version": "1.42.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.42.2",
+  "version": "1.42.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -18,6 +18,26 @@ const messaging = firebase.messaging();
 
 const DEFAULT_CLICK_URL = '/dashboard/profile/notifications';
 
+/**
+ * Same-origin path for SPA soft-nav (#773 Phase 3).
+ * Duplicated here (SW cannot import app modules).
+ * @param {string} absoluteOrRelativeUrl
+ * @returns {string | null}
+ */
+function appPathFromPushTargetUrl(absoluteOrRelativeUrl) {
+  try {
+    const url = new URL(absoluteOrRelativeUrl, self.location.origin);
+    if (url.origin !== self.location.origin) return null;
+    const path = `${url.pathname}${url.search}${url.hash}`;
+    if (!path.startsWith('/') || path.startsWith('//') || path.includes('://')) {
+      return null;
+    }
+    return path;
+  } catch {
+    return null;
+  }
+}
+
 // Registering `onBackgroundMessage` takes over notification display from the
 // FCM SDK's own default handler, which means its automatic `fcmOptions.link`
 // click-to-open behavior no longer applies either — we have to wire our own
@@ -35,13 +55,14 @@ messaging.onBackgroundMessage((payload) => {
   self.registration.showNotification(title, options);
 });
 
-// Focus an existing Setlist Pick'em tab (navigating it to the target URL) or
-// open a new one — without this, tapping/clicking a notification just closes
-// it with no navigation.
+// Focus an existing Setlist Pick'em tab and soft-navigate via postMessage, or
+// open a new window when none exists (#773 Phase 3). Avoid `client.navigate()`
+// on an open SPA tab — that forces a full document reload.
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
   const targetUrl = event.notification?.data?.url || DEFAULT_CLICK_URL;
   const targetHref = new URL(targetUrl, self.location.origin).href;
+  const appPath = appPathFromPushTargetUrl(targetHref) || DEFAULT_CLICK_URL;
 
   event.waitUntil(
     (async () => {
@@ -51,12 +72,10 @@ self.addEventListener('notificationclick', (event) => {
       });
       for (const client of windowClients) {
         if (client.url.startsWith(self.location.origin) && 'focus' in client) {
-          if ('navigate' in client) {
-            try {
-              await client.navigate(targetHref);
-            } catch {
-              // Cross-origin or unsupported navigate — fall back to focus only.
-            }
+          try {
+            client.postMessage({ type: 'NAVIGATE', path: appPath });
+          } catch {
+            // Older clients without a listener — focus only; user can navigate.
           }
           return client.focus();
         }

--- a/scripts/dashboard-boot-shell.mjs
+++ b/scripts/dashboard-boot-shell.mjs
@@ -1,0 +1,278 @@
+/**
+ * Generic branded dashboard boot shell for hard loads (#773 Phase 1).
+ * Pure HTML/CSS — no src/ imports (safe for build scripts).
+ *
+ * Injected into `dist/dashboard/index.html` after Vite build. React
+ * `createRoot` still replaces `#root` once the SPA mounts.
+ */
+
+import { stripPrerenderBodyFromSpaShell } from './seo-strip-body.mjs';
+
+/** Attribute marker asserted by `verify:seo-prerender`. */
+export const DASHBOARD_BOOT_SHELL_MARKER = 'data-dashboard-boot-shell';
+
+const VINYL_MARK_SRC = '/branding/splash-vinyl-mark.webp';
+
+/**
+ * Self-contained critical CSS. Tailwind JIT does not scan this post-build HTML,
+ * so we cannot rely on utility classes that are unused in `src/`. Colors match
+ * `src/index.css` brand tokens (RGB → hex).
+ */
+function bootShellCriticalCss() {
+  return `
+/* Paint brand canvas before the Vite CSS bundle arrives (email hard opens). */
+html, body {
+  margin: 0;
+  min-height: 100%;
+  background: #1e1b4b;
+}
+.dbs-shell {
+  position: relative;
+  display: flex;
+  min-height: 100dvh;
+  width: 100%;
+  overflow: hidden;
+  color: #fff;
+  background: #1e1b4b;
+  font-family: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+}
+.dbs-ambient {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+}
+.dbs-ambient::before,
+.dbs-ambient::after {
+  content: "";
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(100px);
+}
+.dbs-ambient::before {
+  top: -20%;
+  left: 50%;
+  width: min(100vw, 36rem);
+  height: min(100vw, 36rem);
+  transform: translateX(-50%);
+  background: rgb(45 212 191 / 0.12);
+}
+.dbs-ambient::after {
+  bottom: -10%;
+  right: -15%;
+  width: min(85vw, 28rem);
+  height: min(70vh, 32rem);
+  background: rgb(59 130 246 / 0.12);
+}
+.dbs-sidebar {
+  display: none;
+  flex-direction: column;
+  width: 16rem;
+  flex-shrink: 0;
+  padding: 1rem;
+  background: #20283e;
+  border-right: 1px solid rgb(71 85 105 / 0.65);
+  z-index: 10;
+}
+.dbs-sidebar-mark {
+  display: block;
+  width: 7rem;
+  height: 7rem;
+  margin: 0.5rem auto 1.5rem;
+  object-fit: contain;
+}
+.dbs-nav-row {
+  height: 2.75rem;
+  margin-bottom: 0.5rem;
+  border-radius: 0.75rem;
+  background: rgb(26 32 52 / 0.85);
+}
+.dbs-nav-row--active {
+  background: rgb(45 212 191 / 0.12);
+  box-shadow: inset 0 0 0 1px rgb(45 212 191 / 0.25);
+}
+.dbs-mobile-top {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  padding-top: env(safe-area-inset-top, 0px);
+}
+.dbs-brand-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid rgb(51 65 85 / 0.35);
+  background: linear-gradient(to bottom, rgb(15 10 46 / 0.76), rgb(30 27 75 / 0.60));
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow: 0 10px 28px -14px rgba(15, 10, 46, 0.85);
+}
+.dbs-brand-mark {
+  display: block;
+  height: 3.5rem;
+  width: auto;
+  max-width: calc(100vw - 7rem);
+  object-fit: contain;
+}
+.dbs-chip-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+.dbs-chip {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  background: #2a344e;
+  border: 1px solid rgb(51 65 85 / 0.35);
+}
+.dbs-main {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  min-width: 0;
+  padding: calc(env(safe-area-inset-top, 0px) + 5.5rem) 1rem calc(4.5rem + env(safe-area-inset-bottom, 0px));
+}
+.dbs-main-inner {
+  width: 100%;
+  max-width: 36rem;
+  margin: 0 auto;
+}
+.dbs-card {
+  height: 5.5rem;
+  margin-bottom: 0.75rem;
+  border-radius: 1rem;
+  background: #222a3e;
+  border: 1px solid rgb(71 85 105 / 0.35);
+  animation: dbs-pulse 1.4s ease-in-out infinite;
+}
+.dbs-card:nth-child(2) { height: 7rem; animation-delay: 0.12s; }
+.dbs-card:nth-child(3) { height: 4.5rem; animation-delay: 0.24s; }
+.dbs-tabs {
+  position: fixed;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 50;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  align-items: center;
+  height: calc(4rem + env(safe-area-inset-bottom, 0px));
+  padding: 0 0.375rem env(safe-area-inset-bottom, 0px);
+  border-top: 1px solid rgb(51 65 85 / 0.35);
+  background: linear-gradient(to top, rgb(15 10 46 / 0.76), rgb(30 27 75 / 0.60));
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow: 0 -10px 28px -14px rgba(15, 10, 46, 0.85);
+}
+.dbs-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  height: calc(100% - 10px);
+  border-radius: 0.75rem;
+}
+.dbs-tab-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 0.35rem;
+  background: rgb(203 213 225 / 0.35);
+}
+.dbs-tab-label {
+  width: 2.25rem;
+  height: 0.4rem;
+  border-radius: 9999px;
+  background: rgb(203 213 225 / 0.28);
+}
+.dbs-tab--active {
+  background: rgb(45 212 191 / 0.14);
+  box-shadow: inset 0 0 0 1px rgb(45 212 191 / 0.30);
+}
+.dbs-tab--active .dbs-tab-icon,
+.dbs-tab--active .dbs-tab-label {
+  background: rgb(45 212 191 / 0.55);
+}
+@keyframes dbs-pulse {
+  0%, 100% { opacity: 0.72; }
+  50% { opacity: 1; }
+}
+@media (min-width: 768px) {
+  .dbs-sidebar { display: flex; }
+  .dbs-mobile-top,
+  .dbs-tabs { display: none; }
+  .dbs-main {
+    padding: 2rem;
+  }
+  .dbs-main-inner {
+    max-width: 36rem;
+    margin: 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .dbs-card { animation: none; }
+}
+`.trim();
+}
+
+/** Static skeleton markup placed inside `#root`. */
+export function buildDashboardBootShellMarkup() {
+  const tab = (active = false) =>
+    `<div class="dbs-tab${active ? ' dbs-tab--active' : ''}" aria-hidden="true"><div class="dbs-tab-icon"></div><div class="dbs-tab-label"></div></div>`;
+
+  return [
+    `<style id="dashboard-boot-shell-css">${bootShellCriticalCss()}</style>`,
+    `<div ${DASHBOARD_BOOT_SHELL_MARKER}="true" class="dbs-shell" role="status" aria-busy="true" aria-label="Loading Setlist Pick'em">`,
+    `<div class="dbs-ambient" aria-hidden="true"></div>`,
+    `<nav class="dbs-sidebar" aria-hidden="true">`,
+    `<img class="dbs-sidebar-mark" src="${VINYL_MARK_SRC}" alt="" width="112" height="112" decoding="async" fetchpriority="high" />`,
+    `<div class="dbs-nav-row dbs-nav-row--active"></div>`,
+    `<div class="dbs-nav-row"></div>`,
+    `<div class="dbs-nav-row"></div>`,
+    `<div class="dbs-nav-row"></div>`,
+    `</nav>`,
+    `<div class="dbs-mobile-top" aria-hidden="true">`,
+    `<div class="dbs-brand-bar">`,
+    `<img class="dbs-brand-mark" src="${VINYL_MARK_SRC}" alt="" width="64" height="64" decoding="async" fetchpriority="high" />`,
+    `<div class="dbs-chip-row"><div class="dbs-chip"></div><div class="dbs-chip"></div></div>`,
+    `</div>`,
+    `</div>`,
+    `<main class="dbs-main">`,
+    `<div class="dbs-main-inner">`,
+    `<div class="dbs-card" aria-hidden="true"></div>`,
+    `<div class="dbs-card" aria-hidden="true"></div>`,
+    `<div class="dbs-card" aria-hidden="true"></div>`,
+    `</div>`,
+    `</main>`,
+    `<nav class="dbs-tabs" aria-hidden="true">`,
+    tab(true),
+    tab(false),
+    tab(false),
+    tab(false),
+    `</nav>`,
+    `</div>`,
+  ].join('');
+}
+
+/**
+ * Build the branded app boot shell HTML from the pre-prerender Vite SPA shell.
+ * Ensures `#root` has no SEO prerender body, then injects the skeleton.
+ *
+ * @param {string} spaHtml
+ * @returns {string}
+ */
+export function buildDashboardBootShellHtml(spaHtml) {
+  const emptied = stripPrerenderBodyFromSpaShell(spaHtml);
+  if (typeof emptied !== 'string' || !emptied) return emptied;
+  const markup = buildDashboardBootShellMarkup();
+  return emptied.replace(
+    /<div id="root">\s*<\/div>/i,
+    `<div id="root">${markup}</div>`,
+  );
+}

--- a/scripts/dashboard-boot-shell.mjs
+++ b/scripts/dashboard-boot-shell.mjs
@@ -1,10 +1,13 @@
 /**
- * Generic branded dashboard boot shell for hard loads (#773 Phase 1).
+ * Generic branded dashboard boot shell for hard loads (#773 Phase 1–2).
  * Pure HTML/CSS — no src/ imports (safe for build scripts).
  *
  * Injected into `dist/dashboard/index.html` after Vite build. React
  * `createRoot` still replaces `#root` once the SPA mounts.
  */
+
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
 
 import { stripPrerenderBodyFromSpaShell } from './seo-strip-body.mjs';
 
@@ -275,4 +278,54 @@ export function buildDashboardBootShellHtml(spaHtml) {
     /<div id="root">\s*<\/div>/i,
     `<div id="root">${markup}</div>`,
   );
+}
+
+/** Chunk filename prefixes to modulepreload on the dashboard boot shell only (#773). */
+export const DASHBOARD_BOOT_MODULEPRELOAD_PREFIXES = ['DashboardRoute-'];
+
+/**
+ * Resolve hashed asset filenames under `dist/assets` for dashboard boot preloads.
+ *
+ * @param {string} assetsDir
+ * @returns {string[]} absolute hrefs like `/assets/DashboardRoute-….js`
+ */
+export function resolveDashboardBootModulepreloadHrefs(assetsDir) {
+  let names = [];
+  try {
+    names = readdirSync(assetsDir);
+  } catch {
+    return [];
+  }
+  const hrefs = [];
+  for (const prefix of DASHBOARD_BOOT_MODULEPRELOAD_PREFIXES) {
+    const match = names.find(
+      (name) => name.startsWith(prefix) && name.endsWith('.js'),
+    );
+    if (match) hrefs.push(`/assets/${match}`);
+  }
+  return hrefs;
+}
+
+/**
+ * Append `<link rel="modulepreload">` for dashboard-critical chunks into `<head>`.
+ * Idempotent; skips hrefs already present. Does not touch splash `dist/index.html`.
+ *
+ * @param {string} html
+ * @param {string} distDir absolute path to `dist/`
+ * @returns {string}
+ */
+export function injectDashboardBootModulepreloads(html, distDir) {
+  if (typeof html !== 'string' || !html) return html;
+  const hrefs = resolveDashboardBootModulepreloadHrefs(join(distDir, 'assets'));
+  if (!hrefs.length) return html;
+
+  const tags = hrefs
+    .filter((href) => !html.includes(`href="${href}"`))
+    .map(
+      (href) =>
+        `  <link rel="modulepreload" crossorigin href="${href}" data-dashboard-boot-preload="true" />`,
+    );
+  if (!tags.length) return html;
+  if (!/<\/head>/i.test(html)) return html;
+  return html.replace(/<\/head>/i, `${tags.join('\n')}\n</head>`);
 }

--- a/scripts/prerender-seo.mjs
+++ b/scripts/prerender-seo.mjs
@@ -1,6 +1,6 @@
 /**
  * Post-build: write crawler-visible HTML for public marketing routes (#659).
- * Also writes an empty-root SPA shell for dashboard / app hard loads (#743).
+ * Also writes a branded SPA boot shell for dashboard / app hard loads (#743 / #773).
  * Run after `vite build`. Safe to re-run.
  */
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
@@ -10,9 +10,9 @@ import { fileURLToPath } from 'node:url';
 import {
   APP_BOOT_SHELL_REL_PATH,
   PRERENDER_ROUTES,
+  buildDashboardBootShellHtml,
   injectPrerenderHtml,
   prerenderOutputRelPath,
-  stripPrerenderBodyFromSpaShell,
 } from './seo-prerender-lib.mjs';
 
 const root = join(fileURLToPath(new URL('.', import.meta.url)), '..');
@@ -35,14 +35,14 @@ for (const route of PRERENDER_ROUTES) {
   console.log(`prerender-seo: wrote dist/${rel} (${Buffer.byteLength(html, 'utf8')} bytes)`);
 }
 
-// Empty-root boot shell for /dashboard/* (and other app paths via vercel.json).
+// Branded boot shell for /dashboard/* (and other app paths via vercel.json).
 // Use the pre-prerender Vite shell so we never copy home SEO body into it.
-const appBootHtml = stripPrerenderBodyFromSpaShell(shell);
+const appBootHtml = buildDashboardBootShellHtml(shell);
 const appBootPath = join(distDir, APP_BOOT_SHELL_REL_PATH);
 mkdirSync(dirname(appBootPath), { recursive: true });
 writeFileSync(appBootPath, appBootHtml, 'utf8');
 console.log(
-  `prerender-seo: wrote dist/${APP_BOOT_SHELL_REL_PATH} (empty #root boot shell)`,
+  `prerender-seo: wrote dist/${APP_BOOT_SHELL_REL_PATH} (branded #root boot shell)`,
 );
 
 console.log(`prerender-seo: OK (${PRERENDER_ROUTES.length} routes + app boot shell)`);

--- a/scripts/prerender-seo.mjs
+++ b/scripts/prerender-seo.mjs
@@ -11,6 +11,7 @@ import {
   APP_BOOT_SHELL_REL_PATH,
   PRERENDER_ROUTES,
   buildDashboardBootShellHtml,
+  injectDashboardBootModulepreloads,
   injectPrerenderHtml,
   prerenderOutputRelPath,
 } from './seo-prerender-lib.mjs';
@@ -37,12 +38,16 @@ for (const route of PRERENDER_ROUTES) {
 
 // Branded boot shell for /dashboard/* (and other app paths via vercel.json).
 // Use the pre-prerender Vite shell so we never copy home SEO body into it.
-const appBootHtml = buildDashboardBootShellHtml(shell);
+// Phase 2: modulepreload DashboardRoute on this shell only (not splash).
+const appBootHtml = injectDashboardBootModulepreloads(
+  buildDashboardBootShellHtml(shell),
+  distDir,
+);
 const appBootPath = join(distDir, APP_BOOT_SHELL_REL_PATH);
 mkdirSync(dirname(appBootPath), { recursive: true });
 writeFileSync(appBootPath, appBootHtml, 'utf8');
 console.log(
-  `prerender-seo: wrote dist/${APP_BOOT_SHELL_REL_PATH} (branded #root boot shell)`,
+  `prerender-seo: wrote dist/${APP_BOOT_SHELL_REL_PATH} (branded #root boot shell + modulepreload)`,
 );
 
 console.log(`prerender-seo: OK (${PRERENDER_ROUTES.length} routes + app boot shell)`);

--- a/scripts/seo-prerender-lib.mjs
+++ b/scripts/seo-prerender-lib.mjs
@@ -15,6 +15,7 @@ import {
   DASHBOARD_BOOT_SHELL_MARKER,
   buildDashboardBootShellHtml,
   buildDashboardBootShellMarkup,
+  injectDashboardBootModulepreloads,
 } from './dashboard-boot-shell.mjs';
 
 export {
@@ -25,6 +26,7 @@ export {
   DASHBOARD_BOOT_SHELL_MARKER,
   buildDashboardBootShellHtml,
   buildDashboardBootShellMarkup,
+  injectDashboardBootModulepreloads,
 };
 
 function escapeHtml(str) {

--- a/scripts/seo-prerender-lib.mjs
+++ b/scripts/seo-prerender-lib.mjs
@@ -11,12 +11,20 @@ import {
   APP_BOOT_SHELL_REL_PATH,
   stripPrerenderBodyFromSpaShell,
 } from './seo-strip-body.mjs';
+import {
+  DASHBOARD_BOOT_SHELL_MARKER,
+  buildDashboardBootShellHtml,
+  buildDashboardBootShellMarkup,
+} from './dashboard-boot-shell.mjs';
 
 export {
   PRERENDER_ROUTES,
   SEO_FAVICON_VERSION,
   APP_BOOT_SHELL_REL_PATH,
   stripPrerenderBodyFromSpaShell,
+  DASHBOARD_BOOT_SHELL_MARKER,
+  buildDashboardBootShellHtml,
+  buildDashboardBootShellMarkup,
 };
 
 function escapeHtml(str) {

--- a/scripts/seo-strip-body.mjs
+++ b/scripts/seo-strip-body.mjs
@@ -17,5 +17,8 @@ export function stripPrerenderBodyFromSpaShell(spaHtml) {
   );
 }
 
-/** Dist-relative empty-root SPA shell for authenticated / app hard loads (#743). */
+/**
+ * Dist-relative SPA shell for authenticated / app hard loads
+ * (#743 empty root → #773 branded skeleton).
+ */
 export const APP_BOOT_SHELL_REL_PATH = 'dashboard/index.html';

--- a/scripts/verify-seo-prerender.mjs
+++ b/scripts/verify-seo-prerender.mjs
@@ -120,9 +120,18 @@ if (existsSync(distIndex) && existsSync(distHowItWorks)) {
     'app boot shell must not include SEO prerender body',
   );
   assert(
-    existsSync(distIndex) &&
-      readFileSync(distIndex, 'utf8').includes('data-seo-prerender'),
+    appBootHtml.includes('data-dashboard-boot-preload="true"') &&
+      appBootHtml.includes('DashboardRoute-'),
+    'app boot shell must modulepreload DashboardRoute chunk',
+  );
+  const homeHtml = readFileSync(distIndex, 'utf8');
+  assert(
+    homeHtml.includes('data-seo-prerender'),
     'home dist/index.html must still include SEO prerender body',
+  );
+  assert(
+    !homeHtml.includes('data-dashboard-boot-preload'),
+    'home dist/index.html must not gain dashboard boot modulepreloads',
   );
 
   console.log('verify:seo-prerender: dist/ checked');

--- a/scripts/verify-seo-prerender.mjs
+++ b/scripts/verify-seo-prerender.mjs
@@ -11,7 +11,9 @@ import { fileURLToPath } from 'node:url';
 
 import {
   APP_BOOT_SHELL_REL_PATH,
+  DASHBOARD_BOOT_SHELL_MARKER,
   PRERENDER_ROUTES,
+  buildDashboardBootShellHtml,
   buildFixtureShellHtml,
   injectPrerenderHtml,
   prerenderOutputRelPath,
@@ -67,6 +69,26 @@ for (const route of PRERENDER_ROUTES) {
   assertRouteHtml(html, route, `fixture ${route.path}`);
 }
 
+// Fixture: branded dashboard boot shell (#773) — no SEO body, marker present.
+const dirtyShell =
+  '<!DOCTYPE html><html><head><meta charset="UTF-8" /></head><body>' +
+  '<div id="root"><main data-seo-prerender="true"><h1>leak</h1></main></div>' +
+  '</body></html>';
+const fixtureBoot = buildDashboardBootShellHtml(dirtyShell);
+assert(
+  fixtureBoot.includes(`${DASHBOARD_BOOT_SHELL_MARKER}="true"`),
+  'boot shell fixture must include dashboard boot marker',
+);
+assert(
+  fixtureBoot.includes('/branding/splash-vinyl-mark.webp'),
+  'boot shell fixture must include vinyl brand mark',
+);
+assert(
+  !fixtureBoot.includes('data-seo-prerender'),
+  'boot shell fixture must not include SEO prerender body',
+);
+assert(!fixtureBoot.includes('<h1>leak</h1>'), 'boot shell must strip prior #root body');
+
 const distIndex = join(root, 'dist', 'index.html');
 const distHowItWorks = join(root, 'dist', 'how-it-works', 'index.html');
 // Only validate dist when post-build prerender has clearly run (subdir artifact).
@@ -82,8 +104,16 @@ if (existsSync(distIndex) && existsSync(distHowItWorks)) {
   assert(existsSync(appBootPath), `dist missing ${APP_BOOT_SHELL_REL_PATH} — run npm run build`);
   const appBootHtml = readFileSync(appBootPath, 'utf8');
   assert(
-    /<div id="root">\s*<\/div>/i.test(appBootHtml),
-    'app boot shell must have empty #root',
+    appBootHtml.includes(`${DASHBOARD_BOOT_SHELL_MARKER}="true"`),
+    'app boot shell must include branded dashboard skeleton marker',
+  );
+  assert(
+    appBootHtml.includes('/branding/splash-vinyl-mark.webp'),
+    'app boot shell must include vinyl brand mark',
+  );
+  assert(
+    /<div id="root">[\s\S]*?<\/div>/i.test(appBootHtml),
+    'app boot shell must keep a #root mount point',
   );
   assert(
     !appBootHtml.includes('data-seo-prerender'),

--- a/src/app/layout/RootAppShell.jsx
+++ b/src/app/layout/RootAppShell.jsx
@@ -1,11 +1,13 @@
 import React, { Suspense } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 
+import { isDashboardEntryPath } from '../../shared/lib/appBootPath';
 import { useServiceWorkerUpdate } from '../../shared/lib/useServiceWorkerUpdate';
 import AppBackground from '../../shared/ui/AppBackground';
 import RouteSuspenseFallback from '../../shared/ui/RouteSuspenseFallback';
 import UpdateAvailableBanner from '../../shared/ui/UpdateAvailableBanner';
 import { shellTransitionKey } from './model/shellTransitionKey';
+import DashboardBootSkeleton from './ui/DashboardBootSkeleton';
 
 /**
  * Global chrome: ambient background + top-level route outlet with enter animation.
@@ -29,7 +31,15 @@ export default function RootAppShell() {
       <AppBackground />
       <div className="relative z-[1] min-h-screen">
         <div key={transitionKey} className="min-h-screen animate-page-enter">
-          <Suspense fallback={<RouteSuspenseFallback />}>
+          <Suspense
+            fallback={
+              isDashboardEntryPath(pathname) ? (
+                <DashboardBootSkeleton />
+              ) : (
+                <RouteSuspenseFallback />
+              )
+            }
+          >
             <Outlet />
           </Suspense>
         </div>

--- a/src/app/layout/RootAppShell.jsx
+++ b/src/app/layout/RootAppShell.jsx
@@ -2,6 +2,7 @@ import React, { Suspense } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 
 import { isDashboardEntryPath } from '../../shared/lib/appBootPath';
+import { usePushNavigationBridge } from '../../shared/lib/usePushNavigationBridge';
 import { useServiceWorkerUpdate } from '../../shared/lib/useServiceWorkerUpdate';
 import AppBackground from '../../shared/ui/AppBackground';
 import RouteSuspenseFallback from '../../shared/ui/RouteSuspenseFallback';
@@ -25,6 +26,7 @@ export default function RootAppShell() {
   const { pathname } = useLocation();
   const transitionKey = shellTransitionKey(pathname);
   const { updateAvailable, applyUpdate } = useServiceWorkerUpdate();
+  usePushNavigationBridge();
 
   return (
     <>

--- a/src/app/layout/ui/DashboardBootSkeleton.jsx
+++ b/src/app/layout/ui/DashboardBootSkeleton.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+
+import {
+  BRAND_APP_CHROME_MARK_SRC,
+  brandAppChromeMarkImgClassNames,
+  brandWordmarkDashboardMobileBarScaleWrapperClassNames,
+  brandWordmarkDashboardMobileLeadingClassNames,
+  brandWordmarkDashboardSidebarScaleWrapperClassNames,
+} from '../../../shared/config/branding';
+import BrandWordmarkBarRow from '../../../shared/ui/BrandWordmarkBarRow';
+
+/**
+ * React twin of the static `dist/dashboard/index.html` boot shell (#773).
+ * Shown while auth/profile resolve so createRoot does not flash bare "Loading…".
+ */
+export default function DashboardBootSkeleton() {
+  return (
+    <div
+      className="flex h-[100dvh] min-h-0 w-full overflow-hidden bg-transparent text-white"
+      role="status"
+      aria-busy="true"
+      aria-label="Loading Setlist Pick'em"
+      data-dashboard-boot-skeleton="true"
+    >
+      <nav
+        className="z-10 hidden w-64 flex-col border-r border-border-muted/65 bg-surface-chrome p-4 md:flex"
+        aria-hidden="true"
+      >
+        <div className="mb-6 overflow-visible py-2">
+          <div className="w-full overflow-visible text-center leading-none">
+            <span className={brandWordmarkDashboardSidebarScaleWrapperClassNames}>
+              <img
+                src={BRAND_APP_CHROME_MARK_SRC}
+                alt=""
+                width={128}
+                height={128}
+                className={brandAppChromeMarkImgClassNames.dashboardSidebar}
+                decoding="async"
+              />
+            </span>
+          </div>
+        </div>
+        <div className="flex flex-1 flex-col gap-2">
+          <div className="h-11 rounded-xl bg-brand-primary/10 ring-1 ring-inset ring-brand-primary/25" />
+          <div className="h-11 animate-pulse rounded-xl bg-surface-inset" />
+          <div className="h-11 animate-pulse rounded-xl bg-surface-inset" />
+          <div className="h-11 animate-pulse rounded-xl bg-surface-inset" />
+        </div>
+      </nav>
+
+      <div className="fixed left-0 top-0 z-50 w-full pt-[env(safe-area-inset-top,0px)] md:hidden">
+        <div className="border-b border-border-subtle/35 bg-[linear-gradient(to_bottom,rgb(var(--brand-bg-deep)_/_0.76),rgb(var(--brand-bg)_/_0.60))] py-2 shadow-[0_10px_28px_-14px_rgba(15,10,46,0.85)] ring-1 ring-inset ring-white/[0.06] backdrop-blur-xl">
+          <BrandWordmarkBarRow variant="dashboard">
+            <div className={brandWordmarkDashboardMobileLeadingClassNames}>
+              <span className={brandWordmarkDashboardMobileBarScaleWrapperClassNames}>
+                <img
+                  className={brandAppChromeMarkImgClassNames.dashboardMobileBar}
+                  src={BRAND_APP_CHROME_MARK_SRC}
+                  alt=""
+                  aria-hidden="true"
+                  decoding="async"
+                />
+              </span>
+            </div>
+            <div className="flex shrink-0 items-center gap-2" aria-hidden="true">
+              <div className="h-8 w-8 rounded-full border border-border-subtle/35 bg-surface-panel-strong" />
+              <div className="h-8 w-8 rounded-full border border-border-subtle/35 bg-surface-panel-strong" />
+            </div>
+          </BrandWordmarkBarRow>
+        </div>
+      </div>
+
+      <main className="relative min-w-0 flex-1 overflow-y-auto pb-[calc(4rem+env(safe-area-inset-bottom,0px)+0.5rem)] pt-[calc(env(safe-area-inset-top,0px)+5.5rem)] md:p-8 md:pb-8 md:pt-8">
+        <div className="mx-auto w-full max-w-xl min-w-0 space-y-3 px-4 pt-2 md:p-0">
+          <div className="h-20 animate-pulse rounded-2xl bg-surface-panel ring-1 ring-border-muted/35" />
+          <div className="h-28 animate-pulse rounded-2xl bg-surface-panel ring-1 ring-border-muted/35" />
+          <div className="h-16 animate-pulse rounded-2xl bg-surface-panel ring-1 ring-border-muted/35" />
+        </div>
+      </main>
+
+      <nav
+        className="fixed inset-x-0 bottom-0 z-50 w-full border-t border-border-subtle/35 bg-[linear-gradient(to_top,rgb(var(--brand-bg-deep)_/_0.76),rgb(var(--brand-bg)_/_0.60))] pb-[env(safe-area-inset-bottom,0px)] shadow-[inset_0_1px_0_0_rgb(var(--brand-primary)/0.12),0_-10px_28px_-14px_rgba(15,10,46,0.85)] ring-1 ring-inset ring-white/[0.06] backdrop-blur-xl md:hidden"
+        aria-hidden="true"
+      >
+        <div className="grid h-16 grid-cols-4 items-center gap-0.5 px-1.5">
+          <div className="mx-auto h-[calc(100%-10px)] w-full max-w-[4.5rem] rounded-xl bg-brand-primary/[0.14] ring-1 ring-inset ring-brand-primary/30" />
+          <div className="mx-auto h-[calc(100%-10px)] w-full max-w-[4.5rem] animate-pulse rounded-xl bg-surface-inset/80" />
+          <div className="mx-auto h-[calc(100%-10px)] w-full max-w-[4.5rem] animate-pulse rounded-xl bg-surface-inset/80" />
+          <div className="mx-auto h-[calc(100%-10px)] w-full max-w-[4.5rem] animate-pulse rounded-xl bg-surface-inset/80" />
+        </div>
+      </nav>
+    </div>
+  );
+}

--- a/src/app/routes/DashboardRoute.jsx
+++ b/src/app/routes/DashboardRoute.jsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 
 import {
-  AuthLoadingScreen,
   trackAuthPartialProfile,
   useAuth,
 } from '../../features/auth';
@@ -11,6 +10,7 @@ import { ShowCalendarProvider } from '../../features/show-calendar';
 import { ensureAppCheckNow } from '../../shared/lib/firebaseAppCheck';
 import { persistDashboardPath } from '../../shared/lib/dashboardLastPath';
 import DashboardLayout from '../layout/DashboardLayout';
+import DashboardBootSkeleton from '../layout/ui/DashboardBootSkeleton';
 import { decideDashboardRoute } from './profileGuardDecision';
 
 export default function DashboardRoute() {
@@ -18,7 +18,7 @@ export default function DashboardRoute() {
   const { user, userProfile, loading } = useAuth();
   const decision = decideDashboardRoute({ loading, user, userProfile });
 
-  // #535: email deep links need Firestore ASAP — don't wait for idle timeout.
+  // #535 / #773: belt-and-suspenders if soft-nav reached dashboard without boot warm.
   useEffect(() => {
     ensureAppCheckNow();
   }, []);
@@ -45,7 +45,8 @@ export default function DashboardRoute() {
     return <Navigate to="/" replace />;
   }
 
-  if (decision.kind === 'loading') return <AuthLoadingScreen />;
+  // Keep branded chrome while session/profile resolve (#773) — no bare "Loading…".
+  if (decision.kind === 'loading') return <DashboardBootSkeleton />;
   if (decision.kind === 'redirect-setup') {
     return <Navigate to="/setup" replace />;
   }

--- a/src/features/auth/api/splashAuthApi.js
+++ b/src/features/auth/api/splashAuthApi.js
@@ -2,10 +2,12 @@ import {
   createUserWithEmailAndPassword,
   deleteUser,
   getAdditionalUserInfo,
+  getRedirectResult,
   GoogleAuthProvider,
   sendPasswordResetEmail,
   signInWithEmailAndPassword,
   signInWithPopup,
+  signInWithRedirect,
 } from 'firebase/auth';
 
 import { getPasswordResetActionCodeSettings } from '../utils/passwordResetActionSettings';
@@ -33,6 +35,33 @@ function getGoogleProvider() {
  */
 export async function signInWithGoogle(auth) {
   const cred = await signInWithPopup(auth, getGoogleProvider());
+  const extra = getAdditionalUserInfo(cred);
+  return { isNewUser: Boolean(extra?.isNewUser) };
+}
+
+/**
+ * Full-page Google redirect — preferred in email / in-app WebViews where
+ * popups are blocked or flaky (#773 Phase 2b / #576 / #412).
+ *
+ * Does not resolve with a credential; the page navigates away. Call
+ * {@link consumeGoogleRedirectResult} on the next load.
+ *
+ * @param {import('firebase/auth').Auth} auth
+ * @returns {Promise<void>}
+ */
+export function startGoogleSignInRedirect(auth) {
+  return signInWithRedirect(auth, getGoogleProvider());
+}
+
+/**
+ * Complete a pending Google redirect, if any.
+ *
+ * @param {import('firebase/auth').Auth} auth
+ * @returns {Promise<{ isNewUser: boolean } | null>}
+ */
+export async function consumeGoogleRedirectResult(auth) {
+  const cred = await getRedirectResult(auth);
+  if (!cred) return null;
   const extra = getAdditionalUserInfo(cred);
   return { isNewUser: Boolean(extra?.isNewUser) };
 }

--- a/src/features/auth/index.js
+++ b/src/features/auth/index.js
@@ -1,4 +1,5 @@
 export { default as AuthLoadingScreen } from './ui/AuthLoadingScreen';
+export { default as OpenInBrowserBanner } from './ui/OpenInBrowserBanner';
 export { default as SplashAuthEntryCard } from './ui/SplashAuthEntryCard';
 export { default as SplashAuthModalShell } from './ui/SplashAuthModalShell';
 export { default as SplashSignInModal } from './ui/SplashSignInModal';
@@ -7,6 +8,7 @@ export { default as PasswordResetForm } from './ui/PasswordResetForm';
 export { default as ProfileSetupForm } from './ui/ProfileSetupForm';
 export { AuthProvider, useAuth } from './model/AuthContext.jsx';
 export { useAuthSession } from './model/useAuthSession';
+export { useGoogleRedirectCompletion } from './model/useGoogleRedirectCompletion';
 export { trackAuthPartialProfile } from './model/authAnalytics';
 export { usePasswordReset } from './model/usePasswordReset';
 export { usePasswordResetCompleteState } from './model/usePasswordResetCompleteState';

--- a/src/features/auth/model/AuthContext.jsx
+++ b/src/features/auth/model/AuthContext.jsx
@@ -1,6 +1,9 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
 
+import { auth } from '../../../shared/lib/firebase';
+import { ensureAppCheckNow } from '../../../shared/lib/firebaseAppCheck';
 import {
+  fetchUserProfile,
   resolveIsAdmin,
   subscribeToAuthState,
   subscribeToIdTokenChanges,
@@ -12,9 +15,14 @@ const AuthContext = createContext(null);
 /**
  * Single app-wide auth + profile subscription (#496).
  * Replaces N× `useAuth()` listeners with one provider.
+ *
+ * #773 Phase 2: seed from `auth.currentUser`, warm App Check on session, and
+ * paint profile via `getDoc` before attaching `onSnapshot` (mirror #730).
+ * Guards still keep `loading:true` until the first profile result so
+ * `loading:false + user + profile:null` cannot flash Almost There (#727).
  */
 export function AuthProvider({ children }) {
-  const [user, setUser] = useState(null);
+  const [user, setUser] = useState(() => auth.currentUser ?? null);
   const [userProfile, setUserProfile] = useState(null);
   const [loading, setLoading] = useState(true);
   const [isAdmin, setIsAdmin] = useState(false);
@@ -47,8 +55,11 @@ export function AuthProvider({ children }) {
         return;
       }
 
+      // Persisted / fresh session — start App Check immediately (#730 / #773).
+      ensureAppCheckNow();
+
       // Guest → sign-in (and user switches): keep guards in `loading` until the
-      // first profile snapshot. Otherwise `loading:false + user + profile:null`
+      // first profile result. Otherwise `loading:false + user + profile:null`
       // briefly looks like "needs setup" and dumps returning users onto Almost There (#727).
       setUser(u);
       setUserProfile(null);
@@ -63,12 +74,17 @@ export function AuthProvider({ children }) {
         });
 
       try {
+        // Fast path: single getDoc before live listener (#773 / #730).
+        const initialProfile = await fetchUserProfile(u.uid);
+        if (cancelled) return;
+        setUserProfile(initialProfile);
+        setLoading(false);
+
         const unsub = await subscribeToUserProfile(
           u.uid,
           (profile) => {
             if (cancelled) return;
             setUserProfile(profile);
-            setLoading(false);
           },
           (err) => {
             console.error('AuthProvider profile subscription error:', err);
@@ -89,7 +105,7 @@ export function AuthProvider({ children }) {
 
         detachProfile = unsub;
       } catch (err) {
-        console.error('AuthProvider profile subscribe failed:', err);
+        console.error('AuthProvider profile load failed:', err);
         if (!cancelled) {
           setUserProfile(null);
           setLoading(false);

--- a/src/features/auth/model/authAnalytics.js
+++ b/src/features/auth/model/authAnalytics.js
@@ -10,12 +10,13 @@ function mirrorAuthTelemetry(event, params) {
 
 /**
  * @param {string} method
- * @param {{ surface?: AuthModalSurface }} [opts]
+ * @param {{ surface?: AuthModalSurface, auth_flow?: 'popup' | 'redirect' }} [opts]
  */
 export function trackAuthSignUp(method, opts = {}) {
   const params = {
     method,
     ...(opts.surface ? { surface: opts.surface } : {}),
+    ...(opts.auth_flow ? { auth_flow: opts.auth_flow } : {}),
   };
   mirrorAuthTelemetry('sign_up', params);
   ga4Event('sign_up', params);
@@ -23,25 +24,32 @@ export function trackAuthSignUp(method, opts = {}) {
 
 /**
  * @param {string} method
- * @param {{ surface?: AuthModalSurface }} [opts]
+ * @param {{ surface?: AuthModalSurface, auth_flow?: 'popup' | 'redirect' }} [opts]
  */
 export function trackAuthLogin(method, opts = {}) {
   const params = {
     method,
     ...(opts.surface ? { surface: opts.surface } : {}),
+    ...(opts.auth_flow ? { auth_flow: opts.auth_flow } : {}),
   };
   mirrorAuthTelemetry('login', params);
   ga4Event('login', params);
 }
 
 /**
- * @param {{ method: string, error_code?: string, surface?: AuthModalSurface }} payload
+ * @param {{
+ *   method: string,
+ *   error_code?: string,
+ *   surface?: AuthModalSurface,
+ *   auth_flow?: 'popup' | 'redirect',
+ * }} payload
  */
 export function trackAuthError(payload) {
   const params = {
     method: payload.method,
     error_code: payload.error_code ?? 'unknown',
     ...(payload.surface ? { surface: payload.surface } : {}),
+    ...(payload.auth_flow ? { auth_flow: payload.auth_flow } : {}),
   };
   mirrorAuthTelemetry('auth_error', params);
   ga4Event('auth_error', params);

--- a/src/features/auth/model/completeGoogleSplashAuth.js
+++ b/src/features/auth/model/completeGoogleSplashAuth.js
@@ -1,0 +1,89 @@
+import { auth } from '../../../shared/lib/firebase';
+import { signOutUser } from '../api/authApi';
+import { recordTermsPrivacyConsent } from '../api/legalConsentApi';
+import { deleteAuthUserIfPresent } from '../api/splashAuthApi';
+import {
+  trackAuthError,
+  trackAuthLogin,
+  trackAuthRollback,
+  trackAuthRollbackFailed,
+  trackAuthSignUp,
+} from './authAnalytics';
+import { decideSignInModalGoogleAction } from './signInModalGuard';
+
+/**
+ * Finish Google splash auth after popup or redirect (#773 Phase 2b).
+ *
+ * @param {{
+ *   intent: 'signin' | 'signup',
+ *   isNewUser: boolean,
+ *   flow?: 'popup' | 'redirect',
+ * }} params
+ * @returns {Promise<
+ *   | { kind: 'success' }
+ *   | { kind: 'error', message: string }
+ * >}
+ */
+export async function completeGoogleSplashAuth({
+  intent,
+  isNewUser,
+  flow = 'popup',
+}) {
+  const flowOpts = { auth_flow: flow };
+
+  if (intent === 'signin') {
+    const action = decideSignInModalGoogleAction(isNewUser);
+    if (action.kind === 'block-new-user') {
+      await deleteAuthUserIfPresent(auth.currentUser);
+      try {
+        await signOutUser();
+      } catch (signOutErr) {
+        console.error('signOut after sign-in modal block:', signOutErr);
+      }
+      trackAuthError({
+        method: 'google',
+        error_code: action.telemetryErrorCode,
+        surface: 'sign_in',
+        ...flowOpts,
+      });
+      return { kind: 'error', message: action.errorMessage };
+    }
+    trackAuthLogin('google', { surface: 'sign_in', ...flowOpts });
+    return { kind: 'success' };
+  }
+
+  // signup
+  if (isNewUser) {
+    try {
+      await recordTermsPrivacyConsent(auth.currentUser.uid);
+    } catch (consentErr) {
+      console.error('Consent write after Google sign-up:', consentErr);
+      trackAuthRollback({ method: 'google', stage: 'consent_write' });
+      const rollback = await deleteAuthUserIfPresent(auth.currentUser);
+      if (!rollback.deleted) {
+        trackAuthRollbackFailed({
+          method: 'google',
+          error_code: rollback.errorCode || 'unknown',
+        });
+        console.error(
+          'Auth rollback delete failed after Google sign-up:',
+          rollback.errorCode,
+        );
+      }
+      try {
+        await signOutUser();
+      } catch {
+        // best-effort
+      }
+      return {
+        kind: 'error',
+        message: 'Could not finish creating your account. Please try again.',
+      };
+    }
+    trackAuthSignUp('google', { surface: 'create_account', ...flowOpts });
+    return { kind: 'success' };
+  }
+
+  trackAuthLogin('google', { surface: 'create_account', ...flowOpts });
+  return { kind: 'success' };
+}

--- a/src/features/auth/model/completeGoogleSplashAuth.test.js
+++ b/src/features/auth/model/completeGoogleSplashAuth.test.js
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../shared/lib/firebase', () => ({
+  auth: { currentUser: { uid: 'u1' } },
+}));
+
+const signOutUser = vi.fn(async () => {});
+const deleteAuthUserIfPresent = vi.fn(async () => ({ deleted: true }));
+const recordTermsPrivacyConsent = vi.fn(async () => {});
+
+vi.mock('../api/authApi', () => ({
+  signOutUser: (...args) => signOutUser(...args),
+}));
+vi.mock('../api/splashAuthApi', () => ({
+  deleteAuthUserIfPresent: (...args) => deleteAuthUserIfPresent(...args),
+}));
+vi.mock('../api/legalConsentApi', () => ({
+  recordTermsPrivacyConsent: (...args) => recordTermsPrivacyConsent(...args),
+}));
+
+const trackAuthError = vi.fn();
+const trackAuthLogin = vi.fn();
+const trackAuthSignUp = vi.fn();
+
+vi.mock('./authAnalytics', () => ({
+  trackAuthError: (...args) => trackAuthError(...args),
+  trackAuthLogin: (...args) => trackAuthLogin(...args),
+  trackAuthSignUp: (...args) => trackAuthSignUp(...args),
+  trackAuthRollback: vi.fn(),
+  trackAuthRollbackFailed: vi.fn(),
+}));
+
+import { completeGoogleSplashAuth } from './completeGoogleSplashAuth.js';
+
+describe('completeGoogleSplashAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('blocks new Google users on sign-in modal and rolls back', async () => {
+    const out = await completeGoogleSplashAuth({
+      intent: 'signin',
+      isNewUser: true,
+      flow: 'redirect',
+    });
+    expect(out.kind).toBe('error');
+    expect(deleteAuthUserIfPresent).toHaveBeenCalled();
+    expect(signOutUser).toHaveBeenCalled();
+    expect(trackAuthError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error_code: 'signin_modal_new_user_blocked',
+        auth_flow: 'redirect',
+      }),
+    );
+  });
+
+  it('allows returning Google users on sign-in', async () => {
+    const out = await completeGoogleSplashAuth({
+      intent: 'signin',
+      isNewUser: false,
+      flow: 'popup',
+    });
+    expect(out).toEqual({ kind: 'success' });
+    expect(trackAuthLogin).toHaveBeenCalledWith(
+      'google',
+      expect.objectContaining({ surface: 'sign_in', auth_flow: 'popup' }),
+    );
+  });
+
+  it('records consent for new Google sign-up', async () => {
+    const out = await completeGoogleSplashAuth({
+      intent: 'signup',
+      isNewUser: true,
+      flow: 'redirect',
+    });
+    expect(out).toEqual({ kind: 'success' });
+    expect(recordTermsPrivacyConsent).toHaveBeenCalledWith('u1');
+    expect(trackAuthSignUp).toHaveBeenCalled();
+  });
+});

--- a/src/features/auth/model/useGoogleRedirectCompletion.js
+++ b/src/features/auth/model/useGoogleRedirectCompletion.js
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from 'react';
+
+import { auth } from '../../../shared/lib/firebase';
+import { consumeGoogleRedirectResult } from '../api/splashAuthApi';
+import {
+  clearSplashGoogleModalInflight,
+  setSplashGoogleModalInflight,
+} from '../utils/splashGoogleModalInflight';
+import { consumeGoogleRedirectIntent } from '../utils/googleRedirectIntent';
+import { getFirebaseAuthErrorMessage } from '../utils/firebaseAuthMessages';
+import { trackAuthError } from './authAnalytics';
+import { completeGoogleSplashAuth } from './completeGoogleSplashAuth';
+
+/**
+ * Completes a pending Google `signInWithRedirect` on splash / invite landings.
+ *
+ * @param {{
+ *   onOpenSignIn?: () => void,
+ *   onOpenSignUp?: () => void,
+ *   onError?: (message: string, intent: 'signin' | 'signup' | null) => void,
+ * }} [opts]
+ */
+export function useGoogleRedirectCompletion({
+  onOpenSignIn,
+  onOpenSignUp,
+  onError,
+} = {}) {
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    if (ranRef.current) return;
+    ranRef.current = true;
+
+    let cancelled = false;
+
+    (async () => {
+      let result;
+      try {
+        result = await consumeGoogleRedirectResult(auth);
+      } catch (err) {
+        console.error('Google redirect result:', err);
+        const intent = consumeGoogleRedirectIntent();
+        trackAuthError({
+          method: 'google',
+          error_code: err?.code || 'redirect_result_failed',
+          surface: intent === 'signup' ? 'create_account' : 'sign_in',
+          auth_flow: 'redirect',
+        });
+        onError?.(getFirebaseAuthErrorMessage(err?.code), intent);
+        if (intent === 'signup') onOpenSignUp?.();
+        else if (intent === 'signin') onOpenSignIn?.();
+        return;
+      }
+
+      if (cancelled || !result) {
+        // Clear a stale intent if Firebase returned nothing (user cancelled).
+        if (!result) consumeGoogleRedirectIntent();
+        return;
+      }
+
+      const intent = consumeGoogleRedirectIntent() || 'signin';
+      setSplashGoogleModalInflight();
+      try {
+        const outcome = await completeGoogleSplashAuth({
+          intent,
+          isNewUser: result.isNewUser,
+          flow: 'redirect',
+        });
+        if (cancelled) return;
+        if (outcome.kind === 'error') {
+          onError?.(outcome.message, intent);
+          if (intent === 'signup') onOpenSignUp?.();
+          else onOpenSignIn?.();
+        }
+        // success: AuthContext + HomeRoute Navigate handle post-login routing
+      } finally {
+        clearSplashGoogleModalInflight();
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [onError, onOpenSignIn, onOpenSignUp]);
+}

--- a/src/features/auth/model/useSplashSignIn.js
+++ b/src/features/auth/model/useSplashSignIn.js
@@ -1,27 +1,33 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { isLikelyInAppBrowser } from '../../../shared/lib/inAppBrowser';
 import { auth } from '../../../shared/lib/firebase';
-import { signOutUser } from '../api/authApi';
 import { getFirebaseAuthErrorMessage } from '../utils/firebaseAuthMessages';
 import {
-  deleteAuthUserIfPresent,
   sendResetEmail,
   signInWithEmail,
   signInWithGoogle,
+  startGoogleSignInRedirect,
 } from '../api/splashAuthApi';
 import {
   clearSplashGoogleModalInflight,
   setSplashGoogleModalInflight,
 } from '../utils/splashGoogleModalInflight';
+import { stashGoogleRedirectIntent } from '../utils/googleRedirectIntent';
 import { trackAuthError, trackAuthLogin } from './authAnalytics';
-import { decideSignInModalGoogleAction } from './signInModalGuard';
+import { completeGoogleSplashAuth } from './completeGoogleSplashAuth';
 
-export function useSplashSignIn(isOpen, onClose) {
+export function useSplashSignIn(isOpen, onClose, { seedError = '' } = {}) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
   const [resetLinkNotice, setResetLinkNotice] = useState({ text: '', type: '' });
+  const inAppBrowser = isLikelyInAppBrowser();
+
+  useEffect(() => {
+    if (isOpen && seedError) setError(seedError);
+  }, [isOpen, seedError]);
 
   const resetForm = useCallback(() => {
     setEmail('');
@@ -57,30 +63,23 @@ export function useSplashSignIn(isOpen, onClose) {
     setBusy(true);
     setSplashGoogleModalInflight();
     try {
-      const { isNewUser } = await signInWithGoogle(auth);
-      const action = decideSignInModalGoogleAction(isNewUser);
-      if (action.kind === 'block-new-user') {
-        // Sign-in modal is for returning users only — it never presented
-        // the Terms/Privacy clickwrap. Roll back the auth account
-        // (best-effort) and force a sign-out so a partially-rolled-back
-        // account can't sit in a signed-in but unconsented state. Route
-        // them to the Create Account modal where the consent checkbox is
-        // enforced.
-        await deleteAuthUserIfPresent(auth.currentUser);
-        try {
-          await signOutUser();
-        } catch (signOutErr) {
-          console.error('signOut after sign-in modal block:', signOutErr);
-        }
-        trackAuthError({
-          method: 'google',
-          error_code: action.telemetryErrorCode,
-          surface: 'sign_in',
-        });
-        setError(action.errorMessage);
+      if (inAppBrowser) {
+        stashGoogleRedirectIntent('signin');
+        await startGoogleSignInRedirect(auth);
+        // Navigates away — leave busy/inflight set until unload.
         return;
       }
-      trackAuthLogin('google', { surface: 'sign_in' });
+
+      const { isNewUser } = await signInWithGoogle(auth);
+      const outcome = await completeGoogleSplashAuth({
+        intent: 'signin',
+        isNewUser,
+        flow: 'popup',
+      });
+      if (outcome.kind === 'error') {
+        setError(outcome.message);
+        return;
+      }
       closeModal();
     } catch (err) {
       console.error('Google sign-in:', err);
@@ -88,13 +87,16 @@ export function useSplashSignIn(isOpen, onClose) {
         method: 'google',
         error_code: err.code,
         surface: 'sign_in',
+        auth_flow: inAppBrowser ? 'redirect' : 'popup',
       });
       setError(getFirebaseAuthErrorMessage(err.code));
     } finally {
-      clearSplashGoogleModalInflight();
-      setBusy(false);
+      if (!inAppBrowser) {
+        clearSplashGoogleModalInflight();
+        setBusy(false);
+      }
     }
-  }, [closeModal]);
+  }, [closeModal, inAppBrowser]);
 
   const handleEmailSignIn = useCallback(
     async (e) => {
@@ -117,7 +119,7 @@ export function useSplashSignIn(isOpen, onClose) {
         setBusy(false);
       }
     },
-    [closeModal, email, password]
+    [closeModal, email, password],
   );
 
   const handleSendPasswordResetEmail = useCallback(async () => {
@@ -161,5 +163,6 @@ export function useSplashSignIn(isOpen, onClose) {
     handleGoogle,
     handleEmailSignIn,
     handleSendPasswordResetEmail,
+    inAppBrowser,
   };
 }

--- a/src/features/auth/model/useSplashSignUp.js
+++ b/src/features/auth/model/useSplashSignUp.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { isLikelyInAppBrowser } from '../../../shared/lib/inAppBrowser';
 import { auth } from '../../../shared/lib/firebase';
 import { recordTermsPrivacyConsent } from '../api/legalConsentApi';
 import { getFirebaseAuthErrorMessage } from '../utils/firebaseAuthMessages';
@@ -7,26 +8,33 @@ import {
   deleteAuthUserIfPresent,
   registerWithEmail,
   signInWithGoogle,
+  startGoogleSignInRedirect,
 } from '../api/splashAuthApi';
 import {
   clearSplashGoogleModalInflight,
   setSplashGoogleModalInflight,
 } from '../utils/splashGoogleModalInflight';
+import { stashGoogleRedirectIntent } from '../utils/googleRedirectIntent';
 import {
   trackAuthError,
-  trackAuthLogin,
   trackAuthRollback,
   trackAuthRollbackFailed,
   trackAuthSignUp,
 } from './authAnalytics';
+import { completeGoogleSplashAuth } from './completeGoogleSplashAuth';
 
-export function useSplashSignUp(isOpen, onClose) {
+export function useSplashSignUp(isOpen, onClose, { seedError = '' } = {}) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [legalAccepted, setLegalAccepted] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
+  const inAppBrowser = isLikelyInAppBrowser();
+
+  useEffect(() => {
+    if (isOpen && seedError) setError(seedError);
+  }, [isOpen, seedError]);
 
   const resetForm = useCallback(() => {
     setEmail('');
@@ -67,32 +75,21 @@ export function useSplashSignUp(isOpen, onClose) {
     setBusy(true);
     setSplashGoogleModalInflight();
     try {
+      if (inAppBrowser) {
+        stashGoogleRedirectIntent('signup');
+        await startGoogleSignInRedirect(auth);
+        return;
+      }
+
       const { isNewUser } = await signInWithGoogle(auth);
-      if (isNewUser) {
-        try {
-          await recordTermsPrivacyConsent(auth.currentUser.uid);
-        } catch (consentErr) {
-          console.error('Consent write after Google sign-up:', consentErr);
-          trackAuthRollback({ method: 'google', stage: 'consent_write' });
-          const rollback = await deleteAuthUserIfPresent(auth.currentUser);
-          if (!rollback.deleted) {
-            trackAuthRollbackFailed({
-              method: 'google',
-              error_code: rollback.errorCode || 'unknown',
-            });
-            console.error(
-              'Auth rollback delete failed after Google sign-up:',
-              rollback.errorCode
-            );
-          }
-          setError('Could not finish creating your account. Please try again.');
-          return;
-        }
-        trackAuthSignUp('google', { surface: 'create_account' });
-      } else {
-        // Existing Google account used Create account — treat as login, not a
-        // blocked sign-up. Surface tag lets GA4 separate this from Sign-in.
-        trackAuthLogin('google', { surface: 'create_account' });
+      const outcome = await completeGoogleSplashAuth({
+        intent: 'signup',
+        isNewUser,
+        flow: 'popup',
+      });
+      if (outcome.kind === 'error') {
+        setError(outcome.message);
+        return;
       }
       closeModal();
     } catch (err) {
@@ -101,13 +98,16 @@ export function useSplashSignUp(isOpen, onClose) {
         method: 'google',
         error_code: err.code,
         surface: 'create_account',
+        auth_flow: inAppBrowser ? 'redirect' : 'popup',
       });
       setError(getFirebaseAuthErrorMessage(err.code));
     } finally {
-      clearSplashGoogleModalInflight();
-      setBusy(false);
+      if (!inAppBrowser) {
+        clearSplashGoogleModalInflight();
+        setBusy(false);
+      }
     }
-  }, [closeModal, legalAccepted]);
+  }, [closeModal, inAppBrowser, legalAccepted]);
 
   const handleEmailSignUp = useCallback(
     async (e) => {
@@ -178,5 +178,6 @@ export function useSplashSignUp(isOpen, onClose) {
     closeModal,
     handleGoogle,
     handleEmailSignUp,
+    inAppBrowser,
   };
 }

--- a/src/features/auth/ui/AuthLoadingScreen.jsx
+++ b/src/features/auth/ui/AuthLoadingScreen.jsx
@@ -1,10 +1,28 @@
 import React from 'react';
 
-/** Full-screen placeholder while Firebase auth (and profile fetch) resolves for protected areas. */
+import {
+  BRAND_APP_CHROME_MARK_SRC,
+  brandAppChromeMarkImgClassNames,
+} from '../../../shared/config/branding';
+
+/** Branded auth gate (setup / non-dashboard). Dashboard uses `DashboardBootSkeleton`. */
 export default function AuthLoadingScreen() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-transparent font-bold text-white">
-      Loading...
+    <div
+      className="flex min-h-screen flex-col items-center justify-center gap-4 bg-transparent text-white"
+      role="status"
+      aria-busy="true"
+      aria-label="Loading Setlist Pick'em"
+    >
+      <img
+        src={BRAND_APP_CHROME_MARK_SRC}
+        alt=""
+        width={96}
+        height={96}
+        className={`${brandAppChromeMarkImgClassNames.dashboardMobileBar} h-24 w-auto opacity-90`}
+        decoding="async"
+      />
+      <p className="text-sm font-bold text-content-secondary">Loading…</p>
     </div>
   );
 }

--- a/src/features/auth/ui/OpenInBrowserBanner.jsx
+++ b/src/features/auth/ui/OpenInBrowserBanner.jsx
@@ -1,0 +1,65 @@
+import React, { useCallback, useMemo, useState } from 'react';
+
+import {
+  isLikelyInAppBrowser,
+  preferredExternalBrowserLabel,
+} from '../../../shared/lib/inAppBrowser';
+import Button from '../../../shared/ui/Button';
+
+/**
+ * Instructional banner for email / in-app WebViews (#773 Phase 2b).
+ * Browsers cannot force a handoff to Safari/Chrome; we guide the user.
+ */
+export default function OpenInBrowserBanner({ className = '' }) {
+  const [dismissed, setDismissed] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const show = useMemo(() => isLikelyInAppBrowser(), []);
+  const browserLabel = useMemo(() => preferredExternalBrowserLabel(), []);
+
+  const handleCopy = useCallback(async () => {
+    const href = `${window.location.origin}${window.location.pathname}${window.location.search}`;
+    try {
+      await navigator.clipboard.writeText(href);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback: select via prompt so user can still copy manually.
+      window.prompt('Copy this link and open it in your browser:', href);
+    }
+  }, []);
+
+  if (!show || dismissed) return null;
+
+  return (
+    <div
+      className={`border-b border-brand-primary/25 bg-brand-primary/10 px-4 py-3 text-sm text-white ${className}`}
+      role="status"
+      data-open-in-browser-banner="true"
+    >
+      <div className="mx-auto flex max-w-xl flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p className="font-semibold leading-snug text-content-secondary">
+          Signing in works more reliably in {browserLabel}. Use your browser menu
+          → Open in {browserLabel}, or copy the link below.
+        </p>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            variant="text"
+            type="button"
+            onClick={handleCopy}
+            className="rounded-lg bg-brand-primary/20 px-3 py-1.5 text-xs font-bold text-brand-primary ring-1 ring-inset ring-brand-primary/35 hover:bg-brand-primary/30"
+          >
+            {copied ? 'Copied' : 'Copy link'}
+          </Button>
+          <Button
+            variant="text"
+            type="button"
+            onClick={() => setDismissed(true)}
+            className="px-2 py-1 text-xs font-bold text-slate-400 hover:text-white"
+          >
+            Dismiss
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/auth/ui/SplashSignInModal.jsx
+++ b/src/features/auth/ui/SplashSignInModal.jsx
@@ -11,6 +11,7 @@ export default function SplashSignInModal({
   onClose,
   onSwitchToSignUp,
   poolInvitePending = false,
+  seedError = '',
 }) {
   const [showPassword, setShowPassword] = useState(false);
 
@@ -26,7 +27,8 @@ export default function SplashSignInModal({
     handleGoogle,
     handleEmailSignIn,
     handleSendPasswordResetEmail,
-  } = useSplashSignIn(isOpen, onClose);
+    inAppBrowser,
+  } = useSplashSignIn(isOpen, onClose, { seedError });
 
   const prependContent =
     poolInvitePending || error ? (
@@ -52,6 +54,11 @@ export default function SplashSignInModal({
       handleGoogle={handleGoogle}
       busy={busy}
       prependContent={prependContent}
+      googleFootnote={
+        inAppBrowser
+          ? 'Continues with a full-page Google sign-in (more reliable in this browser).'
+          : undefined
+      }
       closeOnBackdropClick={false}
     >
         <form onSubmit={handleEmailSignIn} className="space-y-4 text-left">

--- a/src/features/auth/ui/SplashSignUpModal.jsx
+++ b/src/features/auth/ui/SplashSignUpModal.jsx
@@ -13,6 +13,7 @@ export default function SplashSignUpModal({
   onClose,
   onSwitchToSignIn,
   poolInvitePending = false,
+  seedError = '',
 }) {
   const {
     email,
@@ -28,7 +29,8 @@ export default function SplashSignUpModal({
     closeModal,
     handleGoogle,
     handleEmailSignUp,
-  } = useSplashSignUp(isOpen, onClose);
+    inAppBrowser,
+  } = useSplashSignUp(isOpen, onClose, { seedError });
 
   const consentBlock = (
     <label className="flex cursor-pointer items-start gap-3 rounded-2xl border border-border-subtle bg-surface-field/80 p-4 text-left text-sm font-semibold leading-snug text-slate-200">
@@ -89,7 +91,11 @@ export default function SplashSignUpModal({
       busy={busy}
       googleDisabled={busy || !legalAccepted}
       prependContent={prependContent}
-      googleFootnote="You'll set your username/handle on the next page. Your email address is never shared or visible to other users."
+      googleFootnote={
+        inAppBrowser
+          ? "Continues with a full-page Google sign-in. You'll set your username/handle next. Your email is never shared with other users."
+          : "You'll set your username/handle on the next page. Your email address is never shared or visible to other users."
+      }
       closeOnBackdropClick={false}
     >
         <form onSubmit={handleEmailSignUp} className="space-y-4 text-left">

--- a/src/features/auth/utils/googleRedirectIntent.js
+++ b/src/features/auth/utils/googleRedirectIntent.js
@@ -1,0 +1,41 @@
+const STORAGE_KEY = 'setpicks_google_redirect_intent_v1';
+
+/**
+ * Stash which splash modal started a Google redirect (#773 Phase 2b).
+ * @param {'signin' | 'signup'} intent
+ */
+export function stashGoogleRedirectIntent(intent) {
+  if (intent !== 'signin' && intent !== 'signup') return;
+  try {
+    sessionStorage.setItem(STORAGE_KEY, intent);
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+/**
+ * @returns {'signin' | 'signup' | null}
+ */
+export function consumeGoogleRedirectIntent() {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    sessionStorage.removeItem(STORAGE_KEY);
+    if (raw === 'signin' || raw === 'signup') return raw;
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+/**
+ * @returns {'signin' | 'signup' | null}
+ */
+export function peekGoogleRedirectIntent() {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (raw === 'signin' || raw === 'signup') return raw;
+  } catch {
+    // ignore
+  }
+  return null;
+}

--- a/src/features/auth/utils/googleRedirectIntent.test.js
+++ b/src/features/auth/utils/googleRedirectIntent.test.js
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  consumeGoogleRedirectIntent,
+  peekGoogleRedirectIntent,
+  stashGoogleRedirectIntent,
+} from './googleRedirectIntent.js';
+
+const store = new Map();
+
+beforeEach(() => {
+  store.clear();
+  vi.stubGlobal('sessionStorage', {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => {
+      store.set(k, String(v));
+    },
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('googleRedirectIntent', () => {
+  it('stashes and consumes signin/signup once', () => {
+    stashGoogleRedirectIntent('signin');
+    expect(peekGoogleRedirectIntent()).toBe('signin');
+    expect(consumeGoogleRedirectIntent()).toBe('signin');
+    expect(consumeGoogleRedirectIntent()).toBe(null);
+  });
+
+  it('ignores invalid intents', () => {
+    stashGoogleRedirectIntent('nope');
+    expect(consumeGoogleRedirectIntent()).toBe(null);
+  });
+});

--- a/src/features/invite/model/useInviteLanding.js
+++ b/src/features/invite/model/useInviteLanding.js
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   isSplashGoogleModalInflight,
   useAuth,
+  useGoogleRedirectCompletion,
 } from '../../auth';
 import { normalizeInviteHandle } from '../../../shared/lib/inviteKit';
 import { getDashboardEntryHref } from '../../../shared/lib/dashboardLastPath';
@@ -19,12 +20,23 @@ export function useInviteLanding({ inviteKind, handle: rawHandle }) {
   const handle = normalizeInviteHandle(rawHandle);
   const { user, isAdmin: isAdminUser } = useAuth();
   const [authModal, setAuthModal] = useState(null);
+  const [redirectAuthError, setRedirectAuthError] = useState('');
   const [inviter, setInviter] = useState(null);
   const [resolveState, setResolveState] = useState(handle ? 'loading' : 'idle');
 
   const closeModal = useCallback(() => setAuthModal(null), []);
   const openSignUpModal = useCallback(() => setAuthModal('signup'), []);
   const openSignInModal = useCallback(() => setAuthModal('signin'), []);
+  const onRedirectError = useCallback((message, intent) => {
+    setRedirectAuthError(message || '');
+    if (intent === 'signup') setAuthModal('signup');
+    else setAuthModal('signin');
+  }, []);
+  useGoogleRedirectCompletion({
+    onOpenSignIn: openSignInModal,
+    onOpenSignUp: openSignUpModal,
+    onError: onRedirectError,
+  });
 
   useEffect(() => {
     if (!handle) {
@@ -74,6 +86,8 @@ export function useInviteLanding({ inviteKind, handle: rawHandle }) {
     closeModal,
     openSignUpModal,
     openSignInModal,
+    redirectAuthError,
+    clearRedirectAuthError: () => setRedirectAuthError(''),
     redirectTo,
   };
 }

--- a/src/features/invite/ui/InviteVipLanding.jsx
+++ b/src/features/invite/ui/InviteVipLanding.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useLocation } from 'react-router-dom';
 
+import { OpenInBrowserBanner } from '../../auth';
 import { MarketingPageShell, SplashAuthModals } from '../../landing';
 import { SEO_CONFIG } from '../../../shared/config/seo';
 import Button from '../../../shared/ui/Button';
@@ -19,6 +20,8 @@ export default function InviteVipLanding({
   closeModal,
   openSignUpModal,
   openSignInModal,
+  redirectAuthError = '',
+  clearRedirectAuthError,
 }) {
   const { pathname, search } = useLocation();
   const pageTitle = `${headline} | Setlist Pick'Em`;
@@ -40,6 +43,7 @@ export default function InviteVipLanding({
         <meta name="twitter:image" content={SEO_CONFIG.ogImageUrl} />
         <link rel="canonical" href={canonicalUrl} />
       </Helmet>
+      <OpenInBrowserBanner />
       <MarketingPageShell>
         <section className="mx-auto flex min-h-[calc(100vh-5.35rem)] max-w-2xl flex-col items-center justify-center px-4 py-16 text-center sm:px-6 lg:px-8">
           {resolveState === 'loading' ? (
@@ -83,6 +87,8 @@ export default function InviteVipLanding({
         onSwitchToSignIn={openSignInModal}
         onSwitchToSignUp={openSignUpModal}
         poolInvitePending={poolInvitePending}
+        redirectAuthError={redirectAuthError}
+        onClearRedirectAuthError={clearRedirectAuthError}
       />
     </>
   );

--- a/src/features/landing/ui/SplashAuthModals.jsx
+++ b/src/features/landing/ui/SplashAuthModals.jsx
@@ -8,20 +8,29 @@ export default function SplashAuthModals({
   onSwitchToSignIn,
   onSwitchToSignUp,
   poolInvitePending = false,
+  redirectAuthError = '',
+  onClearRedirectAuthError,
 }) {
+  const handleClose = () => {
+    onClearRedirectAuthError?.();
+    closeModal();
+  };
+
   return (
     <>
       <SplashSignUpModal
         isOpen={authModal === 'signup'}
-        onClose={closeModal}
+        onClose={handleClose}
         onSwitchToSignIn={onSwitchToSignIn}
         poolInvitePending={poolInvitePending}
+        seedError={authModal === 'signup' ? redirectAuthError : ''}
       />
       <SplashSignInModal
         isOpen={authModal === 'signin'}
-        onClose={closeModal}
+        onClose={handleClose}
         onSwitchToSignUp={onSwitchToSignUp}
         poolInvitePending={poolInvitePending}
+        seedError={authModal === 'signin' ? redirectAuthError : ''}
       />
     </>
   );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,12 +7,30 @@ import App from './app/App.jsx'
 import Ga4RouteListener from './app/Ga4RouteListener.jsx'
 import ScrollToTop from './app/ScrollToTop.jsx'
 import { AuthProvider } from './features/auth'
+import {
+  isDashboardEntryPath,
+  shouldWarmAppCheckOnBoot,
+} from './shared/lib/appBootPath'
 import { initGa4 } from './shared/lib/ga4'
-import { initializeAppCheckDeferred } from './shared/lib/firebaseAppCheck'
+import {
+  ensureAppCheckNow,
+  initializeAppCheckDeferred,
+} from './shared/lib/firebaseAppCheck'
 import { registerMessagingServiceWorker } from './shared/lib/firebaseMessaging'
 import './index.css'
 
 initGa4()
+
+// #773 Phase 2: email / app hard opens — warm App Check + kick DashboardRoute
+// chunk before first paint. Splash keeps deferred App Check + lazy dashboard.
+const bootPath =
+  typeof window !== 'undefined' ? window.location.pathname : ''
+if (shouldWarmAppCheckOnBoot(bootPath)) {
+  ensureAppCheckNow()
+}
+if (isDashboardEntryPath(bootPath)) {
+  void import('./app/routes/DashboardRoute.jsx')
+}
 
 // Shared client for React Query caches (#243 profile/tour standings, #507
 // show-scoped standings). Defaults tuned for read-heavy dashboard hooks

--- a/src/pages/landing/SplashPage.jsx
+++ b/src/pages/landing/SplashPage.jsx
@@ -1,7 +1,11 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
-import { consumeSplashResumeAuthModal } from '../../features/auth';
+import {
+  OpenInBrowserBanner,
+  consumeSplashResumeAuthModal,
+  useGoogleRedirectCompletion,
+} from '../../features/auth';
 import {
   SplashAuthModals,
   SplashPageShell,
@@ -16,9 +20,20 @@ let lastDeferredPoolInvitePromptAt = 0;
 
 export default function Splash() {
   const [authModal, setAuthModal] = useState(null);
+  const [redirectAuthError, setRedirectAuthError] = useState('');
   const closeModal = useCallback(() => setAuthModal(null), []);
   const openSignUpModal = useCallback(() => setAuthModal('signup'), []);
   const openSignInModal = useCallback(() => setAuthModal('signin'), []);
+  const onRedirectError = useCallback((message, intent) => {
+    setRedirectAuthError(message || '');
+    if (intent === 'signup') setAuthModal('signup');
+    else setAuthModal('signin');
+  }, []);
+  useGoogleRedirectCompletion({
+    onOpenSignIn: openSignInModal,
+    onOpenSignUp: openSignUpModal,
+    onError: onRedirectError,
+  });
   /** Invite is stored before splash mounts; seed once for modal join-context copy. */
   const [poolInvitePending] = useState(
     () => Boolean(getLocalStorageItem(POOL_INVITE_STORAGE_KEY)?.trim()),
@@ -75,6 +90,7 @@ export default function Splash() {
 
   return (
     <ScoringRulesModalProvider>
+      <OpenInBrowserBanner />
       <SplashPageShell
         howItWorksSectionRef={howItWorksSectionRef}
         howItWorksHeadingRef={howItWorksHeadingRef}
@@ -93,6 +109,8 @@ export default function Splash() {
         onSwitchToSignIn={openSignInModal}
         onSwitchToSignUp={openSignUpModal}
         poolInvitePending={poolInvitePending}
+        redirectAuthError={redirectAuthError}
+        onClearRedirectAuthError={() => setRedirectAuthError('')}
       />
     </ScoringRulesModalProvider>
   );

--- a/src/shared/lib/appBootPath.js
+++ b/src/shared/lib/appBootPath.js
@@ -1,0 +1,27 @@
+/**
+ * Path helpers for cold-boot warming on app / email hard opens (#773 Phase 2).
+ */
+
+/**
+ * @param {string} [pathname]
+ * @returns {boolean}
+ */
+export function isDashboardEntryPath(pathname) {
+  if (typeof pathname !== 'string' || !pathname) return false;
+  return pathname === '/dashboard' || pathname.startsWith('/dashboard/');
+}
+
+/**
+ * Surfaces that need Firestore ASAP on hard open (skip App Check idle deferral).
+ * @param {string} [pathname]
+ * @returns {boolean}
+ */
+export function shouldWarmAppCheckOnBoot(pathname) {
+  if (typeof pathname !== 'string' || !pathname) return false;
+  return (
+    isDashboardEntryPath(pathname) ||
+    pathname === '/setup' ||
+    pathname.startsWith('/join') ||
+    pathname.startsWith('/invite/')
+  );
+}

--- a/src/shared/lib/appBootPath.test.js
+++ b/src/shared/lib/appBootPath.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { isDashboardEntryPath, shouldWarmAppCheckOnBoot } from './appBootPath.js';
+
+describe('isDashboardEntryPath', () => {
+  it('matches /dashboard and nested paths', () => {
+    expect(isDashboardEntryPath('/dashboard')).toBe(true);
+    expect(isDashboardEntryPath('/dashboard/')).toBe(true);
+    expect(isDashboardEntryPath('/dashboard/picks')).toBe(true);
+  });
+
+  it('rejects non-dashboard paths', () => {
+    expect(isDashboardEntryPath('/')).toBe(false);
+    expect(isDashboardEntryPath('/setup')).toBe(false);
+    expect(isDashboardEntryPath('/dashboarding')).toBe(false);
+    expect(isDashboardEntryPath('')).toBe(false);
+    expect(isDashboardEntryPath(undefined)).toBe(false);
+  });
+});
+
+describe('shouldWarmAppCheckOnBoot', () => {
+  it('warms dashboard, setup, join, and invite', () => {
+    expect(shouldWarmAppCheckOnBoot('/dashboard/standings')).toBe(true);
+    expect(shouldWarmAppCheckOnBoot('/setup')).toBe(true);
+    expect(shouldWarmAppCheckOnBoot('/join/ABC')).toBe(true);
+    expect(shouldWarmAppCheckOnBoot('/invite/pat')).toBe(true);
+  });
+
+  it('does not warm splash or marketing', () => {
+    expect(shouldWarmAppCheckOnBoot('/')).toBe(false);
+    expect(shouldWarmAppCheckOnBoot('/how-it-works')).toBe(false);
+    expect(shouldWarmAppCheckOnBoot('/privacy')).toBe(false);
+  });
+});

--- a/src/shared/lib/inAppBrowser.js
+++ b/src/shared/lib/inAppBrowser.js
@@ -1,0 +1,57 @@
+/**
+ * Best-effort detection of email / social in-app browsers (#773 Phase 2b).
+ * Used to prefer redirect Google auth and surface “Open in browser” copy.
+ * Not perfect — especially some iOS Mail SFSafariViewController cases.
+ */
+
+/**
+ * @param {string} [userAgent]
+ * @returns {boolean}
+ */
+export function isLikelyInAppBrowser(userAgent) {
+  const ua =
+    typeof userAgent === 'string'
+      ? userAgent
+      : typeof navigator !== 'undefined'
+        ? navigator.userAgent || ''
+        : '';
+  if (!ua) return false;
+
+  // Android WebView and common in-app shells.
+  if (/; wv\)/i.test(ua)) return true;
+  if (
+    /FBAN|FBAV|FB_IAB|Instagram|Line\/|LinkedInApp|Twitter|GSA\/|Snapchat|BytedanceWebview|musical_ly/i.test(
+      ua,
+    )
+  ) {
+    return true;
+  }
+
+  // iOS WKWebView often omits the Safari token that real Safari / CriOS include.
+  const isIOS = /iPhone|iPad|iPod/i.test(ua);
+  if (isIOS) {
+    const isWebKit = /AppleWebKit/i.test(ua);
+    const hasSafari = /Safari/i.test(ua);
+    const isNamedBrowser = /CriOS|FxiOS|OPiOS|EdgiOS/i.test(ua);
+    if (isWebKit && !hasSafari && !isNamedBrowser) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Human-facing browser name hint for instructional copy.
+ * @param {string} [userAgent]
+ * @returns {'Safari' | 'Chrome' | 'your browser'}
+ */
+export function preferredExternalBrowserLabel(userAgent) {
+  const ua =
+    typeof userAgent === 'string'
+      ? userAgent
+      : typeof navigator !== 'undefined'
+        ? navigator.userAgent || ''
+        : '';
+  if (/Android/i.test(ua)) return 'Chrome';
+  if (/iPhone|iPad|iPod/i.test(ua)) return 'Safari';
+  return 'your browser';
+}

--- a/src/shared/lib/inAppBrowser.test.js
+++ b/src/shared/lib/inAppBrowser.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isLikelyInAppBrowser,
+  preferredExternalBrowserLabel,
+} from './inAppBrowser.js';
+
+describe('isLikelyInAppBrowser', () => {
+  it('detects Android WebView and Gmail/GSA shells', () => {
+    expect(
+      isLikelyInAppBrowser(
+        'Mozilla/5.0 (Linux; Android 14; Pixel 8 Build/UQ1A; wv) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile Safari/537.36',
+      ),
+    ).toBe(true);
+    expect(
+      isLikelyInAppBrowser(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 GSA/300.0 Mobile/15E148',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not flag desktop Chrome or iOS Safari / CriOS', () => {
+    expect(
+      isLikelyInAppBrowser(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      ),
+    ).toBe(false);
+    expect(
+      isLikelyInAppBrowser(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      ),
+    ).toBe(false);
+    expect(
+      isLikelyInAppBrowser(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.0.0 Mobile/15E148 Safari/604.1',
+      ),
+    ).toBe(false);
+  });
+
+  it('detects iOS WKWebView without Safari token', () => {
+    expect(
+      isLikelyInAppBrowser(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('preferredExternalBrowserLabel', () => {
+  it('returns Safari on iOS and Chrome on Android', () => {
+    expect(preferredExternalBrowserLabel('iPhone OS 17_0')).toBe('Safari');
+    expect(preferredExternalBrowserLabel('Linux; Android 14')).toBe('Chrome');
+  });
+});

--- a/src/shared/lib/pushNavigationPath.js
+++ b/src/shared/lib/pushNavigationPath.js
@@ -1,0 +1,41 @@
+/**
+ * Sanitize SW → SPA navigation paths for push soft-nav (#773 Phase 3).
+ *
+ * @param {unknown} path
+ * @returns {string | null} same-origin app path (`/…`) or null if unsafe
+ */
+export function sanitizePushNavigationPath(path) {
+  if (typeof path !== 'string') return null;
+  const trimmed = path.trim();
+  if (!trimmed.startsWith('/') || trimmed.startsWith('//')) return null;
+  if (trimmed.includes('://')) return null;
+  // Block backslash tricks / control chars.
+  if (/[\u0000-\u001F\\]/.test(trimmed)) return null;
+  return trimmed;
+}
+
+/**
+ * @param {string} absoluteOrRelativeUrl
+ * @param {string} [origin]
+ * @returns {string | null}
+ */
+export function appPathFromPushTargetUrl(absoluteOrRelativeUrl, origin) {
+  const base =
+    typeof origin === 'string' && origin
+      ? origin
+      : typeof self !== 'undefined' && self.location?.origin
+        ? self.location.origin
+        : '';
+  if (!base) return null;
+  try {
+    const url = new URL(absoluteOrRelativeUrl, base);
+    if (url.origin !== base) return null;
+    return sanitizePushNavigationPath(
+      `${url.pathname}${url.search}${url.hash}`,
+    );
+  } catch {
+    return null;
+  }
+}
+
+export const PUSH_NAVIGATE_MESSAGE_TYPE = 'NAVIGATE';

--- a/src/shared/lib/pushNavigationPath.test.js
+++ b/src/shared/lib/pushNavigationPath.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  appPathFromPushTargetUrl,
+  sanitizePushNavigationPath,
+} from './pushNavigationPath.js';
+
+describe('sanitizePushNavigationPath', () => {
+  it('accepts app-relative paths', () => {
+    expect(sanitizePushNavigationPath('/dashboard/picks')).toBe(
+      '/dashboard/picks',
+    );
+    expect(sanitizePushNavigationPath('/dashboard/standings?showDate=2026-08-01')).toBe(
+      '/dashboard/standings?showDate=2026-08-01',
+    );
+  });
+
+  it('rejects open redirects and non-paths', () => {
+    expect(sanitizePushNavigationPath('https://evil.example/')).toBe(null);
+    expect(sanitizePushNavigationPath('//evil.example')).toBe(null);
+    expect(sanitizePushNavigationPath('dashboard/picks')).toBe(null);
+    expect(sanitizePushNavigationPath('')).toBe(null);
+  });
+});
+
+describe('appPathFromPushTargetUrl', () => {
+  const origin = 'https://www.setlistpickem.com';
+
+  it('keeps same-origin absolute URLs as paths', () => {
+    expect(
+      appPathFromPushTargetUrl(
+        'https://www.setlistpickem.com/dashboard/picks?x=1',
+        origin,
+      ),
+    ).toBe('/dashboard/picks?x=1');
+  });
+
+  it('rejects cross-origin targets', () => {
+    expect(
+      appPathFromPushTargetUrl('https://evil.example/dashboard', origin),
+    ).toBe(null);
+  });
+});

--- a/src/shared/lib/usePushNavigationBridge.js
+++ b/src/shared/lib/usePushNavigationBridge.js
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import {
+  PUSH_NAVIGATE_MESSAGE_TYPE,
+  sanitizePushNavigationPath,
+} from './pushNavigationPath';
+
+/**
+ * Soft-navigate when the FCM service worker asks an existing tab to move
+ * (#773 Phase 3). Replaces `client.navigate()` full reloads for open tabs.
+ */
+export function usePushNavigationBridge() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+      return undefined;
+    }
+
+    function onMessage(event) {
+      const data = event?.data;
+      if (!data || data.type !== PUSH_NAVIGATE_MESSAGE_TYPE) return;
+      const path = sanitizePushNavigationPath(data.path);
+      if (!path) return;
+      navigate(path);
+    }
+
+    navigator.serviceWorker.addEventListener('message', onMessage);
+    return () => {
+      navigator.serviceWorker.removeEventListener('message', onMessage);
+    };
+  }, [navigate]);
+}


### PR DESCRIPTION
## Summary
- Promote Sprint 11 email CTA cold-boot train (#773) to production
- **1.42.1** branded dashboard boot shell (Phase 1)
- **1.42.2** TTI warm path — App Check, eager DashboardRoute, getDoc profile, boot skeleton (Phase 2)
- **1.42.3** WebView Google redirect + open-in-browser (Phase 2b)
- **1.42.4** Push SPA soft-nav via postMessage (Phase 3)

Tip version on staging: **1.42.4** (tag after merge).

## Test plan
- [x] CI green on staging merges (#789, #790, #791)
- [ ] Vercel production READY after merge
- [ ] Tag `v1.42.4` via `release:publish` after promote


Made with [Cursor](https://cursor.com)