### PR TITLE
fix(qa): stop qa:cache CI hang and flaky byte threshold (#748)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,10 @@ jobs:
   # Requires secrets; skip fork PRs (#349 auth).
   qa-runners:
     runs-on: ubuntu-latest
+    # #748: a hung Playwright runner used to burn the full 6h workflow limit
+    # (nightly matrix cancelled every night since 07-19). Warm-cache runs
+    # finish in ~10 min; 20 min is generous headroom incl. Chromium download.
+    timeout-minutes: 20
     needs: [verify, changes]
     if: >
       (github.event_name == 'schedule' ||

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ## [Unreleased]
 
+### Fixed
+- **`qa:cache` CI hang + flaky threshold (#748)** — QA tooling only, no app surface. Runner now exits explicitly on every path, `vite preview` is killed by process group (orphaned vite kept CI runners alive for the full 6 h workflow limit), `qa-runners` gained `timeout-minutes: 20`, and the noisy byte-savings assertion was replaced with a deterministic count of season-stats document references in Firestore WebChannel POST bodies.
+
 ---
 
 ## [1.44.3] — 2026-08-03

--- a/scripts/qa/_lib/preview.mjs
+++ b/scripts/qa/_lib/preview.mjs
@@ -93,11 +93,16 @@ export async function startPreview() {
   // `--strictPort` makes vite fail fast on conflict instead of silently
   // picking another port (which would invalidate `url`). If we collide,
   // bubble up — the runner can be retried.
+  // `detached: true` gives the npm wrapper its own process group so kill()
+  // can signal the WHOLE tree (npm → sh → vite). Signalling only the npm
+  // wrapper leaves an orphaned vite holding the port AND the stdio pipes —
+  // on CI that kept the runner's event loop alive forever (#748).
   const proc = spawn(
     'npm',
     ['run', 'preview', '--', '--port', String(port), '--strictPort'],
     {
       stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
     },
   );
 
@@ -116,13 +121,27 @@ export async function startPreview() {
 
   await Promise.race([waitForReady(url), exitPromise]);
 
+  /**
+   * Signal the preview's entire process group (negative pid). ESRCH means
+   * the group is already gone — fine.
+   *
+   * @param {NodeJS.Signals} signal
+   */
+  const signalGroup = (signal) => {
+    try {
+      process.kill(-proc.pid, signal);
+    } catch (err) {
+      if (err?.code !== 'ESRCH') throw err;
+    }
+  };
+
   const kill = async () => {
     if (exited) return;
-    proc.kill('SIGTERM');
-    // Give vite a moment to release the port; if it's still alive
-    // after 2s, hard-kill so we don't leak processes.
+    signalGroup('SIGTERM');
+    // Give vite a moment to release the port; if the tree is still alive
+    // after 2s, hard-kill the group so we don't leak processes (#748).
     await Promise.race([once(proc, 'exit'), sleep(2_000)]);
-    if (!exited) proc.kill('SIGKILL');
+    if (!exited) signalGroup('SIGKILL');
   };
 
   // Clean up on process exit signals (Ctrl-C, kill, uncaught throw).

--- a/scripts/qa/firestore-cache.mjs
+++ b/scripts/qa/firestore-cache.mjs
@@ -13,6 +13,18 @@
  * **`QA_TEST_EMAIL` / `QA_TEST_PASSWORD`** via the splash `/?login=true`
  * modal before SPA-navigating to `/user/:uid`.
  *
+ * **Pass criterion (#748):** the old assertion compared CDP
+ * `encodedDataLength` byte totals per phase, but WebChannel byte deltas
+ * sit in a ±2 kB noise floor with off-season data volume — four
+ * consecutive staging runs measured `saved` between -2 kB and +168 B.
+ * The deterministic replacement inspects Firestore **forward-channel POST
+ * bodies**: the season-stats pipeline reads `users/{uid}` (materialized,
+ * #244) or `picks/{date}_{uid}` (live fallback), and those document paths
+ * appear verbatim in the `addTarget` messages the SDK POSTs. First visit
+ * MUST reference the profile's paths; a warm React Query cache return
+ * must reference them strictly fewer times. Data-volume independent.
+ * Byte totals are still logged, informationally.
+ *
  * Failure messages cite recipes.md §B so a failing run is actionable
  * without context-switching.
  */
@@ -23,15 +35,6 @@ import { signInViaSplashEmailPassword } from './_lib/qaAuthSplash.mjs';
 import { enableFirebaseAppCheckDebug } from './_lib/qaBrowserInit.mjs';
 import { PUBLIC_PROFILE_UID } from './fixtures.js';
 import { startPreview } from './_lib/preview.mjs';
-
-// Baseline must show real Firestore traffic (not a broken / empty session).
-// Materialized `users/{uid}` season stats are often **small** WebChannel payloads;
-// the old 5 kB floor assumed a live-compute fan-out — too strict for real accounts.
-const BASELINE_MIN_BYTES = 512;
-// Bytes **saved** on SPA return (baseline − post-nav). CDP `encodedDataLength`
-// on multiplexed WebChannel is noisy for small payloads — real passes have
-// landed ~280–600 B; 350 B was still flaky on some accounts; 1 KiB was too strict.
-const SAVED_MIN_BYTES = 250;
 
 /** Soft-nav away target — marketing route (no Firestore season-stats hook). */
 const BOUNCE_PATH = '/how-it-works';
@@ -93,6 +96,10 @@ function fmtBytes(bytes) {
  * `response.body()` is unreliable for Firestore's streaming WebChannel (often
  * ~100 B); CDP `Network.loadingFinished.encodedDataLength` matches DevTools.
  *
+ * Informational only as of #748 — byte deltas on the multiplexed WebChannel
+ * are inside the noise floor with off-season data, so the PASS/FAIL verdict
+ * comes from `attachFirestoreMarkerCounter` instead.
+ *
  * @param {import('playwright').CDPSession} session
  * @param {() => 'idle'|'baseline'|'postNav'} getPhase
  * @param {{ baseline: number, postNav: number }} phaseBytes
@@ -113,6 +120,54 @@ function attachFirestoreCdpByteCounter(session, getPhase, phaseBytes) {
     if (phase !== 'baseline' && phase !== 'postNav') return;
     const n = e.encodedDataLength ?? 0;
     phaseBytes[phase] += n;
+  });
+}
+
+/**
+ * Count references to the profile's season-stats document paths inside
+ * Firestore **forward-channel POST bodies**, per phase (#748).
+ *
+ * `computeUserSeasonStats` reads `users/{uid}` (materialized #244 path)
+ * and/or `picks/{showDate}_{uid}` (live fallback). The SDK's `addTarget`
+ * messages carry those full document paths in the URL-encoded WebChannel
+ * POST body, so counting path occurrences per phase is independent of
+ * payload size, data volume, and ambient listener chatter:
+ *
+ *   - baseline (first `/user/:uid` visit) MUST reference them ≥ 1 time;
+ *   - postNav (SPA return, warm React Query cache) must reference them
+ *     STRICTLY FEWER times — the cached query never re-issues its reads.
+ *
+ * @param {import('playwright').CDPSession} session
+ * @param {() => 'idle'|'baseline'|'postNav'} getPhase
+ * @param {{ baseline: number, postNav: number }} phaseMarkerHits
+ * @param {string} profileUid
+ */
+function attachFirestoreMarkerCounter(
+  session,
+  getPhase,
+  phaseMarkerHits,
+  profileUid,
+) {
+  const markerRe = new RegExp(
+    `documents/(?:users/${profileUid}(?=["'\\\\/,}]|$)|picks/[0-9]{4}-[0-9]{2}-[0-9]{2}_${profileUid}(?=["'\\\\/,}]|$))`,
+    'g',
+  );
+
+  session.on('Network.requestWillBeSent', (e) => {
+    if (!e.request?.url?.includes('firestore.googleapis.com')) return;
+    if (e.request.method !== 'POST') return;
+    const phase = getPhase();
+    if (phase !== 'baseline' && phase !== 'postNav') return;
+    const raw = e.request.postData;
+    if (!raw) return;
+    let decoded = raw;
+    try {
+      decoded = decodeURIComponent(raw);
+    } catch {
+      // Malformed escape in a body we don't care about — scan it raw.
+    }
+    const hits = decoded.match(markerRe);
+    if (hits) phaseMarkerHits[phase] += hits.length;
   });
 }
 
@@ -148,6 +203,9 @@ function requireCacheEnv() {
   return { appCheckToken, email, password };
 }
 
+/**
+ * @returns {Promise<number>} process exit code
+ */
 async function run() {
   const { email, password } = requireCacheEnv();
 
@@ -156,7 +214,6 @@ async function run() {
   console.log(`[qa:cache] preview ready at ${preview.url}`);
 
   const browser = await chromium.launch({ headless: true });
-  let exitCode = 1;
 
   try {
     const ctx = await browser.newContext();
@@ -165,10 +222,17 @@ async function run() {
 
     let phase = /** @type {'idle'|'baseline'|'postNav'} */ ('idle');
     const phaseBytes = { baseline: 0, postNav: 0 };
+    const phaseMarkerHits = { baseline: 0, postNav: 0 };
 
     const cdp = await ctx.newCDPSession(page);
     await cdp.send('Network.enable');
     attachFirestoreCdpByteCounter(cdp, () => phase, phaseBytes);
+    attachFirestoreMarkerCounter(
+      cdp,
+      () => phase,
+      phaseMarkerHits,
+      PUBLIC_PROFILE_UID,
+    );
 
     await signInViaSplashEmailPassword(page, preview.url, email, password);
 
@@ -176,16 +240,16 @@ async function run() {
     await spaNavigate(page, `/user/${PUBLIC_PROFILE_UID}`);
     await waitForProfileSettled(page);
 
-    if (phaseBytes.baseline < BASELINE_MIN_BYTES) {
+    if (phaseMarkerHits.baseline < 1) {
       console.error(
-        `[qa:cache] FAIL: baseline payload was ${fmtBytes(phaseBytes.baseline)}, ` +
-          `expected >= ${fmtBytes(BASELINE_MIN_BYTES)}.`,
+        '[qa:cache] FAIL: baseline visit issued ZERO Firestore requests referencing ' +
+          `users/${PUBLIC_PROFILE_UID} or picks/*_${PUBLIC_PROFILE_UID}.`,
       );
       console.error(
-        '[qa:cache]   Baseline Firestore bytes are near zero — check App Check, auth, ' +
-          'or WebChannel measurement. See scripts/qa/README.md.',
+        '[qa:cache]   The season-stats read was not observed — check App Check, auth, ' +
+          'QA_PUBLIC_PROFILE_UID, or WebChannel measurement. See scripts/qa/README.md.',
       );
-      return;
+      return 1;
     }
 
     phase = 'idle';
@@ -196,39 +260,44 @@ async function run() {
     await spaNavigate(page, `/user/${PUBLIC_PROFILE_UID}`);
     await waitForProfileSettled(page);
 
-    const saved = phaseBytes.baseline - phaseBytes.postNav;
-    const verdict = saved >= SAVED_MIN_BYTES ? 'PASS' : 'FAIL';
+    const verdict =
+      phaseMarkerHits.postNav < phaseMarkerHits.baseline ? 'PASS' : 'FAIL';
+    const savedBytes = phaseBytes.baseline - phaseBytes.postNav;
 
     console.log(
-      `[qa:cache] baseline=${fmtBytes(phaseBytes.baseline)}  ` +
-        `post-nav=${fmtBytes(phaseBytes.postNav)}  ` +
-        `saved=${fmtBytes(saved)}  ` +
-        `threshold=${fmtBytes(SAVED_MIN_BYTES)}  ` +
-        verdict,
+      `[qa:cache] stats-doc refs: baseline=${phaseMarkerHits.baseline}  ` +
+        `post-nav=${phaseMarkerHits.postNav}  ${verdict}`,
+    );
+    console.log(
+      `[qa:cache] bytes (informational): baseline=${fmtBytes(phaseBytes.baseline)}  ` +
+        `post-nav=${fmtBytes(phaseBytes.postNav)}  saved=${fmtBytes(savedBytes)}`,
     );
 
     if (verdict !== 'PASS') {
       console.error(
-        `[qa:cache] FAIL: saved ${fmtBytes(saved)} is below ${fmtBytes(SAVED_MIN_BYTES)} ` +
-          `(baseline ${fmtBytes(phaseBytes.baseline)}, post-nav ${fmtBytes(phaseBytes.postNav)}). ` +
-          'Likely React Query cache miss on season stats, or threshold needs tuning — see recipes §B.',
+        `[qa:cache] FAIL: SPA return re-referenced the profile's stats docs ` +
+          `${phaseMarkerHits.postNav}x (baseline ${phaseMarkerHits.baseline}x) — ` +
+          'the React Query cache did not absorb the season-stats read. See recipes §B.',
       );
       console.error(
         '[qa:cache]   See `.cursor/skills/pr-qa/recipes.md` §B for context.',
       );
-      return;
+      return 1;
     }
 
-    exitCode = 0;
+    return 0;
   } finally {
     await browser.close().catch(() => {});
     await preview.kill();
   }
-
-  process.exit(exitCode);
 }
 
-run().catch((err) => {
-  console.error('[qa:cache] runner crashed:', err);
-  process.exit(1);
-});
+// Always exit explicitly (#748): a leaked child/pipe handle must never keep
+// the event loop — and a CI runner — alive after the verdict is known.
+run().then(
+  (code) => process.exit(code),
+  (err) => {
+    console.error('[qa:cache] runner crashed:', err);
+    process.exit(1);
+  },
+);


### PR DESCRIPTION
Closes #748

## Summary
- Adds `timeout-minutes: 20` to the `qa-runners` job so a hung Playwright runner fails fast instead of burning the 6-hour workflow limit (the nightly full-matrix run has been cancelled every night since 2026-07-19).
- Root-causes the hang: `preview.kill()` SIGKILLed only the `npm run preview` wrapper, orphaning the vite grandchild whose open stdio pipes kept the runner's event loop alive forever on CI. The preview is now spawned `detached` and the **whole process group** is signalled.
- `firestore-cache.mjs` FAIL paths used to `return` past `process.exit`, so threshold failures exited **0** when the loop drained (and hung when it didn't). The runner now exits explicitly with the right code on every path.
- Replaces the flaky byte-savings assertion (±2 kB WebChannel noise vs a 250 B threshold; measured `saved` of +168 B / −1028 B / −1738 B on unmodified staging) with a **data-independent** criterion: count references to the profile's season-stats document paths (`users/{uid}`, `picks/{date}_{uid}`) inside Firestore forward-channel POST bodies per phase. First visit must reference them ≥1×; a warm React Query cache return must reference them strictly fewer times. Byte totals remain as informational logging.

## Test plan
- [x] `npm run qa:cache` × 3 consecutive local runs: PASS with identical marker counts (`baseline=2, post-nav=1`) and prompt process exit (~5 s post-build)
- [x] `npx eslint` clean on both edited scripts
- [ ] After merge: confirm the next nightly scheduled CI run completes (no 6 h cancel)

QA tooling + CI YAML only — no app surface. Carries `skip-version-bump` per `.cursor/rules/versioning.mdc`.

Made with [Cursor](https://cursor.com)