### PR TITLE
fix(seo): export fetchPhishnetSongsNormalized (1.46.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.46.3] — 2026-08-03
+
+### Fixed
+- **Public tour stats enrichment export (#666)** — `fetchPhishnetSongsNormalized` was used by `refreshPublicTourStats` but not exported from `phishnetSongCatalog.js`, so every refresh logged "is not a function" and wrote unenriched docs (no `lifetimePlays` / `debutYear` / `lastPlayed`). Export added; redeploy + refresh required for live data.
+
+---
+
 ## [1.46.2] — 2026-08-03
 
 ### Changed

--- a/functions/phishnetSongCatalog.js
+++ b/functions/phishnetSongCatalog.js
@@ -264,6 +264,7 @@ async function syncPhishnetSongCatalogToStorage(apiKey, opts = {}) {
 
 module.exports = {
   syncPhishnetSongCatalogToStorage,
+  fetchPhishnetSongsNormalized,
   normalizePhishnetSongRow,
   normalizeDebutField,
   isPhishNetPayloadOk,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.46.2",
+  "version": "1.46.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Hotfix for missing Last-played / lifetime enrichment on live `public_tour_stats`.

`refreshPublicTourStats` required `fetchPhishnetSongsNormalized` from `phishnetSongCatalog.js`, but that helper was never exported — every refresh logged `is not a function` and wrote unenriched docs. Export added; functions already redeployed and refresh re-triggered.

## Test plan
- [x] Deploy `deploy:functions:phishnet`
- [x] Force-run `scheduledPublicTourStatsRefresh`
- [ ] Confirm logs show enrichment loaded + lastPlayed stamped
- [ ] `/tour-stats` and dashboard Tour stats show Last column

Made with [Cursor](https://cursor.com)