### PR TITLE
chore(release): promote staging to main (1.46.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.46.5] — 2026-08-04
+
+### Fixed
+- **Cold-open load regression after 1.44.x / 1.46.4 promote** — marketing SEO shells paint a branded inline Loading overlay over crawler copy so plain h1/p no longer flash before React mounts; Inter (~344KB) is no longer high-priority preloaded (keeps `@font-face` + `font-display: swap`); `/privacy`, `/terms`, `/user/*`, bare `/join`, and related hard opens use `dist/spa-boot/index.html` (branded skeleton **without** `DashboardRoute` modulepreload); FCM service-worker registration is idle-deferred on all non-dashboard/setup hard opens; `/fonts/*` gets long-cache headers.
+- **Lazy `HomeRoute` dependency waterfall (#731)** — splash `modulepreload` now includes the route's **static import closure** (e.g. `auth-*` + `shared-*`, ~360KB) instead of only the 2KB `HomeRoute` leaf, so Landing no longer waits a serial round-trip after the entry bundle parses. Dashboard boot shell uses the same closure walker. FCM messaging is dynamic-imported from `main.jsx` so it leaves the entry static graph.
+
+---
+
 ## [1.46.4] — 2026-08-03
 
 ### Changed

--- a/docs/USER_ROUTING_AND_JOURNEYS.md
+++ b/docs/USER_ROUTING_AND_JOURNEYS.md
@@ -30,7 +30,7 @@ Defined in `src/app/App.jsx`.
 
 ### Email / push hard opens (`/dashboard/*`)
 
-Cold document loads (email CTAs, push, refresh) are rewritten by Vercel to `dist/dashboard/index.html` — a **branded static skeleton** (#773 Phase 1; empty-root precursor #743) so users see chrome before React + Auth mount. `createRoot` replaces `#root` as usual. Marketing SEO prerender stays on `dist/index.html` only (`verify:seo-prerender`).
+Cold document loads for `/dashboard/*` and `/setup` are rewritten by Vercel to `dist/dashboard/index.html` — a **branded static skeleton** with `DashboardRoute` modulepreload (#773). Legal, public profile, bare `/join`, and related hard opens use `dist/spa-boot/index.html` (same skeleton, **no** fat route preload) so they do not download the dashboard graph. Marketing SEO prerender stays on `dist/index.html` (+ marketing boot overlay) (`verify:seo-prerender`).
 
 **Phase 2 (TTI):** on `/dashboard/*` (and related warm paths), `main.jsx` calls `ensureAppCheckNow()` and kicks a dynamic `import()` of `DashboardRoute` before first paint; the boot shell also `modulepreload`s the `DashboardRoute` chunk. Auth seeds `auth.currentUser`, paints profile via `getDoc` then `onSnapshot`, and dashboard loading uses `DashboardBootSkeleton` instead of bare “Loading…”. Splash stays lazy + deferred App Check.
 

--- a/index.html
+++ b/index.html
@@ -39,7 +39,8 @@
       content="Setlist Pick 'Em is a free live setlist prediction game built for Phish fans—and more bands soon. Lock openers, closers, encore, and a wildcard before each show; scores update live as songs are played. Tour insights refresh every night the band plays live. Play to unlock personal stats and compete with friends."
     />
     <meta name="author" content="Road2 Media LLC" />
-    <link rel="preload" href="/fonts/inter/InterVariable.woff2" as="font" type="font/woff2" crossorigin>
+    <!-- Space Grotesk only: Inter (~344KB variable) loads via @font-face +
+         font-display:swap so it does not contend with entry JS on cold opens. -->
     <link rel="preload" href="/fonts/space-grotesk/SpaceGrotesk-VariableFont_wght.woff2" as="font" type="font/woff2" crossorigin>
     <title>Setlist Pick'em | The Ultimate Live Music Prediction Game</title>
   </head>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.46.4",
+  "version": "1.46.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/boot-modulepreload.mjs
+++ b/scripts/boot-modulepreload.mjs
@@ -4,14 +4,16 @@
  *
  * Every top-level route is `lazy()` in `src/app/App.jsx`, so the chunk a given
  * entry HTML is certain to need would otherwise start downloading only after
- * the entry bundle parses. Each shell preloads its own route and nothing else —
- * splash must not pull the dashboard graph, and the app boot shell must not
- * pull Landing.
+ * the entry bundle parses. Each shell preloads its own route **and that route's
+ * static import closure** — preloading only the leaf `HomeRoute-*.js` (~2KB)
+ * left a waterfall on `auth-*.js` + `shared-*.js` (~360KB) before Landing could
+ * paint. Splash must not pull the dashboard graph, and the app boot shell must
+ * not pull Landing.
  *
  * Pure Node — no `src/` imports, safe for build scripts.
  */
 
-import { readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 /** Chunk filename prefixes to modulepreload on the dashboard boot shell (#773). */
@@ -49,6 +51,47 @@ export function resolveBootModulepreloadHrefs(assetsDir, prefixes) {
 }
 
 /**
+ * Walk static `from "./chunk.js"` edges from entry hrefs so modulepreload
+ * covers the full paint-critical graph (not just the lazy leaf).
+ *
+ * @param {string} assetsDir
+ * @param {string[]} entryHrefs `/assets/….js`
+ * @returns {string[]}
+ */
+export function resolveModulepreloadClosure(assetsDir, entryHrefs) {
+  const seen = new Set();
+  const ordered = [];
+  const queue = [...entryHrefs];
+
+  while (queue.length) {
+    const href = queue.shift();
+    if (typeof href !== 'string' || !href || seen.has(href)) continue;
+    seen.add(href);
+    ordered.push(href);
+
+    const fileName = href.replace(/^\/assets\//, '');
+    if (!fileName || fileName.includes('..') || fileName.includes('/')) continue;
+    const filePath = join(assetsDir, fileName);
+    if (!existsSync(filePath)) continue;
+
+    let src = '';
+    try {
+      src = readFileSync(filePath, 'utf8');
+    } catch {
+      continue;
+    }
+
+    for (const match of src.matchAll(/from\s*["']\.\/([^"']+\.js)["']/g)) {
+      const dep = match[1];
+      if (!dep || dep.includes('..') || dep.includes('/')) continue;
+      queue.push(`/assets/${dep}`);
+    }
+  }
+
+  return ordered;
+}
+
+/**
  * Append `<link rel="modulepreload">` tags into `<head>`.
  * Idempotent; skips hrefs already present.
  *
@@ -59,11 +102,21 @@ export function resolveBootModulepreloadHrefs(assetsDir, prefixes) {
  */
 export function injectBootModulepreloads(html, distDir, { prefixes, marker }) {
   if (typeof html !== 'string' || !html) return html;
-  const hrefs = resolveBootModulepreloadHrefs(join(distDir, 'assets'), prefixes);
+  const assetsDir = join(distDir, 'assets');
+  const entryHrefs = resolveBootModulepreloadHrefs(assetsDir, prefixes);
+  if (!entryHrefs.length) return html;
+
+  const hrefs = resolveModulepreloadClosure(assetsDir, entryHrefs);
   if (!hrefs.length) return html;
 
   const tags = hrefs
-    .filter((href) => !html.includes(`href="${href}"`))
+    // Skip assets already present as modulepreload *or* as the entry
+    // `<script type="module" src>` (DashboardRoute can circularly import the
+    // entry chunk; re-preloading it is noise).
+    .filter(
+      (href) =>
+        !html.includes(`href="${href}"`) && !html.includes(`src="${href}"`),
+    )
     .map(
       (href) =>
         `  <link rel="modulepreload" crossorigin href="${href}" ${marker}="true" />`,

--- a/scripts/marketing-boot-shell.mjs
+++ b/scripts/marketing-boot-shell.mjs
@@ -1,0 +1,67 @@
+/**
+ * Inline boot overlay for SEO-prerendered marketing HTML shells.
+ *
+ * Crawler copy stays in `#root` for non-JS consumers, but browsers paint this
+ * branded overlay immediately (no entry JS required) so plain h1/p never flash
+ * before the React Suspense spinner.
+ *
+ * Pure HTML/CSS — no src/ imports (safe for build scripts).
+ */
+
+/** Attribute marker asserted by `verify:seo-prerender`. */
+export const MARKETING_BOOT_SHELL_MARKER = 'data-marketing-boot-shell';
+
+/**
+ * Critical CSS + overlay markup injected into `#root` ahead of the SEO body.
+ * Colors match `src/index.css` brand tokens.
+ */
+export function buildMarketingBootShellMarkup() {
+  const css = `
+html, body {
+  margin: 0;
+  min-height: 100%;
+  background: #1e1b4b;
+}
+[${MARKETING_BOOT_SHELL_MARKER}] {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  background: #1e1b4b;
+  color: #2dd4bf;
+  font-family: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+  font-weight: 700;
+}
+.mbs-spinner {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  border: 3px solid rgb(45 212 191 / 0.25);
+  border-top-color: #2dd4bf;
+  animation: mbs-spin 0.8s linear infinite;
+}
+.mbs-label {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.01em;
+}
+@keyframes mbs-spin {
+  to { transform: rotate(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .mbs-spinner { animation: none; border-top-color: rgb(45 212 191 / 0.45); }
+}
+`.trim();
+
+  return [
+    `<style id="marketing-boot-shell-css">${css}</style>`,
+    `<div ${MARKETING_BOOT_SHELL_MARKER}="true" role="status" aria-busy="true" aria-label="Loading Setlist Pick'em">`,
+    `<div class="mbs-spinner" aria-hidden="true"></div>`,
+    `<p class="mbs-label">Loading…</p>`,
+    `</div>`,
+  ].join('');
+}

--- a/scripts/prerender-seo.mjs
+++ b/scripts/prerender-seo.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   APP_BOOT_SHELL_REL_PATH,
+  LIGHT_SPA_BOOT_SHELL_REL_PATH,
   PRERENDER_ROUTES,
   buildDashboardBootShellHtml,
   injectDashboardBootModulepreloads,
@@ -42,13 +43,11 @@ for (const route of PRERENDER_ROUTES) {
   console.log(`prerender-seo: wrote dist/${rel} (${Buffer.byteLength(html, 'utf8')} bytes)`);
 }
 
-// Branded boot shell for /dashboard/* (and other app paths via vercel.json).
+// Branded boot shell for /dashboard/* + /setup (via vercel.json).
 // Use the pre-prerender Vite shell so we never copy home SEO body into it.
-// Phase 2: modulepreload DashboardRoute on this shell only (not splash).
-const appBootHtml = injectDashboardBootModulepreloads(
-  buildDashboardBootShellHtml(shell),
-  distDir,
-);
+// Phase 2: modulepreload DashboardRoute on this shell only (not splash / light spa).
+const brandedShell = buildDashboardBootShellHtml(shell);
+const appBootHtml = injectDashboardBootModulepreloads(brandedShell, distDir);
 const appBootPath = join(distDir, APP_BOOT_SHELL_REL_PATH);
 mkdirSync(dirname(appBootPath), { recursive: true });
 writeFileSync(appBootPath, appBootHtml, 'utf8');
@@ -56,4 +55,15 @@ console.log(
   `prerender-seo: wrote dist/${APP_BOOT_SHELL_REL_PATH} (branded #root boot shell + modulepreload)`,
 );
 
-console.log(`prerender-seo: OK (${PRERENDER_ROUTES.length} routes + app boot shell)`);
+// Light spa boot: same branded skeleton, no DashboardRoute preload — legal,
+// public profile, bare /join, etc. must not contend for the dashboard graph.
+const lightBootPath = join(distDir, LIGHT_SPA_BOOT_SHELL_REL_PATH);
+mkdirSync(dirname(lightBootPath), { recursive: true });
+writeFileSync(lightBootPath, brandedShell, 'utf8');
+console.log(
+  `prerender-seo: wrote dist/${LIGHT_SPA_BOOT_SHELL_REL_PATH} (branded shell, no route modulepreload)`,
+);
+
+console.log(
+  `prerender-seo: OK (${PRERENDER_ROUTES.length} routes + app boot shell + light spa boot)`,
+);

--- a/scripts/seo-prerender-lib.mjs
+++ b/scripts/seo-prerender-lib.mjs
@@ -9,6 +9,7 @@ import {
 } from '../src/shared/config/seoRoutes.js';
 import {
   APP_BOOT_SHELL_REL_PATH,
+  LIGHT_SPA_BOOT_SHELL_REL_PATH,
   stripPrerenderBodyFromSpaShell,
 } from './seo-strip-body.mjs';
 import {
@@ -16,6 +17,10 @@ import {
   buildDashboardBootShellHtml,
   buildDashboardBootShellMarkup,
 } from './dashboard-boot-shell.mjs';
+import {
+  MARKETING_BOOT_SHELL_MARKER,
+  buildMarketingBootShellMarkup,
+} from './marketing-boot-shell.mjs';
 import {
   DASHBOARD_BOOT_PRELOAD_MARKER,
   SPLASH_BOOT_PRELOAD_MARKER,
@@ -27,12 +32,15 @@ export {
   PRERENDER_ROUTES,
   SEO_FAVICON_VERSION,
   APP_BOOT_SHELL_REL_PATH,
+  LIGHT_SPA_BOOT_SHELL_REL_PATH,
   stripPrerenderBodyFromSpaShell,
   DASHBOARD_BOOT_SHELL_MARKER,
+  MARKETING_BOOT_SHELL_MARKER,
   DASHBOARD_BOOT_PRELOAD_MARKER,
   SPLASH_BOOT_PRELOAD_MARKER,
   buildDashboardBootShellHtml,
   buildDashboardBootShellMarkup,
+  buildMarketingBootShellMarkup,
   injectDashboardBootModulepreloads,
   injectSplashBootModulepreloads,
 };
@@ -126,7 +134,10 @@ function buildCrawlerBody(route) {
   const paras = route.paragraphs
     .map((p) => `    <p>${escapeHtml(p)}</p>`)
     .join('\n');
-  return `<!--seo-prerender:${escapeHtml(route.path)}-->
+  // Boot overlay paints immediately for browsers; crawler main stays in DOM
+  // for non-JS consumers. createRoot replaces the whole #root.
+  return `${buildMarketingBootShellMarkup()}
+<!--seo-prerender:${escapeHtml(route.path)}-->
   <main data-seo-prerender="true">
     <h1>${escapeHtml(route.h1)}</h1>
 ${paras}

--- a/scripts/seo-strip-body.mjs
+++ b/scripts/seo-strip-body.mjs
@@ -19,6 +19,12 @@ export function stripPrerenderBodyFromSpaShell(spaHtml) {
 
 /**
  * Dist-relative SPA shell for authenticated / app hard loads
- * (#743 empty root → #773 branded skeleton).
+ * (#743 empty root → #773 branded skeleton + DashboardRoute modulepreload).
  */
 export const APP_BOOT_SHELL_REL_PATH = 'dashboard/index.html';
+
+/**
+ * Branded skeleton without a fat route modulepreload — for legal / public
+ * profile / bare-join hard opens that must not download DashboardRoute.
+ */
+export const LIGHT_SPA_BOOT_SHELL_REL_PATH = 'spa-boot/index.html';

--- a/scripts/verify-seo-prerender.mjs
+++ b/scripts/verify-seo-prerender.mjs
@@ -11,9 +11,14 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  resolveModulepreloadClosure,
+} from './boot-modulepreload.mjs';
+import {
   APP_BOOT_SHELL_REL_PATH,
   DASHBOARD_BOOT_PRELOAD_MARKER,
   DASHBOARD_BOOT_SHELL_MARKER,
+  LIGHT_SPA_BOOT_SHELL_REL_PATH,
+  MARKETING_BOOT_SHELL_MARKER,
   PRERENDER_ROUTES,
   SPLASH_BOOT_PRELOAD_MARKER,
   buildDashboardBootShellHtml,
@@ -39,6 +44,10 @@ function assertRouteHtml(html, route, label) {
   assert(html.includes(route.h1), `${label}: missing H1`);
   assert(html.includes('application/ld+json'), `${label}: missing JSON-LD`);
   assert(html.includes('data-seo-prerender="true"'), `${label}: missing prerender markers`);
+  assert(
+    html.includes(`${MARKETING_BOOT_SHELL_MARKER}="true"`),
+    `${label}: missing marketing boot overlay (covers SEO body until React mounts)`,
+  );
   assert(html.includes('rel="icon"'), `${label}: missing favicon link`);
   assert(html.includes('/favicon/favicon.ico'), `${label}: missing favicon.ico link`);
   // #662: Google SERP favicons need a linked square icon >= 48px at a stable
@@ -51,6 +60,10 @@ function assertRouteHtml(html, route, label) {
   assert(
     !html.includes('favicon.svg'),
     `${label}: favicon.svg link resurfaced — PNG/ICO are primary (#662)`,
+  );
+  assert(
+    !html.includes('/fonts/inter/InterVariable.woff2'),
+    `${label}: Inter must not be preloaded (contends with entry JS on cold open)`,
   );
   assert(html.includes(route.canonicalUrl), `${label}: missing canonical`);
   for (const p of route.paragraphs) {
@@ -105,11 +118,16 @@ assert(
 );
 assert(!fixtureBoot.includes('<h1>leak</h1>'), 'boot shell must strip prior #root body');
 
-// Fixture: each shell modulepreloads its own route chunk and nothing else (#731).
-// Both chunks exist in the fake assets dir, so a cross-shell leak would show up.
+// Fixture: each shell modulepreloads its own route chunk + static closure (#731).
+// Both route leaves exist; HomeRoute pulls a fake auth dep so closure is covered.
 const fakeDist = mkdtempSync(join(tmpdir(), 'seo-prerender-'));
 mkdirSync(join(fakeDist, 'assets'), { recursive: true });
-writeFileSync(join(fakeDist, 'assets', 'HomeRoute-a1b2c3d4.js'), '', 'utf8');
+writeFileSync(
+  join(fakeDist, 'assets', 'HomeRoute-a1b2c3d4.js'),
+  'import { x } from "./auth-deadbeef.js";\nexport default x;\n',
+  'utf8',
+);
+writeFileSync(join(fakeDist, 'assets', 'auth-deadbeef.js'), 'export const x = 1;\n', 'utf8');
 writeFileSync(join(fakeDist, 'assets', 'DashboardRoute-e5f6a7b8.js'), '', 'utf8');
 
 const fixtureSplashPreload = injectSplashBootModulepreloads(
@@ -122,6 +140,10 @@ assert(
   'splash must modulepreload the HomeRoute chunk',
 );
 assert(
+  fixtureSplashPreload.includes('/assets/auth-deadbeef.js'),
+  'splash must modulepreload HomeRoute static deps (auth closure)',
+);
+assert(
   !fixtureSplashPreload.includes('DashboardRoute-'),
   'splash must not modulepreload the DashboardRoute chunk',
 );
@@ -129,6 +151,12 @@ assert(
   injectSplashBootModulepreloads(fixtureSplashPreload, fakeDist) ===
     fixtureSplashPreload,
   'splash modulepreload injection must be idempotent',
+);
+assert(
+  resolveModulepreloadClosure(join(fakeDist, 'assets'), [
+    '/assets/HomeRoute-a1b2c3d4.js',
+  ]).includes('/assets/auth-deadbeef.js'),
+  'closure walker must follow static from "./chunk.js" edges',
 );
 
 const fixtureDashboardPreload = injectDashboardBootModulepreloads(
@@ -198,10 +226,56 @@ if (existsSync(distIndex) && existsSync(distHowItWorks)) {
       homeHtml.includes('HomeRoute-'),
     'home dist/index.html must modulepreload the lazy HomeRoute chunk (#731)',
   );
+  // Leaf-only preload left a waterfall on Landing's auth/shared graph.
+  assert(
+    (homeHtml.match(new RegExp(`${SPLASH_BOOT_PRELOAD_MARKER}="true"`, 'g')) || [])
+      .length >= 2,
+    'home splash modulepreload must cover HomeRoute static closure, not only the leaf',
+  );
+  assert(
+    /auth-[^"]+\.js/.test(homeHtml) && homeHtml.includes(SPLASH_BOOT_PRELOAD_MARKER),
+    'home splash modulepreload closure should include the auth chunk',
+  );
+  assert(
+    homeHtml.includes(`${MARKETING_BOOT_SHELL_MARKER}="true"`),
+    'home dist/index.html must include marketing boot overlay',
+  );
+  assert(
+    !homeHtml.includes('href="/fonts/inter/InterVariable.woff2"'),
+    'home dist/index.html must not preload Inter (~344KB)',
+  );
   const howItWorksHtml = readFileSync(distHowItWorks, 'utf8');
   assert(
     !howItWorksHtml.includes(SPLASH_BOOT_PRELOAD_MARKER),
     'marketing routes must not gain splash modulepreloads',
+  );
+  assert(
+    howItWorksHtml.includes(`${MARKETING_BOOT_SHELL_MARKER}="true"`),
+    'marketing routes must include marketing boot overlay',
+  );
+
+  const lightBootPath = join(root, 'dist', LIGHT_SPA_BOOT_SHELL_REL_PATH);
+  assert(existsSync(lightBootPath), `dist missing ${LIGHT_SPA_BOOT_SHELL_REL_PATH} — run npm run build`);
+  const lightBootHtml = readFileSync(lightBootPath, 'utf8');
+  assert(
+    lightBootHtml.includes(`${DASHBOARD_BOOT_SHELL_MARKER}="true"`),
+    'light spa boot must include branded skeleton marker',
+  );
+  assert(
+    !lightBootHtml.includes(DASHBOARD_BOOT_PRELOAD_MARKER),
+    'light spa boot must not modulepreload DashboardRoute',
+  );
+  assert(
+    !lightBootHtml.includes('DashboardRoute-'),
+    'light spa boot must not reference DashboardRoute chunk',
+  );
+  assert(
+    !lightBootHtml.includes(SPLASH_BOOT_PRELOAD_MARKER),
+    'light spa boot must not gain splash modulepreloads',
+  );
+  assert(
+    !lightBootHtml.includes('data-seo-prerender'),
+    'light spa boot must not include SEO prerender body',
   );
 
   console.log('verify:seo-prerender: dist/ checked');

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,7 +8,7 @@ import Ga4RouteListener from './app/Ga4RouteListener.jsx'
 import ScrollToTop from './app/ScrollToTop.jsx'
 import { AuthProvider } from './features/auth/provider'
 import {
-  isPublicColdOpenPath,
+  shouldDeferMessagingServiceWorker,
   shouldPrefetchDashboardOnBoot,
   shouldWarmAppCheckOnBoot,
 } from './shared/lib/appBootPath'
@@ -17,7 +17,6 @@ import {
   ensureAppCheckNow,
   initializeAppCheckDeferred,
 } from './shared/lib/firebaseAppCheck'
-import { registerMessagingServiceWorker } from './shared/lib/firebaseMessaging'
 import { hasPersistedSessionHint } from './shared/lib/persistedSessionHint'
 import { prefetchRouteChunk } from './shared/lib/routeChunkPrefetch'
 import { initWebVitals } from './shared/lib/webVitals'
@@ -43,14 +42,18 @@ if (
 }
 
 /**
- * FCM SW: immediate on app surfaces; idle-defer on public cold-open (#732).
- * `getMessagingClient` still registers on demand for push opt-in.
+ * FCM SW: dynamic-import the messaging module so it stays off the entry static
+ * graph (no modulepreload of firebaseMessaging on splash). Immediate register
+ * on dashboard/setup; idle-defer elsewhere. `getMessagingClient` still
+ * registers on demand for push opt-in.
  */
 function scheduleMessagingServiceWorker(pathname) {
-  if (isPublicColdOpenPath(pathname)) {
-    const start = () => {
-      void registerMessagingServiceWorker()
-    }
+  const start = () => {
+    void import('./shared/lib/firebaseMessaging').then((m) => {
+      void m.registerMessagingServiceWorker()
+    })
+  }
+  if (shouldDeferMessagingServiceWorker(pathname)) {
     if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
       window.requestIdleCallback(start, { timeout: 5000 })
     } else {
@@ -58,7 +61,7 @@ function scheduleMessagingServiceWorker(pathname) {
     }
     return
   }
-  void registerMessagingServiceWorker()
+  start()
 }
 
 // Shared client for React Query caches (#243 profile/tour standings, #507

--- a/src/shared/lib/appBootPath.js
+++ b/src/shared/lib/appBootPath.js
@@ -29,6 +29,17 @@ export function isPublicColdOpenPath(pathname) {
 }
 
 /**
+ * Defer FCM service-worker registration until idle on non-app hard opens.
+ * Dashboard/setup keep immediate registration (push surfaces).
+ * @param {string} [pathname]
+ * @returns {boolean}
+ */
+export function shouldDeferMessagingServiceWorker(pathname) {
+  if (typeof pathname !== 'string' || !pathname) return true;
+  return !isDashboardEntryPath(pathname) && pathname !== '/setup';
+}
+
+/**
  * Surfaces that need Firestore ASAP on hard open (skip App Check idle deferral).
  * Invite/join anonymous paths are intentionally excluded (#803) — warm on
  * persisted session or auth modal open instead.

--- a/src/shared/lib/appBootPath.test.js
+++ b/src/shared/lib/appBootPath.test.js
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   isDashboardEntryPath,
   isPublicColdOpenPath,
+  shouldDeferMessagingServiceWorker,
   shouldPrefetchDashboardOnBoot,
   shouldWarmAppCheckOnBoot,
 } from './appBootPath.js';
@@ -49,6 +50,25 @@ describe('shouldWarmAppCheckOnBoot', () => {
     expect(shouldWarmAppCheckOnBoot('/invite/pat')).toBe(false);
     expect(shouldWarmAppCheckOnBoot('/how-it-works')).toBe(false);
     expect(shouldWarmAppCheckOnBoot('/privacy')).toBe(false);
+  });
+});
+
+describe('shouldDeferMessagingServiceWorker', () => {
+  it('keeps FCM registration immediate on dashboard and setup', () => {
+    expect(shouldDeferMessagingServiceWorker('/dashboard')).toBe(false);
+    expect(shouldDeferMessagingServiceWorker('/dashboard/picks')).toBe(false);
+    expect(shouldDeferMessagingServiceWorker('/setup')).toBe(false);
+  });
+
+  it('defers FCM on splash, invite, marketing, and legal hard opens', () => {
+    expect(shouldDeferMessagingServiceWorker('/')).toBe(true);
+    expect(shouldDeferMessagingServiceWorker('/join/ABC')).toBe(true);
+    expect(shouldDeferMessagingServiceWorker('/invite/pat')).toBe(true);
+    expect(shouldDeferMessagingServiceWorker('/how-it-works')).toBe(true);
+    expect(shouldDeferMessagingServiceWorker('/tour-stats')).toBe(true);
+    expect(shouldDeferMessagingServiceWorker('/privacy')).toBe(true);
+    expect(shouldDeferMessagingServiceWorker('/terms')).toBe(true);
+    expect(shouldDeferMessagingServiceWorker('/user/abc')).toBe(true);
   });
 });
 

--- a/vercel.json
+++ b/vercel.json
@@ -50,27 +50,27 @@
     },
     {
       "source": "/user/(.*)",
-      "destination": "/dashboard/index.html"
+      "destination": "/spa-boot/index.html"
     },
     {
       "source": "/password-reset-complete",
-      "destination": "/dashboard/index.html"
+      "destination": "/spa-boot/index.html"
     },
     {
       "source": "/comms-preview",
-      "destination": "/dashboard/index.html"
+      "destination": "/spa-boot/index.html"
     },
     {
       "source": "/privacy",
-      "destination": "/dashboard/index.html"
+      "destination": "/spa-boot/index.html"
     },
     {
       "source": "/terms",
-      "destination": "/dashboard/index.html"
+      "destination": "/spa-boot/index.html"
     },
     {
       "source": "/join",
-      "destination": "/dashboard/index.html"
+      "destination": "/spa-boot/index.html"
     },
     {
       "source": "/(.*)",
@@ -127,6 +127,15 @@
     },
     {
       "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/fonts/(.*)",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Promote **1.46.5** from `staging` → `main`: cold-open load hotfix (#826).
- Fixes `#731` HomeRoute leaf-only modulepreload waterfall, SEO plain-text flash, Inter preload contention, and wrong `DashboardRoute` preload on legal/public shells.
- Follow-up for public `/tour-stats` data spinner: #827 (not blocking this promote).

## Test plan
- [x] #826 merged to staging; release gate passes (`1.46.5` ahead of `v1.46.4`)
- [ ] Promote CI green
- [ ] Tag `v1.46.5` via `npm run release:publish -- --confirm` after merge
- [ ] Smoke prod cold open `/` in a private window
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcb47-d4fa-7c9b-9088-8b7ef93f39b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcb47-d4fa-7c9b-9088-8b7ef93f39b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

