### PR TITLE
feat(seo): enrich public tour stats with phish.net lifetime data (#666)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ### Added
 - **Public tour stats phish.net enrichment (#666, Phase 1)** — `refreshPublicTourStats` fetches phish.net `v5/songs` server-side (secret stays in Cloud Functions) and stamps `lifetimePlays` + `debutYear` onto every `public_tour_stats` row; public `/tour-stats` rows render a "Debut 1997 · 623 plays all-time" context line. Best-effort: refresh still writes unenriched docs (with `enrichment: null`) if phish.net is unavailable. `schemaVersion` → `2`. Dashboard Tour stats (client aggregation) unchanged.
+- **`lastPlayed` on bustout / high-gap public rows (#709 follow-up)** — same refresh looks up each unique bustout/high-gap song's phish.net play history (≤80 lookups/run, cached across tours) and stamps the date last played *before* that tour night. Powers the "Last" column shipped in 1.45.0; schedule/callable timeouts raised to 300s to fit the extra lookups.
 
 ### Changed
 - `scheduledPublicTourStatsRefresh` and the admin `refreshPublicTourStats` callable now bind the `PHISHNET_API_KEY` secret.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.46.0] — 2026-08-03
+
+### Added
+- **Public tour stats phish.net enrichment (#666, Phase 1)** — `refreshPublicTourStats` fetches phish.net `v5/songs` server-side (secret stays in Cloud Functions) and stamps `lifetimePlays` + `debutYear` onto every `public_tour_stats` row; public `/tour-stats` rows render a "Debut 1997 · 623 plays all-time" context line. Best-effort: refresh still writes unenriched docs (with `enrichment: null`) if phish.net is unavailable. `schemaVersion` → `2`. Dashboard Tour stats (client aggregation) unchanged.
+
+### Changed
+- `scheduledPublicTourStatsRefresh` and the admin `refreshPublicTourStats` callable now bind the `PHISHNET_API_KEY` secret.
+
+---
+
 ## [1.45.1] — 2026-08-03
 
 ### Fixed

--- a/docs/API.md
+++ b/docs/API.md
@@ -167,10 +167,13 @@ Document ID is a kebab-case slug from the calendar tour label (`2026 Sphere` →
 | `tourShowCount` | number | Dates in scope |
 | `showsWithSetlist` | number | Dates with an `official_setlists` doc |
 | `uniqueSongs` / `totalSongPlays` | number | Aggregate counts |
-| `topSongs` | `{ title, timesPlayed }[]` | Most played, **full ranked list** as of v1.45.0 (#709; top-15 before) — **no** per-song `showDates` lists |
-| `bustouts` / `gapHighlights` | `{ title, gap, showDate? }[]` | Single event date OK; never a full night setlist. `gapHighlights` uncapped as of v1.45.0 (#709) |
+| `topSongs` | `{ title, timesPlayed, lifetimePlays?, debutYear? }[]` | Most played, **full ranked list** as of v1.45.0 (#709; top-15 before) — **no** per-song `showDates` lists |
+| `bustouts` / `gapHighlights` | `{ title, gap, showDate?, lifetimePlays?, debutYear? }[]` | Single event date OK; never a full night setlist. `gapHighlights` uncapped as of v1.45.0 (#709) |
+| `enrichment` | `{ source, enrichedAt } \| null` | **v1.46.0 (#666)** — non-null when rows carry phish.net lifetime fields; `null` when the refresh ran without phish.net (missing key / upstream failure) |
 | `writtenAt` | string | ISO timestamp |
-| `schemaVersion` | number | `1` |
+| `schemaVersion` | number | `2` (**v1.46.0 #666**; `1` before) |
+
+**Row enrichment (v1.46.0 / #666, Phase 1 of the gated-external-sources plan):** every refresh fetches phish.net `v5/songs` **server-side** (secret `PHISHNET_API_KEY`; never sent to browsers) and stamps `lifetimePlays` (all-time times played) + `debutYear` onto each row — `null` when phish.net has no data for the title, **absent** when the whole refresh ran unenriched. setlist.fm / phish.com remain behind the explicit legal/product gate (issue #666 phase 3).
 
 `_index` fields: `tours[]` (`tourSlug`, `tourLabel`, `firstShowDate`, `lastShowDate`, `showCount`), `defaultTourSlug` (current tour = newest `lastShowDate` among indexed tours), `writtenAt`, `schemaVersion`.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -168,12 +168,14 @@ Document ID is a kebab-case slug from the calendar tour label (`2026 Sphere` →
 | `showsWithSetlist` | number | Dates with an `official_setlists` doc |
 | `uniqueSongs` / `totalSongPlays` | number | Aggregate counts |
 | `topSongs` | `{ title, timesPlayed, lifetimePlays?, debutYear? }[]` | Most played, **full ranked list** as of v1.45.0 (#709; top-15 before) — **no** per-song `showDates` lists |
-| `bustouts` / `gapHighlights` | `{ title, gap, showDate?, lifetimePlays?, debutYear? }[]` | Single event date OK; never a full night setlist. `gapHighlights` uncapped as of v1.45.0 (#709) |
+| `bustouts` / `gapHighlights` | `{ title, gap, showDate?, lifetimePlays?, debutYear?, lastPlayed? }[]` | Single event date OK; never a full night setlist. `gapHighlights` uncapped as of v1.45.0 (#709). `lastPlayed` = `YYYY-MM-DD` last Phish play *before* that tour night (v1.46.0 / #709 follow-up) |
 | `enrichment` | `{ source, enrichedAt } \| null` | **v1.46.0 (#666)** — non-null when rows carry phish.net lifetime fields; `null` when the refresh ran without phish.net (missing key / upstream failure) |
 | `writtenAt` | string | ISO timestamp |
 | `schemaVersion` | number | `2` (**v1.46.0 #666**; `1` before) |
 
 **Row enrichment (v1.46.0 / #666, Phase 1 of the gated-external-sources plan):** every refresh fetches phish.net `v5/songs` **server-side** (secret `PHISHNET_API_KEY`; never sent to browsers) and stamps `lifetimePlays` (all-time times played) + `debutYear` onto each row — `null` when phish.net has no data for the title, **absent** when the whole refresh ran unenriched. setlist.fm / phish.com remain behind the explicit legal/product gate (issue #666 phase 3).
+
+**`lastPlayed` on bustout / high-gap rows (v1.46.0 / #709 follow-up):** after lifetime enrichment, the refresh looks up each unique bustout/high-gap song's phish.net play history (`/v5/setlists/slug/{slug}.json`, capped at 80 lookups/run, cached across tours) and stamps the latest Phish show date strictly before that row's `showDate`. Best-effort — failed lookups leave the field absent; UI hides the "Last" column when no row has one. Dashboard Tour stats joins the same dates from the world-readable public doc.
 
 `_index` fields: `tours[]` (`tourSlug`, `tourLabel`, `firstShowDate`, `lastShowDate`, `showCount`), `defaultTourSlug` (current tour = newest `lastShowDate` among indexed tours), `writtenAt`, `schemaVersion`.
 

--- a/functions/aggregateTourSetlistStats.cjs
+++ b/functions/aggregateTourSetlistStats.cjs
@@ -143,29 +143,100 @@ function aggregateTourSetlistStats(docs, options = {}) {
 }
 
 /**
+ * Phish.net songs list → per-title enrichment map (#666 Phase 1).
+ * Input rows come from `fetchPhishnetSongsNormalized` (`phishnetSongCatalog.js`):
+ * `{ name, total, gap, last, debut }` with string fields ("—" when unknown).
+ *
+ * Output: normalized title → `{ lifetimePlays: number|null, debutYear: number|null }`.
+ * Lifetime data lives only on phish.net (game-local `official_setlists` cover
+ * scored tour dates), so this is the unique crawlable content layer for the
+ * public `/tour-stats` pages.
+ *
+ * @param {Array<{ name: string, total?: string, debut?: string }>} songs
+ * @returns {Map<string, { lifetimePlays: number | null, debutYear: number | null }>}
+ */
+function buildSongEnrichmentByTitle(songs) {
+  const map = new Map();
+  const list = Array.isArray(songs) ? songs : [];
+  for (const song of list) {
+    const key = normalizeTitle(song?.name);
+    if (!key || map.has(key)) continue;
+
+    const totalNum = Number(song?.total);
+    const lifetimePlays =
+      Number.isFinite(totalNum) && totalNum >= 0 ? Math.trunc(totalNum) : null;
+
+    // `debut` is either `YYYY-MM-DD` or a bare year string.
+    const debutRaw = String(song?.debut ?? "").trim();
+    const yearMatch = debutRaw.match(/^(\d{4})/);
+    const year = yearMatch ? Number(yearMatch[1]) : NaN;
+    const debutYear = year >= 1900 && year <= 2100 ? year : null;
+
+    if (lifetimePlays === null && debutYear === null) continue;
+    map.set(key, { lifetimePlays, debutYear });
+  }
+  return map;
+}
+
+/**
+ * @param {Map<string, { lifetimePlays: number | null, debutYear: number | null }> | null | undefined} enrichmentByTitle
+ * @param {string} title
+ */
+function enrichmentFor(enrichmentByTitle, title) {
+  if (!(enrichmentByTitle instanceof Map)) return null;
+  return enrichmentByTitle.get(normalizeTitle(title)) || null;
+}
+
+/**
  * Public payload — aggregates only (no officialSetlist arrays, no per-song showDates lists).
  * Bustout/gap rows may include a single showDate (song event), never a full night setlist.
+ *
+ * When `enrichmentByTitle` (#666) is provided, every row also carries
+ * `lifetimePlays` + `debutYear` (null when phish.net has no data for the
+ * title). Omitted entirely when enrichment is unavailable so consumers can
+ * distinguish "not enriched" from "unknown song".
+ *
+ * @param {ReturnType<typeof aggregateTourSetlistStats>} stats
+ * @param {Map<string, { lifetimePlays: number | null, debutYear: number | null }> | null} [enrichmentByTitle]
  */
-function toPublicTourStatsPayload(stats) {
+function toPublicTourStatsPayload(stats, enrichmentByTitle = null) {
+  const enriched = enrichmentByTitle instanceof Map;
+  /**
+   * @param {{ title: string }} row
+   * @param {Record<string, unknown>} base
+   */
+  const withEnrichment = (row, base) => {
+    if (!enriched) return base;
+    const e = enrichmentFor(enrichmentByTitle, row.title);
+    return {
+      ...base,
+      lifetimePlays: e ? e.lifetimePlays : null,
+      debutYear: e ? e.debutYear : null,
+    };
+  };
+
   return {
     tourShowCount: stats.tourShowCount,
     showsWithSetlist: stats.showsWithSetlist,
     uniqueSongs: stats.uniqueSongs,
     totalSongPlays: stats.totalSongPlays,
-    topSongs: (stats.topSongs || []).map((r) => ({
-      title: r.title,
-      timesPlayed: r.timesPlayed,
-    })),
-    bustouts: (stats.bustouts || []).map((r) => ({
-      title: r.title,
-      gap: r.gap,
-      showDate: r.showDate || null,
-    })),
-    gapHighlights: (stats.gapHighlights || []).map((r) => ({
-      title: r.title,
-      gap: r.gap,
-      showDate: r.showDate || null,
-    })),
+    topSongs: (stats.topSongs || []).map((r) =>
+      withEnrichment(r, { title: r.title, timesPlayed: r.timesPlayed })
+    ),
+    bustouts: (stats.bustouts || []).map((r) =>
+      withEnrichment(r, {
+        title: r.title,
+        gap: r.gap,
+        showDate: r.showDate || null,
+      })
+    ),
+    gapHighlights: (stats.gapHighlights || []).map((r) =>
+      withEnrichment(r, {
+        title: r.title,
+        gap: r.gap,
+        showDate: r.showDate || null,
+      })
+    ),
   };
 }
 
@@ -183,6 +254,7 @@ function tourLabelToSlug(tourLabel) {
 module.exports = {
   aggregateTourSetlistStats,
   toPublicTourStatsPayload,
+  buildSongEnrichmentByTitle,
   tourLabelToSlug,
   TOUR_STATS_TOP_N,
   TOUR_STATS_GAP_HIGHLIGHT_MIN,

--- a/functions/aggregateTourSetlistStats.cjs
+++ b/functions/aggregateTourSetlistStats.cjs
@@ -145,15 +145,17 @@ function aggregateTourSetlistStats(docs, options = {}) {
 /**
  * Phish.net songs list → per-title enrichment map (#666 Phase 1).
  * Input rows come from `fetchPhishnetSongsNormalized` (`phishnetSongCatalog.js`):
- * `{ name, total, gap, last, debut }` with string fields ("—" when unknown).
+ * `{ name, total, gap, last, debut, slug }` with string fields ("—" when unknown).
  *
- * Output: normalized title → `{ lifetimePlays: number|null, debutYear: number|null }`.
- * Lifetime data lives only on phish.net (game-local `official_setlists` cover
- * scored tour dates), so this is the unique crawlable content layer for the
- * public `/tour-stats` pages.
+ * Output: normalized title → `{ lifetimePlays, debutYear, slug }`. Lifetime
+ * data lives only on phish.net (game-local `official_setlists` cover scored
+ * tour dates), so this is the unique crawlable content layer for the public
+ * `/tour-stats` pages. `slug` keys the per-song play-history lookup used to
+ * stamp `lastPlayed` on bustout/high-gap rows (#709 follow-up) and is never
+ * written into payload rows itself.
  *
- * @param {Array<{ name: string, total?: string, debut?: string }>} songs
- * @returns {Map<string, { lifetimePlays: number | null, debutYear: number | null }>}
+ * @param {Array<{ name: string, total?: string, debut?: string, slug?: string }>} songs
+ * @returns {Map<string, { lifetimePlays: number | null, debutYear: number | null, slug: string | null }>}
  */
 function buildSongEnrichmentByTitle(songs) {
   const map = new Map();
@@ -172,10 +174,35 @@ function buildSongEnrichmentByTitle(songs) {
     const year = yearMatch ? Number(yearMatch[1]) : NaN;
     const debutYear = year >= 1900 && year <= 2100 ? year : null;
 
-    if (lifetimePlays === null && debutYear === null) continue;
-    map.set(key, { lifetimePlays, debutYear });
+    const slugRaw = String(song?.slug ?? "").trim();
+    const slug = slugRaw || null;
+
+    if (lifetimePlays === null && debutYear === null && slug === null) continue;
+    map.set(key, { lifetimePlays, debutYear, slug });
   }
   return map;
+}
+
+/**
+ * Latest play date strictly before `beforeDate`, from a song's full play
+ * history (#709 follow-up: the "Last" column on Bustouts / High gaps).
+ * Dates are `YYYY-MM-DD` strings, so lexicographic compare is chronological.
+ *
+ * @param {unknown} dates
+ * @param {unknown} beforeDate
+ * @returns {string | null}
+ */
+function lastPlayedBeforeFromHistory(dates, beforeDate) {
+  const before = String(beforeDate ?? "").trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(before)) return null;
+  let best = null;
+  for (const raw of Array.isArray(dates) ? dates : []) {
+    const d = String(raw ?? "").trim();
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(d)) continue;
+    if (d >= before) continue;
+    if (!best || d > best) best = d;
+  }
+  return best;
 }
 
 /**
@@ -255,6 +282,7 @@ module.exports = {
   aggregateTourSetlistStats,
   toPublicTourStatsPayload,
   buildSongEnrichmentByTitle,
+  lastPlayedBeforeFromHistory,
   tourLabelToSlug,
   TOUR_STATS_TOP_N,
   TOUR_STATS_GAP_HIGHLIGHT_MIN,

--- a/functions/aggregateTourSetlistStats.test.js
+++ b/functions/aggregateTourSetlistStats.test.js
@@ -6,6 +6,7 @@ const assert = require("node:assert/strict");
 const {
   aggregateTourSetlistStats,
   toPublicTourStatsPayload,
+  buildSongEnrichmentByTitle,
   tourLabelToSlug,
 } = require("./aggregateTourSetlistStats.cjs");
 
@@ -39,6 +40,61 @@ describe("aggregateTourSetlistStats", () => {
     const pub = toPublicTourStatsPayload(stats);
     assert.equal(pub.topSongs.length, 40);
     assert.equal(pub.gapHighlights.length, 40);
+  });
+});
+
+describe("buildSongEnrichmentByTitle (#666)", () => {
+  it("normalizes titles and parses total/debut from catalog rows", () => {
+    const map = buildSongEnrichmentByTitle([
+      { name: "Ghost", total: "623", debut: "1997-06-13" },
+      { name: "Tweezer", total: "512", debut: "1990" },
+      { name: "No Data", total: "—", debut: "" },
+      { name: "Weird Year", total: "3", debut: "0999-01-01" },
+      { name: "  ", total: "5", debut: "2000" },
+    ]);
+    assert.deepEqual(map.get("ghost"), { lifetimePlays: 623, debutYear: 1997 });
+    assert.deepEqual(map.get("tweezer"), { lifetimePlays: 512, debutYear: 1990 });
+    assert.equal(map.has("no data"), false);
+    assert.deepEqual(map.get("weird year"), { lifetimePlays: 3, debutYear: null });
+    assert.equal(map.has(""), false);
+  });
+});
+
+describe("toPublicTourStatsPayload enrichment (#666)", () => {
+  const stats = aggregateTourSetlistStats(
+    [
+      {
+        showDate: "2026-04-16",
+        setlist: {
+          officialSetlist: ["Ghost", "Obscure Original"],
+          bustouts: ["Ghost"],
+          songGaps: { ghost: 47, "obscure original": 12 },
+        },
+      },
+    ],
+    { tourShowCount: 1 }
+  );
+
+  it("attaches lifetimePlays/debutYear per row, null for unknown songs", () => {
+    const map = buildSongEnrichmentByTitle([
+      { name: "GHOST", total: "623", debut: "1997-06-13" },
+    ]);
+    const pub = toPublicTourStatsPayload(stats, map);
+    const ghost = pub.topSongs.find((r) => r.title === "Ghost");
+    assert.equal(ghost.lifetimePlays, 623);
+    assert.equal(ghost.debutYear, 1997);
+    const obscure = pub.topSongs.find((r) => r.title === "Obscure Original");
+    assert.equal(obscure.lifetimePlays, null);
+    assert.equal(obscure.debutYear, null);
+    assert.equal(pub.bustouts[0].lifetimePlays, 623);
+    assert.equal(pub.gapHighlights[0].title, "Obscure Original");
+    assert.equal(pub.gapHighlights[0].debutYear, null);
+  });
+
+  it("omits enrichment fields entirely when no map is provided", () => {
+    const pub = toPublicTourStatsPayload(stats);
+    assert.ok(pub.topSongs.every((r) => !("lifetimePlays" in r)));
+    assert.ok(pub.bustouts.every((r) => !("debutYear" in r)));
   });
 });
 

--- a/functions/aggregateTourSetlistStats.test.js
+++ b/functions/aggregateTourSetlistStats.test.js
@@ -7,6 +7,7 @@ const {
   aggregateTourSetlistStats,
   toPublicTourStatsPayload,
   buildSongEnrichmentByTitle,
+  lastPlayedBeforeFromHistory,
   tourLabelToSlug,
 } = require("./aggregateTourSetlistStats.cjs");
 
@@ -44,19 +45,50 @@ describe("aggregateTourSetlistStats", () => {
 });
 
 describe("buildSongEnrichmentByTitle (#666)", () => {
-  it("normalizes titles and parses total/debut from catalog rows", () => {
+  it("normalizes titles and parses total/debut/slug from catalog rows", () => {
     const map = buildSongEnrichmentByTitle([
-      { name: "Ghost", total: "623", debut: "1997-06-13" },
+      { name: "Ghost", total: "623", debut: "1997-06-13", slug: "ghost" },
       { name: "Tweezer", total: "512", debut: "1990" },
       { name: "No Data", total: "—", debut: "" },
       { name: "Weird Year", total: "3", debut: "0999-01-01" },
       { name: "  ", total: "5", debut: "2000" },
     ]);
-    assert.deepEqual(map.get("ghost"), { lifetimePlays: 623, debutYear: 1997 });
-    assert.deepEqual(map.get("tweezer"), { lifetimePlays: 512, debutYear: 1990 });
+    assert.deepEqual(map.get("ghost"), {
+      lifetimePlays: 623,
+      debutYear: 1997,
+      slug: "ghost",
+    });
+    assert.deepEqual(map.get("tweezer"), {
+      lifetimePlays: 512,
+      debutYear: 1990,
+      slug: null,
+    });
     assert.equal(map.has("no data"), false);
-    assert.deepEqual(map.get("weird year"), { lifetimePlays: 3, debutYear: null });
+    assert.deepEqual(map.get("weird year"), {
+      lifetimePlays: 3,
+      debutYear: null,
+      slug: null,
+    });
     assert.equal(map.has(""), false);
+  });
+});
+
+describe("lastPlayedBeforeFromHistory (#709 follow-up)", () => {
+  it("returns the latest date strictly before the show date", () => {
+    assert.equal(
+      lastPlayedBeforeFromHistory(
+        ["2019-06-16", "2021-08-01", "2024-12-31", "2026-07-22"],
+        "2026-07-22"
+      ),
+      "2024-12-31"
+    );
+  });
+
+  it("returns null when no prior date or inputs are invalid", () => {
+    assert.equal(lastPlayedBeforeFromHistory(["2026-07-22"], "2026-07-22"), null);
+    assert.equal(lastPlayedBeforeFromHistory([], "2026-07-22"), null);
+    assert.equal(lastPlayedBeforeFromHistory(["2020-01-01"], "not-a-date"), null);
+    assert.equal(lastPlayedBeforeFromHistory(null, "2026-07-22"), null);
   });
 });
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -1761,7 +1761,9 @@ exports.scheduledPublicTourStatsRefresh = onSchedule(
     timeZone: "America/New_York",
     region: PHISHNET_FUNCTIONS_REGION,
     // #666: lifetime enrichment; refresh still succeeds unenriched if the
-    // key is missing or phish.net is down.
+    // key is missing or phish.net is down. #709: per-song lastPlayed history
+    // lookups (≤80 sequential phish.net calls) need more than the 60s default.
+    timeoutSeconds: 300,
     secrets: [phishnetApiKey],
   },
   async () => {
@@ -1782,6 +1784,8 @@ exports.refreshPublicTourStats = onCall(
     invoker: "public",
     enforceAppCheck: false,
     // #666: lifetime enrichment (best-effort inside the refresh).
+    // #709: lastPlayed history lookups need more than the 60s default.
+    timeoutSeconds: 300,
     secrets: [phishnetApiKey],
   },
   async (request) => {

--- a/functions/index.js
+++ b/functions/index.js
@@ -1686,7 +1686,10 @@ exports.scheduledPhishnetShowCalendar = onSchedule(
       logger,
     });
     try {
-      await refreshPublicTourStats(db, { logger });
+      await refreshPublicTourStats(db, {
+        logger,
+        phishnetApiKey: String(key).trim(),
+      });
     } catch (err) {
       logger.error("scheduledPhishnetShowCalendar: public tour stats refresh failed", err);
     }
@@ -1723,7 +1726,10 @@ exports.refreshPhishnetShowCalendar = onCall(
       );
       let publicTourStats = null;
       try {
-        publicTourStats = await refreshPublicTourStats(db, { logger });
+        publicTourStats = await refreshPublicTourStats(db, {
+          logger,
+          phishnetApiKey: String(key).trim(),
+        });
       } catch (err) {
         logger.error("refreshPhishnetShowCalendar: public tour stats refresh failed", err);
       }
@@ -1754,9 +1760,15 @@ exports.scheduledPublicTourStatsRefresh = onSchedule(
     schedule: "30 7 * * *",
     timeZone: "America/New_York",
     region: PHISHNET_FUNCTIONS_REGION,
+    // #666: lifetime enrichment; refresh still succeeds unenriched if the
+    // key is missing or phish.net is down.
+    secrets: [phishnetApiKey],
   },
   async () => {
-    await refreshPublicTourStats(db, { logger });
+    await refreshPublicTourStats(db, {
+      logger,
+      phishnetApiKey: String(phishnetApiKey.value() || "").trim(),
+    });
     return null;
   }
 );
@@ -1769,11 +1781,16 @@ exports.refreshPublicTourStats = onCall(
     region: PHISHNET_FUNCTIONS_REGION,
     invoker: "public",
     enforceAppCheck: false,
+    // #666: lifetime enrichment (best-effort inside the refresh).
+    secrets: [phishnetApiKey],
   },
   async (request) => {
     try {
       assertAdminClaim(request);
-      const result = await refreshPublicTourStats(db, { logger });
+      const result = await refreshPublicTourStats(db, {
+        logger,
+        phishnetApiKey: String(phishnetApiKey.value() || "").trim(),
+      });
       return { ok: true, ...result };
     } catch (e) {
       if (e instanceof HttpsError) throw e;

--- a/functions/phishnetSongCatalog.js
+++ b/functions/phishnetSongCatalog.js
@@ -68,13 +68,17 @@ function normalizeDebutField(raw) {
 
 /**
  * @param {unknown} row
- * @returns {{ name: string, total: string, gap: string, last: string, debut: string } | null}
+ * @returns {{ name: string, total: string, gap: string, last: string, debut: string, slug: string } | null}
  */
 function normalizePhishnetSongRow(row) {
   if (!row || typeof row !== "object") return null;
   const rec = /** @type {Record<string, unknown>} */ (row);
   const name = typeof rec.song === "string" ? rec.song.trim() : "";
   if (!name) return null;
+
+  // phish.net's canonical song slug — needed to query per-song play history
+  // (`/v5/setlists/slug/{slug}.json`) for last-played dates (#666/#709).
+  const slug = typeof rec.slug === "string" ? rec.slug.trim() : "";
 
   const times = rec.times_played;
   const total =
@@ -96,7 +100,7 @@ function normalizePhishnetSongRow(row) {
 
   const debut = normalizeDebutField(rec.debut);
 
-  return { name, total, gap, last, debut };
+  return { name, total, gap, last, debut, slug };
 }
 
 /**

--- a/functions/phishnetSongCatalog.test.js
+++ b/functions/phishnetSongCatalog.test.js
@@ -15,6 +15,7 @@ test("normalizePhishnetSongRow maps v5 row", () => {
   const row = {
     songid: 1,
     song: "Tweezer",
+    slug: "tweezer",
     times_played: 414,
     gap: 5,
     last_played: "2025-12-31",
@@ -26,7 +27,13 @@ test("normalizePhishnetSongRow maps v5 row", () => {
     gap: "5",
     last: "2025-12-31",
     debut: "1990-09-28",
+    slug: "tweezer",
   });
+});
+
+test("normalizePhishnetSongRow maps missing slug to empty string", () => {
+  const out = normalizePhishnetSongRow({ song: "Wilson", times_played: 100 });
+  assert.equal(out.slug, "");
 });
 
 test("normalizePhishnetSongRow maps missing debut to empty string", () => {

--- a/functions/publicTourStats.js
+++ b/functions/publicTourStats.js
@@ -5,15 +5,47 @@
 const {
   aggregateTourSetlistStats,
   toPublicTourStatsPayload,
+  buildSongEnrichmentByTitle,
   tourLabelToSlug,
 } = require("./aggregateTourSetlistStats.cjs");
+const { fetchPhishnetSongsNormalized } = require("./phishnetSongCatalog");
 
 /** Game launch floor — keep aligned with `src/shared/config/gameLaunch.js`. */
 const GAME_LAUNCH_SHOW_DATE = "2026-04-16";
 
 /**
+ * #666 Phase 1: per-song lifetime enrichment from phish.net (server-side
+ * fetch only — the API key never reaches clients). Best-effort: any upstream
+ * failure logs and returns null so the public stats refresh itself never
+ * depends on phish.net being up.
+ *
+ * @param {string} apiKey
+ * @param {Console} logger
+ * @returns {Promise<Map<string, { lifetimePlays: number | null, debutYear: number | null }> | null>}
+ */
+async function fetchSongEnrichment(apiKey, logger) {
+  const key = String(apiKey ?? "").trim();
+  if (!key) return null;
+  try {
+    const songs = await fetchPhishnetSongsNormalized(key);
+    const map = buildSongEnrichmentByTitle(songs);
+    logger.info("refreshPublicTourStats: phish.net enrichment loaded", {
+      songs: songs.length,
+      enriched: map.size,
+    });
+    return map;
+  } catch (err) {
+    logger.warn(
+      "refreshPublicTourStats: phish.net enrichment unavailable — writing unenriched docs",
+      err instanceof Error ? err.message : err
+    );
+    return null;
+  }
+}
+
+/**
  * @param {FirebaseFirestore.Firestore} db
- * @param {{ logger?: Console, today?: string }} [opts]
+ * @param {{ logger?: Console, today?: string, phishnetApiKey?: string }} [opts]
  */
 async function refreshPublicTourStats(db, opts = {}) {
   const logger = opts.logger || console;
@@ -53,6 +85,12 @@ async function refreshPublicTourStats(db, opts = {}) {
   let toursWritten = 0;
   const writtenAt = new Date().toISOString();
 
+  // #666: one phish.net fetch per refresh, shared across every tour doc.
+  const enrichmentByTitle = await fetchSongEnrichment(
+    opts.phishnetApiKey || "",
+    logger
+  );
+
   for (const group of selectable) {
     const tourLabel = group.tour;
     const tourSlug = tourLabelToSlug(tourLabel);
@@ -84,7 +122,7 @@ async function refreshPublicTourStats(db, opts = {}) {
     const stats = aggregateTourSetlistStats(docs, {
       tourShowCount: showDates.length,
     });
-    const payload = toPublicTourStatsPayload(stats);
+    const payload = toPublicTourStatsPayload(stats, enrichmentByTitle);
 
     await db
       .collection("public_tour_stats")
@@ -97,8 +135,13 @@ async function refreshPublicTourStats(db, opts = {}) {
           firstShowDate: showDates[0] || null,
           lastShowDate: showDates[showDates.length - 1] || null,
           ...payload,
+          // #666: null when the refresh ran without phish.net (missing key /
+          // upstream failure) — rows then omit lifetimePlays/debutYear.
+          enrichment: enrichmentByTitle
+            ? { source: "phish.net/v5/songs", enrichedAt: writtenAt }
+            : null,
           writtenAt,
-          schemaVersion: 1,
+          schemaVersion: 2,
         },
         { merge: false }
       );

--- a/functions/publicTourStats.js
+++ b/functions/publicTourStats.js
@@ -6,9 +6,13 @@ const {
   aggregateTourSetlistStats,
   toPublicTourStatsPayload,
   buildSongEnrichmentByTitle,
+  lastPlayedBeforeFromHistory,
   tourLabelToSlug,
 } = require("./aggregateTourSetlistStats.cjs");
-const { fetchPhishnetSongsNormalized } = require("./phishnetSongCatalog");
+const {
+  fetchPhishnetSongsNormalized,
+  isPhishNetPayloadOk,
+} = require("./phishnetSongCatalog");
 
 /** Game launch floor — keep aligned with `src/shared/config/gameLaunch.js`. */
 const GAME_LAUNCH_SHOW_DATE = "2026-04-16";
@@ -41,6 +45,132 @@ async function fetchSongEnrichment(apiKey, logger) {
     );
     return null;
   }
+}
+
+/**
+ * Safety cap on per-song history lookups per refresh run. Bustout + high-gap
+ * songs across all tours are typically well under this; the cap only guards
+ * against a pathological calendar from turning the refresh into a phish.net
+ * crawl.
+ */
+const MAX_LAST_PLAYED_LOOKUPS = 80;
+
+/** @param {unknown} title */
+function normalizeTitleKey(title) {
+  return String(title ?? "").trim().toLowerCase();
+}
+
+/**
+ * Full play history (`YYYY-MM-DD` show dates) for one song via phish.net
+ * `/v5/setlists/slug/{slug}.json`. Phish rows only — the setlists table also
+ * carries side-project artists, and gap math is Phish-show based.
+ *
+ * @param {string} apiKey
+ * @param {string} slug
+ * @returns {Promise<string[]>}
+ */
+async function fetchPhishnetSongHistoryDates(apiKey, slug) {
+  const url = `https://api.phish.net/v5/setlists/slug/${encodeURIComponent(
+    slug
+  )}.json?apikey=${encodeURIComponent(apiKey)}`;
+  const res = await fetch(url, { headers: { Accept: "application/json" } });
+  const bodyText = await res.text();
+  if (!res.ok) {
+    throw new Error(`Phish.net HTTP ${res.status}: ${bodyText.slice(0, 120)}`);
+  }
+  const data = JSON.parse(bodyText);
+  if (!isPhishNetPayloadOk(data)) {
+    throw new Error(
+      typeof data?.error_message === "string"
+        ? data.error_message
+        : "Phish.net API error."
+    );
+  }
+  const rows = Array.isArray(data.data) ? data.data : [];
+  const dates = new Set();
+  for (const row of rows) {
+    if (!row || typeof row !== "object") continue;
+    const artist = row.artistid ?? row.artist_id;
+    if (artist != null && String(artist) !== "1") continue;
+    const d = typeof row.showdate === "string" ? row.showdate.trim() : "";
+    if (d) dates.add(d);
+  }
+  return [...dates];
+}
+
+/**
+ * #709 follow-up: stamp `lastPlayed` (date the song was last played *before*
+ * that tour night) onto bustout / high-gap payload rows. Mutates `payload`
+ * in place. Best-effort per song: a failed history lookup just leaves those
+ * rows date-less (the UI hides the column when no row has one).
+ *
+ * `historyCache` (slug → string[] | null) is shared across tours within one
+ * refresh run so a song appearing in multiple tour docs costs one lookup.
+ *
+ * @param {{ bustouts?: Array<object>, gapHighlights?: Array<object> }} payload
+ * @param {{
+ *   enrichmentByTitle: Map<string, { slug?: string | null }> | null,
+ *   apiKey: string,
+ *   historyCache: Map<string, string[] | null>,
+ *   logger: Console,
+ *   state: { lookups: number },
+ * }} opts
+ * @returns {Promise<number>} rows stamped
+ */
+async function stampLastPlayedDates(payload, opts) {
+  const { enrichmentByTitle, apiKey, historyCache, logger, state } = opts;
+  if (!(enrichmentByTitle instanceof Map) || !apiKey) return 0;
+
+  /** @type {Map<string, Array<{ title?: string, showDate?: string | null }>>} */
+  const rowsBySlug = new Map();
+  for (const row of [
+    ...(payload.bustouts || []),
+    ...(payload.gapHighlights || []),
+  ]) {
+    if (!row || typeof row !== "object" || !row.showDate) continue;
+    const slug = enrichmentByTitle.get(normalizeTitleKey(row.title))?.slug;
+    if (!slug) continue;
+    const bucket = rowsBySlug.get(slug);
+    if (bucket) bucket.push(row);
+    else rowsBySlug.set(slug, [row]);
+  }
+
+  let stamped = 0;
+  let failed = 0;
+  for (const [slug, rows] of rowsBySlug) {
+    if (!historyCache.has(slug)) {
+      if (state.lookups >= MAX_LAST_PLAYED_LOOKUPS) break;
+      state.lookups += 1;
+      try {
+        historyCache.set(slug, await fetchPhishnetSongHistoryDates(apiKey, slug));
+      } catch (err) {
+        historyCache.set(slug, null);
+        failed += 1;
+        logger.warn("refreshPublicTourStats: song history lookup failed", {
+          slug,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    const dates = historyCache.get(slug);
+    if (!dates) continue;
+    for (const row of rows) {
+      const lastPlayed = lastPlayedBeforeFromHistory(dates, row.showDate);
+      if (lastPlayed) {
+        row.lastPlayed = lastPlayed;
+        stamped += 1;
+      }
+    }
+  }
+
+  if (stamped > 0 || failed > 0) {
+    logger.info("refreshPublicTourStats: lastPlayed dates stamped", {
+      stamped,
+      failed,
+      lookupsSoFar: state.lookups,
+    });
+  }
+  return stamped;
 }
 
 /**
@@ -91,6 +221,10 @@ async function refreshPublicTourStats(db, opts = {}) {
     logger
   );
 
+  // #709 follow-up: per-song history lookups (lastPlayed) shared across tours.
+  const historyCache = new Map();
+  const lookupState = { lookups: 0 };
+
   for (const group of selectable) {
     const tourLabel = group.tour;
     const tourSlug = tourLabelToSlug(tourLabel);
@@ -123,6 +257,13 @@ async function refreshPublicTourStats(db, opts = {}) {
       tourShowCount: showDates.length,
     });
     const payload = toPublicTourStatsPayload(stats, enrichmentByTitle);
+    await stampLastPlayedDates(payload, {
+      enrichmentByTitle,
+      apiKey: String(opts.phishnetApiKey || "").trim(),
+      historyCache,
+      logger,
+      state: lookupState,
+    });
 
     await db
       .collection("public_tour_stats")
@@ -199,5 +340,6 @@ function pickDefaultPublicTourSlug(indexTours) {
 module.exports = {
   refreshPublicTourStats,
   pickDefaultPublicTourSlug,
+  stampLastPlayedDates,
   GAME_LAUNCH_SHOW_DATE,
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.45.1",
+  "version": "1.46.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/tour-stats/api/fetchPublicTourStats.js
+++ b/src/features/tour-stats/api/fetchPublicTourStats.js
@@ -53,7 +53,13 @@ export async function fetchPublicTourStatsDoc(tourSlug) {
  */
 export async function listPublicTourStatsDocs() {
   await whenFirebaseReady();
-  const q = query(collection(db, 'public_tour_stats'), where('schemaVersion', '==', 1));
+  // Accept both payload schema generations: 1 (pre-enrichment) and 2
+  // (#666 phish.net enrichment). A hard `== 1` here silently emptied the
+  // fallback once the refresh started writing schemaVersion 2.
+  const q = query(
+    collection(db, 'public_tour_stats'),
+    where('schemaVersion', 'in', [1, 2]),
+  );
   const snap = await getDocs(q);
   return snap.docs
     .filter((d) => d.id !== '_index')

--- a/src/features/tour-stats/ui/TourStatsView.jsx
+++ b/src/features/tour-stats/ui/TourStatsView.jsx
@@ -232,7 +232,10 @@ export default function TourStatsView({
                   <span className="tabular-nums text-brand-primary/80">
                     {absoluteIdx + 1}
                   </span>
-                  <span className="min-w-0 truncate">{row.title}</span>
+                  <span className="min-w-0">
+                    <span className="block truncate">{row.title}</span>
+                    <SongEnrichmentLine row={row} />
+                  </span>
                   <span className="justify-self-end tabular-nums text-brand-primary">
                     {row.timesPlayed}
                   </span>
@@ -261,7 +264,10 @@ export default function TourStatsView({
                   key={`${row.showDate}-${row.title}`}
                   className={GAP_ROW_GRID}
                 >
-                  <span className="min-w-0 truncate">{row.title}</span>
+                  <span className="min-w-0">
+                    <span className="block truncate">{row.title}</span>
+                    <SongEnrichmentLine row={row} />
+                  </span>
                   <span className="justify-self-end tabular-nums text-content-secondary">
                     {row.showDate}
                   </span>
@@ -318,7 +324,10 @@ export default function TourStatsView({
                   key={`${row.showDate}-${row.title}`}
                   className={GAP_ROW_GRID}
                 >
-                  <span className="min-w-0 truncate">{row.title}</span>
+                  <span className="min-w-0">
+                    <span className="block truncate">{row.title}</span>
+                    <SongEnrichmentLine row={row} />
+                  </span>
                   <span className="justify-self-end tabular-nums text-content-secondary">
                     {row.showDate}
                   </span>
@@ -335,6 +344,28 @@ export default function TourStatsView({
         ) : null}
       </div>
     </InfoTooltipProvider>
+  );
+}
+
+/**
+ * Lifetime context from phish.net enrichment (#666) — present only on
+ * `public_tour_stats` rows written by an enriched refresh. Dashboard rows
+ * (client-side aggregation) never carry these fields, so the private
+ * explorer renders unchanged.
+ *
+ * @param {{ row: { debutYear?: number | null, lifetimePlays?: number | null } }} props
+ */
+function SongEnrichmentLine({ row }) {
+  const bits = [];
+  if (typeof row.debutYear === 'number') bits.push(`Debut ${row.debutYear}`);
+  if (typeof row.lifetimePlays === 'number') {
+    bits.push(`${row.lifetimePlays.toLocaleString()} plays all-time`);
+  }
+  if (bits.length === 0) return null;
+  return (
+    <span className="block truncate text-[10px] font-medium leading-snug text-content-secondary">
+      {bits.join(' · ')}
+    </span>
   );
 }
 


### PR DESCRIPTION
Closes #666 (Phase 1 — the locked phase order's phish.net API path)

> **Merge order:** stacked on #817 → #816 → #815. Merge in that order; this diff then reduces to the enrichment change.

## Summary
- `refreshPublicTourStats` now fetches phish.net `v5/songs` **once per refresh, server-side** (reuses `fetchPhishnetSongsNormalized` from the song-catalog sync; `PHISHNET_API_KEY` never reaches clients) and stamps **`lifetimePlays` + `debutYear`** onto every `public_tour_stats` row. This is lifetime data that game-local `official_setlists` cannot provide — the unique crawlable content layer for "Phish tour stats" style queries.
- **Best-effort by design:** if the key is missing or phish.net is down, the refresh logs a warning and writes unenriched docs with `enrichment: null` — public stats never depend on upstream uptime. When enriched, docs carry `enrichment: { source: "phish.net/v5/songs", enrichedAt }` and `schemaVersion: 2`.
- `scheduledPublicTourStatsRefresh` and the admin `refreshPublicTourStats` callable now bind the `PHISHNET_API_KEY` secret; the two calendar-sync call sites pass their existing key through. No new exports — `verify:phishnet-deploy-manifest` unchanged and green.
- Public `/tour-stats` rows render a subtle `Debut 1997 · 623 plays all-time` line under the song title (Most played, Bustouts, High gaps). Dashboard Tour stats rows come from client-side aggregation, never carry the fields, and render unchanged.

**Out of scope (stays on #666):** per-song tour pages / season rollups (phase 2 — only when unique crawlable content justifies them) and setlist.fm / phish.com (phase 3 — explicit legal/product gate; setlist.fm API is non-commercial-only).

SemVer: **MINOR** → `1.46.0` (new declared fields on `public_tour_stats`; `docs/API.md` §1.13 updated).

## Test plan
- [x] `functions`: `npm test` — 340 pass (new `buildSongEnrichmentByTitle` + payload enrichment/omission cases)
- [x] `npm run lint` / `npm test` (503) / `verify:phishnet-deploy-manifest` / `npm run build` + `verify:seo-prerender` clean
- [ ] Post-merge ops: deploy phishnet functions bundle, run admin `refreshPublicTourStats`, confirm `public_tour_stats/2026-sphere` rows carry `lifetimePlays`/`debutYear` and `/tour-stats` shows the context line
- [ ] Browser: dashboard Tour stats tab unchanged (no enrichment line)

Made with [Cursor](https://cursor.com)