### PR TITLE
WIP DO NOT MERGE: rejected HTML stub approach for #829

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.47.0] — 2026-08-04
+
+### Added
+- **`/login` app auth entry (#829 Bucket A)** — Sign in / Create account for HTML-first marketing CTAs; hard opens use `spa-boot`. Password-reset and QA sign-in retargeted from `/?login=true`.
+
+### Changed
+- **HTML-first public marketing documents (#829 Bucket A)** — `/`, `/how-it-works`, `/how-scoring-works`, `/tour-stats*`, and `/phish-setlist-prediction-game` ship branded static HTML (content + CTAs to `/login`) with **no** Vite SPA entry, modulepreloads, or Firebase on cold open. Returning sessions on `/` still bounce to `/dashboard` via session-hint boot script. Authenticated `/dashboard/*` + `/setup` boot shells unchanged. Outbound email/invite inventory is Bucket B (#830).
+
+---
+
 ## [1.46.5] — 2026-08-04
 
 ### Fixed

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Setlist Pick'em — Public API Declaration
 
-**Version:** 1.42.0  
+**Version:** 1.47.0  
 **SemVer:** https://semver.org  
 **Status:** Stable (≥ 1.0.0)
 
@@ -375,12 +375,13 @@ These routes are part of the public surface. Renaming or removing them is a MAJO
 
 | Path | Auth | Description |
 |------|------|-------------|
-| `/` | None | Public splash / landing page. **v1.32.0+ (#659):** build-time prerender injects crawler-visible H1/body + JSON-LD into `dist/index.html` (SPA still boots for browsers). Social scrapers on `/` may still receive the empty-body OG shell (`middleware.js`). |
-| `/how-it-works` | None | How to play marketing page. **v1.32.0+ (#659):** served as prerendered `dist/how-it-works/index.html` when present. |
-| `/how-scoring-works` | None | Scoring rules marketing page. **v1.32.0+ (#659):** served as prerendered `dist/how-scoring-works/index.html` when present. |
-| `/tour-stats` | None | **v1.33.0 (#665):** public aggregate tour song stats (filter + default Sphere). Prerendered shell; live data from `public_tour_stats`. Never full nightly setlists. |
-| `/tour-stats/:tourSlug` | None | **v1.33.0 (#665):** same surface for a kebab-case tour slug (e.g. `2026-sphere`). Default Sphere slug is also prerendered. |
-| `/phish-setlist-prediction-game` | None | **v1.34.0 (#660):** keyword-intent educational page for Phish setlist prediction game queries; prerendered HTML + FAQ JSON-LD. |
+| `/` | None | Public splash / landing. **v1.47.0 (#829):** HTML-first document (branded content + CTAs, JSON-LD) with **no** SPA/Firebase entry on cold open. Session-hint may redirect to `/dashboard`. Legacy `?login=true` redirects to `/login`. In-app client navigations may still mount `HomeRoute`. Social scrapers on `/` may still receive the empty-body OG shell (`middleware.js`). |
+| `/login` | None | **v1.47.0 (#829):** app auth entry (Sign in / Create account). Hard opens use `spa-boot/index.html`. Marketing CTAs link here so acquisition HTML never boots Firebase. |
+| `/how-it-works` | None | How to play marketing page. **v1.47.0 (#829):** HTML-first (no SPA entry); **v1.32.0+ (#659):** prerendered `dist/how-it-works/index.html`. |
+| `/how-scoring-works` | None | Scoring rules marketing page. **v1.47.0 (#829):** HTML-first; **v1.32.0+ (#659):** prerendered when present. |
+| `/tour-stats` | None | **v1.33.0 (#665):** public aggregate tour song stats. **v1.47.0 (#829):** HTML-first marketing shell on cold open (live interactive table remains available via in-app / follow-ups). Never full nightly setlists. |
+| `/tour-stats/:tourSlug` | None | **v1.33.0 (#665):** same surface for a kebab-case tour slug (e.g. `2026-sphere`). **v1.47.0 (#829):** HTML-first on cold open. |
+| `/phish-setlist-prediction-game` | None | **v1.34.0 (#660):** keyword-intent educational page. **v1.47.0 (#829):** HTML-first; prerendered HTML + FAQ JSON-LD. |
 | `/join/:code` | None | Pool invite deep link; optional `?from={handle}` for inviter personalization; VIP landing stores code and prompts auth (#580); personalized OG (#582) |
 | `/invite/:handle` | None | Site VIP invite deep link; personalized landing when handle resolves; no pool join side effects (#580); personalized OG (#582) |
 | `/user/:userId` | None | Public player profile — **`noindex,follow`** (#661); not a sitemap target |

--- a/docs/USER_ROUTING_AND_JOURNEYS.md
+++ b/docs/USER_ROUTING_AND_JOURNEYS.md
@@ -30,7 +30,7 @@ Defined in `src/app/App.jsx`.
 
 ### Email / push hard opens (`/dashboard/*`)
 
-Cold document loads for `/dashboard/*` and `/setup` are rewritten by Vercel to `dist/dashboard/index.html` — a **branded static skeleton** with `DashboardRoute` modulepreload (#773). Legal, public profile, bare `/join`, and related hard opens use `dist/spa-boot/index.html` (same skeleton, **no** fat route preload) so they do not download the dashboard graph. Marketing SEO prerender stays on `dist/index.html` (+ marketing boot overlay) (`verify:seo-prerender`).
+Cold document loads for `/dashboard/*` and `/setup` are rewritten by Vercel to `dist/dashboard/index.html` — a **branded static skeleton** with `DashboardRoute` modulepreload (#773). `/login`, legal, public profile, bare `/join`, and related app hard opens use `dist/spa-boot/index.html` (same skeleton, **no** fat route preload). **Public marketing hard opens (#829)** use HTML-first documents (no SPA entry / Firebase) with CTAs to `/login`; `verify:seo-prerender` asserts that.
 
 **Phase 2 (TTI):** on `/dashboard/*` (and related warm paths), `main.jsx` calls `ensureAppCheckNow()` and kicks a dynamic `import()` of `DashboardRoute` before first paint; the boot shell also `modulepreload`s the `DashboardRoute` chunk. Auth seeds `auth.currentUser`, paints profile via `getDoc` then `onSnapshot`, and dashboard loading uses `DashboardBootSkeleton` instead of bare “Loading…”. Splash stays lazy + deferred App Check.
 
@@ -134,7 +134,7 @@ If nothing is stored, stored JSON is invalid, or the path is ineligible → **`/
 
 - Last screen was **Profile** (typical sign-out path): Profile is **not** persisted, so restore uses the **previous** eligible tab or **`/dashboard`**.
 - Cleared site data / new browser: no storage → **`/dashboard`**.
-- Deep link **`/?login=true`**: splash opens **Sign in** (password reset, QA, returning users) — not Create account.
+- Deep link **`/login`**: app auth entry opens **Sign in** (password reset, QA). **`/login?signup=1`** opens Create account. Legacy **`/?login=true`** on the HTML-first home document redirects to `/login` (#829).
 
 ### F. Other entry points
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.46.5",
+  "version": "1.47.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/marketing-static-page.mjs
+++ b/scripts/marketing-static-page.mjs
@@ -1,0 +1,262 @@
+/**
+ * HTML-first marketing documents (#829 Bucket A).
+ *
+ * Builds a full branded public page (content + CTAs) and strips the Vite SPA
+ * entry + modulepreloads so cold opens from search/Gen-AI never download
+ * Firebase / AuthProvider / the app graph.
+ *
+ * Pure Node — no src/ imports beyond what callers already use.
+ */
+
+/** Keep in sync with `src/shared/lib/persistedSessionHint.js`. */
+const PERSISTED_SESSION_HINT_STORAGE_KEY = 'setpicks_session_hint_v1';
+
+/** Marker asserted by verify:seo-prerender. */
+export const MARKETING_STATIC_PAGE_MARKER = 'data-marketing-static-page';
+
+const BRAND_BG = '#1e1b4b';
+const BRAND_PRIMARY = '#2dd4bf';
+const BRAND_TEXT = '#ffffff';
+const BRAND_MUTED = '#cbd5e1';
+
+function escapeHtml(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function criticalCss() {
+  return `
+html, body {
+  margin: 0;
+  min-height: 100%;
+  background: ${BRAND_BG};
+  color: ${BRAND_TEXT};
+  font-family: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+}
+[${MARKETING_STATIC_PAGE_MARKER}] {
+  position: relative;
+  min-height: 100dvh;
+  box-sizing: border-box;
+  padding: 1.25rem 1.25rem 3rem;
+  max-width: 42rem;
+  margin: 0 auto;
+}
+.msp-ambient {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+}
+.msp-ambient::before,
+.msp-ambient::after {
+  content: "";
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(100px);
+}
+.msp-ambient::before {
+  top: -20%;
+  left: 50%;
+  width: min(100vw, 36rem);
+  height: min(100vw, 36rem);
+  transform: translateX(-50%);
+  background: rgb(45 212 191 / 0.12);
+}
+.msp-ambient::after {
+  bottom: -10%;
+  right: -15%;
+  width: min(85vw, 28rem);
+  height: min(70vh, 32rem);
+  background: rgb(59 130 246 / 0.12);
+}
+.msp-inner { position: relative; z-index: 1; }
+.msp-brand {
+  display: block;
+  font-size: clamp(1.75rem, 5vw, 2.35rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: ${BRAND_TEXT};
+  text-decoration: none;
+  margin: 0 0 1.5rem;
+}
+.msp-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.1rem;
+  margin: 0 0 2rem;
+  padding: 0;
+  list-style: none;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+.msp-nav a {
+  color: ${BRAND_MUTED};
+  text-decoration: none;
+}
+.msp-nav a:hover { color: ${BRAND_PRIMARY}; }
+.msp-h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(1.55rem, 4.5vw, 2.1rem);
+  line-height: 1.15;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.msp-lead, .msp-p {
+  margin: 0 0 1rem;
+  font-size: 1.05rem;
+  line-height: 1.55;
+  color: ${BRAND_MUTED};
+  font-weight: 500;
+}
+.msp-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1.75rem 0 2.25rem;
+}
+.msp-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.65rem 1.15rem;
+  border-radius: 0.75rem;
+  font-weight: 700;
+  font-size: 1rem;
+  text-decoration: none;
+  border: 1px solid transparent;
+}
+.msp-cta--primary {
+  background: ${BRAND_PRIMARY};
+  color: ${BRAND_BG};
+}
+.msp-cta--secondary {
+  background: transparent;
+  color: ${BRAND_TEXT};
+  border-color: rgb(148 163 184 / 0.45);
+}
+.msp-footer {
+  margin-top: 2.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid rgb(51 65 85 / 0.55);
+  font-size: 0.85rem;
+  color: ${BRAND_MUTED};
+}
+.msp-footer a { color: ${BRAND_PRIMARY}; }
+`.trim();
+}
+
+/** Nav links shared across static marketing pages. */
+const NAV = [
+  { href: '/how-it-works', label: 'How it works' },
+  { href: '/how-scoring-works', label: 'Scoring' },
+  { href: '/tour-stats', label: 'Tour stats' },
+  { href: '/phish-setlist-prediction-game', label: 'The game' },
+];
+
+/**
+ * Inline boot script for `/` only: returning-session → dashboard; legacy
+ * `?login=true` → `/login` app entry (Bucket A bridge until Bucket B retargets).
+ */
+export function buildMarketingBootScript({ includeSessionRedirect = false } = {}) {
+  const key = JSON.stringify(PERSISTED_SESSION_HINT_STORAGE_KEY);
+  const sessionBlock = includeSessionRedirect
+    ? `try{if(localStorage.getItem(${key})==='1'){location.replace('/dashboard');return;}}catch(e){}`
+    : '';
+  return `<script ${MARKETING_STATIC_PAGE_MARKER}-boot="true">
+(function(){
+  ${sessionBlock}
+  try{
+    var q=new URLSearchParams(location.search);
+    if(q.get('login')==='true'){
+      var next='/login';
+      if(q.get('signup')==='1') next='/login?signup=1';
+      location.replace(next);
+    }
+  }catch(e){}
+})();
+</script>`;
+}
+
+/**
+ * Visible marketing body (replaces SPA #root content).
+ * @param {{ path: string, h1: string, paragraphs: string[] }} route
+ */
+export function buildMarketingStaticBody(route) {
+  const paras = (route.paragraphs || [])
+    .map((p, i) => {
+      const cls = i === 0 ? 'msp-lead' : 'msp-p';
+      return `<p class="${cls}">${escapeHtml(p)}</p>`;
+    })
+    .join('\n');
+
+  const nav = NAV.map(
+    (item) =>
+      `<li><a href="${escapeHtml(item.href)}">${escapeHtml(item.label)}</a></li>`,
+  ).join('');
+
+  const isHome = route.path === '/';
+  const primaryCta = isHome
+    ? { href: '/login?signup=1', label: 'Create account' }
+    : { href: '/login?signup=1', label: 'Join free' };
+  const secondaryCta = { href: '/login', label: 'Sign in' };
+
+  return [
+    `<style id="marketing-static-page-css">${criticalCss()}</style>`,
+    `<div ${MARKETING_STATIC_PAGE_MARKER}="true">`,
+    `<div class="msp-ambient" aria-hidden="true"></div>`,
+    `<div class="msp-inner">`,
+    `<a class="msp-brand" href="/">Setlist Pick'em</a>`,
+    `<ul class="msp-nav">${nav}</ul>`,
+    `<main data-seo-prerender="true">`,
+    `<!--seo-prerender:${escapeHtml(route.path)}-->`,
+    `<h1 class="msp-h1">${escapeHtml(route.h1)}</h1>`,
+    paras,
+    `<div class="msp-cta-row">`,
+    `<a class="msp-cta msp-cta--primary" href="${escapeHtml(primaryCta.href)}">${escapeHtml(primaryCta.label)}</a>`,
+    `<a class="msp-cta msp-cta--secondary" href="${escapeHtml(secondaryCta.href)}">${escapeHtml(secondaryCta.label)}</a>`,
+    `</div>`,
+    `</main>`,
+    `<footer class="msp-footer">`,
+    `<a href="/privacy">Privacy</a> · <a href="/terms">Terms</a>`,
+    `</footer>`,
+    `</div></div>`,
+  ].join('\n');
+}
+
+/**
+ * Remove Vite SPA entry + modulepreloads so the document cannot boot the app.
+ * @param {string} html
+ */
+export function stripSpaRuntimeFromHtml(html) {
+  if (typeof html !== 'string' || !html) return html;
+  let out = html;
+  out = out.replace(
+    /<script\b[^>]*\btype=["']module["'][^>]*>\s*<\/script>/gi,
+    '',
+  );
+  out = out.replace(/<script\b[^>]*\btype=["']module["'][^>]*><\/script>/gi, '');
+  out = out.replace(
+    /<link\b[^>]*\brel=["']modulepreload["'][^>]*>/gi,
+    '',
+  );
+  // Full Tailwind bundle is unnecessary — critical CSS is inlined on the page.
+  out = out.replace(
+    /<link\b[^>]*\brel=["']stylesheet["'][^>]*\/assets\/index-[^"']+\.css[^>]*>/gi,
+    '',
+  );
+  // Drop prior SPA-era marketing boot overlay markers if re-running.
+  out = out.replace(
+    /<style id="marketing-boot-shell-css">[\s\S]*?<\/style>/gi,
+    '',
+  );
+  out = out.replace(
+    /<div[^>]*data-marketing-boot-shell=["']true["'][^>]*>[\s\S]*?<\/div>/gi,
+    '',
+  );
+  return out;
+}

--- a/scripts/prerender-seo.mjs
+++ b/scripts/prerender-seo.mjs
@@ -1,6 +1,6 @@
 /**
- * Post-build: write crawler-visible HTML for public marketing routes (#659).
- * Also writes a branded SPA boot shell for dashboard / app hard loads (#743 / #773).
+ * Post-build: write HTML-first public marketing documents (#659 / #829).
+ * Also writes branded SPA boot shells for dashboard / app hard loads (#743 / #773).
  * Run after `vite build`. Safe to re-run.
  */
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
@@ -14,7 +14,6 @@ import {
   buildDashboardBootShellHtml,
   injectDashboardBootModulepreloads,
   injectPrerenderHtml,
-  injectSplashBootModulepreloads,
   prerenderOutputRelPath,
 } from './seo-prerender-lib.mjs';
 
@@ -30,22 +29,16 @@ if (!existsSync(distIndex)) {
 const shell = readFileSync(distIndex, 'utf8');
 
 for (const route of PRERENDER_ROUTES) {
-  let html = injectPrerenderHtml(shell, route);
-  // Splash only: `HomeRoute` is lazy since #731, so preload its chunk here or
-  // the landing paint waits a round trip on the entry bundle.
-  if (route.path === '/') {
-    html = injectSplashBootModulepreloads(html, distDir);
-  }
+  // #829: marketing HTML is a real document — no HomeRoute modulepreload / SPA entry.
+  const html = injectPrerenderHtml(shell, route);
   const rel = prerenderOutputRelPath(route.path);
   const outPath = join(distDir, rel);
   mkdirSync(dirname(outPath), { recursive: true });
   writeFileSync(outPath, html, 'utf8');
-  console.log(`prerender-seo: wrote dist/${rel} (${Buffer.byteLength(html, 'utf8')} bytes)`);
+  console.log(`prerender-seo: wrote dist/${rel} (${Buffer.byteLength(html, 'utf8')} bytes, HTML-first)`);
 }
 
 // Branded boot shell for /dashboard/* + /setup (via vercel.json).
-// Use the pre-prerender Vite shell so we never copy home SEO body into it.
-// Phase 2: modulepreload DashboardRoute on this shell only (not splash / light spa).
 const brandedShell = buildDashboardBootShellHtml(shell);
 const appBootHtml = injectDashboardBootModulepreloads(brandedShell, distDir);
 const appBootPath = join(distDir, APP_BOOT_SHELL_REL_PATH);
@@ -55,8 +48,7 @@ console.log(
   `prerender-seo: wrote dist/${APP_BOOT_SHELL_REL_PATH} (branded #root boot shell + modulepreload)`,
 );
 
-// Light spa boot: same branded skeleton, no DashboardRoute preload — legal,
-// public profile, bare /join, etc. must not contend for the dashboard graph.
+// Light spa boot for /login, legal, public profile, bare /join, etc.
 const lightBootPath = join(distDir, LIGHT_SPA_BOOT_SHELL_REL_PATH);
 mkdirSync(dirname(lightBootPath), { recursive: true });
 writeFileSync(lightBootPath, brandedShell, 'utf8');
@@ -65,5 +57,5 @@ console.log(
 );
 
 console.log(
-  `prerender-seo: OK (${PRERENDER_ROUTES.length} routes + app boot shell + light spa boot)`,
+  `prerender-seo: OK (${PRERENDER_ROUTES.length} HTML-first routes + app boot shell + light spa boot)`,
 );

--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -89,8 +89,7 @@ Two phases:
 **Not covered:** new users who tap Google on the **Sign in** modal — that path is
 intentionally blocked (PR #406) with copy directing them to Create account. Pool
 invite (`/join/:code`) opens **Create account** so new Google joiners see the
-legal checkbox (#577). `/?login=true` still opens **Sign in** (password reset /
-QA / returning deep links).
+legal checkbox (#577). `/login` opens **Sign in** (password reset / QA / returning deep links; #829).
 
 GA4 funnel readout: `npm run ga4:auth-funnel` (needs `GA4_ACCESS_TOKEN` or
 `gcloud` with `analytics.readonly`). See `docs/AUTH_TELEMETRY_RUNBOOK.md`.

--- a/scripts/qa/_lib/qaAuthSplash.mjs
+++ b/scripts/qa/_lib/qaAuthSplash.mjs
@@ -1,5 +1,5 @@
 /**
- * Email/password sign-in via the splash `/?login=true` modal (#349).
+ * Email/password sign-in via the app `/login` entry (#349 / #829).
  * Firestore rules require `signedIn()` for profile reads; headless `qa:cache`
  * must establish a session before visiting `/user/:uid`.
  *
@@ -12,7 +12,7 @@ export async function signInViaSplashEmailPassword(page, origin, email, password
   const base = origin.replace(/\/$/, '');
   // Avoid `networkidle` — after Auth, Firestore keeps a long-lived WebChannel
   // open so idle never settles (AGENTS.md / pr-qa traps).
-  await page.goto(`${base}/?login=true`, {
+  await page.goto(`${base}/login`, {
     waitUntil: 'domcontentloaded',
     timeout: 90_000,
   });

--- a/scripts/qa/auth-scenarios.mjs
+++ b/scripts/qa/auth-scenarios.mjs
@@ -142,7 +142,7 @@ async function openCreateAccountModal(page, origin) {
  */
 async function openSignInModal(page, origin) {
   const base = origin.replace(/\/$/, '');
-  await page.goto(`${base}/?login=true`, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+  await page.goto(`${base}/login`, { waitUntil: 'domcontentloaded', timeout: 60_000 });
   const dialog = page.getByRole('dialog', { name: /^sign in$/i });
   await dialog.waitFor({ state: 'visible', timeout: 30_000 });
   return dialog;
@@ -583,10 +583,10 @@ async function main() {
       results,
     );
 
-    // ── ROUTING E partial: ?login=true ─────────────────────────────────────
+    // ── ROUTING E partial: /login app entry (#829) ─────────────────────────
     await runScenario(
       'UR-E1',
-      '?login=true opens sign-in modal',
+      '/login opens sign-in modal',
       async () => {
         await openSignInModal(page, dev.url);
         await page.keyboard.press('Escape');

--- a/scripts/qa/chunk-split.mjs
+++ b/scripts/qa/chunk-split.mjs
@@ -36,11 +36,12 @@ import { startPreview } from './_lib/preview.mjs';
 // of these appearing on a navigation to a *different* route is a
 // cross-route leak — the static-import graph reaches across routes
 // and partially defeats route-level code splitting (#240/#242).
-// `HomeRoute` is lazy as of #731 and is modulepreloaded by the prerendered
-// `dist/index.html`, so it lands in `initialChunks` on the splash hard load and
-// is correctly excluded from later navigation deltas.
+// Marketing `/` is HTML-first (#829) with no SPA entry, so this runner boots
+// from `/login` (spa-boot). Lazy route names below are still leak-checked on
+// in-app navigations from that app shell.
 const LAZY_ROUTE_COMPONENTS = [
   'HomeRoute',
+  'LoginRoute',
   'PasswordResetCompletePage',
   'PublicProfilePage',
   'PoolInviteMissingCodePage',
@@ -157,13 +158,19 @@ async function run() {
       loadedChunks.add(name);
     });
 
-    // Initial paint: hard-load splash. Anything Vite emits
-    // <link rel="modulepreload"> for ends up in `initialChunks` and
-    // is correctly excluded from later deltas.
-    await page.goto(`${preview.url}/`, { waitUntil: 'networkidle' });
+    // Initial paint: hard-load app auth entry (public `/` has no SPA #829).
+    // Avoid networkidle — Auth/Firestore WebChannel may never go idle.
+    await page.goto(`${preview.url}/login`, {
+      waitUntil: 'domcontentloaded',
+      timeout: NAV_TIMEOUT_MS,
+    });
+    await page
+      .getByRole('button', { name: /sign in/i })
+      .first()
+      .waitFor({ state: 'visible', timeout: NAV_TIMEOUT_MS });
     const initialChunks = new Set(loadedChunks);
 
-    // Scenario 1: / -> /user/<UID> expects PublicProfilePage chunk.
+    // Scenario 1: /login -> /user/<UID> expects PublicProfilePage chunk.
     await spaNavigateAndWaitForChunk(
       page,
       preview.url,
@@ -191,7 +198,7 @@ async function run() {
 
     const scenarios = [
       {
-        from: '/',
+        from: '/login',
         to: '/user/<uid>',
         expected: 'PublicProfilePage',
         delta: userDelta,

--- a/scripts/qa/firestore-cache.mjs
+++ b/scripts/qa/firestore-cache.mjs
@@ -10,7 +10,7 @@
  *
  * **Auth:** `firestore.rules` require `signedIn()` for `users/{uid}`,
  * `pools`, `show_calendar`, etc. The runner signs in with
- * **`QA_TEST_EMAIL` / `QA_TEST_PASSWORD`** via the splash `/?login=true`
+ * **`QA_TEST_EMAIL` / `QA_TEST_PASSWORD`** via the app `/login` entry
  * modal before SPA-navigating to `/user/:uid`.
  *
  * **Pass criterion (#748):** the old assertion compared CDP

--- a/scripts/qa/google-new-user-signup.mjs
+++ b/scripts/qa/google-new-user-signup.mjs
@@ -73,7 +73,7 @@ async function openCreateAccountModal(page, origin) {
  */
 async function openSignInModal(page, origin) {
   const base = origin.replace(/\/$/, '');
-  await page.goto(`${base}/?login=true`, { waitUntil: 'domcontentloaded', timeout: 90_000 });
+  await page.goto(`${base}/login`, { waitUntil: 'domcontentloaded', timeout: 90_000 });
   const dialog = page.getByRole('dialog', { name: /^sign in$/i });
   await dialog.waitFor({ state: 'visible', timeout: 30_000 });
   return dialog;

--- a/scripts/seo-prerender-lib.mjs
+++ b/scripts/seo-prerender-lib.mjs
@@ -1,5 +1,6 @@
 /**
  * Build-time SEO prerender helpers (#659).
+ * #829 Bucket A: marketing routes become HTML-first documents (no SPA entry).
  * Used by `prerender-seo.mjs` (post-vite) and `verify-seo-prerender.mjs` (CI).
  */
 import { SEO_CONFIG } from '../src/shared/config/seo.js';
@@ -22,6 +23,12 @@ import {
   buildMarketingBootShellMarkup,
 } from './marketing-boot-shell.mjs';
 import {
+  MARKETING_STATIC_PAGE_MARKER,
+  buildMarketingBootScript,
+  buildMarketingStaticBody,
+  stripSpaRuntimeFromHtml,
+} from './marketing-static-page.mjs';
+import {
   DASHBOARD_BOOT_PRELOAD_MARKER,
   SPLASH_BOOT_PRELOAD_MARKER,
   injectDashboardBootModulepreloads,
@@ -36,11 +43,14 @@ export {
   stripPrerenderBodyFromSpaShell,
   DASHBOARD_BOOT_SHELL_MARKER,
   MARKETING_BOOT_SHELL_MARKER,
+  MARKETING_STATIC_PAGE_MARKER,
   DASHBOARD_BOOT_PRELOAD_MARKER,
   SPLASH_BOOT_PRELOAD_MARKER,
   buildDashboardBootShellHtml,
   buildDashboardBootShellMarkup,
   buildMarketingBootShellMarkup,
+  buildMarketingStaticBody,
+  stripSpaRuntimeFromHtml,
   injectDashboardBootModulepreloads,
   injectSplashBootModulepreloads,
 };
@@ -122,26 +132,11 @@ function ensureFavicons(html) {
 function injectJsonLd(html, jsonLd) {
   const json = JSON.stringify(jsonLd).replace(/</g, '\\u003c');
   const script = `<script type="application/ld+json" data-seo-prerender="true">${json}</script>`;
-  // Drop prior prerender JSON-LD if re-running.
   const cleaned = html.replace(
     /<script type="application\/ld\+json" data-seo-prerender="true">[\s\S]*?<\/script>\s*/gi,
     '',
   );
   return cleaned.replace(/<\/head>/i, `  ${script}\n</head>`);
-}
-
-function buildCrawlerBody(route) {
-  const paras = route.paragraphs
-    .map((p) => `    <p>${escapeHtml(p)}</p>`)
-    .join('\n');
-  // Boot overlay paints immediately for browsers; crawler main stays in DOM
-  // for non-JS consumers. createRoot replaces the whole #root.
-  return `${buildMarketingBootShellMarkup()}
-<!--seo-prerender:${escapeHtml(route.path)}-->
-  <main data-seo-prerender="true">
-    <h1>${escapeHtml(route.h1)}</h1>
-${paras}
-  </main>`;
 }
 
 function injectRootBody(html, bodyInner) {
@@ -151,9 +146,17 @@ function injectRootBody(html, bodyInner) {
   return html.replace(/<body([^>]*)>/i, `<body$1>\n${replacement}\n`);
 }
 
+function injectHeadBootScript(html, routePath) {
+  const script = buildMarketingBootScript({
+    includeSessionRedirect: routePath === '/',
+  });
+  if (html.includes(`${MARKETING_STATIC_PAGE_MARKER}-boot`)) return html;
+  return html.replace(/<\/head>/i, `  ${script}\n</head>`);
+}
+
 /**
- * Inject route-specific SEO into a Vite SPA `index.html` shell.
- * React `createRoot` still replaces `#root` for browsers.
+ * Build HTML-first marketing document from the Vite shell (#829).
+ * Strips SPA entry + modulepreloads; injects visible content + CTA links.
  */
 export function injectPrerenderHtml(shellHtml, route) {
   let html = shellHtml;
@@ -174,7 +177,9 @@ export function injectPrerenderHtml(shellHtml, route) {
   html = upsertLinkCanonical(html, route.canonicalUrl);
   html = ensureFavicons(html);
   html = injectJsonLd(html, route.buildJsonLd());
-  html = injectRootBody(html, buildCrawlerBody(route));
+  html = injectRootBody(html, buildMarketingStaticBody(route));
+  html = injectHeadBootScript(html, route.path);
+  html = stripSpaRuntimeFromHtml(html);
   return html;
 }
 

--- a/scripts/verify-seo-prerender.mjs
+++ b/scripts/verify-seo-prerender.mjs
@@ -1,6 +1,5 @@
 /**
- * CI guard: prerendered public marketing HTML has unique title/description,
- * crawler body, JSON-LD, and favicon links (#659).
+ * CI guard: HTML-first public marketing documents (#659 / #829).
  *
  * Does not require a Vite build — uses a fixture shell. Optionally re-checks
  * `dist/` when present (after `npm run build`).
@@ -11,14 +10,11 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  resolveModulepreloadClosure,
-} from './boot-modulepreload.mjs';
-import {
   APP_BOOT_SHELL_REL_PATH,
   DASHBOARD_BOOT_PRELOAD_MARKER,
   DASHBOARD_BOOT_SHELL_MARKER,
   LIGHT_SPA_BOOT_SHELL_REL_PATH,
-  MARKETING_BOOT_SHELL_MARKER,
+  MARKETING_STATIC_PAGE_MARKER,
   PRERENDER_ROUTES,
   SPLASH_BOOT_PRELOAD_MARKER,
   buildDashboardBootShellHtml,
@@ -27,6 +23,7 @@ import {
   injectPrerenderHtml,
   injectSplashBootModulepreloads,
   prerenderOutputRelPath,
+  stripSpaRuntimeFromHtml,
 } from './seo-prerender-lib.mjs';
 
 const root = join(fileURLToPath(new URL('.', import.meta.url)), '..');
@@ -38,6 +35,25 @@ function assert(condition, message) {
   }
 }
 
+function assertNoSpaEntry(html, label) {
+  assert(
+    !/<script\b[^>]*\btype=["']module["']/i.test(html),
+    `${label}: must not include SPA type=module entry (#829)`,
+  );
+  assert(
+    !/rel=["']modulepreload["']/i.test(html),
+    `${label}: must not modulepreload app chunks (#829)`,
+  );
+  assert(
+    !/\/assets\/index-[^"'\s>]+\.js/i.test(html),
+    `${label}: must not reference /assets/index-*.js SPA entry (#829)`,
+  );
+  assert(
+    !html.includes('firebase-core'),
+    `${label}: must not reference firebase-core (#829)`,
+  );
+}
+
 function assertRouteHtml(html, route, label) {
   assert(html.includes(`<title>${route.title}</title>`) || html.includes(route.title), `${label}: missing title`);
   assert(html.includes(route.description), `${label}: missing description`);
@@ -45,14 +61,16 @@ function assertRouteHtml(html, route, label) {
   assert(html.includes('application/ld+json'), `${label}: missing JSON-LD`);
   assert(html.includes('data-seo-prerender="true"'), `${label}: missing prerender markers`);
   assert(
-    html.includes(`${MARKETING_BOOT_SHELL_MARKER}="true"`),
-    `${label}: missing marketing boot overlay (covers SEO body until React mounts)`,
+    html.includes(`${MARKETING_STATIC_PAGE_MARKER}="true"`),
+    `${label}: missing HTML-first marketing static page marker (#829)`,
+  );
+  assert(html.includes('href="/login"'), `${label}: missing Sign in CTA to /login`);
+  assert(
+    html.includes('href="/login?signup=1"'),
+    `${label}: missing Create account CTA to /login?signup=1`,
   );
   assert(html.includes('rel="icon"'), `${label}: missing favicon link`);
   assert(html.includes('/favicon/favicon.ico'), `${label}: missing favicon.ico link`);
-  // #662: Google SERP favicons need a linked square icon >= 48px at a stable
-  // URL; PNG/ICO are primary. The old favicon.svg (854 KB embedded raster)
-  // must not come back.
   assert(
     html.includes('/favicon/favicon-96x96.png'),
     `${label}: missing 96x96 PNG icon link (SERP needs square >=48px, #662)`,
@@ -69,6 +87,7 @@ function assertRouteHtml(html, route, label) {
   for (const p of route.paragraphs) {
     assert(html.includes(p.slice(0, Math.min(40, p.length))), `${label}: missing body excerpt`);
   }
+  assertNoSpaEntry(html, label);
 }
 
 assert(PRERENDER_ROUTES.length >= 6, 'expected marketing + tour-stats + keyword-intent routes');
@@ -98,6 +117,13 @@ for (const route of PRERENDER_ROUTES) {
   assertRouteHtml(html, route, `fixture ${route.path}`);
 }
 
+assert(
+  stripSpaRuntimeFromHtml(
+    '<html><head><script type="module" src="/assets/index-x.js"></script><link rel="modulepreload" href="/assets/HomeRoute-x.js"></head><body></body></html>',
+  ).includes('type="module"') === false,
+  'stripSpaRuntimeFromHtml must remove module entry scripts',
+);
+
 // Fixture: branded dashboard boot shell (#773) — no SEO body, marker present.
 const dirtyShell =
   '<!DOCTYPE html><html><head><meta charset="UTF-8" /></head><body>' +
@@ -118,8 +144,7 @@ assert(
 );
 assert(!fixtureBoot.includes('<h1>leak</h1>'), 'boot shell must strip prior #root body');
 
-// Fixture: each shell modulepreloads its own route chunk + static closure (#731).
-// Both route leaves exist; HomeRoute pulls a fake auth dep so closure is covered.
+// App shells still modulepreload their route closure; marketing must not.
 const fakeDist = mkdtempSync(join(tmpdir(), 'seo-prerender-'));
 mkdirSync(join(fakeDist, 'assets'), { recursive: true });
 writeFileSync(
@@ -135,28 +160,8 @@ const fixtureSplashPreload = injectSplashBootModulepreloads(
   fakeDist,
 );
 assert(
-  fixtureSplashPreload.includes(`${SPLASH_BOOT_PRELOAD_MARKER}="true"`) &&
-    fixtureSplashPreload.includes('/assets/HomeRoute-a1b2c3d4.js'),
-  'splash must modulepreload the HomeRoute chunk',
-);
-assert(
-  fixtureSplashPreload.includes('/assets/auth-deadbeef.js'),
-  'splash must modulepreload HomeRoute static deps (auth closure)',
-);
-assert(
-  !fixtureSplashPreload.includes('DashboardRoute-'),
-  'splash must not modulepreload the DashboardRoute chunk',
-);
-assert(
-  injectSplashBootModulepreloads(fixtureSplashPreload, fakeDist) ===
-    fixtureSplashPreload,
-  'splash modulepreload injection must be idempotent',
-);
-assert(
-  resolveModulepreloadClosure(join(fakeDist, 'assets'), [
-    '/assets/HomeRoute-a1b2c3d4.js',
-  ]).includes('/assets/auth-deadbeef.js'),
-  'closure walker must follow static from "./chunk.js" edges',
+  fixtureSplashPreload.includes(`${SPLASH_BOOT_PRELOAD_MARKER}="true"`),
+  'injectSplashBootModulepreloads helper must still work for tests',
 );
 
 const fixtureDashboardPreload = injectDashboardBootModulepreloads(
@@ -173,9 +178,18 @@ assert(
   'app boot shell must not modulepreload the HomeRoute chunk',
 );
 
+const homeFixture = injectPrerenderHtml(shell, PRERENDER_ROUTES.find((r) => r.path === '/'));
+assert(
+  homeFixture.includes('setpicks_session_hint_v1'),
+  'home HTML-first doc must include session-hint redirect boot script',
+);
+assert(
+  homeFixture.includes('/login'),
+  'home boot script / CTAs must reference /login app entry',
+);
+
 const distIndex = join(root, 'dist', 'index.html');
 const distHowItWorks = join(root, 'dist', 'how-it-works', 'index.html');
-// Only validate dist when post-build prerender has clearly run (subdir artifact).
 if (existsSync(distIndex) && existsSync(distHowItWorks)) {
   for (const route of PRERENDER_ROUTES) {
     const outPath = join(root, 'dist', prerenderOutputRelPath(route.path));
@@ -209,50 +223,20 @@ if (existsSync(distIndex) && existsSync(distHowItWorks)) {
     'app boot shell must modulepreload DashboardRoute chunk',
   );
   assert(
-    !appBootHtml.includes(SPLASH_BOOT_PRELOAD_MARKER),
-    'app boot shell must not gain splash modulepreloads',
+    /<script\b[^>]*\btype=["']module["']/i.test(appBootHtml),
+    'app boot shell must keep the SPA module entry',
   );
+
   const homeHtml = readFileSync(distIndex, 'utf8');
   assert(
-    homeHtml.includes('data-seo-prerender'),
-    'home dist/index.html must still include SEO prerender body',
+    homeHtml.includes(`${MARKETING_STATIC_PAGE_MARKER}="true"`),
+    'home dist/index.html must be HTML-first static marketing',
   );
   assert(
-    !homeHtml.includes(DASHBOARD_BOOT_PRELOAD_MARKER),
-    'home dist/index.html must not gain dashboard boot modulepreloads',
+    homeHtml.includes('setpicks_session_hint_v1'),
+    'home dist/index.html must session-redirect returning users',
   );
-  assert(
-    homeHtml.includes(`${SPLASH_BOOT_PRELOAD_MARKER}="true"`) &&
-      homeHtml.includes('HomeRoute-'),
-    'home dist/index.html must modulepreload the lazy HomeRoute chunk (#731)',
-  );
-  // Leaf-only preload left a waterfall on Landing's auth/shared graph.
-  assert(
-    (homeHtml.match(new RegExp(`${SPLASH_BOOT_PRELOAD_MARKER}="true"`, 'g')) || [])
-      .length >= 2,
-    'home splash modulepreload must cover HomeRoute static closure, not only the leaf',
-  );
-  assert(
-    /auth-[^"]+\.js/.test(homeHtml) && homeHtml.includes(SPLASH_BOOT_PRELOAD_MARKER),
-    'home splash modulepreload closure should include the auth chunk',
-  );
-  assert(
-    homeHtml.includes(`${MARKETING_BOOT_SHELL_MARKER}="true"`),
-    'home dist/index.html must include marketing boot overlay',
-  );
-  assert(
-    !homeHtml.includes('href="/fonts/inter/InterVariable.woff2"'),
-    'home dist/index.html must not preload Inter (~344KB)',
-  );
-  const howItWorksHtml = readFileSync(distHowItWorks, 'utf8');
-  assert(
-    !howItWorksHtml.includes(SPLASH_BOOT_PRELOAD_MARKER),
-    'marketing routes must not gain splash modulepreloads',
-  );
-  assert(
-    howItWorksHtml.includes(`${MARKETING_BOOT_SHELL_MARKER}="true"`),
-    'marketing routes must include marketing boot overlay',
-  );
+  assertNoSpaEntry(homeHtml, 'home dist/index.html');
 
   const lightBootPath = join(root, 'dist', LIGHT_SPA_BOOT_SHELL_REL_PATH);
   assert(existsSync(lightBootPath), `dist missing ${LIGHT_SPA_BOOT_SHELL_REL_PATH} — run npm run build`);
@@ -266,16 +250,12 @@ if (existsSync(distIndex) && existsSync(distHowItWorks)) {
     'light spa boot must not modulepreload DashboardRoute',
   );
   assert(
-    !lightBootHtml.includes('DashboardRoute-'),
-    'light spa boot must not reference DashboardRoute chunk',
-  );
-  assert(
-    !lightBootHtml.includes(SPLASH_BOOT_PRELOAD_MARKER),
-    'light spa boot must not gain splash modulepreloads',
-  );
-  assert(
     !lightBootHtml.includes('data-seo-prerender'),
     'light spa boot must not include SEO prerender body',
+  );
+  assert(
+    /<script\b[^>]*\btype=["']module["']/i.test(lightBootHtml),
+    'light spa boot must keep the SPA module entry for /login etc.',
   );
 
   console.log('verify:seo-prerender: dist/ checked');

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -10,13 +10,12 @@ import RootAppShell from './layout/RootAppShell';
 // first paint. The shared Suspense boundary lives in `RootAppShell` (one
 // place → consistent fallback).
 //
-// `HomeRoute` joined them in #731: `/join`, `/invite/:handle` and every
-// dashboard hard open were downloading the Landing graph they never render.
-// The splash keeps its first-paint budget because `prerender-seo.mjs`
-// modulepreloads the HomeRoute chunk into `dist/index.html`.
+// `HomeRoute` is lazy for in-app client navigations. Hard opens of public
+// marketing URLs are HTML-first documents with no SPA entry (#829).
 const loadHomeRoute = () => import('./routes/HomeRoute');
 const loadSetupRoute = () => import('./routes/SetupRoute');
 const loadDashboardRoute = () => import('./routes/DashboardRoute');
+const loadLoginRoute = () => import('./routes/LoginRoute');
 
 // Feature surfaces (auth modals, invite CTAs) prefetch these by key so they
 // never have to import app-layer route modules (#805).
@@ -27,6 +26,7 @@ registerRouteChunkLoaders({
 });
 
 const HomeRoute = lazy(loadHomeRoute);
+const LoginRoute = lazy(loadLoginRoute);
 const PasswordResetCompletePage = lazy(() =>
   import('../pages/auth/PasswordResetCompletePage')
 );
@@ -73,8 +73,11 @@ function App() {
         <Route path="/privacy" element={<PrivacyPolicyPage />} />
         <Route path="/terms" element={<TermsOfServicePage />} />
 
-        {/* Public splash — no auth loading gate (WRS / SEO friendly) */}
+        {/* Public splash — in-app client nav; hard opens use HTML-first dist (#829) */}
         <Route path="/" element={<HomeRoute />} />
+
+        {/* App auth entry for HTML-first marketing CTAs (#829) */}
+        <Route path="/login" element={<LoginRoute />} />
 
         {/* Pool invite: no code — drop stale breadcrumb */}
         <Route path="/join" element={<PoolInviteMissingCodePage />} />

--- a/src/app/routes/LoginRoute.jsx
+++ b/src/app/routes/LoginRoute.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+import LoginPage from '../../pages/auth/LoginPage';
+
+/** Hard-open auth entry served via spa-boot (#829). */
+export default function LoginRoute() {
+  return <LoginPage />;
+}

--- a/src/features/landing/index.js
+++ b/src/features/landing/index.js
@@ -6,6 +6,7 @@ export { MARKETING_LEGAL_NAV, MARKETING_PRIMARY_NAV } from './model/marketingNav
 export { default as PhishSetlistPredictionGamePageContent } from './ui/PhishSetlistPredictionGamePageContent';
 export { default as SplashAboutSection } from './ui/SplashAboutSection';
 export { default as SplashAuthModals } from './ui/SplashAuthModals';
+export { default as LoginScreen } from './ui/LoginScreen';
 export { default as SplashGetStartedSection } from './ui/SplashGetStartedSection';
 export { default as SplashHeader } from './ui/SplashHeader';
 export { default as SplashHeroSection } from './ui/SplashHeroSection';

--- a/src/features/landing/ui/LoginScreen.jsx
+++ b/src/features/landing/ui/LoginScreen.jsx
@@ -1,0 +1,81 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+
+import { useGoogleRedirectCompletion } from '../../auth';
+
+import SplashAuthModals from './SplashAuthModals';
+
+/**
+ * App-shell auth entry for HTML-first public pages (#829).
+ * Marketing CTAs link here so acquisition documents never boot Firebase.
+ */
+export default function LoginScreen() {
+  const [searchParams] = useSearchParams();
+  const initialModal = useMemo(() => {
+    if (searchParams.get('signup') === '1' || searchParams.get('mode') === 'signup') {
+      return 'signup';
+    }
+    return 'signin';
+  }, [searchParams]);
+
+  const [authModal, setAuthModal] = useState(initialModal);
+  const [redirectAuthError, setRedirectAuthError] = useState('');
+
+  const openSignInModal = useCallback(() => setAuthModal('signin'), []);
+  const openSignUpModal = useCallback(() => setAuthModal('signup'), []);
+  const closeModal = useCallback(() => setAuthModal(null), []);
+  const onRedirectAuthError = useCallback((message, modal) => {
+    setRedirectAuthError(message || '');
+    setAuthModal(modal === 'signup' ? 'signup' : 'signin');
+  }, []);
+
+  useGoogleRedirectCompletion({
+    onOpenSignIn: openSignInModal,
+    onOpenSignUp: openSignUpModal,
+    onError: onRedirectAuthError,
+  });
+
+  return (
+    <div className="relative flex min-h-dvh flex-col items-center justify-center bg-brand-bg px-4 py-10 text-white">
+      <div className="w-full max-w-md space-y-6 text-center">
+        <Link to="/" className="inline-block text-2xl font-bold tracking-tight text-white">
+          Setlist Pick&apos;em
+        </Link>
+        <p className="text-sm font-semibold text-content-secondary">
+          {authModal === 'signup'
+            ? 'Create a free account to lock picks and join pools.'
+            : 'Sign in to continue to your dashboard.'}
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <button
+            type="button"
+            className="rounded-xl bg-brand-primary px-4 py-2.5 text-sm font-bold text-brand-bg"
+            onClick={openSignUpModal}
+          >
+            Create account
+          </button>
+          <button
+            type="button"
+            className="rounded-xl border border-border-muted px-4 py-2.5 text-sm font-bold text-white"
+            onClick={openSignInModal}
+          >
+            Sign in
+          </button>
+        </div>
+        <p className="text-xs text-content-secondary">
+          <Link to="/" className="font-semibold text-brand-primary">
+            Back to home
+          </Link>
+        </p>
+      </div>
+      <SplashAuthModals
+        authModal={authModal}
+        closeModal={closeModal}
+        onSwitchToSignIn={openSignInModal}
+        onSwitchToSignUp={openSignUpModal}
+        redirectAuthError={redirectAuthError}
+        onClearRedirectAuthError={() => setRedirectAuthError('')}
+      />
+    </div>
+  );
+}

--- a/src/pages/auth/LoginPage.jsx
+++ b/src/pages/auth/LoginPage.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+import { LoginScreen } from '../../features/landing';
+
+/** App auth entry — composition only (#829). */
+export default function LoginPage() {
+  return <LoginScreen />;
+}

--- a/src/pages/auth/PasswordResetCompletePage.jsx
+++ b/src/pages/auth/PasswordResetCompletePage.jsx
@@ -41,7 +41,7 @@ export default function PasswordResetComplete() {
             and sign in with your email and new password.
           </p>
           <Link
-            to="/?login=true"
+            to="/login"
             className="inline-flex w-full items-center justify-center rounded-2xl bg-brand-primary px-8 py-4 font-black text-brand-bg-deep shadow-glow-brand transition-opacity hover:bg-brand-primary-strong hover:opacity-95 sm:w-auto"
           >
             Go to sign in

--- a/vercel.json
+++ b/vercel.json
@@ -49,6 +49,10 @@
       "destination": "/dashboard/index.html"
     },
     {
+      "source": "/login",
+      "destination": "/spa-boot/index.html"
+    },
+    {
       "source": "/user/(.*)",
       "destination": "/spa-boot/index.html"
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Status: rejected — do not merge

This PR replaced real marketing UI with a minimal text shell and must not land on staging.

**Problems called out in review:**
- Altered home branding / removed graphics
- Eliminated scoring visuals
- Took away live public tour stats

**Revised direction for #829:** keep the existing React marketing UI (splash, scoring, tour stats) and remove Firebase/AuthProvider from the public critical path via a separate marketing entry or SSR of current components — not hand-built copy pages.

Bucket B (#830) unchanged / still blocked on a correct Bucket A.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcb47-d4fa-7c9b-9088-8b7ef93f39b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcb47-d4fa-7c9b-9088-8b7ef93f39b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

