### PR TITLE
perf(invite): lazy firebase-admin + defer FCM SW (#732)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.44.2] — 2026-08-03
+
+### Changed
+- **Invite HTML + FCM SW (#732)** — `api/invite` dynamic-imports `firebase-admin` only for crawler OG lookups; defer FCM service-worker registration on public cold-open routes until idle.
+
+---
+
 ## [1.44.1] — 2026-08-03
 
 ### Changed

--- a/api/invite.js
+++ b/api/invite.js
@@ -31,8 +31,6 @@
 import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { initializeApp, getApps, cert } from 'firebase-admin/app';
-import { getFirestore } from 'firebase-admin/firestore';
 
 import {
   SITE_URL,
@@ -46,10 +44,30 @@ import {
 } from './inviteOgHelpers.mjs';
 
 // ---------------------------------------------------------------------------
-// Firebase Admin — lazy singleton
+// Firebase Admin — dynamic import on crawler/OG path only (#732)
+// Browsers hit skip-firestore + SPA shell and must not pay admin cold import.
 // ---------------------------------------------------------------------------
 
-function initAdmin() {
+/** @type {Promise<{ getApps: Function, initializeApp: Function, cert: Function, getFirestore: Function }> | null} */
+let adminModsPromise = null;
+
+function loadAdminMods() {
+  if (!adminModsPromise) {
+    adminModsPromise = Promise.all([
+      import('firebase-admin/app'),
+      import('firebase-admin/firestore'),
+    ]).then(([appMod, fsMod]) => ({
+      getApps: appMod.getApps,
+      initializeApp: appMod.initializeApp,
+      cert: appMod.cert,
+      getFirestore: fsMod.getFirestore,
+    }));
+  }
+  return adminModsPromise;
+}
+
+async function initAdmin() {
+  const { getApps, initializeApp, cert } = await loadAdminMods();
   if (getApps().length > 0) return;
   const sa = process.env.FIREBASE_SERVICE_ACCOUNT;
   if (sa) {
@@ -64,7 +82,8 @@ function initAdmin() {
  * @returns {Promise<{ name: string } | null>}
  */
 async function fetchPoolByCode(code) {
-  initAdmin();
+  await initAdmin();
+  const { getFirestore } = await loadAdminMods();
   const db = getFirestore();
   const snap = await db
     .collection('pools')
@@ -83,7 +102,8 @@ async function fetchPoolByCode(code) {
 async function fetchPublicProfileByHandle(handle) {
   const h = normalizeInviteHandle(handle);
   if (!h) return null;
-  initAdmin();
+  await initAdmin();
+  const { getFirestore } = await loadAdminMods();
   const db = getFirestore();
   const snap = await db
     .collection('users')

--- a/docs/API.md
+++ b/docs/API.md
@@ -426,6 +426,8 @@ Social crawlers (Meta, X, Slack, …) do not execute JavaScript. Invite URLs are
 
 Copy mirrors `src/shared/lib/inviteKit.js` (`buildSiteInviteShareTitle`, `buildPoolInviteShareTitleFromInviter`) and legacy pool OG (`Join my Setlist Pick 'Em pool: {name}`) when `from` is absent. Constants mirror `src/shared/config/seo.js` in `api/inviteOgHelpers.mjs` (no `src/` imports in serverless).
 
+**v1.44.2 / #732:** `firebase-admin` is dynamic-imported only on the crawler/Firestore branch so browser requests do not pay Admin module cold-start. Client FCM service-worker registration is idle-deferred on `/`, `/join/*`, and `/invite/*` (still on-demand via messaging helpers).
+
 **Vercel env:** `FIREBASE_SERVICE_ACCOUNT` (JSON) enables Firestore Admin lookups for crawlers.
 
 **Tests:** `api/inviteOgHelpers.test.js` (pure helpers; no Vercel runtime).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.44.1",
+  "version": "1.44.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,6 +9,7 @@ import ScrollToTop from './app/ScrollToTop.jsx'
 import { AuthProvider } from './features/auth'
 import {
   isDashboardEntryPath,
+  isPublicColdOpenPath,
   shouldWarmAppCheckOnBoot,
 } from './shared/lib/appBootPath'
 import { initGa4 } from './shared/lib/ga4'
@@ -32,6 +33,25 @@ if (shouldWarmAppCheckOnBoot(bootPath)) {
 }
 if (isDashboardEntryPath(bootPath)) {
   void import('./app/routes/DashboardRoute.jsx')
+}
+
+/**
+ * FCM SW: immediate on app surfaces; idle-defer on public cold-open (#732).
+ * `getMessagingClient` still registers on demand for push opt-in.
+ */
+function scheduleMessagingServiceWorker(pathname) {
+  if (isPublicColdOpenPath(pathname)) {
+    const start = () => {
+      void registerMessagingServiceWorker()
+    }
+    if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
+      window.requestIdleCallback(start, { timeout: 5000 })
+    } else {
+      window.setTimeout(start, 2500)
+    }
+    return
+  }
+  void registerMessagingServiceWorker()
 }
 
 // Shared client for React Query caches (#243 profile/tour standings, #507
@@ -66,4 +86,4 @@ root.render(
 )
 
 initializeAppCheckDeferred()
-registerMessagingServiceWorker()
+scheduleMessagingServiceWorker(bootPath)


### PR DESCRIPTION
Closes #732

## Summary
- Dynamic-import `firebase-admin` in `api/invite.js` only on crawler/Firestore lookup paths.
- Idle-defer FCM service-worker registration on `/`, `/join/*`, `/invite/*` (on-demand registration unchanged).
- SemVer **1.44.2** (PATCH). Stacks on #810 (#803).

## Test plan
- [ ] Browser `/join/:code` and `/invite/:handle` still render VIP SPA shell
- [ ] Crawler/OG smoke (Facebook Sharing Debugger or curl with bot UA) still personalized
- [ ] Public cold-open: SW registers after idle, not blocking first paint
- [ ] Dashboard / push opt-in still registers messaging SW


Made with [Cursor](https://cursor.com)