### PR TITLE
perf(appcheck): defer reCAPTCHA on anon cold-open (#803)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.44.1] — 2026-08-03
+
+### Changed
+- **App Check first-paint policy (#803)** — anonymous `/`, `/join`, `/invite` keep deferred reCAPTCHA until auth modal open; persisted sessions and `/dashboard`/`/setup` still warm immediately.
+
+---
+
 ## [1.44.0] — 2026-08-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.44.0",
+  "version": "1.44.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/auth/model/AuthContext.jsx
+++ b/src/features/auth/model/AuthContext.jsx
@@ -31,6 +31,12 @@ export function AuthProvider({ children }) {
     let cancelled = false;
     let detachProfile = null;
 
+    // Persisted session: warm App Check before auth callback settles (#803).
+    // Anonymous cold-open paths stay on deferred init until auth CTA.
+    if (auth.currentUser) {
+      ensureAppCheckNow();
+    }
+
     const stopProfileListener = () => {
       if (typeof detachProfile === 'function') {
         try {
@@ -55,7 +61,7 @@ export function AuthProvider({ children }) {
         return;
       }
 
-      // Persisted / fresh session — start App Check immediately (#730 / #773).
+      // Persisted / fresh session — start App Check immediately (#803 / #773).
       ensureAppCheckNow();
 
       // Guest → sign-in (and user switches): keep guards in `loading` until the

--- a/src/features/landing/ui/SplashAuthModals.jsx
+++ b/src/features/landing/ui/SplashAuthModals.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { SplashSignInModal, SplashSignUpModal } from '../../auth';
+import { ensureAppCheckNow } from '../../../shared/lib/firebaseAppCheck';
 
 export default function SplashAuthModals({
   authModal,
@@ -11,6 +12,13 @@ export default function SplashAuthModals({
   redirectAuthError = '',
   onClearRedirectAuthError,
 }) {
+  // Anonymous splash/invite: warm reCAPTCHA when auth CTA opens (#803).
+  useEffect(() => {
+    if (authModal === 'signup' || authModal === 'signin') {
+      ensureAppCheckNow();
+    }
+  }, [authModal]);
+
   const handleClose = () => {
     onClearRedirectAuthError?.();
     closeModal();

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -23,8 +23,8 @@ import './index.css'
 initGa4()
 initWebVitals()
 
-// #773 Phase 2: email / app hard opens — warm App Check + kick DashboardRoute
-// chunk before first paint. Splash keeps deferred App Check + lazy dashboard.
+// #773 / #803: dashboard + setup warm App Check on boot; splash/join/invite
+// stay deferred for anonymous visitors (session + auth modal warm instead).
 const bootPath =
   typeof window !== 'undefined' ? window.location.pathname : ''
 if (shouldWarmAppCheckOnBoot(bootPath)) {

--- a/src/shared/lib/appBootPath.js
+++ b/src/shared/lib/appBootPath.js
@@ -1,5 +1,7 @@
 /**
  * Path helpers for cold-boot warming on app / email hard opens (#773 Phase 2).
+ * #803: anonymous `/` `/join` `/invite` keep deferred App Check; session +
+ * dashboard/setup still warm immediately.
  */
 
 /**
@@ -12,16 +14,28 @@ export function isDashboardEntryPath(pathname) {
 }
 
 /**
+ * Public cold-open surfaces where anonymous visitors should not pay reCAPTCHA
+ * before first paint / auth CTA (#803). Returning sessions warm via AuthContext.
+ * @param {string} [pathname]
+ * @returns {boolean}
+ */
+export function isPublicColdOpenPath(pathname) {
+  if (typeof pathname !== 'string' || !pathname) return false;
+  return (
+    pathname === '/' ||
+    pathname.startsWith('/join') ||
+    pathname.startsWith('/invite/')
+  );
+}
+
+/**
  * Surfaces that need Firestore ASAP on hard open (skip App Check idle deferral).
+ * Invite/join anonymous paths are intentionally excluded (#803) — warm on
+ * persisted session or auth modal open instead.
  * @param {string} [pathname]
  * @returns {boolean}
  */
 export function shouldWarmAppCheckOnBoot(pathname) {
   if (typeof pathname !== 'string' || !pathname) return false;
-  return (
-    isDashboardEntryPath(pathname) ||
-    pathname === '/setup' ||
-    pathname.startsWith('/join') ||
-    pathname.startsWith('/invite/')
-  );
+  return isDashboardEntryPath(pathname) || pathname === '/setup';
 }

--- a/src/shared/lib/appBootPath.test.js
+++ b/src/shared/lib/appBootPath.test.js
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { isDashboardEntryPath, shouldWarmAppCheckOnBoot } from './appBootPath.js';
+import {
+  isDashboardEntryPath,
+  isPublicColdOpenPath,
+  shouldWarmAppCheckOnBoot,
+} from './appBootPath.js';
 
 describe('isDashboardEntryPath', () => {
   it('matches /dashboard and nested paths', () => {
@@ -18,16 +22,30 @@ describe('isDashboardEntryPath', () => {
   });
 });
 
-describe('shouldWarmAppCheckOnBoot', () => {
-  it('warms dashboard, setup, join, and invite', () => {
-    expect(shouldWarmAppCheckOnBoot('/dashboard/standings')).toBe(true);
-    expect(shouldWarmAppCheckOnBoot('/setup')).toBe(true);
-    expect(shouldWarmAppCheckOnBoot('/join/ABC')).toBe(true);
-    expect(shouldWarmAppCheckOnBoot('/invite/pat')).toBe(true);
+describe('isPublicColdOpenPath', () => {
+  it('matches splash, join, and site invite', () => {
+    expect(isPublicColdOpenPath('/')).toBe(true);
+    expect(isPublicColdOpenPath('/join/ABC')).toBe(true);
+    expect(isPublicColdOpenPath('/invite/pat')).toBe(true);
   });
 
-  it('does not warm splash or marketing', () => {
+  it('rejects dashboard, setup, marketing', () => {
+    expect(isPublicColdOpenPath('/dashboard')).toBe(false);
+    expect(isPublicColdOpenPath('/setup')).toBe(false);
+    expect(isPublicColdOpenPath('/how-it-works')).toBe(false);
+  });
+});
+
+describe('shouldWarmAppCheckOnBoot', () => {
+  it('warms dashboard and setup only (#803)', () => {
+    expect(shouldWarmAppCheckOnBoot('/dashboard/standings')).toBe(true);
+    expect(shouldWarmAppCheckOnBoot('/setup')).toBe(true);
+  });
+
+  it('does not warm anonymous cold-open or marketing', () => {
     expect(shouldWarmAppCheckOnBoot('/')).toBe(false);
+    expect(shouldWarmAppCheckOnBoot('/join/ABC')).toBe(false);
+    expect(shouldWarmAppCheckOnBoot('/invite/pat')).toBe(false);
     expect(shouldWarmAppCheckOnBoot('/how-it-works')).toBe(false);
     expect(shouldWarmAppCheckOnBoot('/privacy')).toBe(false);
   });


### PR DESCRIPTION
Closes #803

## Summary
- Stop boot-warming App Check on `/join` and `/invite` (anonymous cold-open stays deferred).
- Warm immediately for persisted sessions (`AuthContext`) and when splash/invite auth modals open.
- Keep `/dashboard/*` + `/setup` warm-on-boot from #773.
- SemVer **1.44.1** (PATCH).

## Test plan
- [ ] `npm test` — `appBootPath` tests
- [ ] Signed-out `/` and `/join/:code`: Network — no `recaptcha__en.js` in first ~2s
- [ ] Open Create account / Sign in — App Check / reCAPTCHA starts
- [ ] Signed-in hard open `/dashboard` — App Check still warm (no idle wait)


Made with [Cursor](https://cursor.com)