### PR TITLE
feat(acq): marketing Vite entry + splash laptop spacing (#832, #837)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.47.0] — 2026-08-04
+
+### Added
+- **Marketing cold-open document (#832)** — public splash / educational pages boot from a second Vite entry (`index.html` → `marketingMain`) with no `AuthProvider` / `firebase-core` on the critical path. Authenticated SPA lives at `app.html`; new public route **`/login`** hosts splash auth modals. Invite OG shell prefers `dist/app.html`.
+- **Release train doc** — `docs/RELEASE_TRAIN_COLD_OPEN.md` tracks #832 → #837 → #827 → #830.
+
+### Changed
+- **Splash laptop spacing (#837)** — on `sm+`, hero no longer forces `min-h-screen`; wordmark pulls closer under the fixed header and crops more empty SVG band so kicker/copy are not squeezed.
+
+### Fixed
+- Password-reset success CTA now links to `/login` instead of `/?login=true`.
+
+---
+
 ## [1.46.5] — 2026-08-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 - **Release train doc** — `docs/RELEASE_TRAIN_COLD_OPEN.md` tracks #832 → #837 → #827 → #830.
 
 ### Changed
-- **Splash laptop spacing (#837)** — on `sm+` only (mobile unchanged): hero no longer forces `min-h-screen`; wordmark frame is shorter, SVG crop skips transparent headroom above the letterforms, and kicker/copy/CTA sit closer under the brand.
+- **Splash laptop spacing (#837)** — on `sm+` only (mobile unchanged): wordmark crops SVG headroom and sits closer under the header; hero fills the viewport with leftover dark space *below* the CTA so the next section doesn’t peek above the fold; copy / primary CTA / secondary links get more vertical breathing room.
 
 ### Fixed
 - Password-reset success CTA now links to `/login` instead of `/?login=true`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 - **Release train doc** — `docs/RELEASE_TRAIN_COLD_OPEN.md` tracks #832 → #837 → #827 → #830.
 
 ### Changed
-- **Splash laptop spacing (#837)** — on `sm+`, hero no longer forces `min-h-screen`; wordmark pulls closer under the fixed header and crops more empty SVG band so kicker/copy are not squeezed.
+- **Splash laptop spacing (#837)** — on `sm+` only (mobile unchanged): hero no longer forces `min-h-screen`; wordmark frame is shorter, SVG crop skips transparent headroom above the letterforms, and kicker/copy/CTA sit closer under the brand.
 
 ### Fixed
 - Password-reset success CTA now links to `/login` instead of `/?login=true`.

--- a/api/invite.js
+++ b/api/invite.js
@@ -12,10 +12,11 @@
  * Social crawlers don't execute JavaScript, so they can't read OG tags injected
  * by React. This function intercepts invite requests and:
  *
- *   • Prefer the built SPA shell (`dist/index.html`) with static OG injection for
- *     **both** browsers and crawlers (crawlers read meta; browsers boot React).
- *   • If the shell is missing from the function bundle, fetch the live site `/`
- *     HTML as a fallback (same hashed asset URLs on the CDN).
+ *   • Prefer the authenticated SPA shell (`dist/app.html`, #832) with static OG
+ *     injection for **both** browsers and crawlers (crawlers read meta; browsers
+ *     boot React + AuthProvider).
+ *   • If the shell is missing from the function bundle, fetch the live site
+ *     `/app.html` as a fallback (same hashed asset URLs on the CDN).
  *   • Only when the SPA shell is unavailable: crawlers get minimal OG HTML;
  *     browsers get a non-blank 503 (never empty `<body></body>`).
  *
@@ -132,7 +133,11 @@ function looksLikeSpaShell(html) {
 }
 
 function loadSpaTemplateFromDisk() {
+  // Prefer the authenticated SPA document (#832). Marketing `index.html` has no AuthProvider.
   const candidates = [
+    join(process.cwd(), 'dist', 'app.html'),
+    join(__dirname, '..', 'dist', 'app.html'),
+    join(__dirname, 'dist', 'app.html'),
     join(process.cwd(), 'dist', 'index.html'),
     join(__dirname, '..', 'dist', 'index.html'),
     join(__dirname, 'dist', 'index.html'),
@@ -141,7 +146,14 @@ function loadSpaTemplateFromDisk() {
   for (const p of candidates) {
     try {
       const html = readFileSync(p, 'utf8');
-      if (looksLikeSpaShell(html)) return html;
+      if (!looksLikeSpaShell(html)) continue;
+      // Accept authenticated SPA only (#832) — reject marketing cold-open document.
+      if (
+        html.includes('/assets/app-') ||
+        html.includes('/src/main.jsx')
+      ) {
+        return html;
+      }
     } catch {
       // try next candidate
     }
@@ -150,9 +162,9 @@ function loadSpaTemplateFromDisk() {
 }
 
 /**
- * Resolve SPA index HTML. Prefer the Vercel-bundled `dist/index.html`; if the
- * function package omitted it, fetch production `/` (static) so browsers never
- * receive the empty crawler stub.
+ * Resolve authenticated SPA HTML. Prefer bundled `dist/app.html` (#832); if the
+ * function package omitted it, fetch production `/app.html` so browsers never
+ * receive the marketing document (no AuthProvider).
  *
  * @returns {Promise<string | null>}
  */
@@ -166,7 +178,7 @@ async function loadSpaTemplate() {
   }
 
   try {
-    const res = await fetch(`${SITE_URL}/`, {
+    const res = await fetch(`${SITE_URL}/app.html`, {
       headers: {
         Accept: 'text/html',
         'User-Agent': 'set-picks-invite-og/1.0',
@@ -175,7 +187,10 @@ async function loadSpaTemplate() {
     });
     if (res.ok) {
       const html = await res.text();
-      if (looksLikeSpaShell(html)) {
+      if (
+        looksLikeSpaShell(html) &&
+        (html.includes('/assets/app-') || html.includes('/src/main.jsx'))
+      ) {
         _spaTemplate = html;
         return _spaTemplate;
       }

--- a/app.html
+++ b/app.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <!-- Marketing cold-open document (#832). App/auth SPA lives in app.html. -->
     <!-- Crawlers (e.g. Facebook/Instagram) often do not run JS; keep in sync with `src/shared/config/seo.js`, `og-home-html.mjs`, and `LandingSeo.jsx`. -->
     <meta property="og:site_name" content="Setlist Pick 'Em" />
     <meta property="og:type" content="website" />
@@ -47,6 +46,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/marketingMain.jsx"></script>
+   <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/docs/API.md
+++ b/docs/API.md
@@ -375,12 +375,13 @@ These routes are part of the public surface. Renaming or removing them is a MAJO
 
 | Path | Auth | Description |
 |------|------|-------------|
-| `/` | None | Public splash / landing page. **v1.32.0+ (#659):** build-time prerender injects crawler-visible H1/body + JSON-LD into `dist/index.html` (SPA still boots for browsers). Social scrapers on `/` may still receive the empty-body OG shell (`middleware.js`). |
-| `/how-it-works` | None | How to play marketing page. **v1.32.0+ (#659):** served as prerendered `dist/how-it-works/index.html` when present. |
-| `/how-scoring-works` | None | Scoring rules marketing page. **v1.32.0+ (#659):** served as prerendered `dist/how-scoring-works/index.html` when present. |
-| `/tour-stats` | None | **v1.33.0 (#665):** public aggregate tour song stats (filter + default Sphere). Prerendered shell; live data from `public_tour_stats`. Never full nightly setlists. |
+| `/` | None | Public splash / landing page. **v1.32.0+ (#659):** build-time prerender injects crawler-visible H1/body + JSON-LD into `dist/index.html`. **v1.47.0 (#832):** `/` boots the **marketing** Vite entry (real splash UI, no `AuthProvider` / `firebase-core` on cold open). Social scrapers on `/` may still receive the empty-body OG shell (`middleware.js`). |
+| `/login` | None | **v1.47.0 (#832):** authenticated-SPA auth entry (`app.html`). Hosts splash sign-in / create-account modals. Marketing CTAs hard-navigate here. Compatibility: `/?login=true` on the app document redirects here. |
+| `/how-it-works` | None | How to play marketing page. **v1.32.0+ (#659):** served as prerendered `dist/how-it-works/index.html` when present. **v1.47.0:** marketing document. |
+| `/how-scoring-works` | None | Scoring rules marketing page. **v1.32.0+ (#659):** served as prerendered `dist/how-scoring-works/index.html` when present. **v1.47.0:** marketing document. |
+| `/tour-stats` | None | **v1.33.0 (#665):** public aggregate tour song stats (filter + default Sphere). Prerendered shell; live data from `public_tour_stats`. Never full nightly setlists. **v1.47.0:** remains on the **app** document (Firestore) until #827. |
 | `/tour-stats/:tourSlug` | None | **v1.33.0 (#665):** same surface for a kebab-case tour slug (e.g. `2026-sphere`). Default Sphere slug is also prerendered. |
-| `/phish-setlist-prediction-game` | None | **v1.34.0 (#660):** keyword-intent educational page for Phish setlist prediction game queries; prerendered HTML + FAQ JSON-LD. |
+| `/phish-setlist-prediction-game` | None | **v1.34.0 (#660):** keyword-intent educational page for Phish setlist prediction game queries; prerendered HTML + FAQ JSON-LD. **v1.47.0:** marketing document. |
 | `/join/:code` | None | Pool invite deep link; optional `?from={handle}` for inviter personalization; VIP landing stores code and prompts auth (#580); personalized OG (#582) |
 | `/invite/:handle` | None | Site VIP invite deep link; personalized landing when handle resolves; no pool join side effects (#580); personalized OG (#582) |
 | `/user/:userId` | None | Public player profile — **`noindex,follow`** (#661); not a sitemap target |

--- a/docs/RELEASE_TRAIN_COLD_OPEN.md
+++ b/docs/RELEASE_TRAIN_COLD_OPEN.md
@@ -1,0 +1,33 @@
+# Release train — cold-open / acquisition load
+
+**Goal:** Instant-feeling public marketing cold opens without regressing authenticated boot (email CTA, dashboard, setup).
+
+**Do not revive:** issue #831 hand-built HTML stub (lost branding, scoring graphics, live tour stats).
+
+---
+
+## Train phases
+
+| Phase | Issue | Scope |
+|-------|-------|--------|
+| **A — Marketing entry** | #832 | Real React splash/marketing UI via a **second Vite entry** with no `firebase-core` / `AuthProvider` on the critical path. Auth CTAs → `/login` (app shell). |
+| **A UI pickup** | #837 | Splash laptop spacing: tighten header → hero wordmark → copy (**ships in the #832 PR**). |
+| **A follow** | #827 | Public `/tour-stats` long spinner (App Check / data gate) — keep interactive UI. |
+| **B — Outbound** | #830 | Email / push / invite link inventory; retarget `/?login=true` → `/login`. Depends on A. |
+
+---
+
+## Non-negotiables
+
+- Public hard opens show **today’s** product UI (not SEO text shells).
+- `/dashboard/*` + `/setup` keep `#773` branded boot + `DashboardRoute` preload.
+- Visual parity spot-check before merge (home, scoring, tour stats).
+
+---
+
+## Local verify (after build)
+
+```bash
+npm run build && npm run preview
+# Private window: /, /how-it-works — Network must not request firebase-core until /login
+```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -98,9 +98,16 @@ export default [
         {
           patterns: [
             {
-              group: ["**/features/*/*"],
+              // Block feature internals; allow index.js + intentional secondary
+              // barrels (marketing / auth-modals / splash-entry) per .cursorrules §4.
+              group: [
+                "**/features/*/api/**",
+                "**/features/*/model/**",
+                "**/features/*/ui/**",
+                "**/features/*/components/**",
+              ],
               message:
-                "Import features via their public API only (features/<domain>/index.js).",
+                "Import features via their public API (features/<domain>/index.js or a documented secondary barrel).",
             },
           ],
         },
@@ -122,9 +129,9 @@ export default [
             },
             {
               regex:
-                "^(?:\\.\\./)+(?:admin|auth|landing|picks|pools|profile|scoring|standings)/(?!index(?:\\.[^/]+)?$).+",
+                "^(?:\\.\\./)+(?:admin|auth|landing|picks|pools|profile|scoring|standings)/(?!index(?:\\.[^/]+)?$|marketing(?:\\.[^/]+)?$|auth-modals(?:\\.[^/]+)?$|splash-entry(?:\\.[^/]+)?$).+",
               message:
-                "Cross-feature imports must target feature root only (e.g. ../otherFeature), not deep internals.",
+                "Cross-feature imports must target feature root or a documented secondary barrel, not deep internals.",
             },
           ],
         },
@@ -177,9 +184,9 @@ export default [
             },
             {
               regex:
-                "^(?:\\.\\./)+(?:admin|auth|landing|picks|pools|profile|scoring|standings)/(?!index(?:\\.[^/]+)?$).+",
+                "^(?:\\.\\./)+(?:admin|auth|landing|picks|pools|profile|scoring|standings)/(?!index(?:\\.[^/]+)?$|marketing(?:\\.[^/]+)?$|auth-modals(?:\\.[^/]+)?$|splash-entry(?:\\.[^/]+)?$).+",
               message:
-                "Cross-feature imports must target feature root only (e.g. ../otherFeature), not deep internals.",
+                "Cross-feature imports must target feature root or a documented secondary barrel, not deep internals.",
             },
           ],
         },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.46.5",
+  "version": "1.47.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/prerender-seo.mjs
+++ b/scripts/prerender-seo.mjs
@@ -2,6 +2,9 @@
  * Post-build: write crawler-visible HTML for public marketing routes (#659).
  * Also writes a branded SPA boot shell for dashboard / app hard loads (#743 / #773).
  * Run after `vite build`. Safe to re-run.
+ *
+ * #832: marketing routes prerender from `dist/index.html` (marketing entry).
+ * App-backed public routes (`/tour-stats*`) and boot shells use `dist/app.html`.
  */
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -14,28 +17,35 @@ import {
   buildDashboardBootShellHtml,
   injectDashboardBootModulepreloads,
   injectPrerenderHtml,
-  injectSplashBootModulepreloads,
   prerenderOutputRelPath,
 } from './seo-prerender-lib.mjs';
 
 const root = join(fileURLToPath(new URL('.', import.meta.url)), '..');
 const distDir = join(root, 'dist');
 const distIndex = join(distDir, 'index.html');
+const distApp = join(distDir, 'app.html');
 
 if (!existsSync(distIndex)) {
   console.error('prerender-seo: missing dist/index.html — run vite build first');
   process.exit(1);
 }
+if (!existsSync(distApp)) {
+  console.error('prerender-seo: missing dist/app.html — run vite build first');
+  process.exit(1);
+}
 
-const shell = readFileSync(distIndex, 'utf8');
+const marketingShell = readFileSync(distIndex, 'utf8');
+const appShell = readFileSync(distApp, 'utf8');
+
+function isAppBackedPrerenderRoute(path) {
+  return typeof path === 'string' && path.startsWith('/tour-stats');
+}
 
 for (const route of PRERENDER_ROUTES) {
-  let html = injectPrerenderHtml(shell, route);
-  // Splash only: `HomeRoute` is lazy since #731, so preload its chunk here or
-  // the landing paint waits a round trip on the entry bundle.
-  if (route.path === '/') {
-    html = injectSplashBootModulepreloads(html, distDir);
-  }
+  const shell = isAppBackedPrerenderRoute(route.path) ? appShell : marketingShell;
+  const html = injectPrerenderHtml(shell, route);
+  // Marketing home statically imports splash UI via marketingMain — no lazy
+  // HomeRoute waterfall, so no splash modulepreload injection (#832).
   const rel = prerenderOutputRelPath(route.path);
   const outPath = join(distDir, rel);
   mkdirSync(dirname(outPath), { recursive: true });
@@ -44,9 +54,8 @@ for (const route of PRERENDER_ROUTES) {
 }
 
 // Branded boot shell for /dashboard/* + /setup (via vercel.json).
-// Use the pre-prerender Vite shell so we never copy home SEO body into it.
-// Phase 2: modulepreload DashboardRoute on this shell only (not splash / light spa).
-const brandedShell = buildDashboardBootShellHtml(shell);
+// Use the app document shell so boot loads AuthProvider, not marketingMain.
+const brandedShell = buildDashboardBootShellHtml(appShell);
 const appBootHtml = injectDashboardBootModulepreloads(brandedShell, distDir);
 const appBootPath = join(distDir, APP_BOOT_SHELL_REL_PATH);
 mkdirSync(dirname(appBootPath), { recursive: true });

--- a/scripts/qa/chunk-split.mjs
+++ b/scripts/qa/chunk-split.mjs
@@ -36,11 +36,11 @@ import { startPreview } from './_lib/preview.mjs';
 // of these appearing on a navigation to a *different* route is a
 // cross-route leak — the static-import graph reaches across routes
 // and partially defeats route-level code splitting (#240/#242).
-// `HomeRoute` is lazy as of #731 and is modulepreloaded by the prerendered
-// `dist/index.html`, so it lands in `initialChunks` on the splash hard load and
-// is correctly excluded from later navigation deltas.
+// `HomeRoute` remains lazy on the app document. Marketing `/` (#832) boots a
+// separate entry, so splash hard-load initialChunks no longer include it.
 const LAZY_ROUTE_COMPONENTS = [
   'HomeRoute',
+  'LoginPage',
   'PasswordResetCompletePage',
   'PublicProfilePage',
   'PoolInviteMissingCodePage',

--- a/scripts/qa/chunk-split.mjs
+++ b/scripts/qa/chunk-split.mjs
@@ -126,7 +126,7 @@ async function spaNavigateAndWaitForChunk(
   );
 
   await chunkResponse;
-  await page.waitForLoadState('networkidle');
+  // Do not wait for networkidle — authenticated SPA keeps Firestore WebChannel open.
 }
 
 async function run() {
@@ -157,13 +157,19 @@ async function run() {
       loadedChunks.add(name);
     });
 
-    // Initial paint: hard-load splash. Anything Vite emits
-    // <link rel="modulepreload"> for ends up in `initialChunks` and
-    // is correctly excluded from later deltas.
-    await page.goto(`${preview.url}/`, { waitUntil: 'networkidle' });
+    // Initial paint: hard-load an **app-document** public route (#832).
+    // Marketing `/` is a separate Vite entry — SPA pushState from there
+    // full-reloads into `app.html`, so chunk deltas are not meaningful.
+    // `/login` boots the authenticated SPA without requiring a session.
+    await page.goto(`${preview.url}/login`, { waitUntil: 'domcontentloaded' });
+    // Avoid networkidle — Firestore WebChannel never settles after app boot.
+    await page.waitForFunction(
+      () => document.querySelector('#root')?.childElementCount > 0,
+      { timeout: NAV_TIMEOUT_MS },
+    );
     const initialChunks = new Set(loadedChunks);
 
-    // Scenario 1: / -> /user/<UID> expects PublicProfilePage chunk.
+    // Scenario 1: /login -> /user/<UID> expects PublicProfilePage chunk.
     await spaNavigateAndWaitForChunk(
       page,
       preview.url,
@@ -191,7 +197,7 @@ async function run() {
 
     const scenarios = [
       {
-        from: '/',
+        from: '/login',
         to: '/user/<uid>',
         expected: 'PublicProfilePage',
         delta: userDelta,

--- a/scripts/verify-seo-prerender.mjs
+++ b/scripts/verify-seo-prerender.mjs
@@ -221,20 +221,23 @@ if (existsSync(distIndex) && existsSync(distHowItWorks)) {
     !homeHtml.includes(DASHBOARD_BOOT_PRELOAD_MARKER),
     'home dist/index.html must not gain dashboard boot modulepreloads',
   );
+  // #832: home is the marketing entry — splash UI is static in that graph.
+  // Do not modulepreload lazy HomeRoute / auth (those belong on app.html).
   assert(
-    homeHtml.includes(`${SPLASH_BOOT_PRELOAD_MARKER}="true"`) &&
-      homeHtml.includes('HomeRoute-'),
-    'home dist/index.html must modulepreload the lazy HomeRoute chunk (#731)',
-  );
-  // Leaf-only preload left a waterfall on Landing's auth/shared graph.
-  assert(
-    (homeHtml.match(new RegExp(`${SPLASH_BOOT_PRELOAD_MARKER}="true"`, 'g')) || [])
-      .length >= 2,
-    'home splash modulepreload must cover HomeRoute static closure, not only the leaf',
+    !homeHtml.includes(SPLASH_BOOT_PRELOAD_MARKER),
+    'home marketing document must not inject HomeRoute splash modulepreloads',
   );
   assert(
-    /auth-[^"]+\.js/.test(homeHtml) && homeHtml.includes(SPLASH_BOOT_PRELOAD_MARKER),
-    'home splash modulepreload closure should include the auth chunk',
+    !homeHtml.includes('HomeRoute-'),
+    'home marketing document must not reference HomeRoute chunk',
+  );
+  assert(
+    /\/assets\/marketing-[^"]+\.js/.test(homeHtml),
+    'home dist/index.html must boot the marketing entry chunk',
+  );
+  assert(
+    !/\/assets\/firebase-core-[^"]+\.js/.test(homeHtml),
+    'home marketing document must not load firebase-core on cold open',
   );
   assert(
     homeHtml.includes(`${MARKETING_BOOT_SHELL_MARKER}="true"`),
@@ -244,6 +247,27 @@ if (existsSync(distIndex) && existsSync(distHowItWorks)) {
     !homeHtml.includes('href="/fonts/inter/InterVariable.woff2"'),
     'home dist/index.html must not preload Inter (~344KB)',
   );
+
+  const distApp = join(root, 'dist', 'app.html');
+  assert(existsSync(distApp), 'dist missing app.html — authenticated SPA entry (#832)');
+  const appHtml = readFileSync(distApp, 'utf8');
+  assert(
+    /\/assets\/app-[^"]+\.js/.test(appHtml),
+    'dist/app.html must boot the authenticated SPA entry chunk',
+  );
+
+  const distTourStats = join(root, 'dist', 'tour-stats', 'index.html');
+  if (existsSync(distTourStats)) {
+    const tourHtml = readFileSync(distTourStats, 'utf8');
+    assert(
+      /\/assets\/app-[^"]+\.js/.test(tourHtml),
+      'prerendered /tour-stats must use the app document (live Firestore UI)',
+    );
+    assert(
+      !/\/assets\/marketing-[^"]+\.js/.test(tourHtml),
+      'prerendered /tour-stats must not boot the marketing entry',
+    );
+  }
   const howItWorksHtml = readFileSync(distHowItWorks, 'utf8');
   assert(
     !howItWorksHtml.includes(SPLASH_BOOT_PRELOAD_MARKER),

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -27,6 +27,7 @@ registerRouteChunkLoaders({
 });
 
 const HomeRoute = lazy(loadHomeRoute);
+const LoginPage = lazy(() => import('../pages/auth/LoginPage'));
 const PasswordResetCompletePage = lazy(() =>
   import('../pages/auth/PasswordResetCompletePage')
 );
@@ -53,6 +54,9 @@ function App() {
   return (
     <Routes>
       <Route element={<RootAppShell />}>
+        {/* Auth entry for marketing CTAs (#832) — Firebase boots on this document only */}
+        <Route path="/login" element={<LoginPage />} />
+
         {/* After email password reset — Firebase continueUrl (must stay public) */}
         <Route path="/password-reset-complete" element={<PasswordResetCompletePage />} />
 

--- a/src/app/MarketingApp.jsx
+++ b/src/app/MarketingApp.jsx
@@ -1,0 +1,71 @@
+import React, { useEffect } from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+
+import MarketingHomePage from '../pages/marketing/MarketingHomePage';
+import HowItWorksPage from '../pages/marketing/HowItWorksPage';
+import HowScoringWorksPage from '../pages/marketing/HowScoringWorksPage';
+import PhishSetlistPredictionGamePage from '../pages/marketing/PhishSetlistPredictionGamePage';
+
+/** Paths that still boot the authenticated SPA document (`app.html`) (#832). */
+function isAppDocumentPath(pathname) {
+  if (typeof pathname !== 'string' || !pathname) return false;
+  const prefixes = [
+    '/login',
+    '/dashboard',
+    '/setup',
+    '/tour-stats',
+    '/password-reset-complete',
+    '/privacy',
+    '/terms',
+    '/join',
+    '/comms-preview',
+  ];
+  if (prefixes.some((p) => pathname === p || pathname.startsWith(`${p}/`))) {
+    return true;
+  }
+  return pathname.startsWith('/user/') || pathname.startsWith('/invite/');
+}
+
+/**
+ * Full navigation into the authenticated SPA document.
+ * Used when a marketing-shell Link targets a Firebase-backed route.
+ */
+function LoadAppDocument() {
+  useEffect(() => {
+    const { pathname, search, hash } = window.location;
+    if (!isAppDocumentPath(pathname)) return;
+    window.location.replace(`${pathname}${search}${hash}`);
+  }, []);
+
+  if (typeof window !== 'undefined' && !isAppDocumentPath(window.location.pathname)) {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <div
+      className="flex min-h-screen items-center justify-center bg-brand-bg text-sm font-medium text-slate-400"
+      aria-busy="true"
+    >
+      Loading…
+    </div>
+  );
+}
+
+/**
+ * Marketing cold-open router (#832). Real product UI, no AuthProvider.
+ */
+export default function MarketingApp() {
+  return (
+    <Routes>
+      <Route path="/" element={<MarketingHomePage />} />
+      <Route path="/how-it-works" element={<HowItWorksPage />} />
+      <Route path="/how-scoring-works" element={<HowScoringWorksPage />} />
+      <Route
+        path="/phish-setlist-prediction-game"
+        element={<PhishSetlistPredictionGamePage />}
+      />
+      {/* App-document surfaces — full load so Firebase/AuthProvider can boot. */}
+      <Route path="*" element={<LoadAppDocument />} />
+    </Routes>
+  );
+}

--- a/src/features/auth/index.js
+++ b/src/features/auth/index.js
@@ -1,7 +1,7 @@
 export { default as AuthLoadingScreen } from './ui/AuthLoadingScreen';
 export { default as OpenInBrowserBanner } from './ui/OpenInBrowserBanner';
-export { default as SplashAuthEntryCard } from './ui/SplashAuthEntryCard';
 export { default as SplashAuthModalShell } from './ui/SplashAuthModalShell';
+// SplashAuthEntryCard moved to features/landing (marketing-safe graph, #832).
 // SplashSignInModal / SplashSignUpModal intentionally do NOT re-export here:
 // they live in the `./modals` secondary barrel, whose only consumer is the
 // lazy boundary in features/landing SplashAuthModals (#733). Re-exporting

--- a/src/features/auth/splash-entry.js
+++ b/src/features/auth/splash-entry.js
@@ -1,0 +1,6 @@
+/**
+ * Narrow splash-only auth UI surface (#832).
+ * Importing from `features/auth` root pulls AuthProvider / firebase into the
+ * marketing cold-open graph; get-started only needs the presentational card.
+ */
+export { default as SplashAuthEntryCard } from './ui/SplashAuthEntryCard';

--- a/src/features/auth/splash-entry.js
+++ b/src/features/auth/splash-entry.js
@@ -1,6 +1,0 @@
-/**
- * Narrow splash-only auth UI surface (#832).
- * Importing from `features/auth` root pulls AuthProvider / firebase into the
- * marketing cold-open graph; get-started only needs the presentational card.
- */
-export { default as SplashAuthEntryCard } from './ui/SplashAuthEntryCard';

--- a/src/features/invite/ui/InviteVipLanding.jsx
+++ b/src/features/invite/ui/InviteVipLanding.jsx
@@ -3,7 +3,8 @@ import { Helmet } from 'react-helmet-async';
 import { useLocation } from 'react-router-dom';
 
 import { OpenInBrowserBanner } from '../../auth';
-import { MarketingPageShell, SplashAuthModals } from '../../landing';
+import { MarketingPageShell } from '../../landing';
+import { SplashAuthModals } from '../../landing/auth-modals';
 import { SEO_CONFIG } from '../../../shared/config/seo';
 import Button from '../../../shared/ui/Button';
 

--- a/src/features/landing/auth-modals.js
+++ b/src/features/landing/auth-modals.js
@@ -1,0 +1,6 @@
+/**
+ * App-document auth modal surface (#832 / #733).
+ * Intentionally separate from `features/landing` root so the marketing cold-open
+ * entry does not static-import App Check / splash modals.
+ */
+export { default as SplashAuthModals } from './ui/SplashAuthModals';

--- a/src/features/landing/index.js
+++ b/src/features/landing/index.js
@@ -5,7 +5,8 @@ export { MarketingFooterNav, MarketingHeaderNav } from './ui/MarketingSiteNav';
 export { MARKETING_LEGAL_NAV, MARKETING_PRIMARY_NAV } from './model/marketingNav';
 export { default as PhishSetlistPredictionGamePageContent } from './ui/PhishSetlistPredictionGamePageContent';
 export { default as SplashAboutSection } from './ui/SplashAboutSection';
-export { default as SplashAuthModals } from './ui/SplashAuthModals';
+export { default as SplashAuthEntryCard } from './ui/SplashAuthEntryCard';
+// SplashAuthModals: app-document only — import from `features/landing/auth-modals` (#832).
 export { default as SplashGetStartedSection } from './ui/SplashGetStartedSection';
 export { default as SplashHeader } from './ui/SplashHeader';
 export { default as SplashHeroSection } from './ui/SplashHeroSection';

--- a/src/features/landing/ui/SplashAuthEntryCard.jsx
+++ b/src/features/landing/ui/SplashAuthEntryCard.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import Button from '../../../shared/ui/Button';
 
+/**
+ * Presentational get-started CTA card (marketing-safe — no Firebase).
+ * Owned by landing so the marketing cold-open graph stays AuthProvider-free (#832).
+ */
 export default function SplashAuthEntryCard({ onOpenSignUp, onOpenSignIn, headingRef = null }) {
   return (
     <div className="z-10 w-full max-w-lg">

--- a/src/features/landing/ui/SplashGetStartedSection.jsx
+++ b/src/features/landing/ui/SplashGetStartedSection.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SplashAuthEntryCard } from '../../auth/splash-entry';
+import SplashAuthEntryCard from './SplashAuthEntryCard';
 
 export default function SplashGetStartedSection({
   sectionRef,

--- a/src/features/landing/ui/SplashGetStartedSection.jsx
+++ b/src/features/landing/ui/SplashGetStartedSection.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SplashAuthEntryCard } from '../../auth';
+import { SplashAuthEntryCard } from '../../auth/splash-entry';
 
 export default function SplashGetStartedSection({
   sectionRef,

--- a/src/features/landing/ui/SplashHeroSection.jsx
+++ b/src/features/landing/ui/SplashHeroSection.jsx
@@ -11,10 +11,11 @@ import { LINK_ON_DARK } from '../../../shared/ui/surfaceLinkStyles';
  */
 export default function SplashHeroSection({ onPlayNowClick }) {
   return (
-    <section className="relative flex min-h-[100svh] w-full flex-col bg-transparent pt-[5.35rem] pb-6 sm:min-h-screen sm:pt-[5.25rem] sm:pb-14">
+    {/* #837: on sm+ drop min-h-screen so header→wordmark→copy isn’t viewport-crushed */}
+    <section className="relative flex min-h-[100svh] w-full flex-col bg-transparent pt-[5.35rem] pb-6 sm:min-h-0 sm:pt-[5.25rem] sm:pb-10">
       <div className="relative z-10 mx-auto flex min-h-0 w-full max-w-7xl flex-1 flex-col px-4 pt-1 text-center sm:px-6 sm:pt-0 lg:px-8">
         <h1
-          className="relative left-1/2 w-screen max-w-[100vw] shrink-0 -translate-x-1/2 overflow-visible leading-none sm:left-0 sm:w-full sm:max-w-none sm:translate-x-0"
+          className="relative left-1/2 w-screen max-w-[100vw] shrink-0 -translate-x-1/2 overflow-visible leading-none sm:left-0 sm:w-full sm:max-w-none sm:translate-x-0 sm:-mt-3"
           aria-label={"Setlist Pick 'Em"}
         >
           <SplashHeroWordmark />
@@ -23,7 +24,7 @@ export default function SplashHeroSection({ onPlayNowClick }) {
           </span>
         </h1>
 
-        <div className="mx-auto mt-6 max-w-2xl shrink-0 sm:-mt-0.5 md:-mt-1">
+        <div className="mx-auto mt-6 max-w-2xl shrink-0 sm:mt-3 md:mt-4">
           <p className="mb-3 text-lg font-bold tracking-wide text-teal-400 drop-shadow-[0_0_12px_rgba(45,212,191,0.5)] sm:mb-2 md:text-xl">
             The free Phish setlist prediction game — live on tour.
           </p>

--- a/src/features/landing/ui/SplashHeroSection.jsx
+++ b/src/features/landing/ui/SplashHeroSection.jsx
@@ -16,7 +16,7 @@ import { LINK_ON_DARK } from '../../../shared/ui/surfaceLinkStyles';
  */
 export default function SplashHeroSection({ onPlayNowClick }) {
   return (
-    <section className="relative flex min-h-[100svh] w-full flex-col bg-transparent pt-[5.35rem] pb-6 sm:min-h-[100svh] sm:pt-[4.5rem] sm:pb-10 lg:pt-[5rem] lg:pb-12">
+    <section className="relative flex min-h-[100svh] w-full flex-col bg-transparent pt-[5.35rem] pb-6 sm:min-h-[calc(100svh+2px)] sm:pt-[4.5rem] sm:pb-10 lg:pt-[5rem] lg:pb-12">
       <div className="relative z-10 mx-auto flex min-h-0 w-full max-w-7xl flex-1 flex-col px-4 pt-1 text-center sm:px-6 sm:pt-0 lg:px-8">
         <h1
           className="relative left-1/2 w-screen max-w-[100vw] shrink-0 -translate-x-1/2 overflow-visible leading-none sm:left-0 sm:w-full sm:max-w-none sm:translate-x-0"

--- a/src/features/landing/ui/SplashHeroSection.jsx
+++ b/src/features/landing/ui/SplashHeroSection.jsx
@@ -10,8 +10,8 @@ import { LINK_ON_DARK } from '../../../shared/ui/surfaceLinkStyles';
  * marketing routes for crawlable internal linking (#663).
  */
 export default function SplashHeroSection({ onPlayNowClick }) {
+  // #837: on sm+ drop min-h-screen so header→wordmark→copy isn’t viewport-crushed
   return (
-    {/* #837: on sm+ drop min-h-screen so header→wordmark→copy isn’t viewport-crushed */}
     <section className="relative flex min-h-[100svh] w-full flex-col bg-transparent pt-[5.35rem] pb-6 sm:min-h-0 sm:pt-[5.25rem] sm:pb-10">
       <div className="relative z-10 mx-auto flex min-h-0 w-full max-w-7xl flex-1 flex-col px-4 pt-1 text-center sm:px-6 sm:pt-0 lg:px-8">
         <h1

--- a/src/features/landing/ui/SplashHeroSection.jsx
+++ b/src/features/landing/ui/SplashHeroSection.jsx
@@ -10,12 +10,12 @@ import { LINK_ON_DARK } from '../../../shared/ui/surfaceLinkStyles';
  * marketing routes for crawlable internal linking (#663).
  */
 export default function SplashHeroSection({ onPlayNowClick }) {
-  // #837: on sm+ drop min-h-screen so header→wordmark→copy isn’t viewport-crushed
+  // #837: mobile keeps full-viewport hero + flex spacers; sm+ is content-sized (no min-h-screen)
   return (
-    <section className="relative flex min-h-[100svh] w-full flex-col bg-transparent pt-[5.35rem] pb-6 sm:min-h-0 sm:pt-[5.25rem] sm:pb-10">
+    <section className="relative flex min-h-[100svh] w-full flex-col bg-transparent pt-[5.35rem] pb-6 sm:min-h-0 sm:pt-[5.25rem] sm:pb-8 lg:pb-10">
       <div className="relative z-10 mx-auto flex min-h-0 w-full max-w-7xl flex-1 flex-col px-4 pt-1 text-center sm:px-6 sm:pt-0 lg:px-8">
         <h1
-          className="relative left-1/2 w-screen max-w-[100vw] shrink-0 -translate-x-1/2 overflow-visible leading-none sm:left-0 sm:w-full sm:max-w-none sm:translate-x-0 sm:-mt-3"
+          className="relative left-1/2 w-screen max-w-[100vw] shrink-0 -translate-x-1/2 overflow-visible leading-none sm:left-0 sm:w-full sm:max-w-none sm:translate-x-0 sm:-mt-2 md:-mt-3"
           aria-label={"Setlist Pick 'Em"}
         >
           <SplashHeroWordmark />
@@ -24,7 +24,7 @@ export default function SplashHeroSection({ onPlayNowClick }) {
           </span>
         </h1>
 
-        <div className="mx-auto mt-6 max-w-2xl shrink-0 sm:mt-3 md:mt-4">
+        <div className="mx-auto mt-6 max-w-2xl shrink-0 sm:mt-1 md:mt-2">
           <p className="mb-3 text-lg font-bold tracking-wide text-teal-400 drop-shadow-[0_0_12px_rgba(45,212,191,0.5)] sm:mb-2 md:text-xl">
             The free Phish setlist prediction game — live on tour.
           </p>
@@ -51,7 +51,7 @@ export default function SplashHeroSection({ onPlayNowClick }) {
         {/* Mobile: split leftover viewport 50/50 above vs below CTA (replaces mt-auto). Hidden sm+. */}
         <div className="min-h-2 flex-1 sm:hidden" aria-hidden />
 
-        <div className="mx-auto flex w-full max-w-md shrink-0 flex-col items-center gap-5 sm:mt-6 sm:gap-4">
+        <div className="mx-auto flex w-full max-w-md shrink-0 flex-col items-center gap-5 sm:mt-4 sm:gap-3 md:mt-5">
           <Button
             variant="primary"
             type="button"

--- a/src/features/landing/ui/SplashHeroSection.jsx
+++ b/src/features/landing/ui/SplashHeroSection.jsx
@@ -12,10 +12,10 @@ import { LINK_ON_DARK } from '../../../shared/ui/surfaceLinkStyles';
 export default function SplashHeroSection({ onPlayNowClick }) {
   // #837: mobile keeps full-viewport hero + flex spacers; sm+ is content-sized (no min-h-screen)
   return (
-    <section className="relative flex min-h-[100svh] w-full flex-col bg-transparent pt-[5.35rem] pb-6 sm:min-h-0 sm:pt-[5.25rem] sm:pb-8 lg:pb-10">
+    <section className="relative flex min-h-[100svh] w-full flex-col bg-transparent pt-[5.35rem] pb-6 sm:min-h-0 sm:pt-[4.5rem] sm:pb-8 lg:pt-[5rem] lg:pb-10">
       <div className="relative z-10 mx-auto flex min-h-0 w-full max-w-7xl flex-1 flex-col px-4 pt-1 text-center sm:px-6 sm:pt-0 lg:px-8">
         <h1
-          className="relative left-1/2 w-screen max-w-[100vw] shrink-0 -translate-x-1/2 overflow-visible leading-none sm:left-0 sm:w-full sm:max-w-none sm:translate-x-0 sm:-mt-2 md:-mt-3"
+          className="relative left-1/2 w-screen max-w-[100vw] shrink-0 -translate-x-1/2 overflow-visible leading-none sm:left-0 sm:w-full sm:max-w-none sm:translate-x-0"
           aria-label={"Setlist Pick 'Em"}
         >
           <SplashHeroWordmark />

--- a/src/features/landing/ui/SplashHeroSection.jsx
+++ b/src/features/landing/ui/SplashHeroSection.jsx
@@ -8,11 +8,15 @@ import { LINK_ON_DARK } from '../../../shared/ui/surfaceLinkStyles';
 /**
  * Splash hero — primary CTA stays auth/get-started; secondary links are real
  * marketing routes for crawlable internal linking (#663).
+ *
+ * #837 spacing:
+ * - Mobile: full-viewport hero + 50/50 flex spacers around the CTA.
+ * - sm+: fill the viewport so the next section doesn’t peek above the fold;
+ *   leftover height sits *below* the CTA (dark band), not between header and brand.
  */
 export default function SplashHeroSection({ onPlayNowClick }) {
-  // #837: mobile keeps full-viewport hero + flex spacers; sm+ is content-sized (no min-h-screen)
   return (
-    <section className="relative flex min-h-[100svh] w-full flex-col bg-transparent pt-[5.35rem] pb-6 sm:min-h-0 sm:pt-[4.5rem] sm:pb-8 lg:pt-[5rem] lg:pb-10">
+    <section className="relative flex min-h-[100svh] w-full flex-col bg-transparent pt-[5.35rem] pb-6 sm:min-h-[100svh] sm:pt-[4.5rem] sm:pb-10 lg:pt-[5rem] lg:pb-12">
       <div className="relative z-10 mx-auto flex min-h-0 w-full max-w-7xl flex-1 flex-col px-4 pt-1 text-center sm:px-6 sm:pt-0 lg:px-8">
         <h1
           className="relative left-1/2 w-screen max-w-[100vw] shrink-0 -translate-x-1/2 overflow-visible leading-none sm:left-0 sm:w-full sm:max-w-none sm:translate-x-0"
@@ -24,17 +28,17 @@ export default function SplashHeroSection({ onPlayNowClick }) {
           </span>
         </h1>
 
-        <div className="mx-auto mt-6 max-w-2xl shrink-0 sm:mt-1 md:mt-2">
-          <p className="mb-3 text-lg font-bold tracking-wide text-teal-400 drop-shadow-[0_0_12px_rgba(45,212,191,0.5)] sm:mb-2 md:text-xl">
+        <div className="mx-auto mt-6 max-w-2xl shrink-0 sm:mt-2 md:mt-3">
+          <p className="mb-3 text-lg font-bold tracking-wide text-teal-400 drop-shadow-[0_0_12px_rgba(45,212,191,0.5)] sm:mb-4 md:text-xl">
             The free Phish setlist prediction game — live on tour.
           </p>
 
-          <p className="text-base font-normal leading-relaxed text-slate-300 sm:leading-snug md:text-lg md:leading-relaxed">
+          <p className="text-base font-normal leading-relaxed text-slate-300 md:text-lg md:leading-relaxed">
             Predict the setlist. Win the night. Make picks for tonight&apos;s show, watch scores
             update as songs are played, and compete with your tour crew for the top spot.
           </p>
 
-          <p className="mt-4 text-base font-normal leading-relaxed text-slate-300 sm:leading-snug md:text-lg md:leading-relaxed">
+          <p className="mt-4 text-base font-normal leading-relaxed text-slate-300 sm:mt-5 md:text-lg md:leading-relaxed">
             What started as a game on paper 25 years ago is now a live setlist game for friends at
             the show and on couch tour. Invite your friends, track{' '}
             <Link to="/tour-stats" className={LINK_ON_DARK}>
@@ -48,10 +52,10 @@ export default function SplashHeroSection({ onPlayNowClick }) {
           </p>
         </div>
 
-        {/* Mobile: split leftover viewport 50/50 above vs below CTA (replaces mt-auto). Hidden sm+. */}
+        {/* Mobile: split leftover viewport 50/50 above vs below CTA. Hidden sm+. */}
         <div className="min-h-2 flex-1 sm:hidden" aria-hidden />
 
-        <div className="mx-auto flex w-full max-w-md shrink-0 flex-col items-center gap-5 sm:mt-4 sm:gap-3 md:mt-5">
+        <div className="mx-auto flex w-full max-w-md shrink-0 flex-col items-center gap-5 sm:mt-8 sm:gap-5 md:mt-9">
           <Button
             variant="primary"
             type="button"
@@ -62,7 +66,7 @@ export default function SplashHeroSection({ onPlayNowClick }) {
             Make picks now
           </Button>
           <nav
-            className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm"
+            className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm sm:gap-x-8"
             aria-label="Learn more"
           >
             <Link to="/how-it-works" className={LINK_ON_DARK}>
@@ -77,7 +81,8 @@ export default function SplashHeroSection({ onPlayNowClick }) {
           </nav>
         </div>
 
-        <div className="min-h-2 flex-1 sm:hidden" aria-hidden />
+        {/* Mobile: lower flex spacer. sm+: absorb leftover height under CTA for a clean fold. */}
+        <div className="min-h-2 flex-1" aria-hidden />
       </div>
     </section>
   );

--- a/src/features/scoring/marketing.js
+++ b/src/features/scoring/marketing.js
@@ -1,0 +1,6 @@
+/**
+ * Narrow marketing scoring surface (#832).
+ * Avoid importing the root scoring barrel from the marketing entry — that graph
+ * also re-exports Firestore-backed standings hooks.
+ */
+export { default as ScoringRulesContent } from './ui/ScoringRulesContent';

--- a/src/marketingMain.jsx
+++ b/src/marketingMain.jsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { HelmetProvider } from 'react-helmet-async'
+import { BrowserRouter } from 'react-router-dom'
+
+import MarketingApp from './app/MarketingApp.jsx'
+import { PERSISTED_SESSION_HINT_STORAGE_KEY } from './shared/lib/persistedSessionHint'
+import { initGa4 } from './shared/lib/ga4'
+import { initWebVitals } from './shared/lib/webVitals'
+import './index.css'
+
+/**
+ * Marketing cold-open entry (#832) — loaded from `index.html`.
+ * Real splash/marketing React UI — no AuthProvider / firebase on this graph.
+ * Authenticated SPA boots from `app.html` → `main.jsx`.
+ */
+
+initGa4()
+initWebVitals()
+
+try {
+  if (
+    typeof window !== 'undefined' &&
+    window.localStorage?.getItem(PERSISTED_SESSION_HINT_STORAGE_KEY) === '1'
+  ) {
+    window.location.replace('/dashboard')
+  } else if (typeof window !== 'undefined') {
+    const q = new URLSearchParams(window.location.search)
+    if (q.get('login') === 'true') {
+      const signup = q.get('signup') === '1'
+      window.location.replace(signup ? '/login?signup=1' : '/login')
+    }
+  }
+} catch {
+  // Private mode / blocked storage — continue to marketing UI.
+}
+
+const root = createRoot(document.getElementById('root'))
+root.render(
+  <React.StrictMode>
+    <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <HelmetProvider>
+        <MarketingApp />
+      </HelmetProvider>
+    </BrowserRouter>
+  </React.StrictMode>,
+)

--- a/src/pages/auth/LoginPage.jsx
+++ b/src/pages/auth/LoginPage.jsx
@@ -6,7 +6,7 @@ import {
   useAuth,
   useGoogleRedirectCompletion,
 } from '../../features/auth';
-import { SplashAuthModals } from '../../features/landing';
+import { SplashAuthModals } from '../../features/landing/auth-modals';
 import { getDashboardEntryHref } from '../../shared/lib/dashboardLastPath';
 import { POOL_INVITE_STORAGE_KEY } from '../../shared/config/poolInvite';
 import { getLocalStorageItem } from '../../shared/lib/local-storage';

--- a/src/pages/auth/LoginPage.jsx
+++ b/src/pages/auth/LoginPage.jsx
@@ -1,0 +1,80 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
+
+import {
+  OpenInBrowserBanner,
+  useAuth,
+  useGoogleRedirectCompletion,
+} from '../../features/auth';
+import { SplashAuthModals } from '../../features/landing';
+import { getDashboardEntryHref } from '../../shared/lib/dashboardLastPath';
+import { POOL_INVITE_STORAGE_KEY } from '../../shared/config/poolInvite';
+import { getLocalStorageItem } from '../../shared/lib/local-storage';
+
+/**
+ * Authenticated-SPA login surface (#832). Hosts the existing splash auth modals
+ * on `/login` so marketing cold opens never pay Firebase until a CTA.
+ */
+export default function LoginPage() {
+  const { user, isAdmin: isAdminUser, loading } = useAuth();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const wantSignup = searchParams.get('signup') === '1';
+  const [authModal, setAuthModal] = useState(() => (wantSignup ? 'signup' : 'signin'));
+  const [redirectAuthError, setRedirectAuthError] = useState('');
+  const [poolInvitePending] = useState(
+    () => Boolean(getLocalStorageItem(POOL_INVITE_STORAGE_KEY)?.trim()),
+  );
+  const didStripSignupRef = useRef(false);
+
+  const closeModal = useCallback(() => {
+    // Closing returns to marketing home (separate document).
+    window.location.assign('/');
+  }, []);
+  const openSignUpModal = useCallback(() => setAuthModal('signup'), []);
+  const openSignInModal = useCallback(() => setAuthModal('signin'), []);
+  const onRedirectError = useCallback((message, intent) => {
+    setRedirectAuthError(message || '');
+    if (intent === 'signup') setAuthModal('signup');
+    else setAuthModal('signin');
+  }, []);
+
+  useGoogleRedirectCompletion({
+    onOpenSignIn: openSignInModal,
+    onOpenSignUp: openSignUpModal,
+    onError: onRedirectError,
+  });
+
+  useEffect(() => {
+    if (!wantSignup || didStripSignupRef.current) return;
+    didStripSignupRef.current = true;
+    navigate('/login', { replace: true });
+  }, [navigate, wantSignup]);
+
+  if (!loading && user) {
+    return <Navigate to={getDashboardEntryHref({ isAdminUser })} replace />;
+  }
+
+  return (
+    <div className="relative flex min-h-screen w-full flex-col items-center justify-center bg-transparent text-white">
+      <OpenInBrowserBanner />
+      <div className="relative z-10 px-4 text-center">
+        <p className="mb-2 font-display text-lg font-bold tracking-tight text-white">
+          Setlist Pick&nbsp;&apos;Em
+        </p>
+        <p className="text-sm font-medium text-slate-400">
+          {authModal === 'signup' ? 'Create your free account' : 'Sign in to make picks'}
+        </p>
+      </div>
+      <SplashAuthModals
+        authModal={authModal}
+        closeModal={closeModal}
+        onSwitchToSignIn={openSignInModal}
+        onSwitchToSignUp={openSignUpModal}
+        poolInvitePending={poolInvitePending}
+        redirectAuthError={redirectAuthError}
+        onClearRedirectAuthError={() => setRedirectAuthError('')}
+      />
+    </div>
+  );
+}

--- a/src/pages/auth/PasswordResetCompletePage.jsx
+++ b/src/pages/auth/PasswordResetCompletePage.jsx
@@ -41,13 +41,13 @@ export default function PasswordResetComplete() {
             and sign in with your email and new password.
           </p>
           <Link
-            to="/?login=true"
+            to="/login"
             className="inline-flex w-full items-center justify-center rounded-2xl bg-brand-primary px-8 py-4 font-black text-brand-bg-deep shadow-glow-brand transition-opacity hover:bg-brand-primary-strong hover:opacity-95 sm:w-auto"
           >
             Go to sign in
           </Link>
           <p className="text-xs text-slate-500 font-semibold">
-            Opens the home page — use <span className="text-slate-400">Sign in</span> and your email / password.
+            Opens the sign-in screen — use your email and new password.
           </p>
         </div>
       </div>

--- a/src/pages/landing/SplashPage.jsx
+++ b/src/pages/landing/SplashPage.jsx
@@ -62,10 +62,11 @@ export default function Splash() {
     if (flag !== 'true') return;
 
     didHandleLoginFlagRef.current = true;
-    openSignInModal();
-    // Clear the flag so refresh doesn't re-open the modal.
-    navigate('/', { replace: true });
-  }, [navigate, openSignInModal, searchParams]);
+    // #832: auth lives on `/login` (app document). Keep `?login=true` as a
+    // compatibility hop until outbound links are retargeted (#830).
+    const signup = searchParams.get('signup') === '1';
+    navigate(signup ? '/login?signup=1' : '/login', { replace: true });
+  }, [navigate, searchParams]);
 
   useEffect(() => {
     if (splashResumeAndInviteRef.current) return;

--- a/src/pages/landing/SplashPage.jsx
+++ b/src/pages/landing/SplashPage.jsx
@@ -6,11 +6,8 @@ import {
   consumeSplashResumeAuthModal,
   useGoogleRedirectCompletion,
 } from '../../features/auth';
-import {
-  SplashAuthModals,
-  SplashPageShell,
-  useScrollToSectionFocus,
-} from '../../features/landing';
+import { SplashPageShell, useScrollToSectionFocus } from '../../features/landing';
+import { SplashAuthModals } from '../../features/landing/auth-modals';
 import { ScoringRulesModalProvider } from '../../features/scoring';
 import { POOL_INVITE_STORAGE_KEY } from '../../shared/config/poolInvite';
 import { getLocalStorageItem } from '../../shared/lib/local-storage';

--- a/src/pages/marketing/HowScoringWorksPage.jsx
+++ b/src/pages/marketing/HowScoringWorksPage.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
 
-import { ScoringRulesContent } from '../../features/scoring';
 import { MarketingPageShell } from '../../features/landing';
+import { ScoringRulesContent } from '../../features/scoring/marketing';
 import { SEO_CONFIG } from '../../shared/config/seo';
 import { getPrerenderRoute } from '../../shared/config/seoRoutes';
 import { LINK_ON_LIGHT } from '../../shared/ui/surfaceLinkStyles';

--- a/src/pages/marketing/MarketingHomePage.jsx
+++ b/src/pages/marketing/MarketingHomePage.jsx
@@ -1,0 +1,49 @@
+import React, { useCallback } from 'react';
+
+import {
+  LandingSeo,
+  SplashPageShell,
+  useScrollToSectionFocus,
+} from '../../features/landing';
+
+function goLogin({ signup = false } = {}) {
+  window.location.assign(signup ? '/login?signup=1' : '/login');
+}
+
+/**
+ * Marketing-document splash (#832). Same shell/UI as the app Landing splash,
+ * but auth CTAs hard-navigate to `/login` instead of opening Firebase modals.
+ */
+export default function MarketingHomePage() {
+  const openSignUp = useCallback(() => goLogin({ signup: true }), []);
+  const openSignIn = useCallback(() => goLogin(), []);
+
+  const {
+    howItWorksSectionRef,
+    howItWorksHeadingRef,
+    getStartedSectionRef,
+    getStartedHeadingRef,
+    aboutSectionRef,
+    aboutHeadingRef,
+    handleScrollToGetStarted,
+    handleCreateAccountFromHowItWorks,
+  } = useScrollToSectionFocus({ onCreateAccountRequest: openSignUp });
+
+  return (
+    <>
+      <LandingSeo />
+      <SplashPageShell
+        howItWorksSectionRef={howItWorksSectionRef}
+        howItWorksHeadingRef={howItWorksHeadingRef}
+        getStartedSectionRef={getStartedSectionRef}
+        getStartedHeadingRef={getStartedHeadingRef}
+        aboutSectionRef={aboutSectionRef}
+        aboutHeadingRef={aboutHeadingRef}
+        onScrollToGetStarted={handleScrollToGetStarted}
+        onCreateAccountFromHowItWorks={handleCreateAccountFromHowItWorks}
+        onOpenSignUpModal={openSignUp}
+        onOpenSignInModal={openSignIn}
+      />
+    </>
+  );
+}

--- a/src/shared/config/branding.js
+++ b/src/shared/config/branding.js
@@ -14,18 +14,19 @@ export const BRAND_WORDMARK_SRC = BRAND_GRADIENT_WORDMARK_SRC;
 export const BRAND_HERO_WORDMARK_SRC = BRAND_GRADIENT_WORDMARK_SRC;
 
 /**
- * Hero frame: the SVG’s painted gradient is taller than the letterforms, leaving a band of empty
- * space below the artwork. A wider aspect + overflow clips that band. The splash hero renders this
- * asset as an `<img>` inside `SplashHeroWordmark` with these frame classes; cropping mirrors
- * former `object-cover` + `object-top`.
+ * Hero frame: the SVG’s painted gradient is taller than the letterforms, leaving empty bands in
+ * the artwork. Wider sm+ aspect + overflow clips height; mobile keeps the taller 16/5 frame.
+ * #837: laptop/desktop uses a shorter frame + tighter max-width so header→copy isn’t crushed.
  */
-/** #837: wider sm+ aspect crops more empty SVG band so copy isn’t squeezed under the hero. */
 export const brandHeroWordmarkAspectFrameClassNames =
-  'mx-auto block aspect-[16/5] w-[100vw] max-w-none overflow-hidden sm:aspect-[4/1] sm:w-full sm:max-w-[min(96vw,70rem)] md:max-w-[min(94vw,78rem)] lg:max-w-[min(92vw,86rem)] xl:max-w-[min(90vw,94rem)]';
+  'mx-auto block aspect-[16/5] w-[100vw] max-w-none overflow-hidden sm:aspect-[5/1] sm:w-full sm:max-w-[min(92vw,42rem)] md:max-w-[min(90vw,48rem)] lg:aspect-[4.5/1] lg:max-w-[min(88vw,56rem)] xl:max-w-[min(86vw,64rem)]';
 
-/** Hero `<img>` classes used by `SplashHeroWordmark.jsx`. */
+/**
+ * Hero `<img>` classes. Mobile: `object-top`. sm+: shift crop down so transparent SVG headroom
+ * above the letterforms doesn’t read as a gap under the fixed header (#837).
+ */
 export const brandHeroWordmarkImgClassNames =
-  'block h-full w-full min-h-0 object-cover object-top';
+  'block h-full w-full min-h-0 object-cover object-top sm:object-[center_48%]';
 
 /**
  * Mobile “1.2×” via **layout width** (`120vw` + `-ml-[10vw]`) so the graphic scales as vector paint,

--- a/src/shared/config/branding.js
+++ b/src/shared/config/branding.js
@@ -19,14 +19,14 @@ export const BRAND_HERO_WORDMARK_SRC = BRAND_GRADIENT_WORDMARK_SRC;
  * #837: laptop/desktop uses a shorter frame + tighter max-width so header→copy isn’t crushed.
  */
 export const brandHeroWordmarkAspectFrameClassNames =
-  'mx-auto block aspect-[16/5] w-[100vw] max-w-none overflow-hidden sm:aspect-[5/1] sm:w-full sm:max-w-[min(92vw,42rem)] md:max-w-[min(90vw,48rem)] lg:aspect-[4.5/1] lg:max-w-[min(88vw,56rem)] xl:max-w-[min(86vw,64rem)]';
+  'mx-auto block aspect-[16/5] w-[100vw] max-w-none overflow-hidden sm:aspect-[6/1] sm:w-full sm:max-w-[min(90vw,40rem)] md:max-w-[min(88vw,46rem)] lg:aspect-[5/1] lg:max-w-[min(86vw,54rem)] xl:max-w-[min(84vw,62rem)]';
 
 /**
- * Hero `<img>` classes. Mobile: `object-top`. sm+: shift crop down so transparent SVG headroom
- * above the letterforms doesn’t read as a gap under the fixed header (#837).
+ * Hero `<img>` classes. Mobile: `object-top` (keep current mobile crop).
+ * sm+: higher object-position skips transparent SVG headroom above letterforms (#837).
  */
 export const brandHeroWordmarkImgClassNames =
-  'block h-full w-full min-h-0 object-cover object-top sm:object-[center_48%]';
+  'block h-full w-full min-h-0 object-cover object-top sm:object-[center_62%]';
 
 /**
  * Mobile “1.2×” via **layout width** (`120vw` + `-ml-[10vw]`) so the graphic scales as vector paint,

--- a/src/shared/config/branding.js
+++ b/src/shared/config/branding.js
@@ -19,8 +19,9 @@ export const BRAND_HERO_WORDMARK_SRC = BRAND_GRADIENT_WORDMARK_SRC;
  * asset as an `<img>` inside `SplashHeroWordmark` with these frame classes; cropping mirrors
  * former `object-cover` + `object-top`.
  */
+/** #837: wider sm+ aspect crops more empty SVG band so copy isn’t squeezed under the hero. */
 export const brandHeroWordmarkAspectFrameClassNames =
-  'mx-auto block aspect-[16/5] w-[100vw] max-w-none overflow-hidden sm:aspect-[71/20] sm:w-full sm:max-w-[min(96vw,70rem)] md:max-w-[min(94vw,78rem)] lg:max-w-[min(92vw,86rem)] xl:max-w-[min(90vw,94rem)]';
+  'mx-auto block aspect-[16/5] w-[100vw] max-w-none overflow-hidden sm:aspect-[4/1] sm:w-full sm:max-w-[min(96vw,70rem)] md:max-w-[min(94vw,78rem)] lg:max-w-[min(92vw,86rem)] xl:max-w-[min(90vw,94rem)]';
 
 /** Hero `<img>` classes used by `SplashHeroWordmark.jsx`. */
 export const brandHeroWordmarkImgClassNames =

--- a/src/shared/lib/routeGroup.js
+++ b/src/shared/lib/routeGroup.js
@@ -8,6 +8,7 @@
 export function resolveRouteGroup(pathname) {
   if (typeof pathname !== 'string' || !pathname) return 'other';
   if (pathname === '/') return 'splash';
+  if (pathname === '/login' || pathname.startsWith('/login/')) return 'other';
   if (pathname === '/setup' || pathname.startsWith('/setup/')) return 'setup';
   if (pathname === '/dashboard' || pathname.startsWith('/dashboard/')) {
     return 'dashboard';

--- a/vercel.json
+++ b/vercel.json
@@ -49,6 +49,10 @@
       "destination": "/dashboard/index.html"
     },
     {
+      "source": "/login",
+      "destination": "/app.html"
+    },
+    {
       "source": "/user/(.*)",
       "destination": "/spa-boot/index.html"
     },
@@ -158,6 +162,32 @@
     },
     {
       "source": "/index.html",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/app.html",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/login",
       "headers": [
         {
           "key": "X-Frame-Options",

--- a/vite.config.js
+++ b/vite.config.js
@@ -28,22 +28,40 @@ function isAppDocumentPath(pathname) {
   });
 }
 
+function rewriteAppDocumentRequest(req, _res, next) {
+  const raw = req.url || '';
+  const pathname = raw.split('?')[0];
+  if (
+    pathname === '/app.html' ||
+    pathname.startsWith('/src/') ||
+    pathname.startsWith('/@') ||
+    pathname.startsWith('/node_modules') ||
+    pathname.startsWith('/assets') ||
+    pathname.startsWith('/branding') ||
+    pathname.startsWith('/fonts') ||
+    pathname.startsWith('/favicon')
+  ) {
+    next();
+    return;
+  }
+  // Prefer prerendered app-backed HTML when present (e.g. /tour-stats/).
+  // Otherwise serve `app.html` so /login and /user/* don't fall through to
+  // the marketing document (which would location.replace-loop) (#832).
+  if (isAppDocumentPath(pathname)) {
+    req.url = `/app.html${raw.includes('?') ? `?${raw.split('?')[1]}` : ''}`;
+  }
+  next();
+}
+
 function appDocumentDevMiddleware() {
   return {
     name: 'app-document-dev-middleware',
     configureServer(server) {
-      server.middlewares.use((req, res, next) => {
-        const raw = req.url || '';
-        const pathname = raw.split('?')[0];
-        if (pathname === '/app.html' || pathname.startsWith('/src/') || pathname.startsWith('/@') || pathname.startsWith('/node_modules') || pathname.startsWith('/assets') || pathname.startsWith('/branding') || pathname.startsWith('/fonts') || pathname.startsWith('/favicon')) {
-          next();
-          return;
-        }
-        if (isAppDocumentPath(pathname)) {
-          req.url = `/app.html${raw.includes('?') ? `?${raw.split('?')[1]}` : ''}`;
-        }
-        next();
-      });
+      server.middlewares.use(rewriteAppDocumentRequest);
+    },
+    // qa:chunks / `vite preview` need the same rewrites as `npm run dev`.
+    configurePreviewServer(server) {
+      server.middlewares.use(rewriteAppDocumentRequest);
     },
   };
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,49 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+/** Paths that must boot the authenticated SPA document (`app.html`) in dev (#832). */
+const APP_DOCUMENT_PATH_PREFIXES = [
+  '/login',
+  '/dashboard',
+  '/setup',
+  '/tour-stats',
+  '/user/',
+  '/password-reset-complete',
+  '/privacy',
+  '/terms',
+  '/join',
+  '/invite/',
+  '/comms-preview',
+];
+
+function isAppDocumentPath(pathname) {
+  if (!pathname || pathname === '/') return false;
+  return APP_DOCUMENT_PATH_PREFIXES.some((prefix) => {
+    if (prefix.endsWith('/')) return pathname.startsWith(prefix);
+    return pathname === prefix || pathname.startsWith(`${prefix}/`);
+  });
+}
+
+function appDocumentDevMiddleware() {
+  return {
+    name: 'app-document-dev-middleware',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const raw = req.url || '';
+        const pathname = raw.split('?')[0];
+        if (pathname === '/app.html' || pathname.startsWith('/src/') || pathname.startsWith('/@') || pathname.startsWith('/node_modules') || pathname.startsWith('/assets') || pathname.startsWith('/branding') || pathname.startsWith('/fonts') || pathname.startsWith('/favicon')) {
+          next();
+          return;
+        }
+        if (isAppDocumentPath(pathname)) {
+          req.url = `/app.html${raw.includes('?') ? `?${raw.split('?')[1]}` : ''}`;
+        }
+        next();
+      });
+    },
+  };
+}
+
 // Group third-party modules into stable, cacheable chunks. Returning `undefined`
 // for anything outside `node_modules` preserves Vite's automatic per-route
 // splitting introduced in #240 — do NOT bundle app code here.
@@ -51,7 +94,7 @@ function manualChunks(id) {
 
 export default defineConfig({
   base: '/',
-  plugins: [react()],
+  plugins: [react(), appDocumentDevMiddleware()],
   test: {
     environment: 'node',
     include: ['src/**/*.test.js', 'api/**/*.test.js'],
@@ -67,6 +110,11 @@ export default defineConfig({
   },
   build: {
     rollupOptions: {
+      input: {
+        // Named `marketing` so built HTML references `/assets/marketing-*.js` (#832).
+        marketing: path.resolve(__dirname, 'index.html'),
+        app: path.resolve(__dirname, 'app.html'),
+      },
       output: {
         manualChunks,
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #832  
Closes #837  

## Summary
- Dual-document cold open: marketing `index.html` → `marketingMain` (real splash/educational UI, **no `firebase-core` / `AuthProvider` on cold open**); authenticated SPA at `app.html` with new `/login`.
- Splash auth modals live on `features/landing/auth-modals` so the marketing barrel stays Firebase-free.
- Tour stats + invite/legal stay on the app document for now (#827 follow-up).
- Laptop splash spacing (#837): drop `sm:min-h-screen`, pull wordmark up, crop more empty hero SVG band so copy isn’t squeezed.
- SemVer **1.47.0** (new `/login` route + marketing entry).

## Spot-check focus
1. Laptop-height `/` — header → hero wordmark → copy spacing (#837)
2. Private window Network on `/` / `/how-it-works` — no `firebase-core` until `/login` or `/tour-stats`
3. Sign In / Create account → `/login` modals; scoring graphics + tour stats parity

## Test plan
- [ ] Private window hard-open `/` — Network: no `firebase-core` until `/login` or tour-stats
- [ ] Visual spot-check home on laptop height: header → hero → copy spacing
- [ ] `/how-it-works`, `/how-scoring-works`, scoring graphics intact
- [ ] Sign In / Create account → `/login` modals work; post-auth → dashboard/setup
- [ ] `/tour-stats` still interactive (app document)
- [x] `npm run build` + `verify:seo-prerender` + lint + vitest + dashboard meta/ui

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcb47-d4fa-7c9b-9088-8b7ef93f39b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcb47-d4fa-7c9b-9088-8b7ef93f39b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

