### PR TITLE
chore(release): promote staging to main — Summer 2026 almost-end (1.43.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.43.0] — 2026-08-02
+
+### Added
+- **Summer 2026 almost-end marketing batch** — trigger `marketing_summer_2026_almost_end` / template `summer-2026-almost-end`: email to Summer Tour players (lifecycle prefs), forced in-app inbox for all users (no prefs), React Email template, admin callable `deliverMarketingSummer2026AlmostEnd`, CLI, and one-shot scheduler `scheduledMarketingSummer2026AlmostEnd` (2026-08-03 08:00 America/Denver) with Firestore run-lock.
+
+### Changed
+- `deliverCommsTrigger` accepts optional `channels` filter so multi-channel catalog rows can dispatch a subset (email-only for almost-end while inbox uses a prefs-bypass fanout).
+
+---
+
 ## [1.42.4] — 2026-08-01
 
 ### Changed

--- a/comms/emailBranding.cjs
+++ b/comms/emailBranding.cjs
@@ -4,20 +4,20 @@ const fs = require('fs');
 const path = require('path');
 
 /**
- * Email branding assets — two layers, do not conflate:
+ * Email branding assets — do not conflate layers:
  *
- * 1. **In-body header** (`EMAIL_IN_BODY_LOGO_PATH`) — large vinyl mark inside the opened
- *    email HTML. Controlled by `buildEmailInBodyLogoUrl()` in templates.
+ * 1. **In-body header hero** — horizontal gradient wordmark at
+ *    `/branding/email-gradient-wordmark.png` via {@link buildEmailWordmarkHeroHtml}.
+ *    CSS background (not a linked `<img>`) so clients cannot open the raw PNG on tap;
+ *    Outlook gets a conditional unlinked `<img>` fallback. Used by service shell +
+ *    marketing `MarketingLayout`.
  *
  * 2. **Inbox sender badge** — small avatar beside the sender name in Gmail/Apple Mail list
- *    views. NOT driven by the HTML `<img>`. Requires BIMI + DMARC (primary) and/or domain
+ *    views. NOT driven by the HTML hero. Requires BIMI + DMARC (primary) and/or domain
  *    favicon at the From host (fallback). See docs/comms-triggers/EMAIL_INBOX_BADGE.md (#498).
  *
- * 3. **Service shell wordmark** — raster PNG at `/branding/email-gradient-wordmark.png`
- *    (hosted HTTPS URL, same pattern as marketing `buildEmailLogoUrl`). Asset must live in
- *    `public/branding/` on the deployed site. Do not use CID attachments — Gmail exposes
- *    those as downloadable files. Render as a CSS background (not `<img>`) so clients
- *    cannot open the raw PNG on tap; Outlook gets a conditional unlinked `<img>` fallback.
+ * 3. **Legacy vinyl path** (`EMAIL_IN_BODY_LOGO_PATH` / `buildEmailInBodyLogoUrl`) — kept for
+ *    call-site stability; do not use for new email headers.
  */
 const EMAIL_IN_BODY_LOGO_PATH = '/favicon/web-app-manifest-512x512.png';
 /** Public CDN path — deploy via Vercel (`public/branding/`). */
@@ -25,7 +25,10 @@ const EMAIL_WORDMARK_GRADIENT_PATH = '/branding/email-gradient-wordmark.png';
 const EMAIL_WORDMARK_PNG_FILE = 'email-gradient-wordmark.png';
 /** Resend inline attachment id — referenced as `cid:…` in the HTML shell. */
 const EMAIL_WORDMARK_INLINE_CONTENT_ID = 'email-gradient-wordmark';
-/** design.md brand tokens — service comms HTML shell only. */
+/** ~96% of the 416px inner shell width; height tracks email-gradient-wordmark.svg (~3:1). */
+const EMAIL_SHELL_WORDMARK_WIDTH_PX = 400;
+const EMAIL_SHELL_WORDMARK_HEIGHT_PX = 132;
+/** design.md brand tokens — service / marketing email shells. */
 const EMAIL_BRAND_PRIMARY = '#2dd4bf';
 const EMAIL_BRAND_PRIMARY_STRONG = '#14b8a6';
 const EMAIL_BRAND_BG_DEEP = '#020617';
