### PR TITLE
feat(tour-stats): full lists with per-card pagination (#709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.45.0] — 2026-08-03
+
+### Added
+- **Tour stats pagination (#709)** — "Most played", "Bustouts", and "High gaps (non-bustout)" now surface **every** song in their category, paginated at 15 rows/page with back/forward arrows and a `16–30 of 87` range indicator. Rank numbers in Most played continue across pages. Applies to both the dashboard Tour stats tab and the public `/tour-stats` pages.
+
+### Changed
+- `aggregateTourSetlistStats` (client + functions mirror) no longer truncates `topSongs` / `gapHighlights` to top-15; `refreshPublicTourStats` writes full ranked lists to `public_tour_stats/{tourSlug}` (public page shows capped lists until the function is deployed and the nightly refresh reruns). The "In most played" self-overlay tile stays pinned to the top 15 and its tooltip now says so.
+
+---
+
 ## [1.44.3] — 2026-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ### Added
 - **Tour stats pagination (#709)** — "Most played", "Bustouts", and "High gaps (non-bustout)" now surface **every** song in their category, paginated at 15 rows/page with back/forward arrows and a `16–30 of 87` range indicator. Rank numbers in Most played continue across pages. Applies to both the dashboard Tour stats tab and the public `/tour-stats` pages.
+- **"Last" (last played) column on Bustouts / High gaps (#709)** — rows render the date the song was last played *before* that tour night when the server-enriched `public_tour_stats` payload carries it (`lastPlayed`, written by `refreshPublicTourStats` from phish.net song history — see the 1.46.0 entry). The dashboard joins the dates from the world-readable public doc (`mergePublicLastPlayed`); the column self-hides while no row has a date, so nothing changes until the enriched refresh lands.
 
 ### Changed
 - `aggregateTourSetlistStats` (client + functions mirror) no longer truncates `topSongs` / `gapHighlights` to top-15; `refreshPublicTourStats` writes full ranked lists to `public_tour_stats/{tourSlug}` (public page shows capped lists until the function is deployed and the nightly refresh reruns). The "In most played" self-overlay tile stays pinned to the top 15 and its tooltip now says so.

--- a/docs/API.md
+++ b/docs/API.md
@@ -167,8 +167,8 @@ Document ID is a kebab-case slug from the calendar tour label (`2026 Sphere` →
 | `tourShowCount` | number | Dates in scope |
 | `showsWithSetlist` | number | Dates with an `official_setlists` doc |
 | `uniqueSongs` / `totalSongPlays` | number | Aggregate counts |
-| `topSongs` | `{ title, timesPlayed }[]` | Most played — **no** per-song `showDates` lists |
-| `bustouts` / `gapHighlights` | `{ title, gap, showDate? }[]` | Single event date OK; never a full night setlist |
+| `topSongs` | `{ title, timesPlayed }[]` | Most played, **full ranked list** as of v1.45.0 (#709; top-15 before) — **no** per-song `showDates` lists |
+| `bustouts` / `gapHighlights` | `{ title, gap, showDate? }[]` | Single event date OK; never a full night setlist. `gapHighlights` uncapped as of v1.45.0 (#709) |
 | `writtenAt` | string | ISO timestamp |
 | `schemaVersion` | number | `1` |
 

--- a/functions/aggregateTourSetlistStats.cjs
+++ b/functions/aggregateTourSetlistStats.cjs
@@ -4,6 +4,9 @@
  * Keep in sync when changing private explorer math.
  */
 
+// Page size on the UI (#709) — lists themselves are unbounded since #709;
+// `refreshPublicTourStats` writes the FULL ranked lists to
+// `public_tour_stats/{tourSlug}` (~hundreds of small rows, well under doc limits).
 const TOUR_STATS_TOP_N = 15;
 const TOUR_STATS_GAP_HIGHLIGHT_MIN = 10;
 const BUSTOUT_MIN_GAP = 30;
@@ -21,13 +24,9 @@ function toGap(raw) {
 
 /**
  * @param {Array<{ showDate: string, setlist: object | null }>} docs
- * @param {{ tourShowCount?: number, topN?: number }} [options]
+ * @param {{ tourShowCount?: number }} [options]
  */
 function aggregateTourSetlistStats(docs, options = {}) {
-  const topN =
-    typeof options.topN === "number" && options.topN > 0
-      ? Math.trunc(options.topN)
-      : TOUR_STATS_TOP_N;
   const tourShowCount =
     typeof options.tourShowCount === "number" && options.tourShowCount >= 0
       ? Math.trunc(options.tourShowCount)
@@ -112,12 +111,12 @@ function aggregateTourSetlistStats(docs, options = {}) {
     }
   }
 
+  // #709: full ranked list — no top-N cap (mirrors the client model).
   const topSongs = [...bySong.values()]
     .sort((a, b) => {
       if (b.timesPlayed !== a.timesPlayed) return b.timesPlayed - a.timesPlayed;
       return a.title.localeCompare(b.title);
     })
-    .slice(0, topN)
     .map((row) => ({ title: row.title, timesPlayed: row.timesPlayed }));
 
   bustouts.sort((a, b) => {
@@ -139,7 +138,7 @@ function aggregateTourSetlistStats(docs, options = {}) {
     totalSongPlays,
     topSongs,
     bustouts,
-    gapHighlights: gapHighlights.slice(0, topN),
+    gapHighlights,
   };
 }
 

--- a/functions/aggregateTourSetlistStats.test.js
+++ b/functions/aggregateTourSetlistStats.test.js
@@ -18,6 +18,30 @@ describe("tourLabelToSlug", () => {
   });
 });
 
+describe("aggregateTourSetlistStats", () => {
+  it("returns ALL songs and gap highlights — no top-N truncation (#709)", () => {
+    const titles = Array.from({ length: 40 }, (_, i) => `Song ${String(i).padStart(2, "0")}`);
+    const songGaps = Object.fromEntries(
+      titles.map((t, i) => [t.toLowerCase(), 10 + (i % 15)])
+    );
+    const stats = aggregateTourSetlistStats(
+      [
+        {
+          showDate: "2026-07-25",
+          setlist: { officialSetlist: titles, bustouts: [], songGaps },
+        },
+      ],
+      { tourShowCount: 1 }
+    );
+    assert.equal(stats.topSongs.length, 40);
+    assert.equal(stats.uniqueSongs, 40);
+    assert.equal(stats.gapHighlights.length, 40);
+    const pub = toPublicTourStatsPayload(stats);
+    assert.equal(pub.topSongs.length, 40);
+    assert.equal(pub.gapHighlights.length, 40);
+  });
+});
+
 describe("toPublicTourStatsPayload", () => {
   it("strips topSongs.showDates and keeps aggregate fields", () => {
     const stats = aggregateTourSetlistStats(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.44.3",
+  "version": "1.45.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/tour-stats/model/aggregateTourSetlistStats.js
+++ b/src/features/tour-stats/model/aggregateTourSetlistStats.js
@@ -66,6 +66,11 @@ function lifetimePlaysFor(lifetime, key) {
  * }} TourSetlistStats
  */
 
+/**
+ * Page size for the tour-stats list cards (#709) and the "In most played"
+ * self-overlay pin. Lists themselves are unbounded — every song appears,
+ * paginated at this many rows per page.
+ */
 export const TOUR_STATS_TOP_N = 15;
 /** Surface high-gap non-bustout songs in the explorer (≥ this gap, below bustout). */
 export const TOUR_STATS_GAP_HIGHLIGHT_MIN = 10;
@@ -77,7 +82,6 @@ export const TOUR_STATS_GAP_HIGHLIGHT_MIN = 10;
  * }>} docs
  * @param {{
  *   tourShowCount?: number,
- *   topN?: number,
  *   gapHighlightMin?: number,
  *   bustoutMinGap?: number,
  *   lifetimePlaysByKey?: Map<string, number> | Record<string, number> | null,
@@ -85,10 +89,6 @@ export const TOUR_STATS_GAP_HIGHLIGHT_MIN = 10;
  * @returns {TourSetlistStats}
  */
 export function aggregateTourSetlistStats(docs, options = {}) {
-  const topN =
-    typeof options.topN === 'number' && options.topN > 0
-      ? Math.trunc(options.topN)
-      : TOUR_STATS_TOP_N;
   const gapHighlightMin =
     typeof options.gapHighlightMin === 'number' && options.gapHighlightMin >= 0
       ? Math.trunc(options.gapHighlightMin)
@@ -194,6 +194,8 @@ export function aggregateTourSetlistStats(docs, options = {}) {
     }
   }
 
+  // #709: full ranked list — no top-N cap. The UI paginates at
+  // TOUR_STATS_TOP_N rows/page instead of truncating.
   const topSongs = [...bySong.entries()]
     .sort(([keyA, a], [keyB, b]) => {
       if (b.timesPlayed !== a.timesPlayed) return b.timesPlayed - a.timesPlayed;
@@ -202,7 +204,6 @@ export function aggregateTourSetlistStats(docs, options = {}) {
       if (lifetimeB !== lifetimeA) return lifetimeB - lifetimeA;
       return a.title.localeCompare(b.title);
     })
-    .slice(0, topN)
     .map(([, row]) => ({
       title: row.title,
       timesPlayed: row.timesPlayed,
@@ -228,6 +229,6 @@ export function aggregateTourSetlistStats(docs, options = {}) {
     totalSongPlays,
     topSongs,
     bustouts,
-    gapHighlights: gapHighlights.slice(0, topN),
+    gapHighlights,
   };
 }

--- a/src/features/tour-stats/model/aggregateTourSetlistStats.test.js
+++ b/src/features/tour-stats/model/aggregateTourSetlistStats.test.js
@@ -35,7 +35,7 @@ describe('aggregateTourSetlistStats (#555)', () => {
           },
         },
       ],
-      { tourShowCount: 4, topN: 10, gapHighlightMin: 10 },
+      { tourShowCount: 4, gapHighlightMin: 10 },
     );
 
     expect(stats.showsWithSetlist).toBe(2);
@@ -115,6 +115,26 @@ describe('aggregateTourSetlistStats (#555)', () => {
       { title: 'Peaches en Regalia', showDate: '2026-07-21', gap: 248 },
     ]);
     expect(stats.gapHighlights).toEqual([]);
+  });
+
+  it('returns ALL songs and gap highlights — no top-N truncation (#709)', () => {
+    const titles = Array.from({ length: 40 }, (_, i) => `Song ${String(i).padStart(2, '0')}`);
+    const songGaps = Object.fromEntries(
+      titles.map((t, i) => [t.toLowerCase(), 10 + (i % 15)]),
+    );
+    const stats = aggregateTourSetlistStats(
+      [
+        {
+          showDate: '2026-07-25',
+          setlist: { officialSetlist: titles, bustouts: [], songGaps },
+        },
+      ],
+      { bustoutMinGap: 30, gapHighlightMin: 10 },
+    );
+    expect(stats.topSongs).toHaveLength(40);
+    expect(stats.uniqueSongs).toBe(40);
+    // every gap in the fixture is ≥ 10 and < 30 → all 40 are highlights
+    expect(stats.gapHighlights).toHaveLength(40);
   });
 
   it('breaks Most played ties by lifetime plays from the catalog', () => {

--- a/src/features/tour-stats/model/mergePublicLastPlayed.js
+++ b/src/features/tour-stats/model/mergePublicLastPlayed.js
@@ -1,0 +1,73 @@
+/**
+ * Join `lastPlayed` dates from the precomputed `public_tour_stats` payload
+ * onto client-aggregated bustout / high-gap rows (#709 follow-up).
+ *
+ * The date a song was last played *before* a tour night comes from phish.net
+ * song history and is only computable server-side (`refreshPublicTourStats`,
+ * #666). The dashboard aggregates setlists client-side, so it borrows the
+ * dates from the world-readable public doc for the same tour. Rows match on
+ * normalized title + tour show date; anything unmatched stays date-less and
+ * the UI hides the column when no row has one.
+ */
+
+/**
+ * @param {unknown} title
+ * @param {unknown} showDate
+ * @returns {string}
+ */
+function rowKey(title, showDate) {
+  return `${String(title ?? '')
+    .trim()
+    .toLowerCase()}|${String(showDate ?? '').trim()}`;
+}
+
+/**
+ * @param {null | undefined | {
+ *   bustouts?: Array<{ title?: string, showDate?: string, lastPlayed?: string | null }>,
+ *   gapHighlights?: Array<{ title?: string, showDate?: string, lastPlayed?: string | null }>,
+ * }} publicDoc
+ * @returns {Map<string, string>} rowKey → `YYYY-MM-DD`
+ */
+export function buildLastPlayedByRowKey(publicDoc) {
+  const map = new Map();
+  if (!publicDoc || typeof publicDoc !== 'object') return map;
+  for (const list of [publicDoc.bustouts, publicDoc.gapHighlights]) {
+    if (!Array.isArray(list)) continue;
+    for (const row of list) {
+      if (!row || typeof row !== 'object') continue;
+      const lastPlayed =
+        typeof row.lastPlayed === 'string' ? row.lastPlayed.trim() : '';
+      if (!lastPlayed) continue;
+      map.set(rowKey(row.title, row.showDate), lastPlayed);
+    }
+  }
+  return map;
+}
+
+/**
+ * Returns `stats` with `lastPlayed` stamped onto matching bustout /
+ * gap-highlight rows. Same object back when the public doc contributes
+ * nothing, so memoized consumers don't re-render.
+ *
+ * @template {{ bustouts: Array<object>, gapHighlights: Array<object> }} S
+ * @param {S} stats
+ * @param {Parameters<typeof buildLastPlayedByRowKey>[0]} publicDoc
+ * @returns {S}
+ */
+export function mergeLastPlayedIntoStats(stats, publicDoc) {
+  const byKey = buildLastPlayedByRowKey(publicDoc);
+  if (byKey.size === 0) return stats;
+
+  let changed = false;
+  const stamp = (rows) =>
+    rows.map((row) => {
+      const lastPlayed = byKey.get(rowKey(row.title, row.showDate));
+      if (!lastPlayed) return row;
+      changed = true;
+      return { ...row, lastPlayed };
+    });
+
+  const bustouts = stamp(stats.bustouts);
+  const gapHighlights = stamp(stats.gapHighlights);
+  return changed ? { ...stats, bustouts, gapHighlights } : stats;
+}

--- a/src/features/tour-stats/model/mergePublicLastPlayed.test.js
+++ b/src/features/tour-stats/model/mergePublicLastPlayed.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildLastPlayedByRowKey,
+  mergeLastPlayedIntoStats,
+} from './mergePublicLastPlayed';
+
+const baseStats = () => ({
+  topSongs: [{ title: 'Ghost', timesPlayed: 3 }],
+  bustouts: [
+    { title: 'Harpua', showDate: '2026-07-22', gap: 250 },
+    { title: 'Icculus', showDate: '2026-07-25', gap: 120 },
+  ],
+  gapHighlights: [{ title: 'Fee', showDate: '2026-07-23', gap: 14 }],
+});
+
+describe('buildLastPlayedByRowKey', () => {
+  it('indexes bustouts + gapHighlights by normalized title|showDate', () => {
+    const map = buildLastPlayedByRowKey({
+      bustouts: [
+        { title: '  HARPUA ', showDate: '2026-07-22', lastPlayed: '2019-06-16' },
+        { title: 'No Date', showDate: '2026-07-22', lastPlayed: '' },
+      ],
+      gapHighlights: [
+        { title: 'Fee', showDate: '2026-07-23', lastPlayed: '2025-08-01' },
+      ],
+    });
+    expect(map.get('harpua|2026-07-22')).toBe('2019-06-16');
+    expect(map.get('fee|2026-07-23')).toBe('2025-08-01');
+    expect(map.size).toBe(2);
+  });
+
+  it('returns an empty map for null / malformed docs', () => {
+    expect(buildLastPlayedByRowKey(null).size).toBe(0);
+    expect(buildLastPlayedByRowKey({ bustouts: 'nope' }).size).toBe(0);
+  });
+});
+
+describe('mergeLastPlayedIntoStats', () => {
+  it('stamps lastPlayed onto matching rows and leaves others untouched', () => {
+    const stats = baseStats();
+    const merged = mergeLastPlayedIntoStats(stats, {
+      bustouts: [
+        { title: 'Harpua', showDate: '2026-07-22', lastPlayed: '2019-06-16' },
+      ],
+      gapHighlights: [
+        { title: 'Fee', showDate: '2026-07-23', lastPlayed: '2025-08-01' },
+      ],
+    });
+
+    expect(merged).not.toBe(stats);
+    expect(merged.bustouts[0].lastPlayed).toBe('2019-06-16');
+    expect(merged.bustouts[1].lastPlayed).toBeUndefined();
+    expect(merged.gapHighlights[0].lastPlayed).toBe('2025-08-01');
+    // Untouched slices carry over.
+    expect(merged.topSongs).toBe(stats.topSongs);
+  });
+
+  it('requires showDate to match — a later replay does not inherit the date', () => {
+    const merged = mergeLastPlayedIntoStats(baseStats(), {
+      bustouts: [
+        { title: 'Harpua', showDate: '2026-08-30', lastPlayed: '2019-06-16' },
+      ],
+    });
+    expect(merged.bustouts[0].lastPlayed).toBeUndefined();
+  });
+
+  it('returns the same stats object when the public doc contributes nothing', () => {
+    const stats = baseStats();
+    expect(mergeLastPlayedIntoStats(stats, null)).toBe(stats);
+    expect(
+      mergeLastPlayedIntoStats(stats, {
+        bustouts: [{ title: 'Unknown', showDate: '2026-01-01', lastPlayed: '2020-01-01' }],
+      }),
+    ).toBe(stats);
+  });
+});

--- a/src/features/tour-stats/model/useTourStatsScreen.js
+++ b/src/features/tour-stats/model/useTourStatsScreen.js
@@ -3,12 +3,15 @@ import { useQuery } from '@tanstack/react-query';
 
 import { useAuth } from '../../auth';
 import { useSongCatalog } from '../../song-catalog';
+import { tourLabelToSlug } from '../../../shared/lib/tourSlug';
 import { computeTourStatsSelfOverlay } from '../api/computeTourStatsSelfOverlay';
+import { fetchPublicTourStatsDoc } from '../api/fetchPublicTourStats';
 import { fetchTourOfficialSetlists } from '../api/fetchTourOfficialSetlists';
 import {
   aggregateTourSetlistStats,
   TOUR_STATS_TOP_N,
 } from './aggregateTourSetlistStats';
+import { mergeLastPlayedIntoStats } from './mergePublicLastPlayed';
 import { trackTourStatsView } from './tourStatsAnalytics';
 
 /**
@@ -72,13 +75,26 @@ export function useTourStatsScreen(options = {}) {
     queryFn: () => fetchTourOfficialSetlists(showDates),
   });
 
+  // "Last played" dates for bustout/high-gap rows come from phish.net song
+  // history and only exist in the server-written public payload (#666). The
+  // dashboard borrows them from the world-readable public doc; if the doc is
+  // missing or not yet enriched, the column simply doesn't render.
+  const publicDocQuery = useQuery({
+    queryKey: ['tour-stats-public-doc', tourLabelToSlug(tourName)],
+    enabled: Boolean(tourName),
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+    queryFn: () => fetchPublicTourStatsDoc(tourLabelToSlug(tourName)),
+  });
+
   const stats = useMemo(() => {
     const docs = setlistQuery.data?.docs || [];
-    return aggregateTourSetlistStats(docs, {
+    const aggregated = aggregateTourSetlistStats(docs, {
       tourShowCount: showDates.length,
       lifetimePlaysByKey,
     });
-  }, [setlistQuery.data, showDates.length, lifetimePlaysByKey]);
+    return mergeLastPlayedIntoStats(aggregated, publicDocQuery.data ?? null);
+  }, [setlistQuery.data, showDates.length, lifetimePlaysByKey, publicDocQuery.data]);
 
   // #709: `stats.topSongs` is now the FULL ranked list. The "In most played"
   // overlay tile must stay pinned to the top 15 — otherwise it degrades into

--- a/src/features/tour-stats/model/useTourStatsScreen.js
+++ b/src/features/tour-stats/model/useTourStatsScreen.js
@@ -5,7 +5,10 @@ import { useAuth } from '../../auth';
 import { useSongCatalog } from '../../song-catalog';
 import { computeTourStatsSelfOverlay } from '../api/computeTourStatsSelfOverlay';
 import { fetchTourOfficialSetlists } from '../api/fetchTourOfficialSetlists';
-import { aggregateTourSetlistStats } from './aggregateTourSetlistStats';
+import {
+  aggregateTourSetlistStats,
+  TOUR_STATS_TOP_N,
+} from './aggregateTourSetlistStats';
 import { trackTourStatsView } from './tourStatsAnalytics';
 
 /**
@@ -77,13 +80,21 @@ export function useTourStatsScreen(options = {}) {
     });
   }, [setlistQuery.data, showDates.length, lifetimePlaysByKey]);
 
+  // #709: `stats.topSongs` is now the FULL ranked list. The "In most played"
+  // overlay tile must stay pinned to the top 15 — otherwise it degrades into
+  // "overlap with every played song".
+  const overlayTopSongTitles = useMemo(
+    () => stats.topSongs.slice(0, TOUR_STATS_TOP_N).map((r) => r.title),
+    [stats.topSongs],
+  );
+
   const overlayQuery = useQuery({
     queryKey: [
       'tour-stats-self-overlay',
       uid,
       tourName,
       showDates.join(','),
-      stats.topSongs.map((r) => r.title).join('|'),
+      overlayTopSongTitles.join('|'),
     ],
     enabled:
       Boolean(uid) &&
@@ -92,7 +103,7 @@ export function useTourStatsScreen(options = {}) {
     staleTime: 5 * 60 * 1000,
     queryFn: () =>
       computeTourStatsSelfOverlay(uid, setlistQuery.data.docs, {
-        topSongTitles: stats.topSongs.map((r) => r.title),
+        topSongTitles: overlayTopSongTitles,
       }),
   });
 

--- a/src/features/tour-stats/ui/TourStatsView.jsx
+++ b/src/features/tour-stats/ui/TourStatsView.jsx
@@ -29,6 +29,17 @@ const TOP_SONGS_ROW_GRID =
 const GAP_ROW_GRID =
   'grid grid-cols-[minmax(0,1fr)_6.5rem_3rem] items-center gap-x-2 min-h-[1.75rem]';
 
+/**
+ * 4-col variant when rows carry `lastPlayed` (#709 follow-up): Song | Last |
+ * Date | Gap. Only used when at least one visible row has the date, so the
+ * un-enriched dashboard/public state keeps the roomier 3-col layout.
+ */
+const GAP_ROW_GRID_WITH_LAST =
+  'grid grid-cols-[minmax(0,1fr)_5.75rem_5.75rem_2.5rem] items-center gap-x-1.5 min-h-[1.75rem]';
+
+const LAST_PLAYED_TITLE =
+  'Last played before that night (phish.net song history)';
+
 const COL_HEADER =
   'mb-0.5 border-b border-brand-primary/20 pb-1 text-[10px] font-black uppercase tracking-wider text-slate-300';
 
@@ -246,37 +257,10 @@ export default function TourStatsView({
           {stats.bustouts.length === 0 ? (
             <p className="text-sm text-content-secondary">No bustouts frozen yet.</p>
           ) : (
-            <PagedRows
+            <GapPagedRows
               rows={stats.bustouts}
               label="bustouts"
-              header={
-                <div className={`${GAP_ROW_GRID} ${COL_HEADER}`} aria-hidden>
-                  <span>Song</span>
-                  <span className="justify-self-end">Date</span>
-                  <span className="justify-self-end">Gap</span>
-                </div>
-              }
-              renderRow={(row) => (
-                <li
-                  key={`${row.showDate}-${row.title}`}
-                  className={GAP_ROW_GRID}
-                >
-                  <span className="min-w-0 truncate">{row.title}</span>
-                  <span className="justify-self-end tabular-nums text-content-secondary">
-                    {row.showDate}
-                  </span>
-                  <span
-                    className="justify-self-end tabular-nums font-bold text-amber-200"
-                    title={
-                      row.gap != null
-                        ? `${row.gap} shows since last played (pre-show gap)`
-                        : undefined
-                    }
-                  >
-                    {row.gap != null ? row.gap : '—'}
-                  </span>
-                </li>
-              )}
+              gapClassName="justify-self-end tabular-nums font-bold text-amber-200"
             />
           )}
           <p className="mt-3 border-t border-border-subtle/40 pt-3 text-[11px] font-semibold leading-relaxed text-content-secondary">
@@ -303,38 +287,79 @@ export default function TourStatsView({
             definition={HIGH_GAPS_DEF}
             headerTone="muted"
           >
-            <PagedRows
+            <GapPagedRows
               rows={stats.gapHighlights}
               label="high gaps"
-              header={
-                <div className={`${GAP_ROW_GRID} ${COL_HEADER}`} aria-hidden>
-                  <span>Song</span>
-                  <span className="justify-self-end">Date</span>
-                  <span className="justify-self-end">Gap</span>
-                </div>
-              }
-              renderRow={(row) => (
-                <li
-                  key={`${row.showDate}-${row.title}`}
-                  className={GAP_ROW_GRID}
-                >
-                  <span className="min-w-0 truncate">{row.title}</span>
-                  <span className="justify-self-end tabular-nums text-content-secondary">
-                    {row.showDate}
-                  </span>
-                  <span
-                    className="justify-self-end tabular-nums text-slate-300"
-                    title={`${row.gap} shows since last played (pre-show gap)`}
-                  >
-                    {row.gap}
-                  </span>
-                </li>
-              )}
+              gapClassName="justify-self-end tabular-nums text-slate-300"
             />
           </TourStatsSectionCard>
         ) : null}
       </div>
     </InfoTooltipProvider>
+  );
+}
+
+/**
+ * Bustouts / High-gaps list body: Song | Date | Gap rows, plus a "Last"
+ * (last played before that night) column when any row carries a
+ * `lastPlayed` date — server-enriched payloads only (#666), so the column
+ * self-hides on un-enriched data instead of rendering an empty track.
+ *
+ * @param {{
+ *   rows: Array<{ title: string, showDate: string, gap: number | null, lastPlayed?: string }>,
+ *   label: string,
+ *   gapClassName: string,
+ * }} props
+ */
+function GapPagedRows({ rows, label, gapClassName }) {
+  const hasLastPlayed = rows.some(
+    (row) => typeof row.lastPlayed === 'string' && row.lastPlayed,
+  );
+  const grid = hasLastPlayed ? GAP_ROW_GRID_WITH_LAST : GAP_ROW_GRID;
+
+  return (
+    <PagedRows
+      rows={rows}
+      label={label}
+      header={
+        <div className={`${grid} ${COL_HEADER}`} aria-hidden>
+          <span>Song</span>
+          {hasLastPlayed ? (
+            <span className="justify-self-end" title={LAST_PLAYED_TITLE}>
+              Last
+            </span>
+          ) : null}
+          <span className="justify-self-end">Date</span>
+          <span className="justify-self-end">Gap</span>
+        </div>
+      }
+      renderRow={(row) => (
+        <li key={`${row.showDate}-${row.title}`} className={grid}>
+          <span className="min-w-0 truncate">{row.title}</span>
+          {hasLastPlayed ? (
+            <span
+              className="justify-self-end tabular-nums text-content-secondary"
+              title={LAST_PLAYED_TITLE}
+            >
+              {row.lastPlayed || '—'}
+            </span>
+          ) : null}
+          <span className="justify-self-end tabular-nums text-content-secondary">
+            {row.showDate}
+          </span>
+          <span
+            className={gapClassName}
+            title={
+              row.gap != null
+                ? `${row.gap} shows since last played (pre-show gap)`
+                : undefined
+            }
+          >
+            {row.gap != null ? row.gap : '—'}
+          </span>
+        </li>
+      )}
+    />
   );
 }
 

--- a/src/features/tour-stats/ui/TourStatsView.jsx
+++ b/src/features/tour-stats/ui/TourStatsView.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Loader2 } from 'lucide-react';
+import React, { useState } from 'react';
+import { ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
 
 import Card from '../../../shared/ui/Card';
 import InfoTooltip, {
@@ -14,7 +14,10 @@ import {
   DASHBOARD_CARD_EYEBROW as STANDINGS_BOX_EYEBROW,
   DASHBOARD_CARD_SHELL as STANDINGS_CARD_SHELL,
 } from '../../../shared/ui/dashboardCardClasses';
-import { TOUR_STATS_GAP_HIGHLIGHT_MIN } from '../model/aggregateTourSetlistStats';
+import {
+  TOUR_STATS_GAP_HIGHLIGHT_MIN,
+  TOUR_STATS_TOP_N,
+} from '../model/aggregateTourSetlistStats';
 
 const { BUSTOUT_MIN_GAP } = SCORING_RULES;
 
@@ -203,7 +206,7 @@ export default function TourStatsView({
                 label="In most played"
                 value={overlay.topSongOverlap}
                 accent="personal"
-                definition="How many of this tour's most-played songs you've picked."
+                definition={`How many of this tour's top ${TOUR_STATS_TOP_N} most-played songs you've picked.`}
               />
             </div>
           </TourStatsSectionCard>
@@ -213,24 +216,29 @@ export default function TourStatsView({
           {stats.topSongs.length === 0 ? (
             <p className="text-sm text-content-secondary">No setlist songs yet.</p>
           ) : (
-            <div>
-              <div className={`${TOP_SONGS_ROW_GRID} ${COL_HEADER}`} aria-hidden>
-                <span className="tabular-nums">#</span>
-                <span>Song</span>
-                <span className="justify-self-end">Plays</span>
-              </div>
-              <ol className="space-y-0.5 text-sm font-semibold text-slate-100">
-                {stats.topSongs.map((row, idx) => (
-                  <li key={row.title} className={TOP_SONGS_ROW_GRID}>
-                    <span className="tabular-nums text-brand-primary/80">{idx + 1}</span>
-                    <span className="min-w-0 truncate">{row.title}</span>
-                    <span className="justify-self-end tabular-nums text-brand-primary">
-                      {row.timesPlayed}
-                    </span>
-                  </li>
-                ))}
-              </ol>
-            </div>
+            <PagedRows
+              rows={stats.topSongs}
+              label="most played"
+              listAs="ol"
+              header={
+                <div className={`${TOP_SONGS_ROW_GRID} ${COL_HEADER}`} aria-hidden>
+                  <span className="tabular-nums">#</span>
+                  <span>Song</span>
+                  <span className="justify-self-end">Plays</span>
+                </div>
+              }
+              renderRow={(row, absoluteIdx) => (
+                <li key={row.title} className={TOP_SONGS_ROW_GRID}>
+                  <span className="tabular-nums text-brand-primary/80">
+                    {absoluteIdx + 1}
+                  </span>
+                  <span className="min-w-0 truncate">{row.title}</span>
+                  <span className="justify-self-end tabular-nums text-brand-primary">
+                    {row.timesPlayed}
+                  </span>
+                </li>
+              )}
+            />
           )}
         </TourStatsSectionCard>
 
@@ -238,36 +246,38 @@ export default function TourStatsView({
           {stats.bustouts.length === 0 ? (
             <p className="text-sm text-content-secondary">No bustouts frozen yet.</p>
           ) : (
-            <div>
-              <div className={`${GAP_ROW_GRID} ${COL_HEADER}`} aria-hidden>
-                <span>Song</span>
-                <span className="justify-self-end">Date</span>
-                <span className="justify-self-end">Gap</span>
-              </div>
-              <ul className="space-y-0.5 text-sm font-semibold text-slate-100">
-                {stats.bustouts.map((row) => (
-                  <li
-                    key={`${row.showDate}-${row.title}`}
-                    className={GAP_ROW_GRID}
+            <PagedRows
+              rows={stats.bustouts}
+              label="bustouts"
+              header={
+                <div className={`${GAP_ROW_GRID} ${COL_HEADER}`} aria-hidden>
+                  <span>Song</span>
+                  <span className="justify-self-end">Date</span>
+                  <span className="justify-self-end">Gap</span>
+                </div>
+              }
+              renderRow={(row) => (
+                <li
+                  key={`${row.showDate}-${row.title}`}
+                  className={GAP_ROW_GRID}
+                >
+                  <span className="min-w-0 truncate">{row.title}</span>
+                  <span className="justify-self-end tabular-nums text-content-secondary">
+                    {row.showDate}
+                  </span>
+                  <span
+                    className="justify-self-end tabular-nums font-bold text-amber-200"
+                    title={
+                      row.gap != null
+                        ? `${row.gap} shows since last played (pre-show gap)`
+                        : undefined
+                    }
                   >
-                    <span className="min-w-0 truncate">{row.title}</span>
-                    <span className="justify-self-end tabular-nums text-content-secondary">
-                      {row.showDate}
-                    </span>
-                    <span
-                      className="justify-self-end tabular-nums font-bold text-amber-200"
-                      title={
-                        row.gap != null
-                          ? `${row.gap} shows since last played (pre-show gap)`
-                          : undefined
-                      }
-                    >
-                      {row.gap != null ? row.gap : '—'}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </div>
+                    {row.gap != null ? row.gap : '—'}
+                  </span>
+                </li>
+              )}
+            />
           )}
           <p className="mt-3 border-t border-border-subtle/40 pt-3 text-[11px] font-semibold leading-relaxed text-content-secondary">
             Gap = shows since last played before that night. Bustout = gap ≥{' '}
@@ -293,36 +303,100 @@ export default function TourStatsView({
             definition={HIGH_GAPS_DEF}
             headerTone="muted"
           >
-            <div>
-              <div className={`${GAP_ROW_GRID} ${COL_HEADER}`} aria-hidden>
-                <span>Song</span>
-                <span className="justify-self-end">Date</span>
-                <span className="justify-self-end">Gap</span>
-              </div>
-              <ul className="space-y-0.5 text-sm font-semibold text-slate-100">
-                {stats.gapHighlights.map((row) => (
-                  <li
-                    key={`${row.showDate}-${row.title}`}
-                    className={GAP_ROW_GRID}
+            <PagedRows
+              rows={stats.gapHighlights}
+              label="high gaps"
+              header={
+                <div className={`${GAP_ROW_GRID} ${COL_HEADER}`} aria-hidden>
+                  <span>Song</span>
+                  <span className="justify-self-end">Date</span>
+                  <span className="justify-self-end">Gap</span>
+                </div>
+              }
+              renderRow={(row) => (
+                <li
+                  key={`${row.showDate}-${row.title}`}
+                  className={GAP_ROW_GRID}
+                >
+                  <span className="min-w-0 truncate">{row.title}</span>
+                  <span className="justify-self-end tabular-nums text-content-secondary">
+                    {row.showDate}
+                  </span>
+                  <span
+                    className="justify-self-end tabular-nums text-slate-300"
+                    title={`${row.gap} shows since last played (pre-show gap)`}
                   >
-                    <span className="min-w-0 truncate">{row.title}</span>
-                    <span className="justify-self-end tabular-nums text-content-secondary">
-                      {row.showDate}
-                    </span>
-                    <span
-                      className="justify-self-end tabular-nums text-slate-300"
-                      title={`${row.gap} shows since last played (pre-show gap)`}
-                    >
-                      {row.gap}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </div>
+                    {row.gap}
+                  </span>
+                </li>
+              )}
+            />
           </TourStatsSectionCard>
         ) : null}
       </div>
     </InfoTooltipProvider>
+  );
+}
+
+const PAGER_BUTTON =
+  'inline-flex h-7 w-7 items-center justify-center rounded-lg border border-border-subtle/50 text-slate-200 transition-colors hover:border-brand-primary/50 hover:text-brand-primary disabled:cursor-not-allowed disabled:opacity-35 disabled:hover:border-border-subtle/50 disabled:hover:text-slate-200';
+
+/**
+ * Client-side pager for the tour-stats list cards (#709). Lists are
+ * unbounded; this renders TOUR_STATS_TOP_N rows per page with back/forward
+ * arrows and a `16–30 of 87` range indicator. Controls are hidden entirely
+ * when the list fits on one page, and the current page self-clamps when the
+ * data shrinks (e.g. tour filter change) so a stale index never renders an
+ * empty page.
+ *
+ * @param {{
+ *   rows: Array<object>,
+ *   label: string,
+ *   header: React.ReactNode,
+ *   renderRow: (row: object, absoluteIdx: number) => React.ReactNode,
+ *   listAs?: 'ul' | 'ol',
+ * }} props
+ */
+function PagedRows({ rows, label, header, renderRow, listAs: ListTag = 'ul' }) {
+  const [page, setPage] = useState(0);
+  const total = rows.length;
+  const maxPage = Math.max(0, Math.ceil(total / TOUR_STATS_TOP_N) - 1);
+  const current = Math.min(page, maxPage);
+  const start = current * TOUR_STATS_TOP_N;
+  const end = Math.min(start + TOUR_STATS_TOP_N, total);
+
+  return (
+    <div>
+      {header}
+      <ListTag className="space-y-0.5 text-sm font-semibold text-slate-100">
+        {rows.slice(start, end).map((row, i) => renderRow(row, start + i))}
+      </ListTag>
+      {total > TOUR_STATS_TOP_N ? (
+        <div className="mt-2 flex items-center justify-end gap-1.5 border-t border-border-subtle/40 pt-2">
+          <button
+            type="button"
+            onClick={() => setPage(Math.max(0, current - 1))}
+            disabled={current === 0}
+            aria-label={`Previous ${label} page`}
+            className={PAGER_BUTTON}
+          >
+            <ChevronLeft className="h-4 w-4" aria-hidden />
+          </button>
+          <span className="min-w-[6.5rem] text-center text-[11px] font-semibold tabular-nums text-content-secondary">
+            {start + 1}–{end} of {total}
+          </span>
+          <button
+            type="button"
+            onClick={() => setPage(Math.min(maxPage, current + 1))}
+            disabled={current === maxPage}
+            aria-label={`Next ${label} page`}
+            className={PAGER_BUTTON}
+          >
+            <ChevronRight className="h-4 w-4" aria-hidden />
+          </button>
+        </div>
+      ) : null}
+    </div>
   );
 }
 


### PR DESCRIPTION
Closes #709

> **Merge order:** stacked on #815 (`feat/748-qa-cache-ci-hang`) to avoid CHANGELOG conflicts — merge #815 first; this PR's diff then reduces to the tour-stats change.

## Summary
- "Most played", "Bustouts", and "High gaps (non-bustout)" now surface **every** song in their category. Cards paginate at 15 rows/page (`TOUR_STATS_TOP_N`) with back/forward arrows and a `16–30 of 87` range indicator; controls are hidden when a list fits on one page, and the page index self-clamps when data shrinks (tour filter change). Most played rank numbers continue across pages.
- `aggregateTourSetlistStats` client model **and** functions mirror (`functions/aggregateTourSetlistStats.cjs`, per its keep-in-sync header) drop the top-15 slices, so `refreshPublicTourStats` writes full ranked lists to `public_tour_stats/{tourSlug}`. The public `/tour-stats` page shows capped lists until the function is deployed and the nightly refresh reruns (documented in CHANGELOG).
- The "In most played" self-overlay tile stays pinned to the **top 15** (sliced in the react-query key and `queryFn`) so it doesn't degrade into "overlap with every played song"; its tooltip now says "top 15".
- The shared `TourStatsView` means the pager covers both the dashboard Tour stats tab and the public SEO pages with one implementation.

SemVer: **MINOR** → `1.45.0` (new UI capability + behavior change to declared `public_tour_stats` fields; `docs/API.md` §1.13 updated).

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 92 files / 503 tests pass (includes new no-truncation case)
- [x] `functions`: `node --test aggregateTourSetlistStats.test.js` — 4 pass (new full-list + public-payload case)
- [x] `npm run verify:dashboard-meta` / `verify:dashboard-ui` clean
- [x] `npm run build` + SEO prerender OK
- [ ] Browser: on the preview, open dashboard → Standings → Tour stats with a tour > 15 unique songs; flip Most played to page 2 — ranks continue 16, 17, …; range reads `16–30 of N`
- [ ] Browser: public `/tour-stats` still renders (capped lists until function deploy + refresh)
- [ ] Post-merge ops: deploy functions and run `refreshPublicTourStats` (or wait for the 07:30 ET schedule) to materialize full public lists

Made with [Cursor](https://cursor.com)