### PR TITLE
fix(tour-stats): harden Last column + Tour Frequency mobile chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.46.4] — 2026-08-03
+
+### Changed
+- **Tour stats list chrome (#709)** — "Most played" renamed to **Tour Frequency** (tooltip: all songs this tour, ranked by times played). Bustouts / High gaps column order is Song | Date | Gap | Last. Tour night dates render as `mm-dd`; prior-play Last as `mm-dd-yy` (full ISO on hover). Enrichment sub-line uses `All Time - N`. Mobile meta columns use fixed tracks + nowrap so headers stay aligned.
+
+### Fixed
+- **Public tour stats Last column blank on Summer (#709)** — Tour Frequency rows carry tour-local `lastPlayed` (latest show date on that tour). Bustout/high-gap Last prefers phish.net songs-catalog `last_played` when it is before that night (no HTTP), then paced history lookups (~1.5s gap, 10s 429 backoff, abort after three consecutive 429s, bustouts queued before high gaps) across all tours before writing.
+
+---
+
 ## [1.46.3] — 2026-08-03
 
 ### Fixed

--- a/docs/API.md
+++ b/docs/API.md
@@ -167,7 +167,7 @@ Document ID is a kebab-case slug from the calendar tour label (`2026 Sphere` →
 | `tourShowCount` | number | Dates in scope |
 | `showsWithSetlist` | number | Dates with an `official_setlists` doc |
 | `uniqueSongs` / `totalSongPlays` | number | Aggregate counts |
-| `topSongs` | `{ title, timesPlayed, lifetimePlays?, debutYear? }[]` | Most played, **full ranked list** as of v1.45.0 (#709; top-15 before) — **no** per-song `showDates` lists |
+| `topSongs` | `{ title, timesPlayed, lastPlayed?, lifetimePlays?, debutYear? }[]` | Tour Frequency (UI label; formerly "Most played"), **full ranked list** as of v1.45.0 (#709; top-15 before) — **no** per-song `showDates` lists. `lastPlayed` = latest tour show date the song appeared (`YYYY-MM-DD`, v1.46.4) |
 | `bustouts` / `gapHighlights` | `{ title, gap, showDate?, lifetimePlays?, debutYear?, lastPlayed? }[]` | Single event date OK; never a full night setlist. `gapHighlights` uncapped as of v1.45.0 (#709). `lastPlayed` = `YYYY-MM-DD` last Phish play *before* that tour night (v1.46.0 / #709 follow-up) |
 | `enrichment` | `{ source, enrichedAt } \| null` | **v1.46.0 (#666)** — non-null when rows carry phish.net lifetime fields; `null` when the refresh ran without phish.net (missing key / upstream failure) |
 | `writtenAt` | string | ISO timestamp |
@@ -175,7 +175,9 @@ Document ID is a kebab-case slug from the calendar tour label (`2026 Sphere` →
 
 **Row enrichment (v1.46.0 / #666, Phase 1 of the gated-external-sources plan):** every refresh fetches phish.net `v5/songs` **server-side** (secret `PHISHNET_API_KEY`; never sent to browsers) and stamps `lifetimePlays` (all-time times played) + `debutYear` onto each row — `null` when phish.net has no data for the title, **absent** when the whole refresh ran unenriched. setlist.fm / phish.com remain behind the explicit legal/product gate (issue #666 phase 3).
 
-**`lastPlayed` on bustout / high-gap rows (v1.46.0 / #709 follow-up):** after lifetime enrichment, the refresh looks up each unique bustout/high-gap song's phish.net play history (`/v5/setlists/slug/{slug}.json`, capped at 80 lookups/run, cached across tours) and stamps the latest Phish show date strictly before that row's `showDate`. Best-effort — failed lookups leave the field absent; UI hides the "Last" column when no row has one. Dashboard Tour stats joins the same dates from the world-readable public doc.
+**`lastPlayed` on bustout / high-gap rows (v1.46.0 / #709 follow-up; hardened v1.46.4):** after lifetime enrichment, the refresh prefers songs-catalog `last_played` when it is strictly before the row's `showDate` (zero HTTP). Remaining rows look up phish.net play history (`/v5/setlists/slug/{slug}.json`, capped at 120 lookups/run, ~1.5s pacing, 429 backoff + abort-after-3, bustouts before high gaps, shared across tours) and stamp the latest Phish show date strictly before that night. Best-effort — failed lookups leave the field absent; UI always shows the Last column (`—` when missing). Dashboard Tour stats joins the same dates from the world-readable public doc.
+
+**`lastPlayed` on `topSongs` (v1.46.4):** latest eligible tour show date the song was played (`YYYY-MM-DD`). UI displays tour-scoped `mm-dd`.
 
 `_index` fields: `tours[]` (`tourSlug`, `tourLabel`, `firstShowDate`, `lastShowDate`, `showCount`), `defaultTourSlug` (current tour = newest `lastShowDate` among indexed tours), `writtenAt`, `schemaVersion`.
 

--- a/functions/aggregateTourSetlistStats.cjs
+++ b/functions/aggregateTourSetlistStats.cjs
@@ -34,7 +34,7 @@ function aggregateTourSetlistStats(docs, options = {}) {
         ? docs.length
         : 0;
 
-  /** @type {Map<string, { title: string, timesPlayed: number }>} */
+  /** @type {Map<string, { title: string, timesPlayed: number, lastTourDate: string | null }>} */
   const bySong = new Map();
   /** @type {Array<{ title: string, showDate: string, gap: number | null }>} */
   const bustouts = [];
@@ -63,8 +63,21 @@ function aggregateTourSetlistStats(docs, options = {}) {
       playedThisShow.add(key);
       totalSongPlays += 1;
       const existing = bySong.get(key);
-      if (existing) existing.timesPlayed += 1;
-      else bySong.set(key, { title, timesPlayed: 1 });
+      if (existing) {
+        existing.timesPlayed += 1;
+        if (
+          showDate &&
+          (!existing.lastTourDate || showDate > existing.lastTourDate)
+        ) {
+          existing.lastTourDate = showDate;
+        }
+      } else {
+        bySong.set(key, {
+          title,
+          timesPlayed: 1,
+          lastTourDate: showDate || null,
+        });
+      }
     }
 
     const songGaps =
@@ -112,12 +125,19 @@ function aggregateTourSetlistStats(docs, options = {}) {
   }
 
   // #709: full ranked list — no top-N cap (mirrors the client model).
+  // `lastPlayed` here = most recent *tour* date the song was played (Most
+  // played "Last" column). Bustout/gap rows get a different lastPlayed
+  // (before that night) stamped later from phish.net history.
   const topSongs = [...bySong.values()]
     .sort((a, b) => {
       if (b.timesPlayed !== a.timesPlayed) return b.timesPlayed - a.timesPlayed;
       return a.title.localeCompare(b.title);
     })
-    .map((row) => ({ title: row.title, timesPlayed: row.timesPlayed }));
+    .map((row) => ({
+      title: row.title,
+      timesPlayed: row.timesPlayed,
+      lastPlayed: row.lastTourDate || null,
+    }));
 
   bustouts.sort((a, b) => {
     const ga = a.gap ?? -1;
@@ -147,15 +167,17 @@ function aggregateTourSetlistStats(docs, options = {}) {
  * Input rows come from `fetchPhishnetSongsNormalized` (`phishnetSongCatalog.js`):
  * `{ name, total, gap, last, debut, slug }` with string fields ("—" when unknown).
  *
- * Output: normalized title → `{ lifetimePlays, debutYear, slug }`. Lifetime
- * data lives only on phish.net (game-local `official_setlists` cover scored
- * tour dates), so this is the unique crawlable content layer for the public
- * `/tour-stats` pages. `slug` keys the per-song play-history lookup used to
- * stamp `lastPlayed` on bustout/high-gap rows (#709 follow-up) and is never
- * written into payload rows itself.
+ * Output: normalized title → `{ lifetimePlays, debutYear, slug, lastPlayedCatalog }`.
+ * Lifetime data lives only on phish.net (game-local `official_setlists` cover
+ * scored tour dates), so this is the unique crawlable content layer for the
+ * public `/tour-stats` pages. `slug` keys the per-song play-history lookup;
+ * `lastPlayedCatalog` is phish.net's current `last_played` and can fill
+ * bustout/gap `lastPlayed` when it is strictly before that tour night (no
+ * history HTTP call needed). Neither `slug` nor `lastPlayedCatalog` is written
+ * into payload rows as-is.
  *
- * @param {Array<{ name: string, total?: string, debut?: string, slug?: string }>} songs
- * @returns {Map<string, { lifetimePlays: number | null, debutYear: number | null, slug: string | null }>}
+ * @param {Array<{ name: string, total?: string, debut?: string, slug?: string, last?: string }>} songs
+ * @returns {Map<string, { lifetimePlays: number | null, debutYear: number | null, slug: string | null, lastPlayedCatalog: string | null }>}
  */
 function buildSongEnrichmentByTitle(songs) {
   const map = new Map();
@@ -177,8 +199,20 @@ function buildSongEnrichmentByTitle(songs) {
     const slugRaw = String(song?.slug ?? "").trim();
     const slug = slugRaw || null;
 
-    if (lifetimePlays === null && debutYear === null && slug === null) continue;
-    map.set(key, { lifetimePlays, debutYear, slug });
+    const lastRaw = String(song?.last ?? "").trim();
+    const lastPlayedCatalog = /^\d{4}-\d{2}-\d{2}$/.test(lastRaw)
+      ? lastRaw
+      : null;
+
+    if (
+      lifetimePlays === null &&
+      debutYear === null &&
+      slug === null &&
+      lastPlayedCatalog === null
+    ) {
+      continue;
+    }
+    map.set(key, { lifetimePlays, debutYear, slug, lastPlayedCatalog });
   }
   return map;
 }
@@ -248,7 +282,12 @@ function toPublicTourStatsPayload(stats, enrichmentByTitle = null) {
     uniqueSongs: stats.uniqueSongs,
     totalSongPlays: stats.totalSongPlays,
     topSongs: (stats.topSongs || []).map((r) =>
-      withEnrichment(r, { title: r.title, timesPlayed: r.timesPlayed })
+      withEnrichment(r, {
+        title: r.title,
+        timesPlayed: r.timesPlayed,
+        // Tour-local last play (not phish.net lifetime last).
+        lastPlayed: r.lastPlayed || null,
+      })
     ),
     bustouts: (stats.bustouts || []).map((r) =>
       withEnrichment(r, {

--- a/functions/aggregateTourSetlistStats.test.js
+++ b/functions/aggregateTourSetlistStats.test.js
@@ -57,19 +57,31 @@ describe("buildSongEnrichmentByTitle (#666)", () => {
       lifetimePlays: 623,
       debutYear: 1997,
       slug: "ghost",
+      lastPlayedCatalog: null,
     });
     assert.deepEqual(map.get("tweezer"), {
       lifetimePlays: 512,
       debutYear: 1990,
       slug: null,
+      lastPlayedCatalog: null,
     });
     assert.equal(map.has("no data"), false);
     assert.deepEqual(map.get("weird year"), {
       lifetimePlays: 3,
       debutYear: null,
       slug: null,
+      lastPlayedCatalog: null,
     });
     assert.equal(map.has(""), false);
+  });
+
+  it("keeps catalog last_played when it is a YYYY-MM-DD date", () => {
+    const map = buildSongEnrichmentByTitle([
+      { name: "Ghost", total: "1", debut: "1997", last: "2024-12-31", slug: "ghost" },
+      { name: "Bad Last", total: "1", debut: "1990", last: "—" },
+    ]);
+    assert.equal(map.get("ghost").lastPlayedCatalog, "2024-12-31");
+    assert.equal(map.get("bad last").lastPlayedCatalog, null);
   });
 });
 

--- a/functions/publicTourStats.js
+++ b/functions/publicTourStats.js
@@ -48,16 +48,28 @@ async function fetchSongEnrichment(apiKey, logger) {
 }
 
 /**
- * Safety cap on per-song history lookups per refresh run. Bustout + high-gap
- * songs across all tours are typically well under this; the cap only guards
- * against a pathological calendar from turning the refresh into a phish.net
- * crawl.
+ * Safety cap on per-song history lookups per refresh run. Prefer the songs
+ * catalog `last_played` when it is strictly before the tour night — that
+ * fills most bustout/gap rows with zero HTTP. History fetches are only for
+ * songs whose catalog last is missing or ≥ the night (replayed later).
+ *
+ * Cloudflare rate-limits phish.net aggressively (HTTP 429 / 1015). Pace
+ * lookups ~1.5s apart, back off hard on 429, and abort the history pass after
+ * a short streak of 429s so one bad window doesn't burn the whole budget.
  */
-const MAX_LAST_PLAYED_LOOKUPS = 80;
+const MAX_LAST_PLAYED_LOOKUPS = 120;
+const HISTORY_FETCH_GAP_MS = 1500;
+const HISTORY_429_RETRY_MS = 10000;
+const HISTORY_429_ABORT_AFTER = 3;
 
 /** @param {unknown} title */
 function normalizeTitleKey(title) {
   return String(title ?? "").trim().toLowerCase();
+}
+
+/** @param {number} ms */
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**
@@ -99,78 +111,223 @@ async function fetchPhishnetSongHistoryDates(apiKey, slug) {
 }
 
 /**
- * #709 follow-up: stamp `lastPlayed` (date the song was last played *before*
- * that tour night) onto bustout / high-gap payload rows. Mutates `payload`
- * in place. Best-effort per song: a failed history lookup just leaves those
- * rows date-less (the UI hides the column when no row has one).
- *
- * `historyCache` (slug → string[] | null) is shared across tours within one
- * refresh run so a song appearing in multiple tour docs costs one lookup.
- *
- * @param {{ bustouts?: Array<object>, gapHighlights?: Array<object> }} payload
- * @param {{
- *   enrichmentByTitle: Map<string, { slug?: string | null }> | null,
- *   apiKey: string,
- *   historyCache: Map<string, string[] | null>,
- *   logger: Console,
- *   state: { lookups: number },
- * }} opts
- * @returns {Promise<number>} rows stamped
+ * @param {string} apiKey
+ * @param {string} slug
+ * @param {Console} logger
+ * @returns {Promise<string[] | null>}
  */
-async function stampLastPlayedDates(payload, opts) {
-  const { enrichmentByTitle, apiKey, historyCache, logger, state } = opts;
-  if (!(enrichmentByTitle instanceof Map) || !apiKey) return 0;
+/**
+ * @param {string} apiKey
+ * @param {string} slug
+ * @param {Console} logger
+ * @returns {Promise<{ dates: string[] | null, rateLimited: boolean }>}
+ */
+async function fetchPhishnetSongHistoryDatesWithRetry(apiKey, slug, logger) {
+  try {
+    return {
+      dates: await fetchPhishnetSongHistoryDates(apiKey, slug),
+      rateLimited: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const is429 = msg.includes("HTTP 429");
+    if (!is429) {
+      logger.warn("refreshPublicTourStats: song history lookup failed", {
+        slug,
+        error: msg,
+      });
+      return { dates: null, rateLimited: false };
+    }
+    await sleep(HISTORY_429_RETRY_MS);
+    try {
+      return {
+        dates: await fetchPhishnetSongHistoryDates(apiKey, slug),
+        rateLimited: false,
+      };
+    } catch (err2) {
+      const msg2 = err2 instanceof Error ? err2.message : String(err2);
+      logger.warn("refreshPublicTourStats: song history lookup failed", {
+        slug,
+        error: msg2,
+        retried: true,
+      });
+      return { dates: null, rateLimited: msg2.includes("HTTP 429") };
+    }
+  }
+}
 
-  /** @type {Map<string, Array<{ title?: string, showDate?: string | null }>>} */
-  const rowsBySlug = new Map();
-  for (const row of [
-    ...(payload.bustouts || []),
-    ...(payload.gapHighlights || []),
-  ]) {
+/**
+ * Queue history lookups with bustouts ahead of high-gap rows so a rate-limit
+ * window still fills the higher-signal column first.
+ *
+ * @param {Map<string, Array<object>>} into
+ * @param {object[]} rows
+ * @param {Map<string, { slug?: string | null, lastPlayedCatalog?: string | null }>} enrichmentByTitle
+ * @param {string} apiKey
+ * @returns {number} catalog stamps applied
+ */
+function collectLastPlayedWork(into, rows, enrichmentByTitle, apiKey) {
+  let fromCatalog = 0;
+  for (const row of rows) {
     if (!row || typeof row !== "object" || !row.showDate) continue;
-    const slug = enrichmentByTitle.get(normalizeTitleKey(row.title))?.slug;
-    if (!slug) continue;
-    const bucket = rowsBySlug.get(slug);
+    // Already stamped (e.g. prior refresh / local backfill) — keep it.
+    if (
+      typeof row.lastPlayed === "string" &&
+      /^\d{4}-\d{2}-\d{2}$/.test(row.lastPlayed.trim())
+    ) {
+      continue;
+    }
+    const showDate = String(row.showDate).trim();
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(showDate)) continue;
+
+    const enrich = enrichmentByTitle.get(normalizeTitleKey(row.title));
+    const catalogLast =
+      typeof enrich?.lastPlayedCatalog === "string"
+        ? enrich.lastPlayedCatalog.trim()
+        : "";
+    if (/^\d{4}-\d{2}-\d{2}$/.test(catalogLast) && catalogLast < showDate) {
+      row.lastPlayed = catalogLast;
+      fromCatalog += 1;
+      continue;
+    }
+
+    const slug = enrich?.slug;
+    if (!slug || !apiKey) continue;
+    const bucket = into.get(slug);
     if (bucket) bucket.push(row);
-    else rowsBySlug.set(slug, [row]);
+    else into.set(slug, [row]);
+  }
+  return fromCatalog;
+}
+
+/**
+ * #709 follow-up: stamp `lastPlayed` (date last played *before* that tour
+ * night) onto bustout / high-gap rows across every tour payload.
+ *
+ * 1. Prefer songs-catalog `last_played` when it is strictly before the night
+ *    (zero HTTP).
+ * 2. Otherwise fetch phish.net history once per slug (shared cache, paced +
+ *    429 backoff) up to MAX_LAST_PLAYED_LOOKUPS. Bustout slugs are queued
+ *    before high-gap slugs.
+ *
+ * @param {Array<{ bustouts?: Array<object>, gapHighlights?: Array<object> }>} payloads
+ * @param {{
+ *   enrichmentByTitle: Map<string, { slug?: string | null, lastPlayedCatalog?: string | null }> | null,
+ *   apiKey: string,
+ *   logger: Console,
+ * }} opts
+ * @returns {Promise<{ stamped: number, fromCatalog: number, fromHistory: number, failed: number, lookups: number, aborted429: boolean }>}
+ */
+async function stampLastPlayedDates(payloads, opts) {
+  const { enrichmentByTitle, apiKey, logger } = opts;
+  const empty = {
+    stamped: 0,
+    fromCatalog: 0,
+    fromHistory: 0,
+    failed: 0,
+    lookups: 0,
+    aborted429: false,
+  };
+  if (!(enrichmentByTitle instanceof Map)) return empty;
+
+  /** @type {Map<string, Array<{ title?: string, showDate?: string | null, lastPlayed?: string }>>} */
+  const bustoutHistoryBySlug = new Map();
+  /** @type {Map<string, Array<{ title?: string, showDate?: string | null, lastPlayed?: string }>>} */
+  const gapHistoryBySlug = new Map();
+  let fromCatalog = 0;
+
+  for (const payload of payloads) {
+    fromCatalog += collectLastPlayedWork(
+      bustoutHistoryBySlug,
+      payload.bustouts || [],
+      enrichmentByTitle,
+      apiKey
+    );
+    fromCatalog += collectLastPlayedWork(
+      gapHistoryBySlug,
+      payload.gapHighlights || [],
+      enrichmentByTitle,
+      apiKey
+    );
   }
 
-  let stamped = 0;
+  // Bustouts first; then high-gap slugs not already queued for a bustout row.
+  /** @type {Array<[string, Array<object>]>} */
+  const historyQueue = [...bustoutHistoryBySlug.entries()];
+  for (const [slug, rows] of gapHistoryBySlug) {
+    const existing = bustoutHistoryBySlug.get(slug);
+    if (existing) existing.push(...rows);
+    else historyQueue.push([slug, rows]);
+  }
+
+  let lookups = 0;
   let failed = 0;
-  for (const [slug, rows] of rowsBySlug) {
-    if (!historyCache.has(slug)) {
-      if (state.lookups >= MAX_LAST_PLAYED_LOOKUPS) break;
-      state.lookups += 1;
-      try {
-        historyCache.set(slug, await fetchPhishnetSongHistoryDates(apiKey, slug));
-      } catch (err) {
-        historyCache.set(slug, null);
-        failed += 1;
-        logger.warn("refreshPublicTourStats: song history lookup failed", {
-          slug,
-          error: err instanceof Error ? err.message : String(err),
-        });
+  let fromHistory = 0;
+  let consecutive429 = 0;
+  let aborted429 = false;
+
+  for (const [slug, rows] of historyQueue) {
+    if (lookups >= MAX_LAST_PLAYED_LOOKUPS) break;
+    lookups += 1;
+    if (lookups > 1) await sleep(HISTORY_FETCH_GAP_MS);
+    const { dates, rateLimited } = await fetchPhishnetSongHistoryDatesWithRetry(
+      apiKey,
+      slug,
+      logger
+    );
+    if (!dates) {
+      failed += 1;
+      if (rateLimited) {
+        consecutive429 += 1;
+        if (consecutive429 >= HISTORY_429_ABORT_AFTER) {
+          aborted429 = true;
+          logger.warn(
+            "refreshPublicTourStats: aborting history lookups after repeated 429s",
+            {
+              consecutive429,
+              lookups,
+              remaining: historyQueue.length - lookups,
+            }
+          );
+          break;
+        }
+        // Extra cool-down before the next attempt in the same run.
+        await sleep(HISTORY_429_RETRY_MS);
+      } else {
+        consecutive429 = 0;
       }
+      continue;
     }
-    const dates = historyCache.get(slug);
-    if (!dates) continue;
+    consecutive429 = 0;
     for (const row of rows) {
       const lastPlayed = lastPlayedBeforeFromHistory(dates, row.showDate);
       if (lastPlayed) {
         row.lastPlayed = lastPlayed;
-        stamped += 1;
+        fromHistory += 1;
       }
     }
   }
 
-  if (stamped > 0 || failed > 0) {
+  const stamped = fromCatalog + fromHistory;
+  if (stamped > 0 || failed > 0 || aborted429) {
     logger.info("refreshPublicTourStats: lastPlayed dates stamped", {
       stamped,
+      fromCatalog,
+      fromHistory,
       failed,
-      lookupsSoFar: state.lookups,
+      lookups,
+      aborted429,
+      pendingSlugs: Math.max(0, historyQueue.length - lookups),
     });
   }
-  return stamped;
+  return {
+    stamped,
+    fromCatalog,
+    fromHistory,
+    failed,
+    lookups,
+    aborted429,
+  };
 }
 
 /**
@@ -221,9 +378,8 @@ async function refreshPublicTourStats(db, opts = {}) {
     logger
   );
 
-  // #709 follow-up: per-song history lookups (lastPlayed) shared across tours.
-  const historyCache = new Map();
-  const lookupState = { lookups: 0 };
+  /** @type {Array<{ tourSlug: string, tourLabel: string, showDates: string[], payload: object }>} */
+  const pendingWrites = [];
 
   for (const group of selectable) {
     const tourLabel = group.tour;
@@ -257,14 +413,21 @@ async function refreshPublicTourStats(db, opts = {}) {
       tourShowCount: showDates.length,
     });
     const payload = toPublicTourStatsPayload(stats, enrichmentByTitle);
-    await stampLastPlayedDates(payload, {
+    pendingWrites.push({ tourSlug, tourLabel, showDates, payload });
+  }
+
+  // Stamp bustout/gap lastPlayed across every tour before writing so the
+  // history budget is shared fairly (catalog last_played fills most rows).
+  await stampLastPlayedDates(
+    pendingWrites.map((w) => w.payload),
+    {
       enrichmentByTitle,
       apiKey: String(opts.phishnetApiKey || "").trim(),
-      historyCache,
       logger,
-      state: lookupState,
-    });
+    }
+  );
 
+  for (const { tourSlug, tourLabel, showDates, payload } of pendingWrites) {
     await db
       .collection("public_tour_stats")
       .doc(tourSlug)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.46.3",
+  "version": "1.46.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/tour-stats/ui/TourStatsView.jsx
+++ b/src/features/tour-stats/ui/TourStatsView.jsx
@@ -21,30 +21,91 @@ import {
 
 const { BUSTOUT_MIN_GAP } = SCORING_RULES;
 
-/** Invisible 3-col grid: # | Song | Plays — fixed tracks keep columns aligned. */
+/**
+ * Fixed meta tracks (not `auto`) so the header grid and each data row share
+ * the same column widths — independent `auto` grids were shifting Date/Gap/Last
+ * headers left of their cells. `whitespace-nowrap` keeps mm-dd / mm-dd-yy on
+ * one line at 11px.
+ */
 const TOP_SONGS_ROW_GRID =
-  'grid grid-cols-[1.5rem_minmax(0,1fr)_3.5rem] items-center gap-x-2 min-h-[1.75rem]';
-
-/** Invisible 3-col grid: Song | Date | Gap. */
-const GAP_ROW_GRID =
-  'grid grid-cols-[minmax(0,1fr)_6.5rem_3rem] items-center gap-x-2 min-h-[1.75rem]';
+  'grid grid-cols-[1.5rem_minmax(0,1fr)_2.75rem_2.5rem] items-center gap-x-2 min-h-[1.75rem]';
 
 /**
- * 4-col variant when rows carry `lastPlayed` (#709 follow-up): Song | Last |
- * Date | Gap. Only used when at least one visible row has the date, so the
- * un-enriched dashboard/public state keeps the roomier 3-col layout.
+ * Bustouts / High gaps: Song | Date (mm-dd) | Gap | Last (mm-dd-yy).
+ * Always shown (— when missing) so the column is discoverable even before
+ * enrichment lands or when some history lookups 429.
  */
-const GAP_ROW_GRID_WITH_LAST =
-  'grid grid-cols-[minmax(0,1fr)_5.75rem_5.75rem_2.5rem] items-center gap-x-1.5 min-h-[1.75rem]';
+const GAP_ROW_GRID =
+  'grid grid-cols-[minmax(0,1fr)_2.75rem_2.25rem_4.75rem] items-center gap-x-2 min-h-[1.75rem]';
 
-const LAST_PLAYED_TITLE =
+/** Right-rail numeric cells — nowrap + slightly smaller type on narrow widths. */
+const META_CELL =
+  'justify-self-end whitespace-nowrap tabular-nums text-[11px] leading-none tracking-tight';
+
+const LAST_PLAYED_BEFORE_NIGHT_TITLE =
   'Last played before that night (phish.net song history)';
+
+const LAST_PLAYED_THIS_TOUR_TITLE =
+  'Most recent date this song was played on the selected tour';
+
+/**
+ * Parse `YYYY-MM-DD` → parts, or null.
+ * @param {unknown} iso
+ * @returns {{ y: string, m: string, d: string } | null}
+ */
+function parseIsoDateParts(iso) {
+  const raw = typeof iso === 'string' ? iso.trim() : '';
+  const match = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return null;
+  return { y: match[1], m: match[2], d: match[3] };
+}
+
+/**
+ * Tour-scoped show date: `YYYY-MM-DD` → `MM-DD` (year implied by tour).
+ * @param {unknown} iso
+ * @returns {string}
+ */
+function formatTourShowMd(iso) {
+  const parts = parseIsoDateParts(iso);
+  if (!parts) return typeof iso === 'string' ? iso.trim() : '';
+  return `${parts.m}-${parts.d}`;
+}
+
+/**
+ * Prior-play Last column: `YYYY-MM-DD` → `MM-DD-YY` (keeps decade signal
+ * for bustouts without a full 4-digit year on mobile).
+ * @param {unknown} iso
+ * @returns {string}
+ */
+function formatLastPlayedMdyy(iso) {
+  const parts = parseIsoDateParts(iso);
+  if (!parts) return typeof iso === 'string' ? iso.trim() : '';
+  return `${parts.m}-${parts.d}-${parts.y.slice(2)}`;
+}
+
+/**
+ * Latest YYYY-MM-DD from a song's tour play dates (Tour Frequency "Last" col).
+ * @param {{ showDates?: unknown, lastPlayed?: unknown }} row
+ * @returns {string}
+ */
+function lastPlayedDisplayForTopSong(row) {
+  if (typeof row?.lastPlayed === 'string' && row.lastPlayed.trim()) {
+    return row.lastPlayed.trim();
+  }
+  const dates = Array.isArray(row?.showDates)
+    ? row.showDates
+        .map((d) => String(d ?? '').trim())
+        .filter((d) => /^\d{4}-\d{2}-\d{2}$/.test(d))
+    : [];
+  if (dates.length === 0) return '';
+  return dates.reduce((a, b) => (a > b ? a : b));
+}
 
 const COL_HEADER =
   'mb-0.5 border-b border-brand-primary/20 pb-1 text-[10px] font-black uppercase tracking-wider text-slate-300';
 
-const MOST_PLAYED_DEF =
-  'Ranked by frequency; songs with the same number of plays this tour are sorted by total # of times played all-time.';
+const TOUR_FREQUENCY_DEF =
+  'All songs this tour, ranked by number of times played. Ties break by total # of times played all-time.';
 
 const HIGH_GAPS_DEF = `Gap = shows since last played before that night. Listed when gap ≥ ${TOUR_STATS_GAP_HIGHLIGHT_MIN} and below the bustout threshold.`;
 
@@ -223,35 +284,57 @@ export default function TourStatsView({
           </TourStatsSectionCard>
         ) : null}
 
-        <TourStatsSectionCard title="Most played" definition={MOST_PLAYED_DEF}>
+        <TourStatsSectionCard
+          title="Tour Frequency"
+          definition={TOUR_FREQUENCY_DEF}
+        >
           {stats.topSongs.length === 0 ? (
             <p className="text-sm text-content-secondary">No setlist songs yet.</p>
           ) : (
             <PagedRows
               rows={stats.topSongs}
-              label="most played"
+              label="tour frequency"
               listAs="ol"
               header={
                 <div className={`${TOP_SONGS_ROW_GRID} ${COL_HEADER}`} aria-hidden>
                   <span className="tabular-nums">#</span>
                   <span>Song</span>
-                  <span className="justify-self-end">Plays</span>
+                  <span
+                    className={META_CELL}
+                    title={LAST_PLAYED_THIS_TOUR_TITLE}
+                  >
+                    Last
+                  </span>
+                  <span className={META_CELL}>Plays</span>
                 </div>
               }
-              renderRow={(row, absoluteIdx) => (
-                <li key={row.title} className={TOP_SONGS_ROW_GRID}>
-                  <span className="tabular-nums text-brand-primary/80">
-                    {absoluteIdx + 1}
-                  </span>
-                  <span className="min-w-0">
-                    <span className="block truncate">{row.title}</span>
-                    <SongEnrichmentLine row={row} />
-                  </span>
-                  <span className="justify-self-end tabular-nums text-brand-primary">
-                    {row.timesPlayed}
-                  </span>
-                </li>
-              )}
+              renderRow={(row, absoluteIdx) => {
+                const lastIso = lastPlayedDisplayForTopSong(row);
+                return (
+                  <li key={row.title} className={TOP_SONGS_ROW_GRID}>
+                    <span className="tabular-nums text-brand-primary/80">
+                      {absoluteIdx + 1}
+                    </span>
+                    <span className="min-w-0">
+                      <span className="block truncate">{row.title}</span>
+                      <SongEnrichmentLine row={row} />
+                    </span>
+                    <span
+                      className={`${META_CELL} text-content-secondary`}
+                      title={
+                        lastIso
+                          ? `${LAST_PLAYED_THIS_TOUR_TITLE}: ${lastIso}`
+                          : LAST_PLAYED_THIS_TOUR_TITLE
+                      }
+                    >
+                      {lastIso ? formatTourShowMd(lastIso) : '—'}
+                    </span>
+                    <span className={`${META_CELL} text-brand-primary`}>
+                      {row.timesPlayed}
+                    </span>
+                  </li>
+                );
+              }}
             />
           )}
         </TourStatsSectionCard>
@@ -263,7 +346,7 @@ export default function TourStatsView({
             <GapPagedRows
               rows={stats.bustouts}
               label="bustouts"
-              gapClassName="justify-self-end tabular-nums font-bold text-amber-200"
+              gapClassName={`${META_CELL} font-bold text-amber-200`}
             />
           )}
           <p className="mt-3 border-t border-border-subtle/40 pt-3 text-[11px] font-semibold leading-relaxed text-content-secondary">
@@ -293,7 +376,7 @@ export default function TourStatsView({
             <GapPagedRows
               rows={stats.gapHighlights}
               label="high gaps"
-              gapClassName="justify-self-end tabular-nums text-slate-300"
+              gapClassName={`${META_CELL} text-slate-300`}
             />
           </TourStatsSectionCard>
         ) : null}
@@ -314,7 +397,7 @@ function SongEnrichmentLine({ row }) {
   const bits = [];
   if (typeof row.debutYear === 'number') bits.push(`Debut ${row.debutYear}`);
   if (typeof row.lifetimePlays === 'number') {
-    bits.push(`${row.lifetimePlays.toLocaleString()} plays all-time`);
+    bits.push(`All Time - ${row.lifetimePlays.toLocaleString()}`);
   }
   if (bits.length === 0) return null;
   return (
@@ -325,10 +408,8 @@ function SongEnrichmentLine({ row }) {
 }
 
 /**
- * Bustouts / High-gaps list body: Song | Date | Gap rows, plus a "Last"
- * (last played before that night) column when any row carries a
- * `lastPlayed` date — server-enriched payloads only (#666), so the column
- * self-hides on un-enriched data instead of rendering an empty track.
+ * Bustouts / High-gaps list body: Song | Date (mm-dd) | Gap | Last (mm-dd-yy).
+ * Full ISO dates stay on `title` for hover / assistive context.
  *
  * @param {{
  *   rows: Array<{ title: string, showDate: string, gap: number | null, lastPlayed?: string }>,
@@ -337,56 +418,64 @@ function SongEnrichmentLine({ row }) {
  * }} props
  */
 function GapPagedRows({ rows, label, gapClassName }) {
-  const hasLastPlayed = rows.some(
-    (row) => typeof row.lastPlayed === 'string' && row.lastPlayed,
-  );
-  const grid = hasLastPlayed ? GAP_ROW_GRID_WITH_LAST : GAP_ROW_GRID;
-
   return (
     <PagedRows
       rows={rows}
       label={label}
       header={
-        <div className={`${grid} ${COL_HEADER}`} aria-hidden>
+        <div className={`${GAP_ROW_GRID} ${COL_HEADER}`} aria-hidden>
           <span>Song</span>
-          {hasLastPlayed ? (
-            <span className="justify-self-end" title={LAST_PLAYED_TITLE}>
-              Last
-            </span>
-          ) : null}
-          <span className="justify-self-end">Date</span>
-          <span className="justify-self-end">Gap</span>
+          <span className={META_CELL}>Date</span>
+          <span className={META_CELL}>Gap</span>
+          <span className={META_CELL} title={LAST_PLAYED_BEFORE_NIGHT_TITLE}>
+            Last
+          </span>
         </div>
       }
-      renderRow={(row) => (
-        <li key={`${row.showDate}-${row.title}`} className={grid}>
-          <span className="min-w-0">
-            <span className="block truncate">{row.title}</span>
-            <SongEnrichmentLine row={row} />
-          </span>
-          {hasLastPlayed ? (
-            <span
-              className="justify-self-end tabular-nums text-content-secondary"
-              title={LAST_PLAYED_TITLE}
-            >
-              {row.lastPlayed || '—'}
+      renderRow={(row) => {
+        const lastIso =
+          typeof row.lastPlayed === 'string' && row.lastPlayed.trim()
+            ? row.lastPlayed.trim()
+            : '';
+        return (
+          <li key={`${row.showDate}-${row.title}`} className={GAP_ROW_GRID}>
+            <span className="min-w-0">
+              <span className="block truncate">{row.title}</span>
+              <SongEnrichmentLine row={row} />
             </span>
-          ) : null}
-          <span className="justify-self-end tabular-nums text-content-secondary">
-            {row.showDate}
-          </span>
-          <span
-            className={gapClassName}
-            title={
-              row.gap != null
-                ? `${row.gap} shows since last played (pre-show gap)`
-                : undefined
-            }
-          >
-            {row.gap != null ? row.gap : '—'}
-          </span>
-        </li>
-      )}
+            <span
+              className={`${META_CELL} text-content-secondary`}
+              title={
+                typeof row.showDate === 'string' && row.showDate
+                  ? row.showDate
+                  : undefined
+              }
+            >
+              {formatTourShowMd(row.showDate) || '—'}
+            </span>
+            <span
+              className={gapClassName}
+              title={
+                row.gap != null
+                  ? `${row.gap} shows since last played (pre-show gap)`
+                  : undefined
+              }
+            >
+              {row.gap != null ? row.gap : '—'}
+            </span>
+            <span
+              className={`${META_CELL} text-content-secondary`}
+              title={
+                lastIso
+                  ? `${LAST_PLAYED_BEFORE_NIGHT_TITLE}: ${lastIso}`
+                  : LAST_PLAYED_BEFORE_NIGHT_TITLE
+              }
+            >
+              {lastIso ? formatLastPlayedMdyy(lastIso) : '—'}
+            </span>
+          </li>
+        );
+      }}
     />
   );
 }


### PR DESCRIPTION
References #709

## Summary
- Harden `refreshPublicTourStats` lastPlayed stamping: tour-local `lastPlayed` on Tour Frequency rows; catalog-first then paced phish.net history (1.5s gap, 429 backoff/abort, bustouts before high gaps).
- Tour stats UI: **Tour Frequency** rename, Song | Date | Gap | Last order, `mm-dd` / `mm-dd-yy` display, `All Time - N` sub-line, fixed mobile meta columns so headers align.
- SemVer **1.46.4** + `docs/API.md` / CHANGELOG updates.

## Test plan
- [ ] Hard-refresh `/tour-stats` (Summer): Bustouts/High gaps Last filled; Date `mm-dd`; Last `mm-dd-yy`; headers aligned on iPhone-width
- [ ] Tour Frequency title + tooltip; Last column `mm-dd`
- [ ] Dashboard Stats tab shares the same chrome
- [ ] After merge/deploy: nightly refresh keeps Last populated (no mass `—` from 429s)


Made with [Cursor](https://cursor.com)