### PR TITLE
test(qa): clear stale invite before UR-B2 pool create

### DIFF
--- a/scripts/qa/auth-scenarios.mjs
+++ b/scripts/qa/auth-scenarios.mjs
@@ -439,6 +439,12 @@ async function main() {
       async () => {
         await dismissSplashChrome(page, dev.url);
         try {
+          // UR-B1 leaves a synthetic YEM42 breadcrumb — clear it so #731 early
+          // join does not race pool create on a nonexistent invite code.
+          await page.evaluate(() => {
+            localStorage.removeItem('phish_pool_pending_invite');
+          });
+
           // Ensure signed in as QA returning user.
           if (!page.url().includes('/dashboard')) {
             await signInEmail(page, dev.url, email, password);


### PR DESCRIPTION
## Summary
- Clear `phish_pool_pending_invite` between UR-B1 and UR-B2 in `qa:auth-scenarios` so #731 early join does not race pool create on the synthetic YEM42 code.
- Verified full `npm run qa:auth-scenarios` green (13/13) on staging tip v1.44.3.

## Test plan
- [x] `npm run qa:auth-scenarios` — all PASS including UR-B2 / UR-B3


Made with [Cursor](https://cursor.com)