### PR TITLE
perf(routes): lazy HomeRoute, prefetch, early join (#731, #804, #805)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.44.3] — 2026-08-03
+
+### Added
+- **Route chunk prefetch registry (#805)** — `shared/lib/routeChunkPrefetch` lets features warm `dashboard` / `setup` / `home` chunks by string key without importing app-layer route modules. Splash and invite auth modals prefetch `dashboard` + `setup` on open.
+- **Persisted session hint (#804)** — auth writes `setpicks_session_hint_v1` to localStorage on session resolve and clears it on sign-out, so a cold open on `/` can start the `DashboardRoute` download in the entry tick instead of waiting for Firebase auth to settle. Anonymous visitors are unaffected.
+
+### Changed
+- **Lazy `HomeRoute` (#731)** — the splash route joined every other top-level route behind `lazy()`; `prerender-seo` now modulepreloads the `HomeRoute-*.js` chunk into `dist/index.html` so splash first paint keeps its budget. `verify:seo-prerender` asserts each shell preloads only its own route (splash never gets `DashboardRoute`, the app boot shell never gets `HomeRoute`).
+- **Auth provider barrel (#731)** — `main.jsx` imports `AuthProvider` from `features/auth/provider` so the entry bundle no longer statically pulls splash/auth-modal UI from the root auth barrel.
+- **Earlier pool join (#731)** — `/join/:code` starts the invite join as soon as auth resolves, overlapping the write with the DashboardRoute download and the `/setup` detour. `usePendingPoolJoin` adopts that same in-flight request rather than issuing a second one, so toasts, navigation and the retry timeout are unchanged. Site invites (`/invite/:handle`) remain free of pool side effects.
+
+---
+
 ## [1.44.2] — 2026-08-03
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.44.2",
+  "version": "1.44.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/boot-modulepreload.mjs
+++ b/scripts/boot-modulepreload.mjs
@@ -1,0 +1,102 @@
+/**
+ * Post-build `<link rel="modulepreload">` injection for boot-critical route
+ * chunks (#773 dashboard, #731 splash).
+ *
+ * Every top-level route is `lazy()` in `src/app/App.jsx`, so the chunk a given
+ * entry HTML is certain to need would otherwise start downloading only after
+ * the entry bundle parses. Each shell preloads its own route and nothing else —
+ * splash must not pull the dashboard graph, and the app boot shell must not
+ * pull Landing.
+ *
+ * Pure Node — no `src/` imports, safe for build scripts.
+ */
+
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Chunk filename prefixes to modulepreload on the dashboard boot shell (#773). */
+export const DASHBOARD_BOOT_MODULEPRELOAD_PREFIXES = ['DashboardRoute-'];
+
+/** Chunk filename prefixes to modulepreload on prerendered `dist/index.html` (#731). */
+export const SPLASH_BOOT_MODULEPRELOAD_PREFIXES = ['HomeRoute-'];
+
+/** Attribute markers asserted by `verify:seo-prerender`. */
+export const DASHBOARD_BOOT_PRELOAD_MARKER = 'data-dashboard-boot-preload';
+export const SPLASH_BOOT_PRELOAD_MARKER = 'data-splash-boot-preload';
+
+/**
+ * Resolve hashed asset filenames under `dist/assets` for the given prefixes.
+ *
+ * @param {string} assetsDir
+ * @param {string[]} prefixes
+ * @returns {string[]} absolute hrefs like `/assets/DashboardRoute-….js`
+ */
+export function resolveBootModulepreloadHrefs(assetsDir, prefixes) {
+  let names = [];
+  try {
+    names = readdirSync(assetsDir);
+  } catch {
+    return [];
+  }
+  const hrefs = [];
+  for (const prefix of prefixes) {
+    const match = names.find(
+      (name) => name.startsWith(prefix) && name.endsWith('.js'),
+    );
+    if (match) hrefs.push(`/assets/${match}`);
+  }
+  return hrefs;
+}
+
+/**
+ * Append `<link rel="modulepreload">` tags into `<head>`.
+ * Idempotent; skips hrefs already present.
+ *
+ * @param {string} html
+ * @param {string} distDir absolute path to `dist/`
+ * @param {{ prefixes: string[], marker: string }} options
+ * @returns {string}
+ */
+export function injectBootModulepreloads(html, distDir, { prefixes, marker }) {
+  if (typeof html !== 'string' || !html) return html;
+  const hrefs = resolveBootModulepreloadHrefs(join(distDir, 'assets'), prefixes);
+  if (!hrefs.length) return html;
+
+  const tags = hrefs
+    .filter((href) => !html.includes(`href="${href}"`))
+    .map(
+      (href) =>
+        `  <link rel="modulepreload" crossorigin href="${href}" ${marker}="true" />`,
+    );
+  if (!tags.length) return html;
+  if (!/<\/head>/i.test(html)) return html;
+  return html.replace(/<\/head>/i, `${tags.join('\n')}\n</head>`);
+}
+
+/**
+ * Dashboard-critical chunks for the app boot shell. Does not touch splash.
+ *
+ * @param {string} html
+ * @param {string} distDir
+ * @returns {string}
+ */
+export function injectDashboardBootModulepreloads(html, distDir) {
+  return injectBootModulepreloads(html, distDir, {
+    prefixes: DASHBOARD_BOOT_MODULEPRELOAD_PREFIXES,
+    marker: DASHBOARD_BOOT_PRELOAD_MARKER,
+  });
+}
+
+/**
+ * Splash-critical chunks for prerendered `dist/index.html` only.
+ *
+ * @param {string} html
+ * @param {string} distDir
+ * @returns {string}
+ */
+export function injectSplashBootModulepreloads(html, distDir) {
+  return injectBootModulepreloads(html, distDir, {
+    prefixes: SPLASH_BOOT_MODULEPRELOAD_PREFIXES,
+    marker: SPLASH_BOOT_PRELOAD_MARKER,
+  });
+}

--- a/scripts/dashboard-boot-shell.mjs
+++ b/scripts/dashboard-boot-shell.mjs
@@ -6,9 +6,6 @@
  * `createRoot` still replaces `#root` once the SPA mounts.
  */
 
-import { readdirSync } from 'node:fs';
-import { join } from 'node:path';
-
 import { stripPrerenderBodyFromSpaShell } from './seo-strip-body.mjs';
 
 /** Attribute marker asserted by `verify:seo-prerender`. */
@@ -278,54 +275,4 @@ export function buildDashboardBootShellHtml(spaHtml) {
     /<div id="root">\s*<\/div>/i,
     `<div id="root">${markup}</div>`,
   );
-}
-
-/** Chunk filename prefixes to modulepreload on the dashboard boot shell only (#773). */
-export const DASHBOARD_BOOT_MODULEPRELOAD_PREFIXES = ['DashboardRoute-'];
-
-/**
- * Resolve hashed asset filenames under `dist/assets` for dashboard boot preloads.
- *
- * @param {string} assetsDir
- * @returns {string[]} absolute hrefs like `/assets/DashboardRoute-….js`
- */
-export function resolveDashboardBootModulepreloadHrefs(assetsDir) {
-  let names = [];
-  try {
-    names = readdirSync(assetsDir);
-  } catch {
-    return [];
-  }
-  const hrefs = [];
-  for (const prefix of DASHBOARD_BOOT_MODULEPRELOAD_PREFIXES) {
-    const match = names.find(
-      (name) => name.startsWith(prefix) && name.endsWith('.js'),
-    );
-    if (match) hrefs.push(`/assets/${match}`);
-  }
-  return hrefs;
-}
-
-/**
- * Append `<link rel="modulepreload">` for dashboard-critical chunks into `<head>`.
- * Idempotent; skips hrefs already present. Does not touch splash `dist/index.html`.
- *
- * @param {string} html
- * @param {string} distDir absolute path to `dist/`
- * @returns {string}
- */
-export function injectDashboardBootModulepreloads(html, distDir) {
-  if (typeof html !== 'string' || !html) return html;
-  const hrefs = resolveDashboardBootModulepreloadHrefs(join(distDir, 'assets'));
-  if (!hrefs.length) return html;
-
-  const tags = hrefs
-    .filter((href) => !html.includes(`href="${href}"`))
-    .map(
-      (href) =>
-        `  <link rel="modulepreload" crossorigin href="${href}" data-dashboard-boot-preload="true" />`,
-    );
-  if (!tags.length) return html;
-  if (!/<\/head>/i.test(html)) return html;
-  return html.replace(/<\/head>/i, `${tags.join('\n')}\n</head>`);
 }

--- a/scripts/prerender-seo.mjs
+++ b/scripts/prerender-seo.mjs
@@ -13,6 +13,7 @@ import {
   buildDashboardBootShellHtml,
   injectDashboardBootModulepreloads,
   injectPrerenderHtml,
+  injectSplashBootModulepreloads,
   prerenderOutputRelPath,
 } from './seo-prerender-lib.mjs';
 
@@ -28,7 +29,12 @@ if (!existsSync(distIndex)) {
 const shell = readFileSync(distIndex, 'utf8');
 
 for (const route of PRERENDER_ROUTES) {
-  const html = injectPrerenderHtml(shell, route);
+  let html = injectPrerenderHtml(shell, route);
+  // Splash only: `HomeRoute` is lazy since #731, so preload its chunk here or
+  // the landing paint waits a round trip on the entry bundle.
+  if (route.path === '/') {
+    html = injectSplashBootModulepreloads(html, distDir);
+  }
   const rel = prerenderOutputRelPath(route.path);
   const outPath = join(distDir, rel);
   mkdirSync(dirname(outPath), { recursive: true });

--- a/scripts/qa/chunk-split.mjs
+++ b/scripts/qa/chunk-split.mjs
@@ -36,7 +36,11 @@ import { startPreview } from './_lib/preview.mjs';
 // of these appearing on a navigation to a *different* route is a
 // cross-route leak — the static-import graph reaches across routes
 // and partially defeats route-level code splitting (#240/#242).
+// `HomeRoute` is lazy as of #731 and is modulepreloaded by the prerendered
+// `dist/index.html`, so it lands in `initialChunks` on the splash hard load and
+// is correctly excluded from later navigation deltas.
 const LAZY_ROUTE_COMPONENTS = [
+  'HomeRoute',
   'PasswordResetCompletePage',
   'PublicProfilePage',
   'PoolInviteMissingCodePage',

--- a/scripts/seo-prerender-lib.mjs
+++ b/scripts/seo-prerender-lib.mjs
@@ -15,8 +15,13 @@ import {
   DASHBOARD_BOOT_SHELL_MARKER,
   buildDashboardBootShellHtml,
   buildDashboardBootShellMarkup,
-  injectDashboardBootModulepreloads,
 } from './dashboard-boot-shell.mjs';
+import {
+  DASHBOARD_BOOT_PRELOAD_MARKER,
+  SPLASH_BOOT_PRELOAD_MARKER,
+  injectDashboardBootModulepreloads,
+  injectSplashBootModulepreloads,
+} from './boot-modulepreload.mjs';
 
 export {
   PRERENDER_ROUTES,
@@ -24,9 +29,12 @@ export {
   APP_BOOT_SHELL_REL_PATH,
   stripPrerenderBodyFromSpaShell,
   DASHBOARD_BOOT_SHELL_MARKER,
+  DASHBOARD_BOOT_PRELOAD_MARKER,
+  SPLASH_BOOT_PRELOAD_MARKER,
   buildDashboardBootShellHtml,
   buildDashboardBootShellMarkup,
   injectDashboardBootModulepreloads,
+  injectSplashBootModulepreloads,
 };
 
 function escapeHtml(str) {

--- a/scripts/verify-seo-prerender.mjs
+++ b/scripts/verify-seo-prerender.mjs
@@ -5,17 +5,22 @@
  * Does not require a Vite build — uses a fixture shell. Optionally re-checks
  * `dist/` when present (after `npm run build`).
  */
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
   APP_BOOT_SHELL_REL_PATH,
+  DASHBOARD_BOOT_PRELOAD_MARKER,
   DASHBOARD_BOOT_SHELL_MARKER,
   PRERENDER_ROUTES,
+  SPLASH_BOOT_PRELOAD_MARKER,
   buildDashboardBootShellHtml,
   buildFixtureShellHtml,
+  injectDashboardBootModulepreloads,
   injectPrerenderHtml,
+  injectSplashBootModulepreloads,
   prerenderOutputRelPath,
 } from './seo-prerender-lib.mjs';
 
@@ -89,6 +94,46 @@ assert(
 );
 assert(!fixtureBoot.includes('<h1>leak</h1>'), 'boot shell must strip prior #root body');
 
+// Fixture: each shell modulepreloads its own route chunk and nothing else (#731).
+// Both chunks exist in the fake assets dir, so a cross-shell leak would show up.
+const fakeDist = mkdtempSync(join(tmpdir(), 'seo-prerender-'));
+mkdirSync(join(fakeDist, 'assets'), { recursive: true });
+writeFileSync(join(fakeDist, 'assets', 'HomeRoute-a1b2c3d4.js'), '', 'utf8');
+writeFileSync(join(fakeDist, 'assets', 'DashboardRoute-e5f6a7b8.js'), '', 'utf8');
+
+const fixtureSplashPreload = injectSplashBootModulepreloads(
+  buildFixtureShellHtml(),
+  fakeDist,
+);
+assert(
+  fixtureSplashPreload.includes(`${SPLASH_BOOT_PRELOAD_MARKER}="true"`) &&
+    fixtureSplashPreload.includes('/assets/HomeRoute-a1b2c3d4.js'),
+  'splash must modulepreload the HomeRoute chunk',
+);
+assert(
+  !fixtureSplashPreload.includes('DashboardRoute-'),
+  'splash must not modulepreload the DashboardRoute chunk',
+);
+assert(
+  injectSplashBootModulepreloads(fixtureSplashPreload, fakeDist) ===
+    fixtureSplashPreload,
+  'splash modulepreload injection must be idempotent',
+);
+
+const fixtureDashboardPreload = injectDashboardBootModulepreloads(
+  buildDashboardBootShellHtml(buildFixtureShellHtml()),
+  fakeDist,
+);
+assert(
+  fixtureDashboardPreload.includes(`${DASHBOARD_BOOT_PRELOAD_MARKER}="true"`) &&
+    fixtureDashboardPreload.includes('/assets/DashboardRoute-e5f6a7b8.js'),
+  'app boot shell must modulepreload the DashboardRoute chunk',
+);
+assert(
+  !fixtureDashboardPreload.includes('HomeRoute-'),
+  'app boot shell must not modulepreload the HomeRoute chunk',
+);
+
 const distIndex = join(root, 'dist', 'index.html');
 const distHowItWorks = join(root, 'dist', 'how-it-works', 'index.html');
 // Only validate dist when post-build prerender has clearly run (subdir artifact).
@@ -120,9 +165,13 @@ if (existsSync(distIndex) && existsSync(distHowItWorks)) {
     'app boot shell must not include SEO prerender body',
   );
   assert(
-    appBootHtml.includes('data-dashboard-boot-preload="true"') &&
+    appBootHtml.includes(`${DASHBOARD_BOOT_PRELOAD_MARKER}="true"`) &&
       appBootHtml.includes('DashboardRoute-'),
     'app boot shell must modulepreload DashboardRoute chunk',
+  );
+  assert(
+    !appBootHtml.includes(SPLASH_BOOT_PRELOAD_MARKER),
+    'app boot shell must not gain splash modulepreloads',
   );
   const homeHtml = readFileSync(distIndex, 'utf8');
   assert(
@@ -130,8 +179,18 @@ if (existsSync(distIndex) && existsSync(distHowItWorks)) {
     'home dist/index.html must still include SEO prerender body',
   );
   assert(
-    !homeHtml.includes('data-dashboard-boot-preload'),
+    !homeHtml.includes(DASHBOARD_BOOT_PRELOAD_MARKER),
     'home dist/index.html must not gain dashboard boot modulepreloads',
+  );
+  assert(
+    homeHtml.includes(`${SPLASH_BOOT_PRELOAD_MARKER}="true"`) &&
+      homeHtml.includes('HomeRoute-'),
+    'home dist/index.html must modulepreload the lazy HomeRoute chunk (#731)',
+  );
+  const howItWorksHtml = readFileSync(distHowItWorks, 'utf8');
+  assert(
+    !howItWorksHtml.includes(SPLASH_BOOT_PRELOAD_MARKER),
+    'marketing routes must not gain splash modulepreloads',
   );
 
   console.log('verify:seo-prerender: dist/ checked');

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,14 +1,32 @@
 import React, { lazy } from 'react';
 import { Routes, Route } from 'react-router-dom';
 
-import RootAppShell from './layout/RootAppShell';
-import HomeRoute from './routes/HomeRoute';
+import { registerRouteChunkLoaders } from '../shared/lib/routeChunkPrefetch';
 
-// Keep `HomeRoute` eager: it's the public splash / SEO-facing surface, so it
-// must paint before any dynamic import resolves. Every other top-level route
-// is lazy-loaded so direct hits on e.g. `/dashboard/profile` don't pay the
-// full dashboard+admin+pools download on first paint. The shared Suspense
-// boundary lives in `RootAppShell` (one place → consistent fallback).
+import RootAppShell from './layout/RootAppShell';
+
+// Every top-level route is lazy-loaded so direct hits on e.g.
+// `/dashboard/profile` don't pay the full dashboard+admin+pools download on
+// first paint. The shared Suspense boundary lives in `RootAppShell` (one
+// place → consistent fallback).
+//
+// `HomeRoute` joined them in #731: `/join`, `/invite/:handle` and every
+// dashboard hard open were downloading the Landing graph they never render.
+// The splash keeps its first-paint budget because `prerender-seo.mjs`
+// modulepreloads the HomeRoute chunk into `dist/index.html`.
+const loadHomeRoute = () => import('./routes/HomeRoute');
+const loadSetupRoute = () => import('./routes/SetupRoute');
+const loadDashboardRoute = () => import('./routes/DashboardRoute');
+
+// Feature surfaces (auth modals, invite CTAs) prefetch these by key so they
+// never have to import app-layer route modules (#805).
+registerRouteChunkLoaders({
+  home: loadHomeRoute,
+  setup: loadSetupRoute,
+  dashboard: loadDashboardRoute,
+});
+
+const HomeRoute = lazy(loadHomeRoute);
 const PasswordResetCompletePage = lazy(() =>
   import('../pages/auth/PasswordResetCompletePage')
 );
@@ -26,8 +44,8 @@ const PhishSetlistPredictionGamePage = lazy(
 );
 const PrivacyPolicyPage = lazy(() => import('../pages/legal/PrivacyPolicyPage'));
 const TermsOfServicePage = lazy(() => import('../pages/legal/TermsOfServicePage'));
-const SetupRoute = lazy(() => import('./routes/SetupRoute'));
-const DashboardRoute = lazy(() => import('./routes/DashboardRoute'));
+const SetupRoute = lazy(loadSetupRoute);
+const DashboardRoute = lazy(loadDashboardRoute);
 // Dev-only comms template gallery (redirects home in production builds).
 const CommsPreviewPage = lazy(() => import('../pages/dev/CommsPreviewPage'));
 

--- a/src/features/auth/index.js
+++ b/src/features/auth/index.js
@@ -6,7 +6,7 @@ export { default as SplashSignInModal } from './ui/SplashSignInModal';
 export { default as SplashSignUpModal } from './ui/SplashSignUpModal';
 export { default as PasswordResetForm } from './ui/PasswordResetForm';
 export { default as ProfileSetupForm } from './ui/ProfileSetupForm';
-export { AuthProvider, useAuth } from './model/AuthContext.jsx';
+export { AuthProvider, useAuth } from './provider.js';
 export { useAuthSession } from './model/useAuthSession';
 export { useGoogleRedirectCompletion } from './model/useGoogleRedirectCompletion';
 export { trackAuthPartialProfile } from './model/authAnalytics';

--- a/src/features/auth/model/AuthContext.jsx
+++ b/src/features/auth/model/AuthContext.jsx
@@ -3,6 +3,10 @@ import React, { createContext, useContext, useEffect, useMemo, useState } from '
 import { auth } from '../../../shared/lib/firebase';
 import { ensureAppCheckNow } from '../../../shared/lib/firebaseAppCheck';
 import {
+  clearPersistedSessionHint,
+  markPersistedSession,
+} from '../../../shared/lib/persistedSessionHint';
+import {
   fetchUserProfile,
   resolveIsAdmin,
   subscribeToAuthState,
@@ -35,6 +39,7 @@ export function AuthProvider({ children }) {
     // Anonymous cold-open paths stay on deferred init until auth CTA.
     if (auth.currentUser) {
       ensureAppCheckNow();
+      markPersistedSession();
     }
 
     const stopProfileListener = () => {
@@ -54,6 +59,8 @@ export function AuthProvider({ children }) {
       if (cancelled) return;
 
       if (!u) {
+        // Next cold open on `/` is anonymous — stop prefetching the dashboard (#804).
+        clearPersistedSessionHint();
         setUser(null);
         setUserProfile(null);
         setIsAdmin(false);
@@ -63,6 +70,7 @@ export function AuthProvider({ children }) {
 
       // Persisted / fresh session — start App Check immediately (#803 / #773).
       ensureAppCheckNow();
+      markPersistedSession();
 
       // Guest → sign-in (and user switches): keep guards in `loading` until the
       // first profile result. Otherwise `loading:false + user + profile:null`

--- a/src/features/auth/provider.js
+++ b/src/features/auth/provider.js
@@ -1,0 +1,6 @@
+/**
+ * Narrow auth public surface for app boot (#731).
+ * Importing from `features/auth` root pulls splash/modals into the entry graph;
+ * boot only needs the provider.
+ */
+export { AuthProvider, useAuth } from './model/AuthContext.jsx';

--- a/src/features/landing/ui/SplashAuthModals.jsx
+++ b/src/features/landing/ui/SplashAuthModals.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 
 import { SplashSignInModal, SplashSignUpModal } from '../../auth';
 import { ensureAppCheckNow } from '../../../shared/lib/firebaseAppCheck';
+import { prefetchRouteChunk } from '../../../shared/lib/routeChunkPrefetch';
 
 export default function SplashAuthModals({
   authModal,
@@ -13,9 +14,12 @@ export default function SplashAuthModals({
   onClearRedirectAuthError,
 }) {
   // Anonymous splash/invite: warm reCAPTCHA when auth CTA opens (#803).
+  // Opening this modal is the last user action before `/setup` (sign-up) or
+  // `/dashboard` (sign-in), so warm both chunks alongside it (#805).
   useEffect(() => {
     if (authModal === 'signup' || authModal === 'signin') {
       ensureAppCheckNow();
+      prefetchRouteChunk(['dashboard', 'setup']);
     }
   }, [authModal]);
 

--- a/src/features/pool-invite/index.js
+++ b/src/features/pool-invite/index.js
@@ -4,6 +4,7 @@ export {
   storePoolInviteCodeFromParam,
   usePoolInviteCodeStorage,
 } from './model/usePoolInviteCodeStorage';
+export { useEarlyPoolInviteJoin } from './model/useEarlyPoolInviteJoin';
 export {
   clearPendingPoolJoinInFlight,
   usePendingPoolJoin,

--- a/src/features/pool-invite/model/pendingPoolJoinRunner.js
+++ b/src/features/pool-invite/model/pendingPoolJoinRunner.js
@@ -1,0 +1,55 @@
+import { joinPoolByInviteCode } from '../api/joinPool';
+
+/**
+ * Single in-flight join request shared across surfaces (#731).
+ *
+ * The invite route can start the join the moment auth resolves, while the
+ * dashboard chunk is still downloading; whichever surface owns the UX
+ * afterwards (`usePendingPoolJoin`) awaits the same promise instead of firing a
+ * second write. Keyed by user + code so a different account or a different
+ * invite always starts fresh.
+ *
+ * @type {{ key: string, promise: Promise<{ outcome: string, poolId?: string }> } | null}
+ */
+let inFlight = null;
+
+/**
+ * @param {string} userId
+ * @param {string} inviteCode
+ * @returns {string}
+ */
+export function pendingPoolJoinKey(userId, inviteCode) {
+  return `${userId}:${inviteCode}`;
+}
+
+/**
+ * Start (or adopt) the join for this user + code.
+ *
+ * @param {{ userId: string, inviteCode: string, showDates?: Array<string | { date?: string }> }} params
+ * @returns {Promise<{ outcome: string, poolId?: string }>}
+ */
+export function runPendingPoolJoin({ userId, inviteCode, showDates }) {
+  const key = pendingPoolJoinKey(userId, inviteCode);
+  if (inFlight?.key === key) return inFlight.promise;
+
+  const promise = joinPoolByInviteCode({ userId, inviteCode, showDates });
+  inFlight = { key, promise };
+  // The early starter never awaits — swallow here so a rejection cannot surface
+  // as an unhandled promise. Real consumers still see it via their own await.
+  promise.catch(() => {});
+  return promise;
+}
+
+/**
+ * @param {string} userId
+ * @param {string} inviteCode
+ * @returns {boolean}
+ */
+export function isPendingPoolJoinRunning(userId, inviteCode) {
+  return inFlight?.key === pendingPoolJoinKey(userId, inviteCode);
+}
+
+/** Drop the memoized run so a retry issues a fresh request. */
+export function clearPendingPoolJoinRun() {
+  inFlight = null;
+}

--- a/src/features/pool-invite/model/useEarlyPoolInviteJoin.js
+++ b/src/features/pool-invite/model/useEarlyPoolInviteJoin.js
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+
+import { FALLBACK_SHOW_DATES } from '../../../shared/data/showDates';
+import { getLocalStorageItem } from '../../../shared/lib/local-storage';
+import { useAuthSession } from '../../auth';
+import { POOL_INVITE_STORAGE_KEY } from '../config';
+import { runPendingPoolJoin } from './pendingPoolJoinRunner';
+import { setPendingPoolJoinStatus } from './pendingPoolJoinStatus';
+
+/**
+ * Pool invite only: fire the join as soon as the visitor is authenticated (#731).
+ *
+ * `usePendingPoolJoin` owns toasts, navigation and the timeout, but it lives in
+ * `DashboardLayout` — so the join used to wait on the DashboardRoute chunk, and
+ * for a brand-new signup on the whole `/setup` detour. Starting here overlaps
+ * the write with those downloads. This hook deliberately does not navigate,
+ * clear the breadcrumb, or fail loudly: `/setup` must keep the new user, and
+ * the dashboard still finalizes by adopting the same in-flight request.
+ *
+ * Site invites (`/invite/:handle`) must never call this — no pool side effects.
+ */
+export function useEarlyPoolInviteJoin() {
+  const { userId } = useAuthSession();
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const code = getLocalStorageItem(POOL_INVITE_STORAGE_KEY)?.trim();
+    if (!code) return;
+
+    setPendingPoolJoinStatus({
+      state: 'joining',
+      inviteCode: code,
+      poolId: null,
+      errorKind: null,
+    });
+
+    // Only used for legacy `pick.pools` backfill; the live calendar lives behind
+    // the dashboard provider, and the fallback is what that provider starts with.
+    runPendingPoolJoin({
+      userId,
+      inviteCode: code,
+      showDates: FALLBACK_SHOW_DATES,
+    });
+  }, [userId]);
+}

--- a/src/features/pool-invite/model/usePendingPoolJoin.js
+++ b/src/features/pool-invite/model/usePendingPoolJoin.js
@@ -8,8 +8,8 @@ import {
 } from '../../../shared/lib/local-storage';
 import { showErrorToast, showSuccessToast } from '../../../shared/ui/toast';
 import { invalidateUserPools } from '../../pools';
-import { joinPoolByInviteCode } from '../api/joinPool';
 import { POOL_INVITE_STORAGE_KEY } from '../config';
+import { clearPendingPoolJoinRun, runPendingPoolJoin } from './pendingPoolJoinRunner';
 import {
   resetPendingPoolJoinStatus,
   setPendingPoolJoinStatus,
@@ -27,6 +27,7 @@ export const PENDING_POOL_JOIN_TIMEOUT_MS = 15_000;
  */
 export function clearPendingPoolJoinInFlight() {
   pendingJoinKeyInFlight = null;
+  clearPendingPoolJoinRun();
 }
 
 /**
@@ -105,7 +106,9 @@ export function usePendingPoolJoin(showDates = []) {
 
     (async () => {
       try {
-        const result = await joinPoolByInviteCode({
+        // Adopts the request `useEarlyPoolInviteJoin` may already have started
+        // on `/join/:code` while this chunk was still downloading (#731).
+        const result = await runPendingPoolJoin({
           userId,
           inviteCode: code,
           showDates: showDatesRef.current,

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,10 +6,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './app/App.jsx'
 import Ga4RouteListener from './app/Ga4RouteListener.jsx'
 import ScrollToTop from './app/ScrollToTop.jsx'
-import { AuthProvider } from './features/auth'
+import { AuthProvider } from './features/auth/provider'
 import {
-  isDashboardEntryPath,
   isPublicColdOpenPath,
+  shouldPrefetchDashboardOnBoot,
   shouldWarmAppCheckOnBoot,
 } from './shared/lib/appBootPath'
 import { initGa4 } from './shared/lib/ga4'
@@ -18,6 +18,8 @@ import {
   initializeAppCheckDeferred,
 } from './shared/lib/firebaseAppCheck'
 import { registerMessagingServiceWorker } from './shared/lib/firebaseMessaging'
+import { hasPersistedSessionHint } from './shared/lib/persistedSessionHint'
+import { prefetchRouteChunk } from './shared/lib/routeChunkPrefetch'
 import { initWebVitals } from './shared/lib/webVitals'
 import './index.css'
 
@@ -31,8 +33,13 @@ const bootPath =
 if (shouldWarmAppCheckOnBoot(bootPath)) {
   ensureAppCheckNow()
 }
-if (isDashboardEntryPath(bootPath)) {
-  void import('./app/routes/DashboardRoute.jsx')
+// #804: returning sessions land on `/` only to bounce to the dashboard. Start
+// that chunk in the same tick as the entry bundle instead of after auth
+// resolves, so the redirect is not a serial download.
+if (
+  shouldPrefetchDashboardOnBoot(bootPath, { hasSession: hasPersistedSessionHint() })
+) {
+  prefetchRouteChunk('dashboard')
 }
 
 /**

--- a/src/pages/pool-invite/PoolInvitePage.jsx
+++ b/src/pages/pool-invite/PoolInvitePage.jsx
@@ -6,10 +6,15 @@ import {
   normalizeInviteHandle,
   useInviteLanding,
 } from '../../features/invite';
-import { usePoolInviteCodeStorage } from '../../features/pool-invite';
+import {
+  useEarlyPoolInviteJoin,
+  usePoolInviteCodeStorage,
+} from '../../features/pool-invite';
 
 export default function PoolInvitePage() {
   usePoolInviteCodeStorage();
+  // Pool invites only — `/invite/:handle` must stay side-effect free (#731).
+  useEarlyPoolInviteJoin();
   const [searchParams] = useSearchParams();
   const fromHandle = normalizeInviteHandle(searchParams.get('from'));
   const landing = useInviteLanding({

--- a/src/shared/lib/appBootPath.js
+++ b/src/shared/lib/appBootPath.js
@@ -39,3 +39,21 @@ export function shouldWarmAppCheckOnBoot(pathname) {
   if (typeof pathname !== 'string' || !pathname) return false;
   return isDashboardEntryPath(pathname) || pathname === '/setup';
 }
+
+/**
+ * Should boot kick off the `DashboardRoute` import (#804)?
+ *
+ * Dashboard hard opens always do. Public cold-open surfaces only do when a
+ * persisted session hint says the visitor is about to be redirected there —
+ * anonymous visitors must not pay for the dashboard graph on splash.
+ *
+ * @param {string} [pathname]
+ * @param {{ hasSession?: boolean }} [opts]
+ * @returns {boolean}
+ */
+export function shouldPrefetchDashboardOnBoot(pathname, opts = {}) {
+  if (typeof pathname !== 'string' || !pathname) return false;
+  if (isDashboardEntryPath(pathname)) return true;
+  if (!opts.hasSession) return false;
+  return pathname === '/' || pathname === '/setup' || isPublicColdOpenPath(pathname);
+}

--- a/src/shared/lib/appBootPath.test.js
+++ b/src/shared/lib/appBootPath.test.js
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   isDashboardEntryPath,
   isPublicColdOpenPath,
+  shouldPrefetchDashboardOnBoot,
   shouldWarmAppCheckOnBoot,
 } from './appBootPath.js';
 
@@ -48,5 +49,30 @@ describe('shouldWarmAppCheckOnBoot', () => {
     expect(shouldWarmAppCheckOnBoot('/invite/pat')).toBe(false);
     expect(shouldWarmAppCheckOnBoot('/how-it-works')).toBe(false);
     expect(shouldWarmAppCheckOnBoot('/privacy')).toBe(false);
+  });
+});
+
+describe('shouldPrefetchDashboardOnBoot', () => {
+  it('always prefetches on a dashboard hard open', () => {
+    expect(shouldPrefetchDashboardOnBoot('/dashboard')).toBe(true);
+    expect(shouldPrefetchDashboardOnBoot('/dashboard/pools', { hasSession: false })).toBe(
+      true,
+    );
+  });
+
+  it('prefetches on cold-open surfaces only with a session hint (#804)', () => {
+    expect(shouldPrefetchDashboardOnBoot('/', { hasSession: true })).toBe(true);
+    expect(shouldPrefetchDashboardOnBoot('/join/ABC', { hasSession: true })).toBe(true);
+    expect(shouldPrefetchDashboardOnBoot('/setup', { hasSession: true })).toBe(true);
+    expect(shouldPrefetchDashboardOnBoot('/')).toBe(false);
+    expect(shouldPrefetchDashboardOnBoot('/join/ABC', { hasSession: false })).toBe(false);
+  });
+
+  it('leaves marketing and unknown paths alone', () => {
+    expect(shouldPrefetchDashboardOnBoot('/how-it-works', { hasSession: true })).toBe(
+      false,
+    );
+    expect(shouldPrefetchDashboardOnBoot('', { hasSession: true })).toBe(false);
+    expect(shouldPrefetchDashboardOnBoot(undefined)).toBe(false);
   });
 });

--- a/src/shared/lib/persistedSessionHint.js
+++ b/src/shared/lib/persistedSessionHint.js
@@ -1,0 +1,30 @@
+/**
+ * Synchronous "this browser probably has a signed-in session" hint (#804).
+ *
+ * Firebase persists auth in IndexedDB, which cannot be read before the first
+ * paint, so a cold open on `/` has no way to know a returning user is about to
+ * be redirected to the dashboard. Auth writes this localStorage flag whenever a
+ * session resolves and clears it on sign-out, giving boot code a same-tick
+ * signal for chunk prefetch. It is a hint only — never an authorization check.
+ */
+
+import {
+  getLocalStorageItem,
+  removeLocalStorageItem,
+  setLocalStorageItem,
+} from './local-storage';
+
+export const PERSISTED_SESSION_HINT_STORAGE_KEY = 'setpicks_session_hint_v1';
+
+export function markPersistedSession() {
+  setLocalStorageItem(PERSISTED_SESSION_HINT_STORAGE_KEY, '1');
+}
+
+export function clearPersistedSessionHint() {
+  removeLocalStorageItem(PERSISTED_SESSION_HINT_STORAGE_KEY);
+}
+
+/** @returns {boolean} */
+export function hasPersistedSessionHint() {
+  return getLocalStorageItem(PERSISTED_SESSION_HINT_STORAGE_KEY) === '1';
+}

--- a/src/shared/lib/persistedSessionHint.test.js
+++ b/src/shared/lib/persistedSessionHint.test.js
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  PERSISTED_SESSION_HINT_STORAGE_KEY,
+  clearPersistedSessionHint,
+  hasPersistedSessionHint,
+  markPersistedSession,
+} from './persistedSessionHint';
+
+function installMemoryLocalStorage() {
+  const store = new Map();
+  const localStorage = {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => {
+      store.set(String(key), String(value));
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+  };
+  vi.stubGlobal('window', { localStorage });
+  return localStorage;
+}
+
+describe('persistedSessionHint', () => {
+  beforeEach(() => {
+    installMemoryLocalStorage();
+  });
+
+  it('is absent until a session is marked', () => {
+    expect(hasPersistedSessionHint()).toBe(false);
+    markPersistedSession();
+    expect(hasPersistedSessionHint()).toBe(true);
+  });
+
+  it('clears on sign-out', () => {
+    markPersistedSession();
+    clearPersistedSessionHint();
+    expect(hasPersistedSessionHint()).toBe(false);
+  });
+
+  it('ignores foreign values under the key', () => {
+    window.localStorage.setItem(PERSISTED_SESSION_HINT_STORAGE_KEY, 'maybe');
+    expect(hasPersistedSessionHint()).toBe(false);
+  });
+
+  it('is inert without storage', () => {
+    vi.stubGlobal('window', undefined);
+    expect(() => markPersistedSession()).not.toThrow();
+    expect(hasPersistedSessionHint()).toBe(false);
+  });
+});

--- a/src/shared/lib/routeChunkPrefetch.js
+++ b/src/shared/lib/routeChunkPrefetch.js
@@ -1,0 +1,65 @@
+/**
+ * Route-chunk prefetch registry (#805).
+ *
+ * Features must never import app-layer route modules (FSD boundary), but they
+ * are the surfaces that know when a chunk is about to be needed — an auth modal
+ * opening is the strongest signal that `dashboard` / `setup` are next.
+ *
+ * The app layer registers loaders by string key; features prefetch by key.
+ */
+
+/** @typedef {'home' | 'setup' | 'dashboard'} RouteChunkKey */
+
+/** @type {Map<string, () => Promise<unknown>>} */
+const loaders = new Map();
+/** Keys whose import has already been kicked off (per page load). */
+const started = new Set();
+
+/**
+ * Register dynamic-import loaders for prefetchable top-level routes.
+ * Called once from the app layer; re-registering a key replaces its loader.
+ *
+ * @param {Record<string, () => Promise<unknown>>} entries
+ */
+export function registerRouteChunkLoaders(entries) {
+  if (!entries || typeof entries !== 'object') return;
+  for (const [key, load] of Object.entries(entries)) {
+    if (typeof load !== 'function') continue;
+    loaders.set(key, load);
+  }
+}
+
+/**
+ * Kick off the dynamic import for one or more registered route chunks.
+ * Unknown keys and repeat calls are no-ops; a failed import is retryable.
+ *
+ * @param {string | string[]} keys
+ */
+export function prefetchRouteChunk(keys) {
+  if (typeof window === 'undefined') return;
+  const list = Array.isArray(keys) ? keys : [keys];
+  for (const key of list) {
+    if (started.has(key)) continue;
+    const load = loaders.get(key);
+    if (!load) continue;
+    started.add(key);
+    try {
+      Promise.resolve(load()).catch(() => {
+        started.delete(key);
+      });
+    } catch {
+      started.delete(key);
+    }
+  }
+}
+
+/** @returns {string[]} registered keys, for diagnostics and tests. */
+export function registeredRouteChunkKeys() {
+  return [...loaders.keys()];
+}
+
+/** Test-only: drop registrations and prefetch bookkeeping. */
+export function resetRouteChunkPrefetch() {
+  loaders.clear();
+  started.clear();
+}

--- a/src/shared/lib/routeChunkPrefetch.test.js
+++ b/src/shared/lib/routeChunkPrefetch.test.js
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  prefetchRouteChunk,
+  registerRouteChunkLoaders,
+  registeredRouteChunkKeys,
+  resetRouteChunkPrefetch,
+} from './routeChunkPrefetch';
+
+beforeEach(() => {
+  vi.stubGlobal('window', {});
+  resetRouteChunkPrefetch();
+});
+
+afterEach(() => {
+  resetRouteChunkPrefetch();
+  vi.unstubAllGlobals();
+});
+
+describe('registerRouteChunkLoaders', () => {
+  it('registers loaders by key', () => {
+    registerRouteChunkLoaders({
+      home: () => Promise.resolve(),
+      dashboard: () => Promise.resolve(),
+    });
+    expect(registeredRouteChunkKeys().sort()).toEqual(['dashboard', 'home']);
+  });
+
+  it('ignores non-function entries and non-object input', () => {
+    registerRouteChunkLoaders({ home: 'nope' });
+    registerRouteChunkLoaders(null);
+    expect(registeredRouteChunkKeys()).toEqual([]);
+  });
+});
+
+describe('prefetchRouteChunk', () => {
+  it('runs the registered loader once per key', () => {
+    const dashboard = vi.fn(() => Promise.resolve());
+    registerRouteChunkLoaders({ dashboard });
+
+    prefetchRouteChunk('dashboard');
+    prefetchRouteChunk('dashboard');
+
+    expect(dashboard).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts an array of keys', () => {
+    const dashboard = vi.fn(() => Promise.resolve());
+    const setup = vi.fn(() => Promise.resolve());
+    registerRouteChunkLoaders({ dashboard, setup });
+
+    prefetchRouteChunk(['dashboard', 'setup']);
+
+    expect(dashboard).toHaveBeenCalledTimes(1);
+    expect(setup).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores unregistered keys', () => {
+    expect(() => prefetchRouteChunk('nope')).not.toThrow();
+  });
+
+  it('allows a retry after a failed import', async () => {
+    const dashboard = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('chunk load failed'))
+      .mockResolvedValueOnce(undefined);
+    registerRouteChunkLoaders({ dashboard });
+
+    prefetchRouteChunk('dashboard');
+    await Promise.resolve();
+    await Promise.resolve();
+    prefetchRouteChunk('dashboard');
+
+    expect(dashboard).toHaveBeenCalledTimes(2);
+  });
+
+  it('does nothing outside the browser', () => {
+    const dashboard = vi.fn(() => Promise.resolve());
+    registerRouteChunkLoaders({ dashboard });
+    vi.stubGlobal('window', undefined);
+
+    prefetchRouteChunk('dashboard');
+
+    expect(dashboard).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #731
Closes #804
Closes #805

## Summary
- Lazy `HomeRoute` + splash `HomeRoute` modulepreload; entry imports `AuthProvider` from `features/auth/provider` so `auth-*` is no longer a static entry import.
- Auth modals prefetch `dashboard` + `setup` via `routeChunkPrefetch` (#805).
- Returning `/` sessions use a localStorage hint to start `DashboardRoute` in the entry tick (#804).
- `/join/:code` starts pending join as soon as auth resolves; site invites stay join-free (#731).
- SemVer **1.44.3** (PATCH).

## Test plan
- [ ] `npm test` / `npm run lint` / `npm run verify:seo-prerender` / `npm run qa:chunks`
- [ ] Cold `/join/:code`: Network — `auth-*.js` not in entry static graph; VIP still paints
- [ ] Open Create account — dashboard + setup chunks prefetch
- [ ] Pool invite signup → one join write, setup respected, no double join
- [ ] `/invite/:handle` — no pool breadcrumb / join
- [ ] Returning signed-in `/` — DashboardRoute starts early; sign-out clears hint


Made with [Cursor](https://cursor.com)