@@ -59,6 +62,54 @@ function buildEmailLogoUrl(siteUrl = DEFAULT_SITE_URL) {
 function buildEmailWordmarkUrl(siteUrl = DEFAULT_SITE_URL) {
   const base = String(siteUrl || DEFAULT_SITE_URL).replace(/\/+$/, '');
   return `${base}${EMAIL_WORDMARK_GRADIENT_PATH}`;
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeHtmlAttr(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Non-clickable horizontal brand hero for email headers (service + marketing).
+ * CSS background for modern clients; MSO conditional unlinked `<img>` fallback.
+ *
+ * @param {string} [siteUrl]
+ * @param {{ wordmarkSrc?: string }} [opts]
+ * @returns {string} HTML fragment (no outer wrapper)
+ */
+function buildEmailWordmarkHeroHtml(siteUrl = DEFAULT_SITE_URL, opts = {}) {
+  const resolved =
+    typeof opts.wordmarkSrc === 'string' && opts.wordmarkSrc.trim()
+      ? opts.wordmarkSrc.trim()
+      : buildEmailWordmarkUrl(siteUrl);
+  const src = escapeHtmlAttr(resolved);
+  const w = EMAIL_SHELL_WORDMARK_WIDTH_PX;
+  const h = EMAIL_SHELL_WORDMARK_HEIGHT_PX;
+  const blockStyle = [
+    `width:${w}px`,
+    'max-width:100%',
+    `height:${h}px`,
+    'margin:0 auto',
+    `background-image:url('${src}')`,
+    'background-size:contain',
+    'background-repeat:no-repeat',
+    'background-position:center',
+  ].join(';');
+
+  return `<!--[if mso]>
+<img src="${src}" width="${w}" height="${h}" alt="Setlist Pick'em" style="display:block;margin:0 auto;max-width:${w}px;width:100%;height:auto;border:0;" />
+<![endif]-->
+<!--[if !mso]><!-->
+<div role="presentation" aria-hidden="true" style="${blockStyle}"></div>
+<!--<![endif]-->`;
 }
 
 /**
@@ -121,6 +172,8 @@ module.exports = {
   EMAIL_IN_BODY_LOGO_PATH,
   EMAIL_WORDMARK_GRADIENT_PATH,
   EMAIL_WORDMARK_INLINE_CONTENT_ID,
+  EMAIL_SHELL_WORDMARK_WIDTH_PX,
+  EMAIL_SHELL_WORDMARK_HEIGHT_PX,
   EMAIL_BRAND_PRIMARY,
   EMAIL_BRAND_PRIMARY_STRONG,
   EMAIL_BRAND_BG_DEEP,
@@ -128,6 +181,7 @@ module.exports = {
   buildEmailInBodyLogoUrl,
   buildEmailLogoUrl,
   buildEmailWordmarkUrl,
+  buildEmailWordmarkHeroHtml,
   buildEmailWordmarkCidSrc,
   buildEmailWordmarkResendAttachment,
   formatWordmarkAttachmentForResendApi,

--- a/content/comms/tours/summer-2026-almost-end.md
+++ b/content/comms/tours/summer-2026-almost-end.md
@@ -1,0 +1,167 @@
+# Tour recap — Summer 2026 almost-end (pre–Dick’s)
+
+| Field | Value |
+|-------|--------|
+| **templateId** | `summer-2026-almost-end` |
+| **triggerId** | `marketing_summer_2026_almost_end` (batch — not #510 end-of-tour) |
+| **campaignId** | `summer_2026_almost_end` |
+| **Snapshot** | Through **2026-08-01** (Fenway N2) — 18 graded shows; Dick’s 2026-09-04–06 still ahead |
+| **Audience** | **Email:** Summer Tour players (`seasonStats` shows ≥ 1). **In-app:** all users. Both omit QA/clouddev test accounts (and MrPickPhive). |
+| **Channels** | emailFull + inApp (forced fanout, no prefs) |
+| **Prefs** | Email: `lifecycle`. In-app: none (forced). |
+| **Dedup** | Email: `marketing:summer_2026_almost_end:{uid}` · Inbox doc: `marketing_summer_2026_almost_end` |
+| **Implementation** | `functions/marketingAlmostEndDelivery.js` · React Email · `scheduledMarketingSummer2026AlmostEnd` (2026-08-03 08:00 America/Denver) |
+| **CTAs** | Players: Invite a friend → `/dashboard/standings` · No-play: Check it out on Standings |
+| **Status** | **Wired** — re-verify Top 5 / ranks on send day. |
+
+Edit this file as the editorial source. Do not invent bustouts, gaps, or standings — refresh from Firestore before execute.
+
+**Email HTML (preserve):** full-bleed white `MarketingLayout` + shared `emails/src/styles/marketingEmailText.js` (18px body; section titles as bold `<p>`/`Text` — never `<h2>`/Heading). No footer `<hr>`; unique `messageNonce` + unique preview subjects so Gmail doesn’t trim “identical” thread content.
+
+---
+
+## Subject
+
+Between the Past and Future, Where We Drift in Time: An almost Tour End Recap
+
+## Preheader
+
+18 shows in the books · Fenway wrapped · Dick’s still ahead · your (almost) tour-end tape inside
+
+---
+
+## Opening (shared)
+
+Hey {{greeting_name}},
+
+Well, that's a wrap. Or is it? The Phab Four earned a well deserved break ahead of the official tour-closing Dick's Run. With so much time on our hands between shows (I'm not crying, you're crying), here's some stats to chew on.
+
+---
+
+## Tour tape (shared narrative — facts through 2026-08-01)
+
+Eighteen nights. **188** unique songs. **310** total songs played from Madison through Fenway.
+
+And then there was New York. The five-night MSG run (July 22–29) wasn't just another Garden residency — it was a full-on **'90s time machine**. The band's **92nd through 96th** appearances at the Garden, each night a setlist drawn entirely from one year: **'92 thru '96**. From my seat (and my scorecard), some of the best Phish of the last decade — bicycle kicks and beach balls back from the dead, deep cuts raining from the rafters, and a picking board that refused to behave.
+
+That theme explains half the chaos on the tape. MSG alone coughed up these show gaps: **Cold as Ice** (1,468), **Big Ball Jam** (1,170), **The Vibration of Life** (1,027), **Suspicious Minds** (1,021), plus the cover pile — **Highway to Hell**, **Purple Rain**, **Johnny B. Goode**, **La Grange** — and a full **Forbin → Mockingbird → Harpua** suite. Across those five nights, the field banked **44** <span style="color:#ea580c;font-weight:800;">Bustout Boost™</span> hits. Fenway N1 dropped **Melt the Guns** after **2,051** shows — the longest gap between performances in Phish history. They absolutely nailed this post-punk/new wave relic.
+
+*Email note: brand “Bustout Boost™” **once** (first mention) in orange (`#ea580c` / `orange-600`) for contrast on white — not yellow. Later references = plain “bustout” / “bustouts.” Stat = MSG picks matching `official_setlists.bustouts` (2026-08-02: 44 / 14 players).*
+
+Not every story needed a 1,000-show gap. Merriweather brought **Ass Handed** back after 138; Savannah lit **Fire** (132); and just under the bustout line, songs like **The Old Home Place** (28) and **Izabella** (25) kept the “almost” lane spicy.
+
+The rotation favorites? **Character Zero**, **Free**, **Ghost**, **Hood**, **Possum**, **Antelope**, and **Sand** each showed up **four** times through Fenway — the 1.0 stalwarts that I know and love.
+
+---
+
+## Pre Dick's Leaderboard
+
+*Refresh before send. Snapshot 2026-08-02. Picking avg = correct ÷ (shows × 6); field avg = mean of per-player avgs.*
+
+Field picking average across **28** players: **.231**. The Top 5 all clear it — Rivertranced by the widest margin. It just shows that a few well-placed bustouts can **Catapult** a player to the top in a hurry.
+
+| Rank | Handle | Points | Wins | Nights | Picking avg |
+|------|--------|-------:|-----:|-------:|------------:|
+| 1 | **I have the book** | 385 | 5 | 18 | .296 |
+| 2 | **TheManMulcahy** | 320 | 4 | 18 | .278 |
+| 3 | **ArmenianMan** | 285 | 2 | 18 | .296 |
+| 4 | **Rivertranced** | 270 | 1 | 17 | .353 |
+| 5 | **HotDog Billy** | 250 | 2 | 18 | .269 |
+
+*Email note: if 6 columns wrap poorly on mobile, collapse to Rank / Handle / Points / Avg with wins + nights under the handle.*
+
+Three more nights at Dick’s. The Top 5 is bunched enough that one hot run — or a couple of bustouts — can reshuffle the whole podium. And if you’re sitting just outside looking in: you’re closer than you think. Commerce City is where chasers become contenders.
+
+---
+
+## Your (almost) tour-end tape (personalized)
+
+**Placeholders:** `{{rank}}`, `{{points}}`, `{{wins}}`, `{{showsPlayed}}`, `{{avg_points}}`, `{{batting_avg}}`, `{{participantCount}}`
+
+### Branch: rank 1
+
+You're sitting #1 overall with {{points}} points, {{wins}} nightly wins, and {{avg_points}} points per show across {{showsPlayed}} nights. Own the break — Dick’s is where titles get defended.
+
+### Branch: rank 2–5
+
+You're in the Top 5 at #{{rank}} — {{points}} points, {{wins}} wins, {{avg_points}} pts/show, picking avg {{batting_avg}} over {{showsPlayed}} shows. One hot Dick’s run (or a rival cold streak) and this whole picture redraws.
+
+### Branch: rank 6+ and played ≥12 shows
+
+You're #{{rank}} of {{participantCount}} with {{points}} points across {{showsPlayed}} shows ({{avg_points}} pts/show, batting {{batting_avg}}). Full-tour grinders get paid at Dick’s — keep the card sharp.
+
+### Branch: rank 6+ and played &lt;12 shows
+
+You're #{{rank}} with {{points}} points over {{showsPlayed}} shows ({{avg_points}} pts/show). Spot duty still counts — lock all three Dick’s nights and watch the climb.
+
+### Branch: no rank / no Summer Tour plays
+
+You've been in the mix — just not on the board yet this tour. Three nights at Dick's is a clean slate: lock picks for opener, closer, encore, and a wildcard, and you'll have a tape of your own when the final wrap hits. The field picking average through Fenway is only **.231** — this game is very beatable.
+
+### Fallback (has rank, edge cases)
+
+You're #{{rank}} with {{points}} points. Thanks for playing — see you at Dick’s.
+
+---
+
+## One huge favor (players only — `showsPlayed ≥ 1`)
+
+Before Dick's, can I ask a huge favor? **Invite at least one friend** to join and lock picks for the three-night run. Growing the number of players is my measure of success — and you know I love stats.
+
+→ CTA: Invite a friend from Standings → `/dashboard/standings`  
+*(Wire with invite share block when available: `/join/{code}?from={handle}` or `/invite/{handle}` + UTM `summer_2026_almost_end` / `invite_friend`.)*
+
+*Skip this section for the no-rank / no-plays branch — their job is to get on the board first.*
+
+---
+
+## Building between now and then (shared)
+
+Between now and Dick’s, I'm staying busy building out new features. If you haven't checked these out, they are worth taking a look:
+
+**Live setlist** — Updates as songs land, with **bustout** badges and **last-played / gap** insights so you can see how rare each hit really was.
+
+**Crowd pulse** — How the field is picking that night — consensus heat, where your card sits vs the room, and which songs the crowd is riding.
+
+**Stats** — Personal and tour insights (bustouts, gaps, frequency — the same tape above, live in the app).
+
+**Profile** — Milestone **badges** and **avatars** so you can personalize how you show up on the board.
+
+→ CTA: Check it out on Standings → `/dashboard/standings`
+
+---
+
+## Closing (shared)
+
+Three nights in Commerce City still to go. Rest up, study the gaps, and don’t sleep on the wildcard.
+
+See you at Dick’s.
+
+— Pat  
+from the Setlist Pick 'Em desk
+
+---
+
+## Email structure (channel notes)
+
+1. Subject + preheader (above)
+2. Opening
+3. Tour tape narrative
+4. Top 5 table (or compact ranked list for mobile email)
+5. Your (almost) tour-end tape (rank / no-play branch)
+6. One huge favor — invite a friend (players only)
+7. Feature callouts
+8. Closing + sign-off
+9. Standard footer (prefs / unsubscribe) — no in-body “manage preferences”
+
+**Primary CTA (players):** Invite a friend from Standings → `/dashboard/standings`  
+**Primary CTA (no-play):** Check it out on Standings → `/dashboard/standings`
+
+---
+
+## Delivery notes
+
+- CLI: `cd functions && npm run comms:deliver-summer-2026-almost-end` (dry-run default; `--execute`, `--uid`, `--force-resend`)
+- Scheduler: `scheduledMarketingSummer2026AlmostEnd` — 2026-08-03 08:00 America/Denver; abort via `comms_marketing_runs/summer_2026_almost_end` status `cancelled`
+- Email: Summer Tour players only · In-app: all users (QA excluded) · no-play branch when missing tour stats
+- Re-pull Top 5 on send day; do **not** treat as `#510` `tour_recap`

--- a/docs/API.md
+++ b/docs/API.md
@@ -274,6 +274,16 @@ Batch marketing email for Summer Tour 2026 pre-opener. Resolves Sphere alum ∪ 
 
 CLI: `functions/scripts/deliverMarketingSummerTour2026Launch.js` (`--execute`, `--uid <uid>`, `--force-resend`). Secrets: `RESEND_API_KEY`, `RESEND_WEBHOOK_SECRET` (Secret Manager on the callable).
 
+### 2.2a-ii `deliverMarketingSummer2026AlmostEnd` + `scheduledMarketingSummer2026AlmostEnd` (admin / one-shot)
+
+Mid-tour almost-end recap (pre–Dick’s). **Email** → Summer Tour players (`seasonStats["2026 Summer Tour"].shows ≥ 1`, lifecycle prefs). **In-app** → all users (QA handles excluded), **no prefs gate**, fixed inbox doc `marketing_summer_2026_almost_end`. Non-players get the `noPlay` copy branch (inbox only).
+
+**Callable request:** same shape as §2.2a (`dryRun` default true, `forceResend`, `onlyUids`).
+
+**Scheduler:** `scheduledMarketingSummer2026AlmostEnd` — cron `0 8 3 8 *` `America/Denver` (2026-08-03 08:00 MT / 10:00 ET). Firestore run-lock `comms_marketing_runs/summer_2026_almost_end` (`pending` → `running` → `completed` / `cancelled` / `failed`). Abort before send: set status `cancelled`.
+
+CLI: `functions/scripts/deliverMarketingSummer2026AlmostEnd.js` (`npm run comms:deliver-summer-2026-almost-end` in `functions/`). Email channel uses `deliverCommsTrigger` with `channels: ["email"]`; inbox is a Sphere-style Admin SDK fanout.
+
 ### 2.2b `lockPicksForShowNow` (admin-only, #522)
 
 One-click War Room escape hatch: stamps `show_lock_state/{showDate}` so clients lock picks immediately. Idempotent; no setlist or scoring side effects.
@@ -447,7 +457,7 @@ Set in Firebase Functions config or Cloud Secret Manager. Adding one is a MINOR 
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `RESEND_API_KEY` | For email channel | Resend API key (Secret Manager); bound to `runCommsTrigger`, `deliverMarketingSummerTour2026Launch`, and comms adapters |
+| `RESEND_API_KEY` | For email channel | Resend API key (Secret Manager); bound to `runCommsTrigger`, `deliverMarketingSummerTour2026Launch`, `deliverMarketingSummer2026AlmostEnd`, `scheduledMarketingSummer2026AlmostEnd`, and comms adapters |
 | `RESEND_WEBHOOK_SECRET` | For email deliverability | Resend/Svix webhook signing secret (`whsec_…`); also signs one-click unsubscribe URLs |
 | `GA4_MEASUREMENT_ID` | For server `comms_delivered` MP | Same `G-…` id as `VITE_GA_MEASUREMENT_ID`; Functions `defineString` / `.env.set-picks` |
 | `GA4_MP_API_SECRET` | For server `comms_delivered` MP | GA4 Measurement Protocol API secret (Secret Manager); bound on all `deliverCommsTrigger` hosts; unset → no-op |

--- a/docs/comms-triggers/CTA_ROUTE_AUDIT.md
+++ b/docs/comms-triggers/CTA_ROUTE_AUDIT.md
@@ -29,6 +29,7 @@ Label rule: **never promise a surface the href does not deliver.** Inbox cards s
 | `show-recap` | `/dashboard/standings#self-recap` | Rare (email folded into morning send #451) |
 | `tour-rankings_daily` | `/dashboard/picks` | Catalog: “Make picks for next show”; includes invite share block when `invite_url` present (#583) |
 | `summer-tour-2026-launch` | invite `shareUrl` / `invite_url` | Pool `/join/{code}?from={handle}` or site `/invite/{handle}` + UTMs (#583) |
+| `summer-2026-almost-end` | `/dashboard/standings` (invite / check it out) | Players: invite CTA; no-play: Standings CTA + UTMs `summer_2026_almost_end` |
 | `picks-lock-reminder` | `/dashboard/picks` | |
 
 ## Push deep links

--- a/docs/comms-triggers/TRIGGER_CATALOG.md
+++ b/docs/comms-triggers/TRIGGER_CATALOG.md
@@ -549,6 +549,37 @@ Founder letter (Pat) with feature blocks + primary CTA (share with friends via `
 
 ---
 
+## 11 — `marketing_summer_2026_almost_end`
+
+| Field | Value |
+|-------|-------|
+| **Status** | `shipped` |
+| **Automation** | `batch` — one-shot `scheduledMarketingSummer2026AlmostEnd` (2026-08-03 08:00 America/Denver) + admin callable / CLI |
+| **Event** | Manual / scheduled execute via `deliverMarketingSummer2026AlmostEnd` |
+| **Channels** | `email` + `inApp` |
+| **Audience** | **Email:** Summer Tour players (`seasonStats["2026 Summer Tour"].shows ≥ 1`). **In-app:** all users. Both exclude QA handles (`QATester`, `MrPickPhive`). |
+| **Prefs** | Email honors `lifecycle`. **In-app ignores prefs** (Sphere-style forced fanout; fixed inbox doc id `marketing_summer_2026_almost_end`). |
+| **Dedup** | Email: `marketing:{campaignId}:{uid}` (`campaignId` = `summer_2026_almost_end`). Inbox: fixed doc id. |
+| **Implementation** | `functions/marketingBatchDelivery.js` · React Email `Summer2026AlmostEnd.jsx` |
+| **Editorial** | `content/comms/tours/summer-2026-almost-end.md` |
+
+#### Variables used
+
+`{{greeting_name}}`, `{{branch}}`, `{{rank}}`, `{{points}}`, `{{wins}}`, `{{showsPlayed}}`, `{{avg_points}}`, `{{batting_avg}}`, `{{participantCount}}`, Top 5 snapshot, invite fields
+
+#### Template — Email (full)
+
+**Subject:** `Between the Past and Future, Where We Drift in Time: An almost Tour End Recap`  
+**Preview:** `18 shows in the books · Fenway wrapped · Dick's still ahead · your (almost) tour-end tape inside`
+
+Mid-tour recap (Pat) with tour tape, Top 5 table, personalized rank branch, invite ask (players), feature callouts. Non-players get the `noPlay` branch (inbox-only for non-players).
+
+#### Template — In-app
+
+Abbreviated recap + Standings / invite CTA. Forced to every inbox (no play filter, no prefs).
+
+---
+
 ## System triggers
 
 ### `push_canary`

--- a/docs/comms-triggers/catalog.json
+++ b/docs/comms-triggers/catalog.json
@@ -334,6 +334,38 @@
         { "name": "pool_name", "source": "users.pools[0] → pools.name", "fallback": null },
         { "name": "campaignId", "source": "vars.campaignId", "fallback": "summer_tour_2026" }
       ]
+    },
+    {
+      "triggerId": "marketing_summer_2026_almost_end",
+      "displayName": "Marketing — Summer 2026 almost-end (pre–Dick’s)",
+      "status": "shipped",
+      "phase": "v1",
+      "family": "lifecycle",
+      "priority": "P1",
+      "automation": "batch",
+      "event": "one-shot scheduler 2026-08-03 08:00 America/Denver; also admin callable / CLI",
+      "audience": "email: summer_tour_players; inApp: all_users (QA handles excluded); inApp ignores prefs",
+      "channels": ["email", "inApp"],
+      "prefKeys": ["lifecycle"],
+      "dedupKey": "marketing:{campaignId}:{uid}",
+      "templateId": "summer-2026-almost-end",
+      "implementationModule": "functions/marketingBatchDelivery.js",
+      "githubIssue": null,
+      "variables": [
+        { "name": "greeting_name", "source": "users/{uid}.handle", "fallback": "friend" },
+        { "name": "branch", "source": "rank / showsPlayed", "fallback": "noPlay" },
+        { "name": "rank", "source": "competition rank from seasonStats", "fallback": null },
+        { "name": "points", "source": "seasonStats.totalPoints", "fallback": 0 },
+        { "name": "wins", "source": "seasonStats.wins", "fallback": 0 },
+        { "name": "showsPlayed", "source": "seasonStats.shows", "fallback": 0 },
+        { "name": "avg_points", "source": "points / shows", "fallback": null },
+        { "name": "batting_avg", "source": "correctSlots / (shows * 6)", "fallback": null },
+        { "name": "participantCount", "source": "email cohort size", "fallback": null },
+        { "name": "fieldPickingAvg", "source": "mean of player batting avgs", "fallback": null },
+        { "name": "top5", "source": "Top 5 snapshot from players", "fallback": [] },
+        { "name": "share_url", "source": "invite kit URL with email UTMs", "fallback": null },
+        { "name": "campaignId", "source": "vars.campaignId", "fallback": "summer_2026_almost_end" }
+      ]
     }
   ],
   "system": [

--- a/emails/scripts/build.mjs
+++ b/emails/scripts/build.mjs
@@ -1,22 +1,34 @@
 /**
- * Bundle React Email templates to a CJS module for Cloud Functions.
+ * Bundle React Email templates to CJS modules for Cloud Functions.
  */
 import * as esbuild from "esbuild";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const outFile = path.join(__dirname, "../../functions/emails/renderSummerTour2026Launch.cjs");
+const functionsEmails = path.join(__dirname, "../../functions/emails");
 
-await esbuild.build({
-  entryPoints: [path.join(__dirname, "../src/renderSummerTour2026Launch.jsx")],
-  outfile: outFile,
-  bundle: true,
-  platform: "node",
-  format: "cjs",
-  jsx: "automatic",
-  target: "node24",
-  logLevel: "info",
-});
+const entries = [
+  {
+    entry: path.join(__dirname, "../src/renderSummerTour2026Launch.jsx"),
+    outfile: path.join(functionsEmails, "renderSummerTour2026Launch.cjs"),
+  },
+  {
+    entry: path.join(__dirname, "../src/renderSummer2026AlmostEnd.jsx"),
+    outfile: path.join(functionsEmails, "renderSummer2026AlmostEnd.cjs"),
+  },
+];
 
-console.log(`Built ${outFile}`);
+for (const { entry, outfile } of entries) {
+  await esbuild.build({
+    entryPoints: [entry],
+    outfile,
+    bundle: true,
+    platform: "node",
+    format: "cjs",
+    jsx: "automatic",
+    target: "node24",
+    logLevel: "info",
+  });
+  console.log(`Built ${outfile}`);
+}

--- a/emails/src/components/FeatureBlock.jsx
+++ b/emails/src/components/FeatureBlock.jsx
@@ -2,7 +2,7 @@ import { Text } from "@react-email/components";
 
 const titleStyle = {
   margin: "0 0 4px",
-  fontSize: "15px",
+  fontSize: "18px",
   fontWeight: 700,
   color: "#1a1a2e",
   lineHeight: 1.4,
@@ -10,7 +10,7 @@ const titleStyle = {
 
 const bodyStyle = {
   margin: "0 0 16px",
-  fontSize: "15px",
+  fontSize: "18px",
   color: "#333355",
   lineHeight: 1.55,
 };

--- a/emails/src/components/InviteShareBlock.jsx
+++ b/emails/src/components/InviteShareBlock.jsx
@@ -2,15 +2,15 @@ import { Link, Text } from "@react-email/components";
 
 const introStyle = {
   margin: "24px 0 8px",
-  fontSize: "15px",
+  fontSize: "18px",
   fontWeight: 400,
-  lineHeight: 1.5,
+  lineHeight: 1.55,
   color: "#1a1a2e",
 };
 
 const forwardStyle = {
   margin: "0 0 8px",
-  fontSize: "14px",
+  fontSize: "16px",
   fontWeight: 400,
   lineHeight: 1.5,
   color: "#64748b",
@@ -24,7 +24,7 @@ const softLinkStyle = {
   color: "#2563eb",
   textDecoration: "underline",
   fontWeight: 700,
-  fontSize: "15px",
+  fontSize: "18px",
 };
 
 const INVITE_NUDGE_INTRO =

--- a/emails/src/components/MarketingLayout.jsx
+++ b/emails/src/components/MarketingLayout.jsx
@@ -2,100 +2,130 @@ import {
   Body,
   Container,
   Head,
-  Hr,
   Html,
-  Img,
   Link,
   Preview,
   Section,
   Text,
 } from "@react-email/components";
 
-import { buildEmailLogoUrl } from "../../../comms/emailBranding.cjs";
+import {
+  buildEmailWordmarkHeroHtml,
+  EMAIL_BRAND_PRIMARY,
+} from "../../../comms/emailBranding.cjs";
 
+/**
+ * Full-bleed white shell for long marketing emails.
+ *
+ * Mobile QA lessons (preserve for all marketing templates):
+ * - White body + no border-radius — dark framed cards fragment in Gmail.
+ * - Teal top rule only for brand (keep).
+ * - Pair with emails/src/styles/marketingEmailText.js — body 18px, section
+ *   titles as bold <Text>/<p>, never Heading/<h2> (Gmail mid-email clip).
+ * - No <hr> before footer — Gmail treats hr + repeated footers as quote trim.
+ * - Include messageNonce (unique per send) so Gmail doesn’t collapse “identical”
+ *   content when previews/campaigns share a thread.
+ */
 const styles = {
   body: {
     margin: 0,
     padding: 0,
-    backgroundColor: "#0b0b14",
+    backgroundColor: "#ffffff",
+    WebkitTextSizeAdjust: "100%",
     fontFamily:
       '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
   },
   outer: {
-    backgroundColor: "#0b0b14",
-    padding: "32px 16px",
+    backgroundColor: "#ffffff",
+    padding: "0",
+    width: "100%",
   },
   card: {
-    maxWidth: "520px",
+    maxWidth: "600px",
+    width: "100%",
     backgroundColor: "#ffffff",
-    borderRadius: "16px",
-    overflow: "hidden",
     margin: "0 auto",
+    borderTop: `3px solid ${EMAIL_BRAND_PRIMARY}`,
   },
   header: {
-    padding: "32px 32px 8px",
+    padding: "20px 20px 8px",
     textAlign: "center",
   },
-  brand: {
-    marginTop: "12px",
-    fontSize: "18px",
-    fontWeight: 800,
-    color: "#1a1a2e",
-  },
   content: {
-    padding: "8px 32px 24px",
+    padding: "8px 20px 8px",
     color: "#1a1a2e",
-    fontSize: "15px",
-    lineHeight: 1.6,
+    fontSize: "18px",
+    lineHeight: 1.55,
   },
   footer: {
-    padding: "24px 32px",
-    borderTop: "1px solid #eeeeee",
+    padding: "24px 20px 20px",
     textAlign: "center",
   },
   footerText: {
     margin: "0 0 8px",
-    fontSize: "12px",
+    fontSize: "13px",
+    lineHeight: 1.5,
     color: "#888888",
   },
   footerLink: {
-    color: "#7c3aed",
+    color: "#0f766e",
     textDecoration: "underline",
+  },
+  /** Visually hidden uniqueness token — defeats Gmail “trimmed content”. */
+  nonce: {
+    display: "none",
+    maxHeight: 0,
+    overflow: "hidden",
+    opacity: 0,
+    fontSize: "1px",
+    lineHeight: "1px",
+    color: "#ffffff",
   },
 };
 
 /**
  * Shared shell for long-form marketing / lifecycle email (#468).
+ * Header uses the same non-clickable horizontal wordmark hero as service comms.
+ *
+ * @param {{
+ *   siteUrl?: string,
+ *   settingsUrl?: string,
+ *   preheader?: string,
+ *   messageNonce?: string,
+ *   children?: import('react').ReactNode,
+ * }} props
  */
 export function MarketingLayout({
   siteUrl = "https://www.setlistpickem.com",
   settingsUrl,
   preheader = "",
+  messageNonce,
   children,
 }) {
   const base = siteUrl.replace(/\/+$/, "");
-  const logoUrl = buildEmailLogoUrl(base);
   const prefsUrl = settingsUrl || `${base}/dashboard/profile/notifications`;
+  const wordmarkHeroHtml = buildEmailWordmarkHeroHtml(base);
+  const nonce =
+    typeof messageNonce === "string" && messageNonce.trim()
+      ? messageNonce.trim()
+      : `m${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
 
   return (
     <Html>
-      <Head />
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="x-apple-disable-message-reformatting" />
+      </Head>
       {preheader ? <Preview>{preheader}</Preview> : null}
       <Body style={styles.body}>
         <Section style={styles.outer}>
           <Container style={styles.card}>
             <Section style={styles.header}>
-              <Img
-                src={logoUrl}
-                width="48"
-                height="48"
-                alt="Setlist Pick'em"
-                style={{ borderRadius: "12px", display: "inline-block" }}
+              <div
+                dangerouslySetInnerHTML={{ __html: wordmarkHeroHtml }}
               />
-              <Text style={styles.brand}>Setlist Pick&apos;em</Text>
             </Section>
             <Section style={styles.content}>{children}</Section>
-            <Hr style={{ borderColor: "#eeeeee", margin: 0 }} />
             <Section style={styles.footer}>
               <Text style={styles.footerText}>
                 You&apos;re receiving this because you have a Setlist Pick&apos;em account.
@@ -109,6 +139,7 @@ export function MarketingLayout({
                   Unsubscribe
                 </Link>
               </Text>
+              <Text style={styles.nonce}>{nonce}</Text>
             </Section>
           </Container>
         </Section>

--- a/emails/src/renderSummer2026AlmostEnd.jsx
+++ b/emails/src/renderSummer2026AlmostEnd.jsx
@@ -1,0 +1,15 @@
+import { render } from "@react-email/render";
+import { Summer2026AlmostEnd } from "./templates/Summer2026AlmostEnd.jsx";
+
+/**
+ * Render Summer 2026 almost-end marketing email to HTML + plain text.
+ *
+ * @param {Record<string, unknown>} props
+ * @returns {Promise<{ html: string, text: string }>}
+ */
+export async function renderSummer2026AlmostEndEmail(props) {
+  const element = <Summer2026AlmostEnd {...props} />;
+  const html = await render(element);
+  const text = await render(element, { plainText: true });
+  return { html, text };
+}

--- a/emails/src/styles/marketingEmailText.js
+++ b/emails/src/styles/marketingEmailText.js
@@ -1,0 +1,62 @@
+/**
+ * Shared marketing-email typography (mobile-first).
+ *
+ * Lessons from Summer 2026 almost-end Gmail QA:
+ * - Full-bleed white shell lives in MarketingLayout (no dark frame / card radius).
+ * - Never use <h1>–<h6> / Heading — Gmail mobile clips mid-message at headings
+ *   and redraws the rest as a nested card with a "…" expander.
+ * - Section titles = bold <Text>/<p> via sectionHeadingStyle.
+ * - Body ≥ 18px so type stays readable when Gmail doesn't auto-scale.
+ * - No <hr> before footer; pass messageNonce per send; preview subjects must be
+ *   unique — otherwise Gmail conversation view trims “identical” body blocks.
+ */
+
+export const greetingStyle = {
+  margin: "0 0 18px",
+  fontSize: "18px",
+  fontWeight: 700,
+  lineHeight: 1.55,
+  color: "#1a1a2e",
+};
+
+export const paragraphStyle = {
+  margin: "0 0 18px",
+  fontSize: "18px",
+  lineHeight: 1.55,
+  color: "#1a1a2e",
+};
+
+/** Bold paragraph — do not swap for Heading / <h2>. */
+export const sectionHeadingStyle = {
+  margin: "28px 0 12px",
+  fontSize: "20px",
+  fontWeight: 800,
+  lineHeight: 1.3,
+  color: "#1a1a2e",
+};
+
+export const signoffStyle = {
+  margin: "24px 0 8px",
+  fontSize: "18px",
+  lineHeight: 1.55,
+  color: "#1a1a2e",
+};
+
+export const inlineLinkStyle = {
+  display: "block",
+  margin: "-8px 0 16px",
+  fontSize: "16px",
+  color: "#0f766e",
+  textDecoration: "underline",
+};
+
+export const ctaButtonStyle = {
+  display: "inline-block",
+  padding: "16px 28px",
+  fontSize: "18px",
+  fontWeight: 700,
+  color: "#0b0b14",
+  textDecoration: "none",
+  backgroundColor: "#2dd4bf",
+  borderRadius: "12px",
+};

--- a/emails/src/templates/Summer2026AlmostEnd.jsx
+++ b/emails/src/templates/Summer2026AlmostEnd.jsx
@@ -1,0 +1,240 @@
+import { Link, Text } from "@react-email/components";
+import { FeatureBlock } from "../components/FeatureBlock.jsx";
+import { InviteShareBlock } from "../components/InviteShareBlock.jsx";
+import { MarketingLayout } from "../components/MarketingLayout.jsx";
+import {
+  ctaButtonStyle,
+  greetingStyle,
+  paragraphStyle,
+  sectionHeadingStyle,
+  signoffStyle,
+} from "../styles/marketingEmailText.js";
+
+const thStyle = {
+  padding: "10px 6px",
+  borderBottom: "2px solid #1a1a2e",
+  fontSize: "12px",
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  color: "#64748b",
+};
+
+const tdStyle = {
+  padding: "10px 6px",
+  borderBottom: "1px solid #eeeeee",
+  fontSize: "16px",
+  color: "#1a1a2e",
+};
+
+const bustoutBrandStyle = {
+  color: "#ea580c",
+  fontWeight: 800,
+};
+
+/**
+ * Marketing — Summer 2026 almost-end (pre–Dick's).
+ *
+ * @param {Record<string, unknown>} props
+ */
+export function Summer2026AlmostEnd({
+  greetingName = "friend",
+  personalTape = "",
+  top5 = [],
+  fieldPickingAvg = ".231",
+  fieldPlayerCount = 28,
+  showInvite = true,
+  standingsUrl,
+  shareUrl,
+  siteUrl = "https://www.setlistpickem.com",
+  settingsUrl,
+  messageNonce,
+  preheader =
+    "18 shows in the books · Fenway wrapped · Dick's still ahead · your (almost) tour-end tape inside",
+}) {
+  const base = String(siteUrl).replace(/\/+$/, "");
+  const standings =
+    typeof standingsUrl === "string" && standingsUrl.trim()
+      ? standingsUrl.trim()
+      : `${base}/dashboard/standings`;
+  const rows = Array.isArray(top5) ? top5 : [];
+
+  return (
+    <MarketingLayout
+      siteUrl={siteUrl}
+      settingsUrl={settingsUrl}
+      preheader={preheader}
+      messageNonce={messageNonce}
+    >
+      <Text style={greetingStyle}>Hey {greetingName},</Text>
+
+      <Text style={paragraphStyle}>
+        Well, that&apos;s a wrap. Or is it? The Phab Four earned a well deserved break ahead of the
+        official tour-closing Dick&apos;s Run. With so much time on our hands between shows (I&apos;m
+        not crying, you&apos;re crying), here&apos;s some stats to chew on.
+      </Text>
+
+      <Text style={sectionHeadingStyle}>Tour tape</Text>
+      <Text style={paragraphStyle}>
+        Eighteen nights. <strong>188</strong> unique songs. <strong>310</strong> total songs played
+        from Madison through Fenway.
+      </Text>
+      <Text style={paragraphStyle}>
+        And then there was New York. The five-night MSG run (July 22–29) wasn&apos;t just another
+        Garden residency — it was a full-on <strong>&apos;90s time machine</strong>. The band&apos;s{" "}
+        <strong>92nd through 96th</strong> appearances at the Garden, each night a setlist drawn
+        entirely from one year: <strong>&apos;92 thru &apos;96</strong>. From my seat (and my
+        scorecard), some of the best Phish of the last decade — bicycle kicks and beach balls back
+        from the dead, deep cuts raining from the rafters, and a picking board that refused to
+        behave.
+      </Text>
+      <Text style={paragraphStyle}>
+        That theme explains half the chaos on the tape. MSG alone coughed up these show gaps:{" "}
+        <strong>Cold as Ice</strong> (1,468), <strong>Big Ball Jam</strong> (1,170),{" "}
+        <strong>The Vibration of Life</strong> (1,027), <strong>Suspicious Minds</strong> (1,021),
+        plus the cover pile — <strong>Highway to Hell</strong>, <strong>Purple Rain</strong>,{" "}
+        <strong>Johnny B. Goode</strong>, <strong>La Grange</strong> — and a full{" "}
+        <strong>Forbin → Mockingbird → Harpua</strong> suite. Across those five nights, the field
+        banked <strong>44</strong>{" "}
+        <span style={bustoutBrandStyle}>Bustout Boost™</span> hits. Fenway N1 dropped{" "}
+        <strong>Melt the Guns</strong> after <strong>2,051</strong> shows — the longest gap between
+        performances in Phish history. They absolutely nailed this post-punk/new wave relic.
+      </Text>
+      <Text style={paragraphStyle}>
+        Not every story needed a 1,000-show gap. Merriweather brought <strong>Ass Handed</strong>{" "}
+        back after 138; Savannah lit <strong>Fire</strong> (132); and just under the bustout line,
+        songs like <strong>The Old Home Place</strong> (28) and <strong>Izabella</strong> (25) kept
+        the “almost” lane spicy.
+      </Text>
+      <Text style={paragraphStyle}>
+        The rotation favorites? <strong>Character Zero</strong>, <strong>Free</strong>,{" "}
+        <strong>Ghost</strong>, <strong>Hood</strong>, <strong>Possum</strong>,{" "}
+        <strong>Antelope</strong>, and <strong>Sand</strong> each showed up <strong>four</strong>{" "}
+        times through Fenway — the 1.0 stalwarts that I know and love.
+      </Text>
+
+      <Text style={sectionHeadingStyle}>Pre Dick&apos;s Leaderboard</Text>
+      <Text style={paragraphStyle}>
+        Field picking average across <strong>{fieldPlayerCount}</strong> players:{" "}
+        <strong>{fieldPickingAvg}</strong>. The Top 5 all clear it — Rivertranced by the widest
+        margin. It just shows that a few well-placed bustouts can <strong>Catapult</strong> a player
+        to the top in a hurry.
+      </Text>
+
+      {rows.length > 0 ? (
+        <table
+          role="presentation"
+          width="100%"
+          cellSpacing="0"
+          cellPadding="0"
+          style={{ borderCollapse: "collapse", margin: "12px 0 16px" }}
+        >
+          <thead>
+            <tr>
+              <th align="left" style={thStyle}>
+                Rank
+              </th>
+              <th align="left" style={thStyle}>
+                Handle
+              </th>
+              <th align="right" style={thStyle}>
+                Pts
+              </th>
+              <th align="right" style={thStyle}>
+                Wins
+              </th>
+              <th align="right" style={thStyle}>
+                Nights
+              </th>
+              <th align="right" style={thStyle}>
+                Avg
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={`${row.rank}-${row.handle}`}>
+                <td style={tdStyle}>{row.rank}</td>
+                <td style={{ ...tdStyle, fontWeight: 700 }}>{row.handle}</td>
+                <td style={{ ...tdStyle, textAlign: "right" }}>{row.points}</td>
+                <td style={{ ...tdStyle, textAlign: "right" }}>{row.wins}</td>
+                <td style={{ ...tdStyle, textAlign: "right" }}>{row.nights}</td>
+                <td style={{ ...tdStyle, textAlign: "right" }}>{row.battingAvg}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : null}
+
+      <Text style={paragraphStyle}>
+        Three more nights at Dick&apos;s. The Top 5 is bunched enough that one hot run — or a couple
+        of bustouts — can reshuffle the whole podium. And if you&apos;re sitting just outside looking
+        in: you&apos;re closer than you think. Commerce City is where chasers become contenders.
+      </Text>
+
+      <Text style={sectionHeadingStyle}>Your (almost) tour-end tape</Text>
+      <Text style={paragraphStyle}>{personalTape}</Text>
+
+      {showInvite ? (
+        <>
+          <Text style={sectionHeadingStyle}>One huge favor</Text>
+          <Text style={paragraphStyle}>
+            Before Dick&apos;s, can I ask a huge favor? <strong>Invite at least one friend</strong>{" "}
+            to join and lock picks for the three-night run. Growing the number of players is my
+            measure of success — and you know I love stats.
+          </Text>
+          <Text style={{ margin: "0 0 24px" }}>
+            <Link href={standings} style={ctaButtonStyle}>
+              Invite a friend from Standings
+            </Link>
+          </Text>
+        </>
+      ) : (
+        <Text style={{ margin: "0 0 24px" }}>
+          <Link href={standings} style={ctaButtonStyle}>
+            Check it out on Standings
+          </Link>
+        </Text>
+      )}
+
+      <Text style={sectionHeadingStyle}>Building between now and then</Text>
+      <Text style={paragraphStyle}>
+        Between now and Dick&apos;s, I&apos;m staying busy building out new features. If you
+        haven&apos;t checked these out, they are worth taking a look:
+      </Text>
+      <FeatureBlock title="Live setlist">
+        Updates as songs land, with bustout badges and last-played / gap insights so you can see how
+        rare each hit really was.
+      </FeatureBlock>
+      <FeatureBlock title="Crowd pulse">
+        How the field is picking that night — consensus heat, where your card sits vs the room, and
+        which songs the crowd is riding.
+      </FeatureBlock>
+      <FeatureBlock title="Stats">
+        Personal and tour insights (bustouts, gaps, frequency — the same tape above, live in the
+        app).
+      </FeatureBlock>
+      <FeatureBlock title="Profile">
+        Milestone badges and avatars so you can personalize how you show up on the board.
+      </FeatureBlock>
+
+      <Text style={paragraphStyle}>
+        Three nights in Commerce City still to go. Rest up, study the gaps, and don&apos;t sleep on
+        the wildcard.
+      </Text>
+      <Text style={paragraphStyle}>See you at Dick&apos;s.</Text>
+      <Text style={signoffStyle}>
+        — Pat
+        <br />
+        from the Setlist Pick &apos;Em desk
+      </Text>
+
+      {showInvite ? (
+        <InviteShareBlock
+          standingsUrl={standings}
+          inviteUrl={typeof shareUrl === "string" ? shareUrl : undefined}
+          ctaLabel="Open Standings to share →"
+        />
+      ) : null}
+    </MarketingLayout>
+  );
+}

--- a/emails/src/templates/SummerTour2026Launch.jsx
+++ b/emails/src/templates/SummerTour2026Launch.jsx
@@ -3,42 +3,13 @@ import { CommsEmailHeader } from "../components/CommsEmailHeader.jsx";
 import { FeatureBlock } from "../components/FeatureBlock.jsx";
 import { InviteShareBlock } from "../components/InviteShareBlock.jsx";
 import { MarketingLayout } from "../components/MarketingLayout.jsx";
-
-const greetingStyle = {
-  margin: "0 0 16px",
-  fontSize: "16px",
-  fontWeight: 700,
-  color: "#1a1a2e",
-};
-
-const paragraphStyle = {
-  margin: "0 0 16px",
-  fontSize: "15px",
-  lineHeight: 1.6,
-  color: "#1a1a2e",
-};
-
-const sectionHeadingStyle = {
-  margin: "24px 0 12px",
-  fontSize: "16px",
-  fontWeight: 800,
-  color: "#1a1a2e",
-};
-
-const signoffStyle = {
-  margin: "24px 0 8px",
-  fontSize: "15px",
-  lineHeight: 1.6,
-  color: "#1a1a2e",
-};
-
-const inlineLinkStyle = {
-  display: "block",
-  margin: "-8px 0 16px",
-  fontSize: "14px",
-  color: "#7c3aed",
-  textDecoration: "underline",
-};
+import {
+  greetingStyle,
+  inlineLinkStyle,
+  paragraphStyle,
+  sectionHeadingStyle,
+  signoffStyle,
+} from "../styles/marketingEmailText.js";
 
 /**
  * Marketing email #1 — Summer Tour 2026 pre-opener launch (#468).
@@ -59,6 +30,7 @@ export function SummerTour2026Launch({
   openerLabel = "Tuesday, July 7",
   siteUrl = "https://www.setlistpickem.com",
   settingsUrl,
+  messageNonce,
   /** Tour / run label for header eyebrow — e.g. Summer Tour 2026, Fall Tour, Dick's. */
   tourLabel = "Summer Tour 2026",
   /** Header title under eyebrow. */
@@ -83,6 +55,7 @@ export function SummerTour2026Launch({
       siteUrl={siteUrl}
       settingsUrl={settingsUrl}
       preheader={`Bring your crew → Summer Tour starts ${openerLabel}.`}
+      messageNonce={messageNonce}
     >
       <CommsEmailHeader
         icon="🎸"

--- a/functions/comms/emailBranding.cjs
+++ b/functions/comms/emailBranding.cjs
@@ -4,20 +4,20 @@ const fs = require('fs');
 const path = require('path');
 
 /**
- * Email branding assets — two layers, do not conflate:
+ * Email branding assets — do not conflate layers:
  *
- * 1. **In-body header** (`EMAIL_IN_BODY_LOGO_PATH`) — large vinyl mark inside the opened
- *    email HTML. Controlled by `buildEmailInBodyLogoUrl()` in templates.
+ * 1. **In-body header hero** — horizontal gradient wordmark at
+ *    `/branding/email-gradient-wordmark.png` via {@link buildEmailWordmarkHeroHtml}.
+ *    CSS background (not a linked `<img>`) so clients cannot open the raw PNG on tap;
+ *    Outlook gets a conditional unlinked `<img>` fallback. Used by service shell +
+ *    marketing `MarketingLayout`.
  *
  * 2. **Inbox sender badge** — small avatar beside the sender name in Gmail/Apple Mail list
- *    views. NOT driven by the HTML `<img>`. Requires BIMI + DMARC (primary) and/or domain
+ *    views. NOT driven by the HTML hero. Requires BIMI + DMARC (primary) and/or domain
  *    favicon at the From host (fallback). See docs/comms-triggers/EMAIL_INBOX_BADGE.md (#498).
  *
- * 3. **Service shell wordmark** — raster PNG at `/branding/email-gradient-wordmark.png`
- *    (hosted HTTPS URL, same pattern as marketing `buildEmailLogoUrl`). Asset must live in
- *    `public/branding/` on the deployed site. Do not use CID attachments — Gmail exposes
- *    those as downloadable files. Render as a CSS background (not `<img>`) so clients
- *    cannot open the raw PNG on tap; Outlook gets a conditional unlinked `<img>` fallback.
+ * 3. **Legacy vinyl path** (`EMAIL_IN_BODY_LOGO_PATH` / `buildEmailInBodyLogoUrl`) — kept for
+ *    call-site stability; do not use for new email headers.
  */
 const EMAIL_IN_BODY_LOGO_PATH = '/favicon/web-app-manifest-512x512.png';
 /** Public CDN path — deploy via Vercel (`public/branding/`). */
@@ -25,7 +25,10 @@ const EMAIL_WORDMARK_GRADIENT_PATH = '/branding/email-gradient-wordmark.png';
 const EMAIL_WORDMARK_PNG_FILE = 'email-gradient-wordmark.png';
 /** Resend inline attachment id — referenced as `cid:…` in the HTML shell. */
 const EMAIL_WORDMARK_INLINE_CONTENT_ID = 'email-gradient-wordmark';
-/** design.md brand tokens — service comms HTML shell only. */
+/** ~96% of the 416px inner shell width; height tracks email-gradient-wordmark.svg (~3:1). */
+const EMAIL_SHELL_WORDMARK_WIDTH_PX = 400;
+const EMAIL_SHELL_WORDMARK_HEIGHT_PX = 132;
+/** design.md brand tokens — service / marketing email shells. */
 const EMAIL_BRAND_PRIMARY = '#2dd4bf';
 const EMAIL_BRAND_PRIMARY_STRONG = '#14b8a6';
 const EMAIL_BRAND_BG_DEEP = '#020617';
@@ -59,6 +62,54 @@ function buildEmailLogoUrl(siteUrl = DEFAULT_SITE_URL) {
 function buildEmailWordmarkUrl(siteUrl = DEFAULT_SITE_URL) {
   const base = String(siteUrl || DEFAULT_SITE_URL).replace(/\/+$/, '');
   return `${base}${EMAIL_WORDMARK_GRADIENT_PATH}`;
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeHtmlAttr(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Non-clickable horizontal brand hero for email headers (service + marketing).
+ * CSS background for modern clients; MSO conditional unlinked `<img>` fallback.
+ *
+ * @param {string} [siteUrl]
+ * @param {{ wordmarkSrc?: string }} [opts]
+ * @returns {string} HTML fragment (no outer wrapper)
+ */
+function buildEmailWordmarkHeroHtml(siteUrl = DEFAULT_SITE_URL, opts = {}) {
+  const resolved =
+    typeof opts.wordmarkSrc === 'string' && opts.wordmarkSrc.trim()
+      ? opts.wordmarkSrc.trim()
+      : buildEmailWordmarkUrl(siteUrl);
+  const src = escapeHtmlAttr(resolved);
+  const w = EMAIL_SHELL_WORDMARK_WIDTH_PX;
+  const h = EMAIL_SHELL_WORDMARK_HEIGHT_PX;
+  const blockStyle = [
+    `width:${w}px`,
+    'max-width:100%',
+    `height:${h}px`,
+    'margin:0 auto',
+    `background-image:url('${src}')`,
+    'background-size:contain',
+    'background-repeat:no-repeat',
+    'background-position:center',
+  ].join(';');
+
+  return `<!--[if mso]>
+<img src="${src}" width="${w}" height="${h}" alt="Setlist Pick'em" style="display:block;margin:0 auto;max-width:${w}px;width:100%;height:auto;border:0;" />
+<![endif]-->
+<!--[if !mso]><!-->
+<div role="presentation" aria-hidden="true" style="${blockStyle}"></div>
+<!--<![endif]-->`;
 }
 
 /**
@@ -121,6 +172,8 @@ module.exports = {
   EMAIL_IN_BODY_LOGO_PATH,
   EMAIL_WORDMARK_GRADIENT_PATH,
   EMAIL_WORDMARK_INLINE_CONTENT_ID,
+  EMAIL_SHELL_WORDMARK_WIDTH_PX,
+  EMAIL_SHELL_WORDMARK_HEIGHT_PX,
   EMAIL_BRAND_PRIMARY,
   EMAIL_BRAND_PRIMARY_STRONG,
   EMAIL_BRAND_BG_DEEP,
@@ -128,6 +181,7 @@ module.exports = {
   buildEmailInBodyLogoUrl,
   buildEmailLogoUrl,
   buildEmailWordmarkUrl,
+  buildEmailWordmarkHeroHtml,
   buildEmailWordmarkCidSrc,
   buildEmailWordmarkResendAttachment,
   formatWordmarkAttachmentForResendApi,

--- a/functions/commsCatalog.js
+++ b/functions/commsCatalog.js
@@ -123,6 +123,17 @@ const TRIGGER_SPECS = {
     family: "lifecycle",
     priority: "P1",
   },
+  // inApp is forced for all users via Sphere-style fanout (no prefs gate).
+  // Email uses deliverCommsTrigger with channelFilter=["email"] + lifecycle prefs.
+  marketing_summer_2026_almost_end: {
+    triggerId: "marketing_summer_2026_almost_end",
+    templateId: "summer-2026-almost-end",
+    channels: ["email", "inApp"],
+    prefKeys: ["lifecycle"],
+    dedupKey: "marketing:{campaignId}:{uid}",
+    family: "lifecycle",
+    priority: "P1",
+  },
 };
 
 /**

--- a/functions/commsDelivery.js
+++ b/functions/commsDelivery.js
@@ -79,6 +79,7 @@ function recipientAllowsChannel(userData, spec, channel) {
  *   bypassDailyCap?: boolean,
  *   fatigueCap?: number,
  *   variant?: string,
+ *   channels?: string[],
  *   logger?: { info?: Function, warn?: Function, error?: Function },
  *   sendGa4Delivered?: typeof sendCommsDeliveredEvent,
  * }} params
@@ -94,6 +95,7 @@ async function deliverCommsTrigger({
   bypassDailyCap = false,
   fatigueCap = DEFAULT_FATIGUE_CAP,
   variant = "control",
+  channels: channelFilter,
   logger,
   sendGa4Delivered = sendCommsDeliveredEvent,
 }) {
@@ -101,6 +103,11 @@ async function deliverCommsTrigger({
   if (!spec) {
     return { ok: false, reason: "unknown_trigger", triggerId };
   }
+
+  const activeChannels =
+    Array.isArray(channelFilter) && channelFilter.length > 0
+      ? spec.channels.filter((c) => channelFilter.includes(c))
+      : spec.channels;
 
   const summary = {
     ok: true,
@@ -171,7 +178,7 @@ async function deliverCommsTrigger({
 
     const deliveredChannels = [];
     const channelResults = {};
-    for (const channel of spec.channels) {
+    for (const channel of activeChannels) {
       const worker = workers[channel];
       if (typeof worker !== "function") {
         channelResults[channel] = { ok: false, skipReason: "no_worker" };
@@ -238,7 +245,9 @@ async function deliverCommsTrigger({
       summary.results.push({
         uid,
         status: dryRun ? "would_deliver" : "delivered",
-        channels: dryRun ? spec.channels.filter((c) => channelResults[c]?.ok) : deliveredChannels,
+        channels: dryRun
+          ? activeChannels.filter((c) => channelResults[c]?.ok)
+          : deliveredChannels,
         dedupId,
       });
     } else {

--- a/functions/commsDeployManifest.js
+++ b/functions/commsDeployManifest.js
@@ -52,6 +52,18 @@ const COMMS_DEPLOY_GROUPS = {
       note: "admin batch marketing email #468",
       secretExpectation: "resend",
     },
+    {
+      export: "deliverMarketingSummer2026AlmostEnd",
+      triggerId: "marketing_summer_2026_almost_end",
+      note: "admin batch almost-end email + forced inbox",
+      secretExpectation: "resend",
+    },
+    {
+      export: "scheduledMarketingSummer2026AlmostEnd",
+      triggerId: "marketing_summer_2026_almost_end",
+      note: "one-shot 2026-08-03 08:00 America/Denver",
+      secretExpectation: "resend",
+    },
     { export: "commsResendWebhook", note: "Resend bounce/complaint webhook", secretExpectation: "webhook" },
     { export: "commsEmailUnsubscribe", note: "RFC 8058 one-click unsubscribe", secretExpectation: "none" },
     { export: "getCommsEmailStatus", note: "email prefs status", secretExpectation: "none" },

--- a/functions/commsEmailWorker.js
+++ b/functions/commsEmailWorker.js
@@ -38,7 +38,7 @@ const { buildOneClickUnsubscribeUrl } = require("./commsEmailUnsubscribe");
 const { reserveEmailDailyCapSlot } = require("./commsEmailDailyCap");
 const { getTriggerSpec } = require("./commsCatalog");
 const {
-  buildEmailWordmarkUrl,
+  buildEmailWordmarkHeroHtml,
   EMAIL_BRAND_PRIMARY,
   EMAIL_BRAND_PRIMARY_STRONG,
   EMAIL_BRAND_BG_DEEP,
@@ -49,9 +49,6 @@ const { buildCommsEmailHeaderHtml } = require("./comms/emailCommsHeader.cjs");
 const DEFAULT_FROM = "Setlist Pick'em <updates@setlistpickem.com>";
 const DEFAULT_SITE_URL = "https://www.setlistpickem.com";
 const UNSUB_PATH = "/dashboard/profile/notifications";
-/** ~96% of the 416px inner shell width; height tracks email-gradient-wordmark.svg (~3:1). */
-const EMAIL_SHELL_WORDMARK_WIDTH_PX = 400;
-const EMAIL_SHELL_WORDMARK_HEIGHT_PX = 132;
 const EMAIL_SHELL_ACCENT_BORDER_PX = 2;
 
 /**
@@ -278,10 +275,7 @@ function buildBrandedEmailHtml({ siteUrl, bodyText, ctaUrl, settingsUrl, ctaLabe
   const buttonLabel = typeof ctaLabel === "string" && ctaLabel.trim() ? ctaLabel.trim() : "Open Setlist Pick'em";
   const signOffLine = typeof signOff === "string" ? signOff.trim() : "";
   const base = (siteUrl || DEFAULT_SITE_URL).replace(/\/+$/, "");
-  const resolvedWordmarkSrc =
-    typeof wordmarkSrc === "string" && wordmarkSrc.trim()
-      ? wordmarkSrc.trim()
-      : buildEmailWordmarkUrl(base);
+  const wordmarkHeroHtml = buildEmailWordmarkHeroHtml(base, { wordmarkSrc });
   const paragraphs = bodyTextToHtmlParagraphs(bodyText, { signOff: signOffLine });
   const headerHtml = buildCommsEmailHeaderHtml(header);
   const signOffHtml = signOffLine
@@ -289,16 +283,6 @@ function buildBrandedEmailHtml({ siteUrl, bodyText, ctaUrl, settingsUrl, ctaLabe
     : "";
   const inviteHtml =
     typeof inviteBlockHtml === "string" && inviteBlockHtml.trim() ? inviteBlockHtml.trim() : "";
-  const wordmarkBlockStyle = [
-    `width:${EMAIL_SHELL_WORDMARK_WIDTH_PX}px`,
-    "max-width:100%",
-    `height:${EMAIL_SHELL_WORDMARK_HEIGHT_PX}px`,
-    "margin:0 auto",
-    `background-image:url('${escapeHtml(resolvedWordmarkSrc)}')`,
-    "background-size:contain",
-    "background-repeat:no-repeat",
-    "background-position:center",
-  ].join(";");
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -315,12 +299,7 @@ function buildBrandedEmailHtml({ siteUrl, bodyText, ctaUrl, settingsUrl, ctaLabe
           <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width:480px;width:100%;background-color:#ffffff;border-radius:16px;overflow:hidden;border-top:${EMAIL_SHELL_ACCENT_BORDER_PX}px solid ${EMAIL_BRAND_PRIMARY};">
             <tr>
               <td style="padding:16px 24px 8px 24px;text-align:center;">
-                <!--[if mso]>
-                <img src="${escapeHtml(resolvedWordmarkSrc)}" width="${EMAIL_SHELL_WORDMARK_WIDTH_PX}" height="${EMAIL_SHELL_WORDMARK_HEIGHT_PX}" alt="Setlist Pick'em" style="display:block;margin:0 auto;max-width:${EMAIL_SHELL_WORDMARK_WIDTH_PX}px;width:100%;height:auto;border:0;" />
-                <![endif]-->
-                <!--[if !mso]><!-->
-                <div role="presentation" aria-hidden="true" style="${wordmarkBlockStyle}"></div>
-                <!--<![endif]-->
+                ${wordmarkHeroHtml}
               </td>
             </tr>
             <tr>

--- a/functions/commsTemplates.js
+++ b/functions/commsTemplates.js
@@ -468,6 +468,17 @@ async function renderCommsTemplate(templateId, payload = {}) {
     };
   }
 
+  if (templateId === "summer-2026-almost-end") {
+    // eslint-disable-next-line global-require
+    const { buildSummer2026AlmostEndChannels } = require("./marketingCommsTemplates");
+    const channels = await buildSummer2026AlmostEndChannels(payload);
+    return {
+      inApp: channels.inApp || { templateId, payload },
+      push: channels.push,
+      email: channels.email,
+    };
+  }
+
   const builder = BUILDERS[templateId];
   const channels = builder
     ? builder(payload)
@@ -494,6 +505,7 @@ async function renderCommsTemplate(templateId, payload = {}) {
 
 function hasTemplate(templateId) {
   if (templateId === "summer-tour-2026-launch") return true;
+  if (templateId === "summer-2026-almost-end") return true;
   return Object.prototype.hasOwnProperty.call(BUILDERS, templateId);
 }
 

--- a/functions/commsTemplates.test.js
+++ b/functions/commsTemplates.test.js
@@ -16,13 +16,24 @@ test("every catalog template renders push + email + inApp payloads", async () =>
             siteUrl: "https://www.setlistpickem.com",
             settingsUrl: "https://www.setlistpickem.com/dashboard/profile/notifications",
           }
+        : spec.templateId === "summer-2026-almost-end"
+          ? {
+              greetingName: "RiverTranced",
+              personalTape: "You're #2 with 320 points.",
+              showInvite: true,
+              siteUrl: "https://www.setlistpickem.com",
+              standingsUrl: "https://www.setlistpickem.com/dashboard/standings",
+            }
         : { handle: "RiverTranced" };
     const out = await renderCommsTemplate(spec.templateId, payload);
     assert.equal(out.inApp.templateId, spec.templateId, `${spec.templateId} inApp`);
     assert.ok(out.push.title, `${spec.templateId} push.title`);
     assert.ok(out.push.body, `${spec.templateId} push.body`);
     assert.ok(out.email.subject, `${spec.templateId} email.subject`);
-    if (spec.templateId === "summer-tour-2026-launch") {
+    if (
+      spec.templateId === "summer-tour-2026-launch" ||
+      spec.templateId === "summer-2026-almost-end"
+    ) {
       assert.ok(out.email.html, `${spec.templateId} email.html`);
       assert.match(out.email.text, /RiverTranced|Rivertranced/i, `${spec.templateId} personalized text`);
     } else {

--- a/functions/index.js
+++ b/functions/index.js
@@ -49,6 +49,11 @@ const {
 const { applyRevertRollupForShow } = require("./revertRollupCore");
 const { deliverSphere2026TourRecapInbox } = require("./sphereTourRecapDelivery");
 const { deliverMarketingSummerTour2026Launch } = require("./marketingBatchDelivery");
+const { deliverMarketingSummer2026AlmostEnd } = require("./marketingAlmostEndDelivery");
+const { claimMarketingRun, finishMarketingRun } = require("./marketingRunLock");
+const {
+  CAMPAIGN_ID: ALMOST_END_CAMPAIGN_ID,
+} = require("./marketingAlmostEndCore");
 const { evaluateManualFinalizeTimingGate } = require("./showFinalizationGate");
 const { applyLockPicksForShowNow } = require("./picksLockOverride");
 const { runAccountDeletionForCaller } = require("./accountDelete");
@@ -513,6 +518,91 @@ exports.deliverMarketingSummerTour2026Launch = onCall(
       resendWebhookSecret: process.env.RESEND_WEBHOOK_SECRET,
       logger,
     });
+  }
+);
+
+/**
+ * Admin-only batch — Summer 2026 almost-end (email players + forced inbox all users).
+ * Defaults to dryRun. Pass dryRun: false to send.
+ */
+exports.deliverMarketingSummer2026AlmostEnd = onCall(
+  {
+    region: PHISHNET_FUNCTIONS_REGION,
+    invoker: "public",
+    enforceAppCheck: false,
+    secrets: commsDeliverySecrets,
+  },
+  async (request) => {
+    assertAdminClaim(request);
+    const dryRun = request.data?.dryRun !== false;
+    const forceResend = request.data?.forceResend === true;
+    const onlyUids = Array.isArray(request.data?.onlyUids)
+      ? request.data.onlyUids.map((u) => String(u).trim()).filter(Boolean)
+      : undefined;
+    return deliverMarketingSummer2026AlmostEnd({
+      db,
+      admin,
+      dryRun,
+      forceResend,
+      onlyUids,
+      resendApiKey: process.env.RESEND_API_KEY,
+      resendWebhookSecret: process.env.RESEND_WEBHOOK_SECRET,
+      logger,
+    });
+  }
+);
+
+/**
+ * One-shot scheduled send — Summer 2026 almost-end at 08:00 America/Denver on 2026-08-03.
+ * Uses Firestore run-lock `comms_marketing_runs/summer_2026_almost_end`.
+ */
+exports.scheduledMarketingSummer2026AlmostEnd = onSchedule(
+  {
+    schedule: "0 8 3 8 *",
+    timeZone: "America/Denver",
+    region: PHISHNET_FUNCTIONS_REGION,
+    secrets: commsDeliverySecrets,
+  },
+  async () => {
+    const runId = ALMOST_END_CAMPAIGN_ID;
+    const targetDate = "2026-08-03";
+    try {
+      const claim = await claimMarketingRun(db, admin, runId, { targetDate });
+      if (!claim.claimed) {
+        logger.info("scheduledMarketingSummer2026AlmostEnd skipped", claim);
+        return null;
+      }
+      const result = await deliverMarketingSummer2026AlmostEnd({
+        db,
+        admin,
+        dryRun: false,
+        forceResend: false,
+        resendApiKey: process.env.RESEND_API_KEY,
+        resendWebhookSecret: process.env.RESEND_WEBHOOK_SECRET,
+        logger,
+      });
+      await finishMarketingRun(db, admin, runId, result.ok !== false ? "completed" : "failed", {
+        resultSummary: {
+          ok: result.ok,
+          inboxDelivered: result.inboxDelivered,
+          emailCohortSize: result.emailCohortSize,
+        },
+      });
+      logger.info("scheduledMarketingSummer2026AlmostEnd complete", {
+        ok: result.ok,
+        inboxDelivered: result.inboxDelivered,
+        emailCohortSize: result.emailCohortSize,
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      logger.error("scheduledMarketingSummer2026AlmostEnd failed", { msg, err: e });
+      try {
+        await finishMarketingRun(db, admin, runId, "failed", { error: msg });
+      } catch (finishErr) {
+        logger.error("failed to mark almost-end run failed", { finishErr });
+      }
+    }
+    return null;
   }
 );
 

--- a/functions/marketingAlmostEndCore.js
+++ b/functions/marketingAlmostEndCore.js
@@ -1,0 +1,212 @@
+/**
+ * Pure helpers for Summer 2026 almost-end marketing batch.
+ * Rank / branch / batting math — no Firestore I/O.
+ */
+
+"use strict";
+
+const TOUR_KEY = "2026 Summer Tour";
+/** Explicit QA handles that may not contain the substring "qa". */
+const QA_HANDLES = new Set(["qatester", "mrpickphive"]);
+const INBOX_DOC_ID = "marketing_summer_2026_almost_end";
+const TEMPLATE_ID = "summer-2026-almost-end";
+const TRIGGER_ID = "marketing_summer_2026_almost_end";
+const CAMPAIGN_ID = "summer_2026_almost_end";
+const SITE_URL = "https://www.setlistpickem.com";
+const DEFAULT_SUBJECT =
+  "Between the Past and Future, Where We Drift in Time: An almost Tour End Recap";
+const DEFAULT_PREHEADER =
+  "18 shows in the books · Fenway wrapped · Dick's still ahead · your (almost) tour-end tape inside";
+
+/**
+ * @param {string | null | undefined} handle
+ * @returns {boolean}
+ */
+function isExcludedQaHandle(handle) {
+  if (typeof handle !== "string") return false;
+  const h = handle.trim().toLowerCase();
+  return QA_HANDLES.has(h) || h.includes("qa");
+}
+
+/**
+ * Drop any recipient whose uid, handle, or email looks like QA / clouddev test.
+ *
+ * @param {string} uid
+ * @param {Record<string, unknown> | null | undefined} userData
+ * @returns {boolean}
+ */
+function isExcludedQaUser(uid, userData) {
+  if (isExcludedQaHandle(userData?.handle)) return true;
+  const email =
+    userData && typeof userData.email === "string" ? userData.email.trim().toLowerCase() : "";
+  const handle =
+    userData && typeof userData.handle === "string" ? userData.handle.trim().toLowerCase() : "";
+  const id = typeof uid === "string" ? uid.trim().toLowerCase() : "";
+  const haystack = `${id} ${handle} ${email}`;
+  return (
+    haystack.includes("qa") ||
+    haystack.includes("clouddev") ||
+    email.endsWith("@example.com") ||
+    email.endsWith("@setlistpickem-qa.test")
+  );
+}
+
+/**
+ * @param {Record<string, unknown> | null | undefined} userData
+ * @returns {{ totalPoints: number, shows: number, wins: number, correctSlots: number } | null}
+ */
+function seasonStatsFromUser(userData) {
+  const map = userData && typeof userData.seasonStats === "object" ? userData.seasonStats : null;
+  const raw = map && typeof map[TOUR_KEY] === "object" ? map[TOUR_KEY] : null;
+  if (!raw) return null;
+  const shows = Number(raw.shows);
+  if (!Number.isFinite(shows) || shows < 1) return null;
+  return {
+    totalPoints: Number.isFinite(Number(raw.totalPoints)) ? Number(raw.totalPoints) : 0,
+    shows,
+    wins: Number.isFinite(Number(raw.wins)) ? Number(raw.wins) : 0,
+    correctSlots: Number.isFinite(Number(raw.correctSlots)) ? Number(raw.correctSlots) : 0,
+  };
+}
+
+/**
+ * @param {number} correctSlots
+ * @param {number} shows
+ * @returns {number}
+ */
+function battingAvg(correctSlots, shows) {
+  const denom = shows * 6;
+  if (!Number.isFinite(denom) || denom <= 0) return 0;
+  return correctSlots / denom;
+}
+
+/**
+ * @param {number} n
+ * @returns {string}
+ */
+function formatBatting(n) {
+  if (!Number.isFinite(n)) return ".000";
+  const s = Math.max(0, Math.min(1, n)).toFixed(3);
+  return s.startsWith("0") ? s.slice(1) : s;
+}
+
+/**
+ * @param {number} n
+ * @returns {string}
+ */
+function formatAvgPoints(n) {
+  if (!Number.isFinite(n)) return "0";
+  return Number.isInteger(n) ? String(n) : n.toFixed(1);
+}
+
+/**
+ * @param {{ uid: string, handle: string, totalPoints: number, wins: number, shows: number, correctSlots: number }[]} players
+ * @returns {Map<string, { rank: number, row: (typeof players)[0] }>}
+ */
+function assignCompetitionRanks(players) {
+  const sorted = [...players].sort((a, b) => {
+    if (b.totalPoints !== a.totalPoints) return b.totalPoints - a.totalPoints;
+    if (b.wins !== a.wins) return b.wins - a.wins;
+    return a.handle.localeCompare(b.handle);
+  });
+  /** @type {Map<string, { rank: number, row: (typeof players)[0] }>} */
+  const out = new Map();
+  let rank = 0;
+  let prevPoints = null;
+  for (let i = 0; i < sorted.length; i++) {
+    const row = sorted[i];
+    if (prevPoints === null || row.totalPoints < prevPoints) {
+      rank = i + 1;
+      prevPoints = row.totalPoints;
+    }
+    out.set(row.uid, { rank, row });
+  }
+  return out;
+}
+
+/**
+ * @param {{ shows: number, correctSlots: number }[]} players
+ * @returns {number}
+ */
+function meanFieldPickingAvg(players) {
+  if (!players.length) return 0;
+  let sum = 0;
+  for (const p of players) {
+    sum += battingAvg(p.correctSlots, p.shows);
+  }
+  return sum / players.length;
+}
+
+/**
+ * @param {number | null | undefined} rank
+ * @param {number} showsPlayed
+ * @returns {'rank1' | 'rank2to5' | 'rank6plusFull' | 'rank6plusSpot' | 'noPlay'}
+ */
+function resolveBranch(rank, showsPlayed) {
+  if (rank == null || !Number.isFinite(rank) || showsPlayed < 1) return "noPlay";
+  if (rank === 1) return "rank1";
+  if (rank >= 2 && rank <= 5) return "rank2to5";
+  if (showsPlayed >= 12) return "rank6plusFull";
+  return "rank6plusSpot";
+}
+
+/**
+ * @param {{
+ *   branch: string,
+ *   rank?: number | null,
+ *   points?: number,
+ *   wins?: number,
+ *   showsPlayed?: number,
+ *   avgPoints?: number,
+ *   battingAvg?: number,
+ *   participantCount?: number,
+ *   fieldPickingAvg?: number,
+ * }} p
+ * @returns {string}
+ */
+function buildPersonalTape(p) {
+  const points = p.points ?? 0;
+  const wins = p.wins ?? 0;
+  const shows = p.showsPlayed ?? 0;
+  const avg = formatAvgPoints(p.avgPoints ?? 0);
+  const bat = formatBatting(p.battingAvg ?? 0);
+  const rank = p.rank;
+  const n = p.participantCount ?? 0;
+  const field = formatBatting(p.fieldPickingAvg ?? 0);
+
+  switch (p.branch) {
+    case "rank1":
+      return `You're sitting #1 overall with ${points} points, ${wins} nightly wins, and ${avg} points per show across ${shows} nights. Own the break — Dick's is where titles get defended.`;
+    case "rank2to5":
+      return `You're in the Top 5 at #${rank} — ${points} points, ${wins} wins, ${avg} pts/show, picking avg ${bat} over ${shows} shows. One hot Dick's run (or a rival cold streak) and this whole picture redraws.`;
+    case "rank6plusFull":
+      return `You're #${rank} of ${n} with ${points} points across ${shows} shows (${avg} pts/show, batting ${bat}). Full-tour grinders get paid at Dick's — keep the card sharp.`;
+    case "rank6plusSpot":
+      return `You're #${rank} with ${points} points over ${shows} shows (${avg} pts/show). Spot duty still counts — lock all three Dick's nights and watch the climb.`;
+    case "noPlay":
+    default:
+      return `You've been in the mix — just not on the board yet this tour. Three nights at Dick's is a clean slate: lock picks for opener, closer, encore, and a wildcard, and you'll have a tape of your own when the final wrap hits. The field picking average through Fenway is only ${field} — this game is very beatable.`;
+  }
+}
+
+module.exports = {
+  TOUR_KEY,
+  QA_HANDLES,
+  INBOX_DOC_ID,
+  TEMPLATE_ID,
+  TRIGGER_ID,
+  CAMPAIGN_ID,
+  SITE_URL,
+  DEFAULT_SUBJECT,
+  DEFAULT_PREHEADER,
+  isExcludedQaHandle,
+  isExcludedQaUser,
+  seasonStatsFromUser,
+  battingAvg,
+  formatBatting,
+  formatAvgPoints,
+  assignCompetitionRanks,
+  meanFieldPickingAvg,
+  resolveBranch,
+  buildPersonalTape,
+};

--- a/functions/marketingAlmostEndCore.test.js
+++ b/functions/marketingAlmostEndCore.test.js
@@ -1,0 +1,107 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  isExcludedQaHandle,
+  isExcludedQaUser,
+  seasonStatsFromUser,
+  battingAvg,
+  formatBatting,
+  assignCompetitionRanks,
+  meanFieldPickingAvg,
+  resolveBranch,
+  buildPersonalTape,
+  TOUR_KEY,
+} = require("./marketingAlmostEndCore");
+
+test("isExcludedQaHandle matches QA handles case-insensitively", () => {
+  assert.equal(isExcludedQaHandle("QATester"), true);
+  assert.equal(isExcludedQaHandle("mrpickphive"), true);
+  assert.equal(isExcludedQaHandle("qamrwewy2t"), true);
+  assert.equal(isExcludedQaHandle("Rivertranced"), false);
+});
+
+test("isExcludedQaUser matches qa / clouddev / test domains", () => {
+  assert.equal(isExcludedQaUser("qa-e2e-test-uid", { handle: "friend" }), true);
+  assert.equal(
+    isExcludedQaUser("abc", { handle: "clouddevtester1", email: "x@y.com" }),
+    true
+  );
+  assert.equal(
+    isExcludedQaUser("abc", { handle: "Dummy", email: "qa.wave0@example.com" }),
+    true
+  );
+  assert.equal(
+    isExcludedQaUser("abc", { handle: "Rivertranced", email: "hi@gmail.com" }),
+    false
+  );
+});
+
+test("seasonStatsFromUser requires shows ≥ 1", () => {
+  assert.equal(seasonStatsFromUser({}), null);
+  assert.equal(
+    seasonStatsFromUser({ seasonStats: { [TOUR_KEY]: { shows: 0, totalPoints: 10 } } }),
+    null
+  );
+  const stats = seasonStatsFromUser({
+    seasonStats: { [TOUR_KEY]: { shows: 18, totalPoints: 385, wins: 5, correctSlots: 32 } },
+  });
+  assert.equal(stats.shows, 18);
+  assert.equal(stats.totalPoints, 385);
+  assert.equal(stats.correctSlots, 32);
+});
+
+test("battingAvg and formatBatting", () => {
+  assert.ok(Math.abs(battingAvg(32, 18) - 32 / 108) < 1e-9);
+  assert.equal(formatBatting(0.231), ".231");
+  assert.equal(formatBatting(1), "1.000");
+});
+
+test("assignCompetitionRanks ties share rank on equal points", () => {
+  const ranks = assignCompetitionRanks([
+    { uid: "a", handle: "A", totalPoints: 100, wins: 1, shows: 10, correctSlots: 10 },
+    { uid: "b", handle: "B", totalPoints: 100, wins: 0, shows: 10, correctSlots: 10 },
+    { uid: "c", handle: "C", totalPoints: 50, wins: 0, shows: 10, correctSlots: 5 },
+  ]);
+  assert.equal(ranks.get("a").rank, 1);
+  assert.equal(ranks.get("b").rank, 1); // competition rank ties on points
+  assert.equal(ranks.get("c").rank, 3);
+});
+
+test("meanFieldPickingAvg averages per-player batting", () => {
+  const mean = meanFieldPickingAvg([
+    { shows: 10, correctSlots: 12 }, // 0.2
+    { shows: 10, correctSlots: 24 }, // 0.4
+  ]);
+  assert.ok(Math.abs(mean - 0.3) < 1e-9);
+});
+
+test("resolveBranch covers rank and noPlay", () => {
+  assert.equal(resolveBranch(1, 18), "rank1");
+  assert.equal(resolveBranch(3, 18), "rank2to5");
+  assert.equal(resolveBranch(6, 17), "rank6plusFull");
+  assert.equal(resolveBranch(10, 5), "rank6plusSpot");
+  assert.equal(resolveBranch(null, 0), "noPlay");
+});
+
+test("buildPersonalTape includes key stats per branch", () => {
+  assert.match(
+    buildPersonalTape({
+      branch: "rank1",
+      points: 385,
+      wins: 5,
+      showsPlayed: 18,
+      avgPoints: 21.4,
+    }),
+    /#1 overall/
+  );
+  assert.match(
+    buildPersonalTape({
+      branch: "noPlay",
+      fieldPickingAvg: 0.231,
+    }),
+    /\.231/
+  );
+});

--- a/functions/marketingAlmostEndDelivery.js
+++ b/functions/marketingAlmostEndDelivery.js
@@ -1,0 +1,427 @@
+/**
+ * Summer 2026 almost-end marketing batch.
+ *
+ * 1) Forced inApp fanout → all users (no prefs)
+ * 2) Email → Summer Tour players via deliverCommsTrigger (lifecycle prefs)
+ */
+
+"use strict";
+
+const { deliverCommsTrigger, buildDefaultWorkers } = require("./commsDelivery");
+const { createCommsEmailWorker, buildResendClient } = require("./commsEmailWorker");
+const {
+  resolveSummer2026AlmostEndEmailAudience,
+  resolveSummer2026AlmostEndInboxAudience,
+} = require("./marketingAudience");
+const {
+  inviteContextForUser,
+  buildInviteEmailFields,
+} = require("./comms/inviteContext.cjs");
+const {
+  TRIGGER_ID,
+  CAMPAIGN_ID,
+  TEMPLATE_ID,
+  INBOX_DOC_ID,
+  SITE_URL,
+  DEFAULT_SUBJECT,
+  DEFAULT_PREHEADER,
+  seasonStatsFromUser,
+  battingAvg,
+  formatBatting,
+  formatAvgPoints,
+  assignCompetitionRanks,
+  meanFieldPickingAvg,
+  resolveBranch,
+  buildPersonalTape,
+} = require("./marketingAlmostEndCore");
+
+const MAX_FIRESTORE_BATCH = 500;
+
+/**
+ * @param {Record<string, unknown> | undefined} userData
+ * @returns {string}
+ */
+function handleFromUser(userData) {
+  const h = userData && typeof userData.handle === "string" ? userData.handle.trim() : "";
+  return h || "friend";
+}
+
+/**
+ * @param {import("firebase-admin").firestore.Firestore} db
+ * @param {Set<string> | null} onlyUidSet
+ * @returns {Promise<{
+ *   players: Array<{ uid: string, handle: string, totalPoints: number, wins: number, shows: number, correctSlots: number, userData: Record<string, unknown> }>,
+ *   ranks: Map<string, { rank: number, row: object }>,
+ *   top5: Array<{ rank: number, handle: string, points: number, wins: number, nights: number, battingAvg: string }>,
+ *   fieldPickingAvg: number,
+ *   participantCount: number,
+ * }>}
+ */
+async function loadPlayerBoard(db, onlyUidSet) {
+  const emailAudience = await resolveSummer2026AlmostEndEmailAudience(db);
+  /** @type {typeof emailAudience} */
+  let filtered = emailAudience;
+  if (onlyUidSet) {
+    // Still need full board for ranks/Top5; onlyUidSet filters delivery later.
+    filtered = emailAudience;
+  }
+
+  /** @type {Array<{ uid: string, handle: string, totalPoints: number, wins: number, shows: number, correctSlots: number, userData: Record<string, unknown> }>} */
+  const players = [];
+  for (const member of filtered) {
+    // eslint-disable-next-line no-await-in-loop
+    const snap = await db.collection("users").doc(member.uid).get();
+    const userData = snap.exists ? snap.data() || {} : {};
+    const stats = seasonStatsFromUser(userData);
+    if (!stats) continue;
+    players.push({
+      uid: member.uid,
+      handle: handleFromUser(userData),
+      totalPoints: stats.totalPoints,
+      wins: stats.wins,
+      shows: stats.shows,
+      correctSlots: stats.correctSlots,
+      userData,
+    });
+  }
+
+  const ranks = assignCompetitionRanks(players);
+  const fieldPickingAvg = meanFieldPickingAvg(players);
+  const participantCount = players.length;
+
+  const top5 = [...ranks.values()]
+    .sort((a, b) => a.rank - b.rank)
+    .slice(0, 5)
+    .map(({ rank, row }) => ({
+      rank,
+      handle: row.handle,
+      points: row.totalPoints,
+      wins: row.wins,
+      nights: row.shows,
+      battingAvg: formatBatting(battingAvg(row.correctSlots, row.shows)),
+    }));
+
+  return { players, ranks, top5, fieldPickingAvg, participantCount };
+}
+
+/**
+ * @param {{
+ *   uid: string,
+ *   userData: Record<string, unknown>,
+ *   ranks: Map<string, { rank: number, row: object }>,
+ *   top5: object[],
+ *   fieldPickingAvg: number,
+ *   participantCount: number,
+ *   inviteCode: string | null,
+ *   poolName: string | null,
+ * }} args
+ */
+function buildAlmostEndPayload({
+  uid,
+  userData,
+  ranks,
+  top5,
+  fieldPickingAvg,
+  participantCount,
+  inviteCode,
+  poolName,
+}) {
+  const base = SITE_URL.replace(/\/+$/, "");
+  const greetingName = handleFromUser(userData);
+  const inviterHandle =
+    typeof userData.handle === "string" ? userData.handle.trim() : "";
+  const ranked = ranks.get(uid);
+  const showsPlayed = ranked ? ranked.row.shows : 0;
+  const points = ranked ? ranked.row.totalPoints : 0;
+  const wins = ranked ? ranked.row.wins : 0;
+  const correctSlots = ranked ? ranked.row.correctSlots : 0;
+  const rank = ranked ? ranked.rank : null;
+  const branch = resolveBranch(rank, showsPlayed);
+  const avgPoints = showsPlayed > 0 ? points / showsPlayed : 0;
+  const bat = battingAvg(correctSlots, showsPlayed);
+  const personalTape = buildPersonalTape({
+    branch,
+    rank,
+    points,
+    wins,
+    showsPlayed,
+    avgPoints,
+    battingAvg: bat,
+    participantCount,
+    fieldPickingAvg,
+  });
+
+  const inviteFields =
+    branch !== "noPlay"
+      ? buildInviteEmailFields({
+          baseUrl: base,
+          inviterHandle,
+          inviteCode,
+          poolName,
+          campaign: CAMPAIGN_ID,
+          utmContent: "invite_friend",
+        }) || {}
+      : {};
+
+  const standingsUrl = `${base}/dashboard/standings?utm_source=email&utm_campaign=${CAMPAIGN_ID}&utm_content=${
+    branch === "noPlay" ? "standings" : "invite_friend"
+  }`;
+
+  return {
+    greetingName,
+    handle: greetingName,
+    branch,
+    rank,
+    points,
+    wins,
+    showsPlayed,
+    avgPoints: formatAvgPoints(avgPoints),
+    battingAvg: formatBatting(bat),
+    participantCount,
+    fieldPickingAvg: formatBatting(fieldPickingAvg),
+    fieldPlayerCount: participantCount,
+    top5,
+    personalTape,
+    showInvite: branch !== "noPlay",
+    subject: DEFAULT_SUBJECT,
+    preheader: DEFAULT_PREHEADER,
+    siteUrl: base,
+    settingsUrl: `${base}/dashboard/profile/notifications`,
+    standingsUrl,
+    shareUrl: inviteFields.invite_url || standingsUrl,
+    inviterHandle,
+    ...(inviteCode ? { inviteCode } : {}),
+    ...(poolName ? { poolName } : {}),
+    ...inviteFields,
+  };
+}
+
+/**
+ * @param {{
+ *   db: import("firebase-admin").firestore.Firestore,
+ *   admin: typeof import("firebase-admin"),
+ *   items: Array<{ uid: string, payload: Record<string, unknown> }>,
+ *   dryRun: boolean,
+ *   logger?: { info?: Function, warn?: Function },
+ * }} args
+ */
+async function writeInboxFanout({ db, admin, items, dryRun, logger }) {
+  if (dryRun) {
+    return { delivered: 0, wouldDeliver: items.length };
+  }
+  let batch = db.batch();
+  let opCount = 0;
+  let delivered = 0;
+  for (const item of items) {
+    if (opCount >= MAX_FIRESTORE_BATCH) {
+      // eslint-disable-next-line no-await-in-loop
+      await batch.commit();
+      batch = db.batch();
+      opCount = 0;
+    }
+    const ref = db
+      .collection("users")
+      .doc(item.uid)
+      .collection("commsInbox")
+      .doc(INBOX_DOC_ID);
+    batch.set(
+      ref,
+      {
+        templateId: TEMPLATE_ID,
+        payload: item.payload,
+        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+    opCount += 1;
+    delivered += 1;
+  }
+  if (opCount > 0) {
+    await batch.commit();
+  }
+  logger?.info?.("summer2026AlmostEnd: inbox fanout", { delivered });
+  return { delivered, wouldDeliver: 0 };
+}
+
+/**
+ * @param {{
+ *   db: import("firebase-admin").firestore.Firestore,
+ *   admin: typeof import("firebase-admin"),
+ *   dryRun?: boolean,
+ *   forceResend?: boolean,
+ *   onlyUids?: string[],
+ *   resendApiKey?: string,
+ *   resendWebhookSecret?: string,
+ *   logger?: { info?: Function, warn?: Function },
+ * }} params
+ */
+async function deliverMarketingSummer2026AlmostEnd({
+  db,
+  admin,
+  dryRun = true,
+  forceResend = false,
+  onlyUids,
+  resendApiKey,
+  resendWebhookSecret,
+  logger,
+}) {
+  const onlyUidSet =
+    Array.isArray(onlyUids) && onlyUids.length > 0
+      ? new Set(onlyUids.map((u) => String(u).trim()).filter(Boolean))
+      : null;
+
+  const board = await loadPlayerBoard(db, onlyUidSet);
+  let inboxAudience = await resolveSummer2026AlmostEndInboxAudience(db);
+  if (onlyUidSet) {
+    inboxAudience = inboxAudience.filter((m) => onlyUidSet.has(m.uid));
+  }
+
+  /** @type {Array<{ uid: string, branch: string, handle: string, email: string | null, channel: string }>} */
+  const preview = [];
+  /** @type {Array<{ uid: string, payload: Record<string, unknown> }>} */
+  const inboxItems = [];
+  /** @type {Array<{ uid: string, userData: object, payload: object, vars: object }>} */
+  const emailRecipients = [];
+
+  const playerByUid = new Map(board.players.map((p) => [p.uid, p]));
+
+  for (const member of inboxAudience) {
+    // eslint-disable-next-line no-await-in-loop
+    const snap = await db.collection("users").doc(member.uid).get();
+    const userData = snap.exists ? snap.data() || {} : {};
+    const player = playerByUid.get(member.uid);
+    const data = player ? player.userData : userData;
+    // eslint-disable-next-line no-await-in-loop
+    const { inviteCode, poolName } = await inviteContextForUser(db, data);
+    const payload = buildAlmostEndPayload({
+      uid: member.uid,
+      userData: data,
+      ranks: board.ranks,
+      top5: board.top5,
+      fieldPickingAvg: board.fieldPickingAvg,
+      participantCount: board.participantCount,
+      inviteCode,
+      poolName,
+    });
+
+    inboxItems.push({ uid: member.uid, payload });
+    preview.push({
+      uid: member.uid,
+      branch: payload.branch,
+      handle: payload.greetingName,
+      email:
+        typeof data.email === "string" && data.email.includes("@")
+          ? data.email.trim()
+          : null,
+      channel: "inApp",
+    });
+  }
+
+  for (const player of board.players) {
+    if (onlyUidSet && !onlyUidSet.has(player.uid)) continue;
+    const email =
+      typeof player.userData.email === "string" && player.userData.email.includes("@")
+        ? player.userData.email.trim()
+        : null;
+    // eslint-disable-next-line no-await-in-loop
+    const { inviteCode, poolName } = await inviteContextForUser(db, player.userData);
+    const payload = buildAlmostEndPayload({
+      uid: player.uid,
+      userData: player.userData,
+      ranks: board.ranks,
+      top5: board.top5,
+      fieldPickingAvg: board.fieldPickingAvg,
+      participantCount: board.participantCount,
+      inviteCode,
+      poolName,
+    });
+    preview.push({
+      uid: player.uid,
+      branch: payload.branch,
+      handle: payload.greetingName,
+      email,
+      channel: "email",
+    });
+    if (!email) continue;
+    emailRecipients.push({
+      uid: player.uid,
+      userData: player.userData,
+      payload,
+      vars: { uid: player.uid, campaignId: CAMPAIGN_ID },
+    });
+  }
+
+  if (dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      triggerId: TRIGGER_ID,
+      campaignId: CAMPAIGN_ID,
+      templateId: TEMPLATE_ID,
+      inboxCohortSize: inboxAudience.length,
+      emailCohortSize: board.players.filter((p) => !onlyUidSet || onlyUidSet.has(p.uid))
+        .length,
+      emailSendable: emailRecipients.length,
+      top5: board.top5,
+      fieldPickingAvg: formatBatting(board.fieldPickingAvg),
+      onlyUids: onlyUidSet ? [...onlyUidSet] : undefined,
+      preview,
+    };
+  }
+
+  const inboxResult = await writeInboxFanout({
+    db,
+    admin,
+    items: inboxItems,
+    dryRun: false,
+    logger,
+  });
+
+  const emailWorker = createCommsEmailWorker({
+    resendClient: buildResendClient(resendApiKey, logger),
+    db,
+    admin,
+    unsubscribeSigningSecret: resendWebhookSecret,
+    logger,
+  });
+
+  const delivery =
+    emailRecipients.length > 0
+      ? await deliverCommsTrigger({
+          db,
+          admin,
+          triggerId: TRIGGER_ID,
+          recipients: emailRecipients,
+          workers: buildDefaultWorkers({ emailWorker }),
+          dryRun: false,
+          forceResend,
+          bypassDailyCap: true,
+          channels: ["email"],
+          logger,
+        })
+      : { ok: true, delivered: 0, processed: 0, message: "no_email_recipients" };
+
+  return {
+    ok: delivery.ok !== false,
+    dryRun: false,
+    triggerId: TRIGGER_ID,
+    campaignId: CAMPAIGN_ID,
+    templateId: TEMPLATE_ID,
+    inboxDelivered: inboxResult.delivered,
+    emailCohortSize: emailRecipients.length,
+    top5: board.top5,
+    fieldPickingAvg: formatBatting(board.fieldPickingAvg),
+    preview,
+    delivery,
+  };
+}
+
+module.exports = {
+  TRIGGER_ID,
+  CAMPAIGN_ID,
+  TEMPLATE_ID,
+  INBOX_DOC_ID,
+  deliverMarketingSummer2026AlmostEnd,
+  buildAlmostEndPayload,
+  loadPlayerBoard,
+};

--- a/functions/marketingAudience.js
+++ b/functions/marketingAudience.js
@@ -119,8 +119,52 @@ async function resolveSummerTour2026LaunchAudience(db) {
   return [...byUid.entries()].map(([uid, segment]) => ({ uid, segment }));
 }
 
+const {
+  isExcludedQaUser,
+  seasonStatsFromUser,
+} = require("./marketingAlmostEndCore");
+
+/**
+ * Summer 2026 almost-end — email cohort: players with ≥1 Summer Tour show.
+ *
+ * @param {import("firebase-admin").firestore.Firestore} db
+ * @returns {Promise<Array<{ uid: string }>>}
+ */
+async function resolveSummer2026AlmostEndEmailAudience(db) {
+  const usersSnap = await db.collection("users").get();
+  /** @type {Array<{ uid: string }>} */
+  const out = [];
+  for (const doc of usersSnap.docs) {
+    const data = doc.data() || {};
+    if (isExcludedQaUser(doc.id, data)) continue;
+    if (!seasonStatsFromUser(data)) continue;
+    out.push({ uid: doc.id });
+  }
+  return out;
+}
+
+/**
+ * Summer 2026 almost-end — inbox cohort: all users (QA excluded). No play filter.
+ *
+ * @param {import("firebase-admin").firestore.Firestore} db
+ * @returns {Promise<Array<{ uid: string }>>}
+ */
+async function resolveSummer2026AlmostEndInboxAudience(db) {
+  const usersSnap = await db.collection("users").get();
+  /** @type {Array<{ uid: string }>} */
+  const out = [];
+  for (const doc of usersSnap.docs) {
+    const data = doc.data() || {};
+    if (isExcludedQaUser(doc.id, data)) continue;
+    out.push({ uid: doc.id });
+  }
+  return out;
+}
+
 module.exports = {
   SPHERE_2026_INAUGURAL_SHOW_DATES,
   SPHERE_GO_LIVE_ISO,
   resolveSummerTour2026LaunchAudience,
+  resolveSummer2026AlmostEndEmailAudience,
+  resolveSummer2026AlmostEndInboxAudience,
 };

--- a/functions/marketingBatchDelivery.js
+++ b/functions/marketingBatchDelivery.js
@@ -210,10 +210,19 @@ async function deliverMarketingSummerTour2026Launch({
   };
 }
 
+const {
+  deliverMarketingSummer2026AlmostEnd,
+  TRIGGER_ID: ALMOST_END_TRIGGER_ID,
+  CAMPAIGN_ID: ALMOST_END_CAMPAIGN_ID,
+} = require("./marketingAlmostEndDelivery");
+
 module.exports = {
   TRIGGER_ID,
   CAMPAIGN_ID,
   deliverMarketingSummerTour2026Launch,
   buildEmailPayload,
   buildSummerTour2026LaunchChannels,
+  deliverMarketingSummer2026AlmostEnd,
+  ALMOST_END_TRIGGER_ID,
+  ALMOST_END_CAMPAIGN_ID,
 };

--- a/functions/marketingCommsTemplates.js
+++ b/functions/marketingCommsTemplates.js
@@ -1,10 +1,15 @@
 /**
- * Marketing email template renderers (#468).
+ * Marketing email template renderers (#468 launch + almost-end).
  *
- * Long-form React Email HTML is pre-built in `emails/renderSummerTour2026Launch.cjs`.
+ * Long-form React Email HTML is pre-built under `functions/emails/*.cjs`.
  */
 
 "use strict";
+
+const {
+  DEFAULT_SUBJECT: ALMOST_END_SUBJECT,
+  TEMPLATE_ID: ALMOST_END_TEMPLATE_ID,
+} = require("./marketingAlmostEndCore");
 
 const DEFAULT_SUBJECT = "Summer Tour's almost here — bring your crew →";
 
@@ -15,6 +20,11 @@ const DEFAULT_SUBJECT = "Summer Tour's almost here — bring your crew →";
 function loadRenderSummerTour2026LaunchEmail() {
   // eslint-disable-next-line global-require
   return require("./emails/renderSummerTour2026Launch.cjs").renderSummerTour2026LaunchEmail;
+}
+
+function loadRenderSummer2026AlmostEndEmail() {
+  // eslint-disable-next-line global-require
+  return require("./emails/renderSummer2026AlmostEnd.cjs").renderSummer2026AlmostEndEmail;
 }
 
 /**
@@ -49,7 +59,55 @@ async function buildSummerTour2026LaunchChannels(payload = {}) {
   };
 }
 
+/**
+ * @param {Record<string, unknown>} payload
+ * @returns {Promise<{
+ *   inApp: { templateId: string, payload: Record<string, unknown> },
+ *   push: { title: string, body: string },
+ *   email: { subject: string, text: string, html: string, ctaUrl?: string }
+ * }>}
+ */
+async function buildSummer2026AlmostEndChannels(payload = {}) {
+  const renderSummer2026AlmostEndEmail = loadRenderSummer2026AlmostEndEmail();
+  const withNonce = {
+    ...payload,
+    messageNonce:
+      typeof payload.messageNonce === "string" && payload.messageNonce.trim()
+        ? payload.messageNonce.trim()
+        : `ae${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`,
+  };
+  const { html, text } = await renderSummer2026AlmostEndEmail(withNonce);
+  const subject =
+    typeof withNonce.subject === "string" && withNonce.subject.trim()
+      ? withNonce.subject.trim()
+      : ALMOST_END_SUBJECT;
+  const ctaUrl =
+    typeof withNonce.standingsUrl === "string" && withNonce.standingsUrl.trim()
+      ? withNonce.standingsUrl.trim()
+      : typeof withNonce.shareUrl === "string" && withNonce.shareUrl.trim()
+        ? withNonce.shareUrl.trim()
+        : undefined;
+
+  return {
+    inApp: {
+      templateId: ALMOST_END_TEMPLATE_ID,
+      payload: withNonce,
+    },
+    push: {
+      title: "Almost tour end",
+      body: "Fenway wrapped · Dick's still ahead — your tape is inside.",
+    },
+    email: {
+      subject,
+      text,
+      html,
+      ...(ctaUrl ? { ctaUrl } : {}),
+    },
+  };
+}
+
 module.exports = {
   buildSummerTour2026LaunchChannels,
+  buildSummer2026AlmostEndChannels,
   DEFAULT_SUBJECT,
 };

--- a/functions/marketingCommsTemplates.test.js
+++ b/functions/marketingCommsTemplates.test.js
@@ -40,3 +40,36 @@ test("post_sphere_signup segment uses welcome copy in html", async () => {
   assert.match(out.email.html, /Welcome/i);
   assert.doesNotMatch(out.email.html, /Sphere weekend 1/i);
 });
+
+const { buildSummer2026AlmostEndChannels } = require("./marketingCommsTemplates");
+
+test("buildSummer2026AlmostEndChannels returns html, subject, and inApp", async () => {
+  const out = await buildSummer2026AlmostEndChannels({
+    greetingName: "YarmouthMeg",
+    personalTape: "You're #6 of 28 with 230 points across 17 shows.",
+    showInvite: true,
+    fieldPickingAvg: ".231",
+    fieldPlayerCount: 28,
+    top5: [
+      {
+        rank: 1,
+        handle: "I have the book",
+        points: 385,
+        wins: 5,
+        nights: 18,
+        battingAvg: ".296",
+      },
+    ],
+    standingsUrl: "https://www.setlistpickem.com/dashboard/standings",
+    siteUrl: "https://www.setlistpickem.com",
+  });
+
+  assert.match(out.email.subject, /almost Tour End Recap/i);
+  assert.match(out.email.html, /YarmouthMeg/);
+  assert.match(out.email.html, /Melt the Guns/);
+  assert.match(out.email.html, /Bustout Boost/);
+  assert.match(out.email.html, /I have the book/);
+  assert.match(out.email.html, /Invite a friend from Standings/);
+  assert.equal(out.inApp.templateId, "summer-2026-almost-end");
+  assert.ok(out.email.html.includes("<!DOCTYPE html") || out.email.html.includes("<html"));
+});

--- a/functions/marketingRunLock.js
+++ b/functions/marketingRunLock.js
@@ -1,0 +1,84 @@
+/**
+ * Firestore run-lock for one-shot marketing batch schedules.
+ */
+
+"use strict";
+
+const RUN_COLLECTION = "comms_marketing_runs";
+
+/**
+ * Atomically claim a pending (or missing) run. Returns false if cancelled/completed/already running.
+ *
+ * @param {import("firebase-admin").firestore.Firestore} db
+ * @param {typeof import("firebase-admin")} admin
+ * @param {string} runId
+ * @param {{ targetDate?: string }} [opts]
+ * @returns {Promise<{ claimed: boolean, reason?: string, status?: string }>}
+ */
+async function claimMarketingRun(db, admin, runId, opts = {}) {
+  const ref = db.collection(RUN_COLLECTION).doc(runId);
+  return db.runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+
+    if (!snap.exists) {
+      tx.set(ref, {
+        status: "running",
+        ...(opts.targetDate ? { targetDate: opts.targetDate } : {}),
+        claimedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+      return { claimed: true, status: "running" };
+    }
+
+    const data = snap.data() || {};
+    const status = typeof data.status === "string" ? data.status : "pending";
+
+    if (opts.targetDate && data.targetDate && data.targetDate !== opts.targetDate) {
+      return { claimed: false, reason: "target_date_mismatch", status };
+    }
+
+    if (status === "completed" || status === "cancelled") {
+      return { claimed: false, reason: status, status };
+    }
+    if (status === "running") {
+      return { claimed: false, reason: "already_running", status };
+    }
+
+    tx.set(
+      ref,
+      {
+        status: "running",
+        ...(opts.targetDate ? { targetDate: opts.targetDate } : {}),
+        claimedAt: admin.firestore.FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+    return { claimed: true, status: "running" };
+  });
+}
+
+/**
+ * @param {import("firebase-admin").firestore.Firestore} db
+ * @param {typeof import("firebase-admin")} admin
+ * @param {string} runId
+ * @param {'completed' | 'failed' | 'cancelled'} status
+ * @param {Record<string, unknown>} [extra]
+ */
+async function finishMarketingRun(db, admin, runId, status, extra = {}) {
+  await db
+    .collection(RUN_COLLECTION)
+    .doc(runId)
+    .set(
+      {
+        status,
+        finishedAt: admin.firestore.FieldValue.serverTimestamp(),
+        ...extra,
+      },
+      { merge: true }
+    );
+}
+
+module.exports = {
+  RUN_COLLECTION,
+  claimMarketingRun,
+  finishMarketingRun,
+};

--- a/functions/marketingRunLock.test.js
+++ b/functions/marketingRunLock.test.js
@@ -1,0 +1,100 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { claimMarketingRun, finishMarketingRun } = require("./marketingRunLock");
+
+function makeFakeDb() {
+  /** @type {Map<string, Record<string, unknown>>} */
+  const docs = new Map();
+  const admin = {
+    firestore: {
+      FieldValue: {
+        serverTimestamp: () => ({ _ts: true }),
+      },
+    },
+  };
+
+  const db = {
+    collection: (name) => ({
+      doc: (id) => {
+        const key = `${name}/${id}`;
+        return {
+          id,
+          async get() {
+            const data = docs.get(key);
+            return {
+              exists: Boolean(data),
+              data: () => (data ? { ...data } : undefined),
+            };
+          },
+          async set(data, opts) {
+            const prev = docs.get(key) || {};
+            docs.set(key, opts?.merge ? { ...prev, ...data } : { ...data });
+          },
+        };
+      },
+    }),
+    async runTransaction(fn) {
+      const tx = {
+        async get(ref) {
+          return ref.get();
+        },
+        set(ref, data, opts) {
+          return ref.set(data, opts);
+        },
+      };
+      return fn(tx);
+    },
+    _docs: docs,
+  };
+
+  return { db, admin };
+}
+
+test("claimMarketingRun creates running when missing", async () => {
+  const { db, admin } = makeFakeDb();
+  const claim = await claimMarketingRun(db, admin, "summer_2026_almost_end", {
+    targetDate: "2026-08-03",
+  });
+  assert.equal(claim.claimed, true);
+  assert.equal(
+    db._docs.get("comms_marketing_runs/summer_2026_almost_end").status,
+    "running"
+  );
+});
+
+test("claimMarketingRun skips completed status", async () => {
+  const { db, admin } = makeFakeDb();
+  await db.collection("comms_marketing_runs").doc("summer_2026_almost_end").set({
+    status: "completed",
+    targetDate: "2026-08-03",
+  });
+  const claim = await claimMarketingRun(db, admin, "summer_2026_almost_end", {
+    targetDate: "2026-08-03",
+  });
+  assert.equal(claim.claimed, false);
+  assert.equal(claim.reason, "completed");
+});
+
+test("claimMarketingRun skips cancelled", async () => {
+  const { db, admin } = makeFakeDb();
+  await db.collection("comms_marketing_runs").doc("summer_2026_almost_end").set({
+    status: "cancelled",
+  });
+  const claim = await claimMarketingRun(db, admin, "summer_2026_almost_end");
+  assert.equal(claim.claimed, false);
+  assert.equal(claim.reason, "cancelled");
+});
+
+test("finishMarketingRun marks completed", async () => {
+  const { db, admin } = makeFakeDb();
+  await finishMarketingRun(db, admin, "summer_2026_almost_end", "completed", {
+    ok: true,
+  });
+  assert.equal(
+    db._docs.get("comms_marketing_runs/summer_2026_almost_end").status,
+    "completed"
+  );
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
-    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js accountDelete.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js showFinalizationGate.test.js revertRollupCore.test.js postShowRollupPush.test.js picksLockReminder.test.js fcmMessagingCore.test.js sphereTourRecapDelivery.test.js tourRankingsDailyCore.test.js badgeAwards.test.js commsCatalog.test.js commsTemplates.test.js commsEmailWorker.test.js commsEmailSuppression.test.js commsEmailDailyCap.test.js commsEmailUnsubscribe.test.js commsEmailPrefs.test.js commsResendWebhook.test.js commsDelivery.test.js commsGa4Measurement.test.js commsEventAdapters.test.js commsDeployManifest.test.js marketingCommsTemplates.test.js aggregateTourSetlistStats.test.js ../comms/emailLinks.test.cjs",
+    "test": "node --test phishnetShowCalendar.test.js phishnetSongCatalog.test.js phishnetLiveSetlistAutomation.test.js songCatalogSource.test.js adminAuth.test.js accountDelete.test.js poolDelete.test.js rollupSeasonAggregates.test.js scoringCore.test.js showFinalizationGate.test.js revertRollupCore.test.js postShowRollupPush.test.js picksLockReminder.test.js fcmMessagingCore.test.js sphereTourRecapDelivery.test.js tourRankingsDailyCore.test.js badgeAwards.test.js commsCatalog.test.js commsTemplates.test.js commsEmailWorker.test.js commsEmailSuppression.test.js commsEmailDailyCap.test.js commsEmailUnsubscribe.test.js commsEmailPrefs.test.js commsResendWebhook.test.js commsDelivery.test.js commsGa4Measurement.test.js commsEventAdapters.test.js commsDeployManifest.test.js marketingCommsTemplates.test.js marketingAlmostEndCore.test.js marketingRunLock.test.js aggregateTourSetlistStats.test.js ../comms/emailLinks.test.cjs",
     "serve": "firebase emulators:start --only functions",
     "shell": "firebase functions:shell",
     "start": "npm run shell",
@@ -21,6 +21,7 @@
     "rollup:reset-premature-grade": "node scripts/resetPrematureGrade.js",
     "comms:deliver-sphere-inbox": "node scripts/deliverSphere2026TourRecapInbox.js",
     "comms:deliver-summer-tour-launch": "node scripts/deliverMarketingSummerTour2026Launch.js",
+    "comms:deliver-summer-2026-almost-end": "node scripts/deliverMarketingSummer2026AlmostEnd.js",
     "release:gate": "node ../scripts/release-gate.mjs",
     "release:gate:full": "node ../scripts/release-gate.mjs --verify",
     "release:publish": "node ../scripts/release-publish.mjs",

--- a/functions/scripts/deliverMarketingSummer2026AlmostEnd.js
+++ b/functions/scripts/deliverMarketingSummer2026AlmostEnd.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * CLI: deliver Summer 2026 almost-end marketing (email players + inbox all users).
+ *
+ * Usage:
+ *   node scripts/deliverMarketingSummer2026AlmostEnd.js              # dry run (default)
+ *   node scripts/deliverMarketingSummer2026AlmostEnd.js --uid <uid>  # dry run one user (canary)
+ *   node scripts/deliverMarketingSummer2026AlmostEnd.js --execute --uid <uid>  # send canary
+ *   node scripts/deliverMarketingSummer2026AlmostEnd.js --execute    # send full cohort
+ *
+ * Requires Application Default Credentials with Firestore read access.
+ * Execute mode also needs RESEND_API_KEY (and RESEND_WEBHOOK_SECRET for signed unsubscribe links).
+ */
+
+const admin = require("firebase-admin");
+const {
+  deliverMarketingSummer2026AlmostEnd,
+} = require("../marketingAlmostEndDelivery");
+
+admin.initializeApp();
+const db = admin.firestore();
+
+const execute = process.argv.includes("--execute");
+const forceResend = process.argv.includes("--force-resend");
+
+/** @type {string[]} */
+const onlyUids = [];
+for (let i = 0; i < process.argv.length; i += 1) {
+  const arg = process.argv[i];
+  if (arg === "--uid" && process.argv[i + 1]) {
+    onlyUids.push(process.argv[i + 1]);
+    i += 1;
+  } else if (arg.startsWith("--uid=")) {
+    onlyUids.push(arg.slice("--uid=".length));
+  }
+}
+
+deliverMarketingSummer2026AlmostEnd({
+  db,
+  admin,
+  dryRun: !execute,
+  forceResend,
+  onlyUids: onlyUids.length > 0 ? onlyUids : undefined,
+  resendApiKey: process.env.RESEND_API_KEY,
+  resendWebhookSecret: process.env.RESEND_WEBHOOK_SECRET,
+  logger: console,
+})
+  .then((r) => {
+    console.log(JSON.stringify(r, null, 2));
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.42.4",
+  "version": "1.43.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/preview-summer-2026-almost-end.mjs
+++ b/scripts/preview-summer-2026-almost-end.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+/**
+ * One-off draft preview for Summer 2026 almost-end recap.
+ * Renders branded HTML from content/comms/tours/summer-2026-almost-end.md
+ * (personalized as rank-1 sample) and optionally sends via Resend.
+ *
+ * Usage:
+ *   node scripts/preview-summer-2026-almost-end.mjs
+ *   node scripts/preview-summer-2026-almost-end.mjs --send pat@road2media.com
+ */
+
+import { createRequire } from 'node:module';
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const require = createRequire(import.meta.url);
+
+const envPath = resolve(root, '.env');
+try {
+  for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+    const m = line.match(/^([^#=]+)=(.*)$/);
+    if (!m) continue;
+    const key = m[1].trim();
+    const value = m[2].trim().replace(/^"|"$/g, '');
+    if (!process.env[key] || (key === 'RESEND_API_KEY' && !String(process.env[key]).startsWith('re_'))) {
+      process.env[key] = value;
+    }
+  }
+} catch {
+  // optional
+}
+
+const args = process.argv.slice(2);
+const sendTo =
+  (args.includes('--send') ? args[args.indexOf('--send') + 1] : null) || null;
+
+const {
+  buildEmailWordmarkHeroHtml,
+  EMAIL_BRAND_PRIMARY,
+  EMAIL_BRAND_BG_DEEP,
+} = require(resolve(root, 'comms/emailBranding.cjs'));
+const { buildEmailTrackedCtaUrl } = require(resolve(root, 'comms/emailLinks.cjs'));
+
+const siteUrl = 'https://www.setlistpickem.com';
+const settingsUrl = `${siteUrl}/dashboard/profile/notifications`;
+const wordmarkHeroHtml = buildEmailWordmarkHeroHtml(siteUrl);
+const inviteCtaUrl = buildEmailTrackedCtaUrl(`${siteUrl}/dashboard/standings`, {
+  triggerId: 'marketing_summer_2026_almost_end',
+  templateId: 'summer-2026-almost-end',
+  cta: 'Invite a friend from Standings',
+});
+const standingsCtaUrl = buildEmailTrackedCtaUrl(`${siteUrl}/dashboard/standings`, {
+  triggerId: 'marketing_summer_2026_almost_end',
+  templateId: 'summer-2026-almost-end',
+  cta: 'Check it out on Standings',
+});
+
+const subjectBase =
+  "Between the Past and Future, Where We Drift in Time: An almost Tour End Recap";
+const preheader =
+  "18 shows in the books · Fenway wrapped · Dick's still ahead · your (almost) tour-end tape inside";
+/** Unique per send — Gmail threads identical subjects and trims “duplicate” body. */
+const previewStamp = new Date().toISOString().replace(/[:.]/g, '-');
+const messageNonce = `preview-${previewStamp}-${Math.random().toString(36).slice(2, 8)}`;
+
+/** Final preview: player branch (rank 6+ / ≥12) so invite ask is included */
+const previewHandle = 'YarmouthMeg';
+const personal =
+  "You're #6 of 28 with 230 points across 17 shows (13.5 pts/show, batting .235). Full-tour grinders get paid at Dick's — keep the card sharp.";
+const ctaButton = (href, label) =>
+  `<table role="presentation" cellspacing="0" cellpadding="0" style="margin:24px 0;">
+    <tr>
+      <td style="border-radius:12px;background:${EMAIL_BRAND_PRIMARY};">
+        <a href="${href}" style="display:inline-block;padding:16px 28px;font-size:18px;font-weight:700;color:${EMAIL_BRAND_BG_DEEP};text-decoration:none;">${label}</a>
+      </td>
+    </tr>
+  </table>`;
+
+// Body copy as <p> only — Gmail mobile often clips at <h2>/<h3> and redraws
+// the rest as a nested “card” with a … expander (wonky mid-email break).
+const p = (html) =>
+  `<p style="margin:0 0 18px;font-size:18px;line-height:1.55;color:#1a1a2e;">${html}</p>`;
+const sectionTitle = (text) =>
+  `<p style="margin:28px 0 12px;font-size:20px;font-weight:800;line-height:1.3;color:#1a1a2e;">${text}</p>`;
+const strong = (t) => `<strong>${t}</strong>`;
+
+const tableRows = [
+  ['1', 'I have the book', '385', '5', '18', '.296'],
+  ['2', 'TheManMulcahy', '320', '4', '18', '.278'],
+  ['3', 'ArmenianMan', '285', '2', '18', '.296'],
+  ['4', 'Rivertranced', '270', '1', '17', '.353'],
+  ['5', 'HotDog Billy', '250', '2', '18', '.269'],
+]
+  .map(
+    ([rank, handle, pts, wins, nights, avg]) => `
+      <tr>
+        <td style="padding:10px 6px;border-bottom:1px solid #eee;font-size:16px;color:#1a1a2e;">${rank}</td>
+        <td style="padding:10px 6px;border-bottom:1px solid #eee;font-size:16px;color:#1a1a2e;font-weight:700;">${handle}</td>
+        <td style="padding:10px 6px;border-bottom:1px solid #eee;font-size:16px;color:#1a1a2e;text-align:right;">${pts}</td>
+        <td style="padding:10px 6px;border-bottom:1px solid #eee;font-size:16px;color:#1a1a2e;text-align:right;">${wins}</td>
+        <td style="padding:10px 6px;border-bottom:1px solid #eee;font-size:16px;color:#1a1a2e;text-align:right;">${nights}</td>
+        <td style="padding:10px 6px;border-bottom:1px solid #eee;font-size:16px;color:#1a1a2e;text-align:right;">${avg}</td>
+      </tr>`
+  )
+  .join('');
+
+const leaderboardTable = `
+<table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="border-collapse:collapse;margin:12px 0 16px;">
+  <thead>
+    <tr>
+      <th align="left" style="padding:10px 6px;border-bottom:2px solid #1a1a2e;font-size:12px;text-transform:uppercase;letter-spacing:0.04em;color:#64748b;">Rank</th>
+      <th align="left" style="padding:10px 6px;border-bottom:2px solid #1a1a2e;font-size:12px;text-transform:uppercase;letter-spacing:0.04em;color:#64748b;">Handle</th>
+      <th align="right" style="padding:10px 6px;border-bottom:2px solid #1a1a2e;font-size:12px;text-transform:uppercase;letter-spacing:0.04em;color:#64748b;">Pts</th>
+      <th align="right" style="padding:10px 6px;border-bottom:2px solid #1a1a2e;font-size:12px;text-transform:uppercase;letter-spacing:0.04em;color:#64748b;">Wins</th>
+      <th align="right" style="padding:10px 6px;border-bottom:2px solid #1a1a2e;font-size:12px;text-transform:uppercase;letter-spacing:0.04em;color:#64748b;">Nights</th>
+      <th align="right" style="padding:10px 6px;border-bottom:2px solid #1a1a2e;font-size:12px;text-transform:uppercase;letter-spacing:0.04em;color:#64748b;">Avg</th>
+    </tr>
+  </thead>
+  <tbody>${tableRows}</tbody>
+</table>`;
+
+const bodyInner = [
+  p(`Hey ${strong(previewHandle)},`),
+  p(
+    `Well, that's a wrap. Or is it? The Phab Four earned a well deserved break ahead of the official tour-closing Dick's Run. With so much time on our hands between shows (I'm not crying, you're crying), here's some stats to chew on.`
+  ),
+  sectionTitle('Tour tape'),
+  p(
+    `Eighteen nights. ${strong('188')} unique songs. ${strong('310')} total songs played from Madison through Fenway.`
+  ),
+  p(
+    `And then there was New York. The five-night MSG run (July 22–29) wasn't just another Garden residency — it was a full-on ${strong("'90s time machine")}. The band's ${strong('92nd through 96th')} appearances at the Garden, each night a setlist drawn entirely from one year: ${strong("'92 thru '96")}. From my seat (and my scorecard), some of the best Phish of the last decade — bicycle kicks and beach balls back from the dead, deep cuts raining from the rafters, and a picking board that refused to behave.`
+  ),
+  p(
+    `That theme explains half the chaos on the tape. MSG alone coughed up these show gaps: ${strong('Cold as Ice')} (1,468), ${strong('Big Ball Jam')} (1,170), ${strong('The Vibration of Life')} (1,027), ${strong('Suspicious Minds')} (1,021), plus the cover pile — ${strong('Highway to Hell')}, ${strong('Purple Rain')}, ${strong('Johnny B. Goode')}, ${strong('La Grange')} — and a full ${strong('Forbin → Mockingbird → Harpua')} suite. Across those five nights, the field banked ${strong('44')} <span style="color:#ea580c;font-weight:800;">Bustout Boost™</span> hits. Fenway N1 dropped ${strong('Melt the Guns')} after ${strong('2,051')} shows — the longest gap between performances in Phish history. They absolutely nailed this post-punk/new wave relic.`
+  ),
+  p(
+    `Not every story needed a 1,000-show gap. Merriweather brought ${strong('Ass Handed')} back after 138; Savannah lit ${strong('Fire')} (132); and just under the bustout line, songs like ${strong('The Old Home Place')} (28) and ${strong('Izabella')} (25) kept the “almost” lane spicy.`
+  ),
+  p(
+    `The rotation favorites? ${strong('Character Zero')}, ${strong('Free')}, ${strong('Ghost')}, ${strong('Hood')}, ${strong('Possum')}, ${strong('Antelope')}, and ${strong('Sand')} each showed up ${strong('four')} times through Fenway — the 1.0 stalwarts that I know and love.`
+  ),
+  sectionTitle("Pre Dick's Leaderboard"),
+  p(
+    `Field picking average across ${strong('28')} players: ${strong('.231')}. The Top 5 all clear it — Rivertranced by the widest margin. It just shows that a few well-placed bustouts can ${strong('Catapult')} a player to the top in a hurry.`
+  ),
+  leaderboardTable,
+  p(
+    `Three more nights at Dick's. The Top 5 is bunched enough that one hot run — or a couple of bustouts — can reshuffle the whole podium. And if you're sitting just outside looking in: you're closer than you think. Commerce City is where chasers become contenders.`
+  ),
+  sectionTitle('Your (almost) tour-end tape'),
+  p(personal),
+  sectionTitle('One huge favor'),
+  p(
+    `Before Dick's, can I ask a huge favor? ${strong('Invite at least one friend')} to join and lock picks for the three-night run. Growing the number of players is my measure of success — and you know I love stats.`
+  ),
+  ctaButton(inviteCtaUrl, 'Invite a friend from Standings'),
+  sectionTitle('Building between now and then'),
+  p(
+    `Between now and Dick's, I'm staying busy building out new features. If you haven't checked these out, they are worth taking a look:`
+  ),
+  p(
+    `${strong('Live setlist')} — Updates as songs land, with bustout badges and last-played / gap insights so you can see how rare each hit really was.`
+  ),
+  p(
+    `${strong('Crowd pulse')} — How the field is picking that night — consensus heat, where your card sits vs the room, and which songs the crowd is riding.`
+  ),
+  p(
+    `${strong('Stats')} — Personal and tour insights (bustouts, gaps, frequency — the same tape above, live in the app).`
+  ),
+  p(
+    `${strong('Profile')} — Milestone badges and avatars so you can personalize how you show up on the board.`
+  ),
+  p(`Three nights in Commerce City still to go. Rest up, study the gaps, and don't sleep on the wildcard.`),
+  p(`See you at Dick's.`),
+  `<p style="margin:24px 0 8px;font-size:18px;line-height:1.55;color:#1a1a2e;">— Pat<br />from the Setlist Pick 'Em desk</p>`,
+].join('\n');
+
+// Single continuous white table — teal top rule only. No <h2> (Gmail clip trigger).
+const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="x-apple-disable-message-reformatting" />
+  <meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no" />
+  <title>Setlist Pick'em</title>
+</head>
+<body style="margin:0;padding:0;background-color:#ffffff;-webkit-text-size-adjust:100%;font-size:18px;line-height:1.55;color:#1a1a2e;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">
+  <div style="display:none;max-height:0;overflow:hidden;opacity:0;mso-hide:all;">${preheader}</div>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#ffffff;border-collapse:collapse;">
+    <tr>
+      <td align="center" style="background-color:#ffffff;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;background-color:#ffffff;border-collapse:collapse;border-top:3px solid ${EMAIL_BRAND_PRIMARY};">
+          <tr>
+            <td style="padding:20px 20px 8px 20px;text-align:center;background-color:#ffffff;">
+              ${wordmarkHeroHtml}
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:8px 20px 28px 20px;background-color:#ffffff;font-size:18px;line-height:1.55;color:#1a1a2e;">
+              ${bodyInner}
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 20px 20px;text-align:center;background-color:#ffffff;">
+              <p style="margin:0 0 8px 0;font-size:14px;line-height:1.5;color:#888888;">
+                You&apos;re receiving this because you have a Setlist Pick&apos;em account.
+              </p>
+              <p style="margin:0;font-size:14px;line-height:1.5;color:#888888;">
+                <a href="${settingsUrl}" style="color:#0f766e;text-decoration:underline;">Manage preferences</a>
+                &nbsp;&middot;&nbsp;
+                <a href="${settingsUrl}" style="color:#0f766e;text-decoration:underline;">Unsubscribe</a>
+              </p>
+              <p style="display:none;max-height:0;overflow:hidden;opacity:0;font-size:1px;line-height:1px;color:#ffffff;mso-hide:all;">${messageNonce}</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+
+const text = [
+  `Hey ${previewHandle},`,
+  '',
+  "Well, that's a wrap. Or is it? ...",
+  '',
+  personal,
+  '',
+  "Before Dick's, can I ask a huge favor? Invite at least one friend...",
+  inviteCtaUrl,
+  '',
+  'Check it out on Standings:',
+  standingsCtaUrl,
+  '',
+  "— Pat\nfrom the Setlist Pick 'Em desk",
+].join('\n');
+
+const outDir = resolve(root, 'emails/preview');
+mkdirSync(outDir, { recursive: true });
+const outFile = resolve(outDir, 'summer-2026-almost-end-preview.html');
+writeFileSync(outFile, html, 'utf8');
+console.log(`✓ Wrote ${outFile}`);
+
+if (!sendTo && process.platform === 'darwin') {
+  execSync(`open "${outFile}"`);
+}
+
+if (sendTo) {
+  const resendKey = process.env.RESEND_API_KEY;
+  if (!resendKey || !resendKey.startsWith('re_')) {
+    console.error('✗ --send requires RESEND_API_KEY in .env');
+    process.exit(1);
+  }
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${resendKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: "Setlist Pick'em <updates@setlistpickem.com>",
+      to: [sendTo],
+      // Unique subject breaks Gmail conversation threading that hides body as trimmed.
+      subject: `[LOCAL PREVIEW ${previewStamp}] ${subjectBase}`,
+      html,
+      text,
+    }),
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    console.error('✗ Resend error:', res.status, JSON.stringify(json, null, 2));
+    process.exit(1);
+  }
+  console.log(`✓ Sent preview to ${sendTo} (id: ${json.id || 'unknown'})`);
+}

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.jsx
@@ -704,6 +704,53 @@ export const COMMS_TEMPLATE_REGISTRY = {
     ],
   },
 
+  'summer-2026-almost-end': {
+    triggerId: 'marketing_summer_2026_almost_end',
+    displayName: 'Summer 2026 almost-end',
+    build: (p) => {
+      const tape =
+        typeof p.personalTape === 'string' && p.personalTape.trim()
+          ? p.personalTape.trim()
+          : "Fenway wrapped · Dick's still ahead — your (almost) tour-end tape is ready.";
+      const invite = p.showInvite === true || (p.branch && p.branch !== 'noPlay');
+      return {
+        icon: Trophy,
+        accentClassName: 'text-teal-300',
+        eyebrow: 'Summer Tour 2026',
+        title: 'An almost tour-end recap',
+        paragraphs: [
+          `${handleOf(p)}, ${tape.charAt(0).toLowerCase()}${tape.slice(1)}`,
+          "Three more nights at Dick's — rest up, study the gaps, and don't sleep on the wildcard.",
+        ],
+        cta: invite
+          ? { label: 'Invite a friend from Standings', href: '/dashboard/standings' }
+          : { label: 'Check it out on Standings', href: '/dashboard/standings' },
+      };
+    },
+    samples: [
+      {
+        name: 'Top 5 player',
+        payload: {
+          handle: 'Rivertranced',
+          branch: 'rank2to5',
+          showInvite: true,
+          personalTape:
+            "You're in the Top 5 at #4 — 270 points, 1 win, 15.9 pts/show, picking avg .353 over 17 shows. One hot Dick's run (or a rival cold streak) and this whole picture redraws.",
+        },
+      },
+      {
+        name: 'No plays yet',
+        payload: {
+          handle: 'NewPicker',
+          branch: 'noPlay',
+          showInvite: false,
+          personalTape:
+            "You've been in the mix — just not on the board yet this tour. Three nights at Dick's is a clean slate.",
+        },
+      },
+    ],
+  },
+
   [SPHERE_2026_RECAP_ID]: {
     triggerId: 'tour_recap_sphere_2026',
     displayName: "Sphere 2026 recap",

--- a/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.test.js
+++ b/src/features/notifications/ui/commsTemplates/commsTemplateRegistry.test.js
@@ -19,6 +19,7 @@ const EXPECTED_TEMPLATE_IDS = [
   'picks-lock-reminder',
   'tour-engagement-reminder',
   'sphere-2026-inaugural',
+  'summer-2026-almost-end',
 ];
 
 describe('comms template registry', () => {


### PR DESCRIPTION
## Summary
- Promote **1.43.0** Summer 2026 almost-end marketing batch to production (inbox template registry + marketing email shell fixes).
- Firebase callable/scheduler already deployed from staging tip; this ships the SPA so the forced inbox message renders the new `summer-2026-almost-end` template.

Tip version on staging: **1.43.0**.

## Test plan
- [x] CI green on #793 (`verify`, `functions`, `build`, Vercel)
- [ ] Vercel production READY after merge
- [ ] Confirm canary inbox renders on production after deploy
- [ ] Tag `v1.43.0` via `release:publish` only if requested after promote


Made with [Cursor](https://cursor.com)