### PR TITLE
feat(auth): T0a auth/content RUM — route_group + timing (#857)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.49.1] — 2026-08-04
+
+### Added
+- **Auth/content RUM (#857 / epic #856)** — `route_group` splits for `/login` (`login`), educational marketing pages (`marketing`), and `/tour-stats*` (`tour_stats`). GA4 `auth_surface_timing` (paint→Auth warm ready) and `auth_google_timing` (click→OAuth invoke / credential→nav). Ops: `docs/AUTH_TELEMETRY_RUNBOOK.md`, `docs/WEB_VITALS_RUM.md`, `docs/AUTH_SEAMLESS_PATH.md`.
+
+---
+
 ## [1.49.0] — 2026-08-04
 
 ### Changed

--- a/docs/API.md
+++ b/docs/API.md
@@ -397,7 +397,9 @@ Dashboard sub-routes are documented in `docs/DASHBOARD_IA.md`. Notable secondary
 
 **Picks — Prediction Lab (**v1.38.0 / #651**):** opt-in collapsed panel on `/dashboard/picks` consuming Storage `pick-recommendations.json` (see §2.3). Manual autocomplete unchanged when Lab unused/unavailable. **GA4 (client):** `prediction_lab_open` `{ show_id, model_version }`, `prediction_lab_impression` `{ show_id, slot, model_version, risk_band, rank }`, `prediction_lab_select` `{ show_id, slot, model_version, risk_band, rank, song_normalized }`.
 
-**Field RUM — web-vitals (**v1.44.0 / #801**):** production hostnames only. Client emits GA4 `web_vital` for LCP, INP, CLS, TTFB, FCP after idle. Params: `{ metric_name, value, metric_id, metric_rating, route_group, navigation_type }` where `route_group` is `splash` \| `invite_join` \| `invite_site` \| `dashboard` \| `setup` \| `other` and `navigation_type` is `navigate` \| `reload` \| `back_forward` \| `prerender`. Ops: [`docs/WEB_VITALS_RUM.md`](WEB_VITALS_RUM.md).
+**Field RUM — web-vitals (**v1.44.0 / #801**, route groups **v1.49.1 / #857**):** production hostnames only. Client emits GA4 `web_vital` for LCP, INP, CLS, TTFB, FCP after idle. Params: `{ metric_name, value, metric_id, metric_rating, route_group, navigation_type }` where `route_group` is `splash` \| `login` \| `marketing` \| `tour_stats` \| `invite_join` \| `invite_site` \| `dashboard` \| `setup` \| `other` and `navigation_type` is `navigate` \| `reload` \| `back_forward` \| `prerender`. Ops: [`docs/WEB_VITALS_RUM.md`](WEB_VITALS_RUM.md).
+
+**Auth interaction timings (**v1.49.1 / #857**):** production hostnames only (same `ga4Event` gate). `auth_surface_timing` `{ phase: paint_to_ready, value, route_group: login, warm_path, navigation_type }` once per `/login` warm. `auth_google_timing` `{ phase: click_to_popup \| credential_to_nav, value, method: google, auth_flow, outcome, error_code? }`. Ops: [`docs/AUTH_TELEMETRY_RUNBOOK.md`](AUTH_TELEMETRY_RUNBOOK.md) · plan [`docs/AUTH_SEAMLESS_PATH.md`](AUTH_SEAMLESS_PATH.md) §7.
 
 ### 3.1 Email CTA click-through host (`click.setlistpickem.com`)
 

--- a/docs/AUTH_BOOT_PRACTICES.md
+++ b/docs/AUTH_BOOT_PRACTICES.md
@@ -2,7 +2,7 @@
 
 Standing rules for app-document auth and any surface that opens Google/`signInWithPopup` or touches Firestore under App Check. Learned from the v1.48.4 Safari hotfix (#850); apply on Phase E work (`/tour-stats`, invite/join, further `/login` feel) without re-deriving.
 
-**Related:** `docs/RELEASE_TRAIN_COLD_OPEN.md` · `docs/OUTBOUND_AUTH_HANDOFF.md` · `docs/API.md` (`/login`) · code: `src/shared/lib/ensureFirebase.js`, `src/features/auth/model/warmLoginAuthSurface.js`
+**Related:** `docs/RELEASE_TRAIN_COLD_OPEN.md` · `docs/OUTBOUND_AUTH_HANDOFF.md` · `docs/API.md` (`/login`) · **roadmap / top-tier gap close:** `docs/AUTH_SEAMLESS_PATH.md` · code: `src/shared/lib/ensureFirebase.js`, `src/features/auth/model/warmLoginAuthSurface.js`
 
 ---
 

--- a/docs/AUTH_SEAMLESS_PATH.md
+++ b/docs/AUTH_SEAMLESS_PATH.md
@@ -1,0 +1,256 @@
+# Seamless auth & no-lag entry — path to top-tier feel
+
+**Status:** Decision / roadmap doc (2026-08-04). Delivery epic [#856](https://github.com/pat792/set-picks/issues/856).  
+**T0a:** [#857](https://github.com/pat792/set-picks/issues/857) — `route_group` + auth timing emitters (shipped in train; register GA4 dims per runbook).  
+
+**Standing rules today:** `docs/AUTH_BOOT_PRACTICES.md` (#850).  
+**Related:** `docs/RELEASE_TRAIN_COLD_OPEN.md` · predecessor [#835](https://github.com/pat792/set-picks/issues/835) · children: T0a [#857](https://github.com/pat792/set-picks/issues/857) · T0b [#858](https://github.com/pat792/set-picks/issues/858) · T1 [#859](https://github.com/pat792/set-picks/issues/859) · T2 [#860](https://github.com/pat792/set-picks/issues/860) · T3 [#861](https://github.com/pat792/set-picks/issues/861).
+
+This answers: how top-tier platforms feel instant; what we can close in this repo; what needs reconfiguration; and a staged path that starts by killing the **new** first-tap Google errors (absent on the old modal path).
+
+---
+
+## 1) What “top-tier” platforms actually do
+
+They do **not** magically make a cold 300KB+ Auth SDK + popup feel free. They arrange the product so the user rarely pays that cost at the moment of the Google tap.
+
+### Entry / paint (no-lag public pages)
+
+| Pattern | Examples / shape | What it buys | What we have |
+|--------|-------------------|--------------|--------------|
+| **Thin document + deferred app** | Marketing site / docs / landing separate from the authenticated app | Instant HTML/CSS; no Auth on SERP/GenAI cold opens | **Have** — dual-entry marketing (#832); `/tour-stats*` on marketing too (#853). Auth CTAs hard-nav to `/login`. |
+| **SSR / edge HTML shell** | Next/Remix/Firebase Hosting SSR, prerender | First paint without waiting on client graph | **Partial** — branded `login/index.html` + SEO prerender shells; not full SSR of React. Enough for marketing/login chrome; not the auth-lag gap. |
+| **Session-aware boot** | Cookie / IndexedDB hint → skip marketing, go dashboard | Returning users never see auth chrome | **Have** — persisted session hint + dashboard/email boot (#773 / #804). Anon visitors still see marketing/`/login`. |
+| **Prefetch on intent** | Hover/focus “Log in” preloads auth route + Auth SDK | Hard-nav to `/login` already warm | **Gap** — marketing Sign in is a cold hard-nav; Auth warm starts only after `/login` paints (soft idle today). Tier 2. |
+
+### Auth (seamless Google / email)
+
+| Pattern | What top-tier does | What we do |
+|--------|--------------------|------------|
+| **A. Auth SDK ready before CTA is live** | Auth route loads Firebase Auth (or GIS) as part of becoming interactive; button disabled or hidden until ready | **Gap** — soft idle-warm after `/login` paint (#850); Google CTA stays enabled. Fast Safari tap can race Auth download → first-tap error. Tier 0. |
+| **B. Click handler is sync into OAuth** | No `await` download/init between tap and `signInWithPopup` / redirect / GIS | **Gap** — click still `await ensureAuthReady()` + dynamic-import `splashAuthApi` / `completeGoogleSplashAuth` before popup. Tier 0. |
+| **C. App Check / backend off OAuth path** | reCAPTCHA / attestation after credential or parallel; never in front of account picker | **Have** — `#850`: `ensureAuthReady` does not await App Check; Check only before Firestore (`AUTH_BOOT_PRACTICES`). Must not regress. |
+| **D. Mobile prefers redirect (or popup→redirect fallback)** | Firebase docs: redirect preferred on mobile; many apps try popup then fall back on `popup-blocked` | **Partial** — `signInWithRedirect` only for in-app browsers; real Safari uses popup. Custom `authDomain` + `/__/auth` proxy ready. Tier 1. |
+| **E. Dedicated auth surface / host** | `accounts.*` or dedicated auth app with Auth always in the graph | **Partial** — full-page `/login` on app document (#834); not a separate auth host. Enough for Tier 0–1; Tier 3 only if needed. |
+| **F. Google Identity Services (GIS) button** | Google-owned button/iframe owns the gesture | **Gap** — Firebase `GoogleAuthProvider` + popup/redirect only. Tier 3 optional. |
+| **G. Returning session invisible** | Silent restore; auth UI only for signed-out | **Have** — session hint + AuthProvider restore on dashboard/email (#773); signed-in `/login` → dashboard. |
+
+**Bottom line:** “Instant Google” on best platforms ≈ **Auth already loaded + no work in the gesture + often redirect on mobile + users often already signed in.** It is product sequencing, not a secret API.
+
+---
+
+## 2) Why the old modal felt fine (and `/login` regressed)
+
+Old splash/invite **modal** path (`SplashAuthModals`):
+
+1. User was already on the **app document** (Firebase/AuthProvider in play, or soon to be).
+2. First click was often **“Sign in” / “Create account”** → modal opens → `ensureAppCheckNow()` + dashboard prefetch **without awaiting before Google**.
+3. Second click was **Continue with Google** → Auth/`splashAuthApi` usually already warm → popup inside the gesture.
+
+New `/login` path (#834 / #835):
+
+1. Hard-nav from marketing → **anon `/login` deliberately has no firebase modulepreload**.
+2. Form paints with Auth **cold**.
+3. First interaction is often **Continue with Google itself**.
+4. Soft idle-warm (#850) can lose to a fast Safari tap → `await ensureAuthReady()` + dynamic imports steal the gesture → **first-tap error** (new); second tap works.
+
+So the regression is not “popup stopped working.” It is **we removed the modal’s natural intent buffer and deferred Auth onto the Google button.**
+
+---
+
+## 3) Gaps: closable today vs needs reconfiguration
+
+### Closable in current architecture (no redesign)
+
+| Gap | Symptom | Close with | Gets us to top-tier? |
+|-----|---------|------------|----------------------|
+| Soft idle-warm race | First Google tap error; second works | **Hard gate:** disable Google until Auth + sign-in modules ready | **Yes (required)** — restores modal-era first-tap reliability; table stakes, not polish |
+| Click still dynamic-imports | Extra await before popup | Prefetch `splashAuthApi` + `completeGoogleSplashAuth`; click path sync into `signInWithPopup` | **Yes (required)** — same gesture invariant as top-tier; pairs with hard gate |
+| Idle delayed up to 800ms | Warm starts late | Start Auth warm **immediately after paint** on `/login` (keep marketing Firebase-free) | **Yes (partial)** — shrinks “Preparing…” window; gate still needed |
+| Mobile no hover warm | `pointerenter` useless on touch | Gate + immediate warm; optional `pointerdown` kick | **Yes (partial)** — touch parity with desktop intent; gate covers the rest |
+| App Check in front of OAuth | Fixed in #850; must not regress | Keep `AUTH_BOOT_PRACTICES` rule 4 | **Yes (already)** — hold the line; regressing drops us below tier |
+
+### Needs reconfiguration (real ceiling lifts)
+
+| Gap | Why we can’t fully match top-tier today | Reconfiguration | Gets us to top-tier? |
+|-----|------------------------------------------|-----------------|----------------------|
+| Safari popup residual flakiness | Even with perfect sequencing, Safari/ITP/popup blockers remain; Firebase prefers redirect on mobile | **Safari/touch → `signInWithRedirect`** (or popup then fallback). We already have redirect plumbing for WebViews + custom `authDomain` / `/__/auth` proxy | **Yes (mobile floor)** — without this, Safari can still flake after Tier 0 |
+| Auth page still “feels heavy” after OAuth | Post-auth: AuthProvider wake, profile/`whenFirebaseReady`, dashboard chunk | Keep dashboard/setup prefetch; consider eager AuthProvider on `/login` once warm starts; measure profile path | **Yes (partial)** — post-login snappiness; not the first-tap error |
+| Marketing→login still a full document swap | Dual-entry hard-nav is correct for cold marketing, but Auth starts at zero on arrival | Optional: `<link rel="modulepreload">` / prefetch Auth **from marketing Sign-in CTA** (intent prefetch) without booting Auth on `/` | **Yes (partial)** — virtually no lag into ready CTA; marketing stays Firebase-free |
+| GIS / federated button | Not integrated | Later: Google Identity Services → `signInWithCredential` if we want Google-rendered CTA | **No (optional)** — native-Google chrome; not required once A–D are solid |
+| True SSR auth shell | Vite SPA + branded `login/index.html` shell | Only if paint of login chrome itself is still the complaint after Tier 1 | **No (optional)** — only if login *paint* (not OAuth) is still the issue |
+
+**Not a security vulnerability** for the first-tap error. Custom auth domain + auth proxy are the *right* Firebase setup for redirect. CSP is still Report-Only for framing — separate from this race (see #412 post-mortem).
+
+**Honest non-goal without reconfiguration:** matching native Google One Tap / accounts.google.com feel while keeping **popup-only on Safari** and **Auth cold until Google click**.
+
+---
+
+## 4) Solution set (documented options)
+
+### Tier 0 — Quick wins (restore modal-era reliability)
+
+**Goal:** Eliminate first-tap “Something went wrong” / popup-blocked class on private Safari.  
+**Accept:** brief disabled/“Preparing sign-in…” on Google CTA if Auth is still downloading.  
+**Keep:** marketing `/` Firebase-free; App Check off OAuth path.
+
+1. On `/login` paint: start `warmLoginAuthSurface()` **immediately** (not only `requestIdleCallback`).
+2. Expand warm to include **everything the click path imports** (`splashAuthApi`, `completeGoogleSplashAuth`, Google provider construct).
+3. Expose `authSurfaceReady` (promise/state); **disable Continue with Google until ready**.
+4. Click handler: if ready, call `signInWithPopup` with **no chunk `await`s** (Auth instance already held).
+5. Human AC: private Safari, cold `/login`, **first** Continue with Google opens account picker (or starts redirect — Tier 1).
+
+SemVer: likely **PATCH**. Risk: low if gate is correct; no marketing regression.
+
+### Tier 1 — Match Firebase mobile guidance
+
+**Goal:** Reliability floor of top-tier mobile web auth.
+
+1. Real Safari / iOS / touch (or `matchMedia` coarse pointer): prefer **`signInWithRedirect`** (reuse existing stash + `useGoogleRedirectCompletion`).
+2. Desktop: keep popup.
+3. Optional: popup first, on `auth/popup-blocked` / cancelled-as-blocked → one-shot redirect fallback (common industry pattern).
+
+SemVer: **MINOR** if behavior/API docs change for auth flow. Needs Safari human QA + Chromium smoke.
+
+### Tier 2 — Intent prefetch (marketing → login)
+
+**Goal:** Virtually no lag between “Sign in” on marketing and ready Google CTA.
+
+1. Marketing Sign in / Create account links: `rel` prefetch / dynamic `import()` of login warm chunk **without** initializing Auth on marketing document (or only prefetch JS URLs).
+2. Optionally add `firebase-core` modulepreload **only** on `dist/login/index.html` (lift `LOGIN_BOOT_PRELOAD_BLOCKLIST` for login shell only).
+
+Tradeoff: login document slightly heavier; marketing cold open unchanged.
+
+### Tier 3 — Reconfiguration (only if Tier 0–2 still feel short of “top-tier”)
+
+| Option | When |
+|--------|------|
+| GIS Google button | Want Google-owned gesture / brand button |
+| Broader redirect-default | Popup still flakes after Tier 0+1 |
+| Separate `auth.` host / micro-frontend | Multi-product SSO later — overkill now |
+| SSR login | Login chrome paint still slow after Auth gate feels fine |
+
+---
+
+## 5) Recommended path (order)
+
+```text
+NOW (Tier 0)     → Kill first-tap errors; hard-ready CTA
+THEN (Tier 1)    → Safari/touch redirect (or popup→redirect)
+THEN (Tier 2)    → Marketing intent prefetch + optional login firebase modulepreload
+LATER (Tier 3)   → GIS / deeper host split only if product still wants more
+```
+
+**Do not** put Firebase back on marketing `/`.  
+**Do not** await App Check before OAuth.  
+**Do** treat “Auth ready before Google enabled” as the modal-era invariant we accidentally dropped.
+
+### Success metrics
+
+| Metric | Pass |
+|--------|------|
+| Private Safari cold `/login` | First Google action succeeds (picker or redirect) — no prior error banner |
+| Private Safari cold `/` | No `firebase-core` until auth CTA / `/login` |
+| Chromium smoke | Existing `qa:*` still green |
+| Regression watch | `/tour-stats` stays marketing entry (#853) |
+| Field (GA4) | See §7 — `web_vital` by route group + auth timing / error rates |
+
+### Revise standing rule?
+
+`AUTH_BOOT_PRACTICES` rule 2 (“paint before firebase-core”) stays for **first paint**. Add a sibling rule after Tier 0 ships:
+
+> **2b. Google CTA must not be enabled until Auth surface is ready.** Soft idle-warm alone is insufficient on Safari.
+
+---
+
+## 6) Decision checklist (before coding)
+
+- [ ] Approve Tier 0 as the immediate hotfix (hard gate > soft idle).
+- [ ] Choose Tier 1 now or after Tier 0 soak: redirect-on-Safari vs popup-only + gate.
+- [ ] Confirm we will **not** reopen marketing Firebase for auth feel.
+- [ ] Human Safari private-window is the release gate (agents cannot prove WebKit).
+- [ ] Ship §7 telemetry with Tier 0 (or immediately before) so soak has baselines.
+
+---
+
+## 7) Telemetry — listeners for content + auth load
+
+Build on what already ships; fill the holes so Tier 0–2 changes are measurable in prod GA4 (not only private Safari anecdotes).
+
+**Existing (keep):**
+
+| Signal | Where | Use for this train |
+|--------|--------|--------------------|
+| `web_vital` (LCP/FCP/TTFB/INP/CLS) | `webVitals.js` + `routeGroup.js` (#801) · [`WEB_VITALS_RUM.md`](WEB_VITALS_RUM.md) | Content / shell paint by `route_group` + `navigation_type` |
+| `page_view` | `Ga4RouteListener` | Funnel volume by path |
+| `auth_error` / `login` / `sign_up` | `authAnalytics.js` · [`AUTH_TELEMETRY_RUNBOOK.md`](AUTH_TELEMETRY_RUNBOOK.md) | Google failure codes (`popup-blocked`, etc.), success rate by `method` + `auth_flow` |
+
+**Hole today:** `/login`, `/tour-stats*`, and marketing educational routes all collapse into `route_group = other`, so content vs auth RUM cannot be split in Explorations.
+
+### 7.1 Quick win — fix `route_group` cardinality
+
+Extend `resolveRouteGroup` (stable GA4 dimension — register new values once):
+
+| Path | New `route_group` | Why |
+|------|-------------------|-----|
+| `/login` | `login` | Auth entry RUM (today: `other`) |
+| `/`, already `splash` | `splash` | unchanged |
+| `/how-it-works`, `/how-scoring-works`, `/phish-setlist-prediction-game` | `marketing` | Content cold-open vs splash |
+| `/tour-stats*` | `tour_stats` | #853 marketing-entry soak |
+| invite/join/dashboard/setup | unchanged | |
+
+**Listener:** none new — existing `web_vital` emitter picks up groups automatically.  
+**GA4:** register `route_group` values if Explorations filter by exact enum; compare p75 LCP/FCP/TTFB: `splash` / `marketing` / `tour_stats` / `login` / `dashboard`.
+
+### 7.2 Auth interaction timings (ship with Tier 0)
+
+Custom events (prod-only via `ga4Event`). Use `performance.now()` deltas; round ms; cap/omit absurd outliers (>60s).
+
+| Event | When | Params | Answers |
+|-------|------|--------|---------|
+| `auth_surface_timing` | Once per `/login` visit when Auth surface becomes ready (gate enables Google) | `phase`: `paint_to_ready` · `value` (ms) · `route_group=login` · `navigation_type` · `warm_path`: `immediate` \| `idle` \| `intent` | Did Tier 0 shrink time-to-ready? |
+| `auth_google_timing` | After Google attempt settles (success or error) | `phase`: `click_to_popup` (ms from click until `signInWithPopup`/`Redirect` invoked) · optional `phase`: `credential_to_nav` (ms until leave `/login`) · `method=google` · `auth_flow` · `outcome`: `success` \| `error` · `error_code?` | Is click path sync (near-0 `click_to_popup`)? Post-OAuth still heavy? |
+| `auth_cta_gated` (optional, low volume) | First paint of disabled Google CTA | `route_group=login` | Prove gate is active (DebugView / rare Exploration) |
+
+**Marks (implementation sketch, not shipped):**
+
+```text
+login paint     → performance.mark('auth_login_paint')
+surface ready   → mark('auth_surface_ready') + measure → auth_surface_timing
+Google click    → mark('auth_google_click')
+popup/redirect  → mark('auth_google_oauth_start') + measure click→start → auth_google_timing phase=click_to_popup
+login success   → measure oauth_start→navigate → phase=credential_to_nav
+```
+
+Wire from `LoginPage` / `warmLoginAuthSurface` / `useSplashSignIn|Up.handleGoogle` — keep emitters in `authAnalytics.js` next to existing auth events.
+
+### 7.3 Auth quality listeners (already half there)
+
+| Check after Tier 0/1 | How |
+|----------------------|-----|
+| First-tap failures drop | `auth_error` where `method=google` and `error_code` in (`auth/popup-blocked`, `auth/cancelled-popup-request`, `unknown`) — rate vs `login`+`sign_up` google |
+| Redirect adoption (Tier 1) | `login` / `auth_error` split by `auth_flow` (`popup` \| `redirect`) — register `auth_flow` as custom dimension if not already |
+| Content not regressed | p75 `web_vital` LCP for `splash` / `marketing` / `tour_stats` unchanged vs pre-Tier-0 week |
+
+### 7.4 What not to add
+
+| Skip | Why |
+|------|-----|
+| Per-chunk download timings to GA4 | Noisy; Network panel / human Safari enough for Tier 0 |
+| Emitting RUM on localhost/preview | Same host gate as #801 |
+| Replacing human Safari AC | Chromium QA + GA4 cannot prove WebKit gesture |
+| Dual systems (Vercel Speed Insights) | Optional later; one RUM path first |
+
+### 7.5 Implementation order with tiers
+
+1. **With Tier 0 PR:** `route_group` splits (§7.1) + `auth_surface_timing` + `auth_google_timing` `click_to_popup` (§7.2). Update `AUTH_TELEMETRY_RUNBOOK.md` + `WEB_VITALS_RUM.md` + register GA4 dims/metrics.  
+2. **With Tier 1:** ensure `auth_flow` on all google success/error; Exploration by flow.  
+3. **With Tier 2:** optional `warm_path=intent` on `auth_surface_timing` when marketing prefetch shortens `paint_to_ready`.
+
+### 7.6 Soak dashboard (manual GA4 recipe)
+
+1. Explore → Free form, last 7 days, device mobile, browser Safari (when sample allows).  
+2. **Content:** `web_vital` / LCP p75 by `route_group` ∈ {`splash`,`marketing`,`tour_stats`}.  
+3. **Auth ready:** `auth_surface_timing` / `paint_to_ready` p75.  
+4. **Auth click:** `auth_google_timing` / `click_to_popup` p75 (target: ~0–50ms after Tier 0).  
+5. **Auth errors:** `auth_error` count / google attempts — expect drop vs week before Tier 0.

--- a/docs/AUTH_TELEMETRY_RUNBOOK.md
+++ b/docs/AUTH_TELEMETRY_RUNBOOK.md
@@ -26,6 +26,20 @@ on `setlistpickem.com` (prod) — preview/staging/localhost stay silent.
 | `auth_partial_profile` | `DashboardRoute` | `has_consent` (`true`/`false`), `surface` (`dashboard_route`) | **ANOMALY** — `users/{uid}` exists but `handle` missing |
 | `auth_rollback` | `useSplashSignUp` | `method`, `stage` (`consent_write`) | Post-signup Firestore write failed; Auth account deletion initiated |
 | `auth_rollback_failed` | `useSplashSignUp` | `method`, `error_code` | The `deleteUser` rollback itself failed — phantom Auth account exists |
+| `auth_surface_timing` | `warmLoginAuthSurface` / `authLoginTiming` (**v1.49.1 / #857**) | `phase` (`paint_to_ready`), `value` (ms), `route_group` (`login`), `warm_path` (`immediate` \| `idle` \| `intent`), `navigation_type` | Once per `/login` visit when Auth + click-path modules finish warming |
+| `auth_google_timing` | `useSplashSignIn` / `useSplashSignUp` (**v1.49.1 / #857**) | `phase` (`click_to_popup` \| `credential_to_nav`), `value` (ms), `method` (`google`), `auth_flow`, `outcome` (`success` \| `error`), `error_code?` | Click→OAuth invoke latency; optional post-credential leave-login latency |
+
+### 1.1 Auth / content soak (epic #856)
+
+Plan: [`docs/AUTH_SEAMLESS_PATH.md`](AUTH_SEAMLESS_PATH.md) §7. Field RUM groups: [`docs/WEB_VITALS_RUM.md`](WEB_VITALS_RUM.md).
+
+1. Explore → Free form, last 7 days, device mobile, browser Safari (when sample allows).
+2. **Content:** `web_vital` / LCP p75 by `route_group` ∈ {`splash`,`marketing`,`tour_stats`}.
+3. **Auth ready:** `auth_surface_timing` / `paint_to_ready` p75.
+4. **Auth click:** `auth_google_timing` / `click_to_popup` p75 (Tier 0 target after T0b: ~0–50ms).
+5. **Auth errors:** `auth_error` count / google attempts — expect drop vs week before Tier 0.
+
+Outliers `value` > 60s are omitted client-side.
 
 ## 2. Required GA4 console configuration
 
@@ -46,6 +60,18 @@ custom dimensions. Same for the params on the new events.
 | `auth_rollback_stage` | Event | `stage` | Which post-signup write failed (`consent_write`) |
 | `auth_partial_has_consent` | Event | `has_consent` | Whether the partial doc has `termsPrivacyAcceptedAt` |
 | `auth_partial_surface` | Event | `surface` | Auth UI/route context — `sign_in`, `create_account`, or `dashboard_route` (partial-profile anomaly) |
+| `auth_timing_phase` | Event | `phase` | Timing phase — `paint_to_ready`, `click_to_popup`, `credential_to_nav` (#857) |
+| `auth_warm_path` | Event | `warm_path` | How `/login` Auth warm started — `immediate`, `idle`, `intent` (#857) |
+| `auth_flow` | Event | `auth_flow` | Google OAuth transport — `popup` or `redirect` |
+| `auth_timing_outcome` | Event | `outcome` | Timing sample outcome — `success` or `error` (#857) |
+
+**Custom metrics (Event scope)** — register once if Explorations need p75 of `value` on timing events:
+
+| Metric name (UI) | Event parameter | Unit |
+|---|---|---|
+| `auth_timing_ms` | `value` | Milliseconds |
+
+(`web_vital` already uses `value` / `route_group` / `navigation_type` — reuse those definitions; add `login` / `marketing` / `tour_stats` to any enum filters.)
 
 Historical data is **not backfilled**. New events landing after
 registration become queryable via `run_report` with

--- a/docs/RELEASE_TRAIN_COLD_OPEN.md
+++ b/docs/RELEASE_TRAIN_COLD_OPEN.md
@@ -4,7 +4,8 @@
 
 **Do not revive:** issue #831 hand-built HTML stub (lost branding, scoring graphics, live tour stats).
 
-**Auth / App Check sequencing (standing):** `docs/AUTH_BOOT_PRACTICES.md` — idle-warm Auth after paint; never await App Check before `signInWithPopup` (#850).
+**Auth / App Check sequencing (standing):** `docs/AUTH_BOOT_PRACTICES.md` — idle-warm Auth after paint; never await App Check before `signInWithPopup` (#850).  
+**Top-tier auth feel / residual first-tap race:** `docs/AUTH_SEAMLESS_PATH.md` · delivery epic [#856](https://github.com/pat792/set-picks/issues/856) (T0a–T3: #857–#861).
 
 ---
 

--- a/docs/WEB_VITALS_RUM.md
+++ b/docs/WEB_VITALS_RUM.md
@@ -23,10 +23,20 @@ Metrics: **LCP**, **INP**, **CLS**, **TTFB**, **FCP**.
 | `value` | LCP/INP/TTFB/FCP: ms rounded; CLS: 3 decimals |
 | `metric_id` | web-vitals id (keeps CLS updates distinct from GA dedupe) |
 | `metric_rating` | `good` \| `needs-improvement` \| `poor` |
-| `route_group` | `splash` \| `invite_join` \| `invite_site` \| `dashboard` \| `setup` \| `other` |
+| `route_group` | `splash` \| `login` \| `marketing` \| `tour_stats` \| `invite_join` \| `invite_site` \| `dashboard` \| `setup` \| `other` (**v1.49.1 / #857**) |
 | `navigation_type` | `navigate` \| `reload` \| `back_forward` \| `prerender` |
 
 Declared in [`docs/API.md`](API.md) §3.
+
+### `route_group` map (#857)
+
+| Path | `route_group` |
+|------|---------------|
+| `/` | `splash` |
+| `/login` | `login` |
+| `/how-it-works`, `/how-scoring-works`, `/phish-setlist-prediction-game` | `marketing` |
+| `/tour-stats*` | `tour_stats` |
+| `/join*`, `/invite/*`, `/dashboard*`, `/setup*` | unchanged |
 
 ## GA4 Exploration recipe
 
@@ -35,9 +45,13 @@ Declared in [`docs/API.md`](API.md) §3.
 3. Values: `value` (custom metric) or Event count
 4. Filter: Event name = `web_vital`, `metric_name` = `LCP` (or INP/CLS)
 5. Optional: split by Device category / Browser to match the 82% mobile / iOS audience
-6. Compare **p75** of `value` by `route_group` after Sprint 12 Wave 1 lands
+6. Compare **p75** of `value` by `route_group` — especially `splash` / `marketing` / `tour_stats` / `login` / `dashboard`
 
-DebugView: open production with GA DebugView (or Tag Assistant) and hard-reload `/`, `/join/:code`, `/dashboard` — expect one `web_vital` per metric as they settle.
+DebugView: open production with GA DebugView (or Tag Assistant) and hard-reload `/`, `/login`, `/tour-stats`, `/join/:code`, `/dashboard` — expect one `web_vital` per metric as they settle.
+
+## Related — auth interaction timings
+
+Auth surface / Google click timings (`auth_surface_timing`, `auth_google_timing`): [`docs/AUTH_TELEMETRY_RUNBOOK.md`](AUTH_TELEMETRY_RUNBOOK.md) §1.1 · plan [`docs/AUTH_SEAMLESS_PATH.md`](AUTH_SEAMLESS_PATH.md) §7.
 
 ## Non-goals
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.49.0",
+  "version": "1.49.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/auth/login.js
+++ b/src/features/auth/login.js
@@ -7,6 +7,7 @@ export { default as LoginAuthScreen } from './ui/LoginAuthScreen';
 export { AuthProvider, useAuth } from './provider.js';
 export { useGoogleRedirectCompletion } from './model/useGoogleRedirectCompletion';
 export { warmLoginAuthSurface } from './model/warmLoginAuthSurface';
+export { markLoginAuthPaint } from './model/authLoginTiming';
 export {
   stashSplashResumeAuthModal,
   consumeSplashResumeAuthModal,

--- a/src/features/auth/model/authAnalytics.js
+++ b/src/features/auth/model/authAnalytics.js
@@ -1,11 +1,72 @@
 import { ga4Event } from '../../../shared/lib/ga4';
 
 /** @typedef {'sign_in' | 'create_account'} AuthModalSurface */
+/** @typedef {'immediate' | 'idle' | 'intent'} AuthWarmPath */
+/** @typedef {'popup' | 'redirect'} AuthFlow */
+/** @typedef {'success' | 'error'} AuthTimingOutcome */
+
+/** Drop absurd outliers (tab backgrounded, etc.) — AUTH_SEAMLESS_PATH §7.2 */
+export const AUTH_TIMING_MAX_MS = 60_000;
 
 function mirrorAuthTelemetry(event, params) {
   if (import.meta.env.DEV) {
     console.info(`[telemetry] ${event}`, params);
   }
+}
+
+/**
+ * Round and cap timing ms for GA4. Returns null when the sample should be omitted.
+ * @param {number} ms
+ * @returns {number | null}
+ */
+export function clampAuthTimingMs(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return null;
+  const rounded = Math.round(ms);
+  if (rounded > AUTH_TIMING_MAX_MS) return null;
+  return rounded;
+}
+
+/**
+ * @param {{
+ *   valueMs: number,
+ *   warmPath?: AuthWarmPath,
+ *   navigationType?: string,
+ * }} input
+ * @returns {Record<string, string | number> | null}
+ */
+export function buildAuthSurfaceTimingParams(input) {
+  const value = clampAuthTimingMs(input.valueMs);
+  if (value == null) return null;
+  return {
+    phase: 'paint_to_ready',
+    value,
+    route_group: 'login',
+    warm_path: input.warmPath || 'idle',
+    navigation_type: input.navigationType || 'navigate',
+  };
+}
+
+/**
+ * @param {{
+ *   phase: 'click_to_popup' | 'credential_to_nav',
+ *   valueMs: number,
+ *   authFlow?: AuthFlow,
+ *   outcome: AuthTimingOutcome,
+ *   errorCode?: string,
+ * }} input
+ * @returns {Record<string, string | number> | null}
+ */
+export function buildAuthGoogleTimingParams(input) {
+  const value = clampAuthTimingMs(input.valueMs);
+  if (value == null) return null;
+  return {
+    phase: input.phase,
+    value,
+    method: 'google',
+    auth_flow: input.authFlow || 'popup',
+    outcome: input.outcome,
+    ...(input.errorCode ? { error_code: input.errorCode } : {}),
+  };
 }
 
 /**
@@ -107,4 +168,36 @@ export function trackAuthRollbackFailed(payload) {
   };
   mirrorAuthTelemetry('auth_rollback_failed', params);
   ga4Event('auth_rollback_failed', params);
+}
+
+/**
+ * `/login` Auth surface ready (paint → warm complete). Once per visit (#857).
+ * @param {{
+ *   valueMs: number,
+ *   warmPath?: AuthWarmPath,
+ *   navigationType?: string,
+ * }} payload
+ */
+export function trackAuthSurfaceTiming(payload) {
+  const params = buildAuthSurfaceTimingParams(payload);
+  if (!params) return;
+  mirrorAuthTelemetry('auth_surface_timing', params);
+  ga4Event('auth_surface_timing', params);
+}
+
+/**
+ * Google OAuth interaction timing on `/login` (#857).
+ * @param {{
+ *   phase: 'click_to_popup' | 'credential_to_nav',
+ *   valueMs: number,
+ *   authFlow?: AuthFlow,
+ *   outcome: AuthTimingOutcome,
+ *   errorCode?: string,
+ * }} payload
+ */
+export function trackAuthGoogleTiming(payload) {
+  const params = buildAuthGoogleTimingParams(payload);
+  if (!params) return;
+  mirrorAuthTelemetry('auth_google_timing', params);
+  ga4Event('auth_google_timing', params);
 }

--- a/src/features/auth/model/authAnalytics.test.js
+++ b/src/features/auth/model/authAnalytics.test.js
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../shared/lib/ga4', () => ({
+  ga4Event: vi.fn(),
+}));
+
+import { ga4Event } from '../../../shared/lib/ga4';
+import {
+  AUTH_TIMING_MAX_MS,
+  buildAuthGoogleTimingParams,
+  buildAuthSurfaceTimingParams,
+  clampAuthTimingMs,
+  trackAuthGoogleTiming,
+  trackAuthSurfaceTiming,
+} from './authAnalytics.js';
+
+describe('clampAuthTimingMs', () => {
+  it('rounds and rejects outliers', () => {
+    expect(clampAuthTimingMs(12.6)).toBe(13);
+    expect(clampAuthTimingMs(-1)).toBeNull();
+    expect(clampAuthTimingMs(AUTH_TIMING_MAX_MS + 1)).toBeNull();
+    expect(clampAuthTimingMs(Number.NaN)).toBeNull();
+  });
+});
+
+describe('buildAuthSurfaceTimingParams', () => {
+  it('builds paint_to_ready params', () => {
+    expect(
+      buildAuthSurfaceTimingParams({
+        valueMs: 420.4,
+        warmPath: 'idle',
+        navigationType: 'navigate',
+      }),
+    ).toEqual({
+      phase: 'paint_to_ready',
+      value: 420,
+      route_group: 'login',
+      warm_path: 'idle',
+      navigation_type: 'navigate',
+    });
+  });
+
+  it('omits absurd values', () => {
+    expect(
+      buildAuthSurfaceTimingParams({ valueMs: AUTH_TIMING_MAX_MS + 50 }),
+    ).toBeNull();
+  });
+});
+
+describe('buildAuthGoogleTimingParams', () => {
+  it('builds click_to_popup params', () => {
+    expect(
+      buildAuthGoogleTimingParams({
+        phase: 'click_to_popup',
+        valueMs: 8.2,
+        authFlow: 'popup',
+        outcome: 'success',
+      }),
+    ).toEqual({
+      phase: 'click_to_popup',
+      value: 8,
+      method: 'google',
+      auth_flow: 'popup',
+      outcome: 'success',
+    });
+  });
+
+  it('includes error_code on failures', () => {
+    expect(
+      buildAuthGoogleTimingParams({
+        phase: 'click_to_popup',
+        valueMs: 120,
+        authFlow: 'redirect',
+        outcome: 'error',
+        errorCode: 'auth/popup-blocked',
+      }),
+    ).toEqual({
+      phase: 'click_to_popup',
+      value: 120,
+      method: 'google',
+      auth_flow: 'redirect',
+      outcome: 'error',
+      error_code: 'auth/popup-blocked',
+    });
+  });
+});
+
+describe('trackAuth*Timing', () => {
+  beforeEach(() => {
+    ga4Event.mockClear();
+  });
+
+  it('emits surface + google timing via ga4Event', () => {
+    trackAuthSurfaceTiming({
+      valueMs: 100,
+      warmPath: 'intent',
+      navigationType: 'reload',
+    });
+    trackAuthGoogleTiming({
+      phase: 'credential_to_nav',
+      valueMs: 50,
+      authFlow: 'popup',
+      outcome: 'success',
+    });
+
+    expect(ga4Event).toHaveBeenNthCalledWith(1, 'auth_surface_timing', {
+      phase: 'paint_to_ready',
+      value: 100,
+      route_group: 'login',
+      warm_path: 'intent',
+      navigation_type: 'reload',
+    });
+    expect(ga4Event).toHaveBeenNthCalledWith(2, 'auth_google_timing', {
+      phase: 'credential_to_nav',
+      value: 50,
+      method: 'google',
+      auth_flow: 'popup',
+      outcome: 'success',
+    });
+  });
+
+  it('skips emit when value is capped out', () => {
+    trackAuthSurfaceTiming({ valueMs: AUTH_TIMING_MAX_MS + 1 });
+    expect(ga4Event).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/auth/model/authLoginTiming.js
+++ b/src/features/auth/model/authLoginTiming.js
@@ -1,0 +1,131 @@
+/**
+ * Performance marks + GA4 timing for `/login` Google auth (#857).
+ * Marks are best-effort; emitters no-op off prod host via ga4Event.
+ */
+
+import { resolveNavigationType } from '../../../shared/lib/webVitals';
+import {
+  trackAuthGoogleTiming,
+  trackAuthSurfaceTiming,
+} from './authAnalytics';
+
+export const AUTH_LOGIN_PAINT_MARK = 'auth_login_paint';
+export const AUTH_SURFACE_READY_MARK = 'auth_surface_ready';
+export const AUTH_GOOGLE_CLICK_MARK = 'auth_google_click';
+export const AUTH_GOOGLE_OAUTH_START_MARK = 'auth_google_oauth_start';
+
+let paintMarked = false;
+let surfaceTimingSent = false;
+/** @type {number | null} */
+let googleClickAt = null;
+/** @type {number | null} */
+let googleOauthStartAt = null;
+
+function nowMs() {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+function safeMark(name) {
+  try {
+    performance?.mark?.(name);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Call once when `/login` form paints (before idle warm).
+ */
+export function markLoginAuthPaint() {
+  if (paintMarked) return;
+  paintMarked = true;
+  safeMark(AUTH_LOGIN_PAINT_MARK);
+}
+
+/**
+ * Emit `auth_surface_timing` once when Auth warm completes.
+ * @param {{ warmPath?: 'immediate' | 'idle' | 'intent' }} [opts]
+ */
+export function reportLoginAuthSurfaceReady(opts = {}) {
+  if (surfaceTimingSent) return;
+  surfaceTimingSent = true;
+  safeMark(AUTH_SURFACE_READY_MARK);
+  const paintAt = (() => {
+    try {
+      const entry = performance
+        ?.getEntriesByName?.(AUTH_LOGIN_PAINT_MARK, 'mark')
+        ?.[0];
+      return entry?.startTime ?? null;
+    } catch {
+      return null;
+    }
+  })();
+  const readyAt = nowMs();
+  const valueMs = paintAt == null ? readyAt : readyAt - paintAt;
+  trackAuthSurfaceTiming({
+    valueMs,
+    warmPath: opts.warmPath || 'idle',
+    navigationType: resolveNavigationType(),
+  });
+}
+
+/**
+ * Mark Google CTA click (start of click_to_popup).
+ */
+export function markGoogleAuthClick() {
+  googleClickAt = nowMs();
+  googleOauthStartAt = null;
+  safeMark(AUTH_GOOGLE_CLICK_MARK);
+}
+
+/**
+ * Mark immediately before `signInWithPopup` / `signInWithRedirect`.
+ */
+export function markGoogleOauthStart() {
+  googleOauthStartAt = nowMs();
+  safeMark(AUTH_GOOGLE_OAUTH_START_MARK);
+}
+
+/**
+ * Emit click→OAuth timing after the Google attempt settles.
+ * @param {{
+ *   authFlow: 'popup' | 'redirect',
+ *   outcome: 'success' | 'error',
+ *   errorCode?: string,
+ * }} payload
+ */
+export function trackGoogleClickToOauthTiming(payload) {
+  if (googleClickAt == null || googleOauthStartAt == null) return;
+  trackAuthGoogleTiming({
+    phase: 'click_to_popup',
+    valueMs: googleOauthStartAt - googleClickAt,
+    authFlow: payload.authFlow,
+    outcome: payload.outcome,
+    errorCode: payload.errorCode,
+  });
+}
+
+/**
+ * Emit OAuth-start → leave-login timing on success.
+ * @param {{ authFlow: 'popup' | 'redirect' }} payload
+ */
+export function trackGoogleCredentialToNavTiming(payload) {
+  if (googleOauthStartAt == null) return;
+  trackAuthGoogleTiming({
+    phase: 'credential_to_nav',
+    valueMs: nowMs() - googleOauthStartAt,
+    authFlow: payload.authFlow,
+    outcome: 'success',
+  });
+}
+
+/** @visibleForTesting */
+export function resetAuthLoginTimingForTests() {
+  paintMarked = false;
+  surfaceTimingSent = false;
+  googleClickAt = null;
+  googleOauthStartAt = null;
+}

--- a/src/features/auth/model/useSplashSignIn.js
+++ b/src/features/auth/model/useSplashSignIn.js
@@ -9,6 +9,12 @@ import {
 } from '../utils/splashGoogleModalInflight';
 import { stashGoogleRedirectIntent } from '../utils/googleRedirectIntent';
 import { trackAuthError, trackAuthLogin } from './authAnalytics';
+import {
+  markGoogleAuthClick,
+  markGoogleOauthStart,
+  trackGoogleClickToOauthTiming,
+  trackGoogleCredentialToNavTiming,
+} from './authLoginTiming';
 
 export function useSplashSignIn(isOpen, onClose, { seedError = '' } = {}) {
   const [email, setEmail] = useState('');
@@ -55,6 +61,9 @@ export function useSplashSignIn(isOpen, onClose, { seedError = '' } = {}) {
     setError('');
     setBusy(true);
     setSplashGoogleModalInflight();
+    markGoogleAuthClick();
+    const authFlow = inAppBrowser ? 'redirect' : 'popup';
+    let oauthMarked = false;
     try {
       const { auth } = await ensureAuthReady();
       const [{ signInWithGoogle, startGoogleSignInRedirect }, { completeGoogleSplashAuth }] =
@@ -64,11 +73,19 @@ export function useSplashSignIn(isOpen, onClose, { seedError = '' } = {}) {
         ]);
       if (inAppBrowser) {
         stashGoogleRedirectIntent('signin');
+        markGoogleOauthStart();
+        oauthMarked = true;
+        trackGoogleClickToOauthTiming({
+          authFlow: 'redirect',
+          outcome: 'success',
+        });
         await startGoogleSignInRedirect(auth);
         // Navigates away — leave busy/inflight set until unload.
         return;
       }
 
+      markGoogleOauthStart();
+      oauthMarked = true;
       const { isNewUser } = await signInWithGoogle(auth);
       const outcome = await completeGoogleSplashAuth({
         intent: 'signin',
@@ -76,17 +93,34 @@ export function useSplashSignIn(isOpen, onClose, { seedError = '' } = {}) {
         flow: 'popup',
       });
       if (outcome.kind === 'error') {
+        trackGoogleClickToOauthTiming({
+          authFlow: 'popup',
+          outcome: 'error',
+          errorCode: 'complete_error',
+        });
         setError(outcome.message);
         return;
       }
+      trackGoogleClickToOauthTiming({
+        authFlow: 'popup',
+        outcome: 'success',
+      });
+      trackGoogleCredentialToNavTiming({ authFlow: 'popup' });
       closeModal();
     } catch (err) {
       console.error('Google sign-in:', err);
+      if (oauthMarked) {
+        trackGoogleClickToOauthTiming({
+          authFlow,
+          outcome: 'error',
+          errorCode: err.code || 'unknown',
+        });
+      }
       trackAuthError({
         method: 'google',
         error_code: err.code,
         surface: 'sign_in',
-        auth_flow: inAppBrowser ? 'redirect' : 'popup',
+        auth_flow: authFlow,
       });
       setError(getFirebaseAuthErrorMessage(err.code));
     } finally {

--- a/src/features/auth/model/useSplashSignUp.js
+++ b/src/features/auth/model/useSplashSignUp.js
@@ -14,6 +14,12 @@ import {
   trackAuthRollbackFailed,
   trackAuthSignUp,
 } from './authAnalytics';
+import {
+  markGoogleAuthClick,
+  markGoogleOauthStart,
+  trackGoogleClickToOauthTiming,
+  trackGoogleCredentialToNavTiming,
+} from './authLoginTiming';
 
 export function useSplashSignUp(isOpen, onClose, { seedError = '' } = {}) {
   const [email, setEmail] = useState('');
@@ -66,6 +72,9 @@ export function useSplashSignUp(isOpen, onClose, { seedError = '' } = {}) {
     }
     setBusy(true);
     setSplashGoogleModalInflight();
+    markGoogleAuthClick();
+    const authFlow = inAppBrowser ? 'redirect' : 'popup';
+    let oauthMarked = false;
     try {
       const { auth } = await ensureAuthReady();
       const [{ signInWithGoogle, startGoogleSignInRedirect }, { completeGoogleSplashAuth }] =
@@ -75,10 +84,18 @@ export function useSplashSignUp(isOpen, onClose, { seedError = '' } = {}) {
         ]);
       if (inAppBrowser) {
         stashGoogleRedirectIntent('signup');
+        markGoogleOauthStart();
+        oauthMarked = true;
+        trackGoogleClickToOauthTiming({
+          authFlow: 'redirect',
+          outcome: 'success',
+        });
         await startGoogleSignInRedirect(auth);
         return;
       }
 
+      markGoogleOauthStart();
+      oauthMarked = true;
       const { isNewUser } = await signInWithGoogle(auth);
       const outcome = await completeGoogleSplashAuth({
         intent: 'signup',
@@ -86,17 +103,34 @@ export function useSplashSignUp(isOpen, onClose, { seedError = '' } = {}) {
         flow: 'popup',
       });
       if (outcome.kind === 'error') {
+        trackGoogleClickToOauthTiming({
+          authFlow: 'popup',
+          outcome: 'error',
+          errorCode: 'complete_error',
+        });
         setError(outcome.message);
         return;
       }
+      trackGoogleClickToOauthTiming({
+        authFlow: 'popup',
+        outcome: 'success',
+      });
+      trackGoogleCredentialToNavTiming({ authFlow: 'popup' });
       closeModal();
     } catch (err) {
       console.error('Google sign-in:', err);
+      if (oauthMarked) {
+        trackGoogleClickToOauthTiming({
+          authFlow,
+          outcome: 'error',
+          errorCode: err.code || 'unknown',
+        });
+      }
       trackAuthError({
         method: 'google',
         error_code: err.code,
         surface: 'create_account',
-        auth_flow: inAppBrowser ? 'redirect' : 'popup',
+        auth_flow: authFlow,
       });
       setError(getFirebaseAuthErrorMessage(err.code));
     } finally {

--- a/src/features/auth/model/warmLoginAuthSurface.js
+++ b/src/features/auth/model/warmLoginAuthSurface.js
@@ -1,9 +1,11 @@
 /**
- * Post-paint warm for `/login` (#850).
+ * Post-paint warm for `/login` (#850 / #857).
  *
  * SPA practice: Auth SDK ready before Continue with Google so Safari keeps the
  * user gesture for `signInWithPopup`. App Check warms in parallel (not awaited).
  * Dashboard/setup chunks prefetch so post-auth navigation is not a cold download.
+ *
+ * #857: when Auth + click-path modules resolve, emit `auth_surface_timing`.
  */
 
 import {
@@ -12,20 +14,39 @@ import {
   requestAuthBoot,
 } from '../../../shared/lib/ensureFirebase';
 import { prefetchRouteChunk } from '../../../shared/lib/routeChunkPrefetch';
+import { reportLoginAuthSurfaceReady } from './authLoginTiming';
 
 let warmed = false;
+/** @type {'immediate' | 'idle' | 'intent'} */
+let warmPathUsed = 'idle';
+/** @type {Promise<void> | null} */
+let readyPromise = null;
 
 /**
  * Idempotent warm after `/login` form paint (or Google button intent).
+ * @param {{ warmPath?: 'immediate' | 'idle' | 'intent' }} [opts]
+ * @returns {Promise<void>}
  */
-export function warmLoginAuthSurface() {
-  if (warmed) return;
-  warmed = true;
-
-  void ensureFirebase().then(() => {
-    requestAuthBoot();
-  });
-  kickAppCheckWarm();
-  void import('../api/splashAuthApi');
-  prefetchRouteChunk(['dashboard', 'setup']);
+export function warmLoginAuthSurface(opts = {}) {
+  if (!warmed) {
+    warmed = true;
+    warmPathUsed = opts.warmPath || 'idle';
+    readyPromise = (async () => {
+      try {
+        await ensureFirebase().then(() => {
+          requestAuthBoot();
+        });
+        kickAppCheckWarm();
+        await Promise.all([
+          import('../api/splashAuthApi'),
+          import('./completeGoogleSplashAuth'),
+        ]);
+        reportLoginAuthSurfaceReady({ warmPath: warmPathUsed });
+      } catch {
+        // Best-effort warm + telemetry — CTAs still call ensureAuthReady.
+      }
+    })();
+    prefetchRouteChunk(['dashboard', 'setup']);
+  }
+  return readyPromise || Promise.resolve();
 }

--- a/src/features/auth/model/warmLoginAuthSurface.test.js
+++ b/src/features/auth/model/warmLoginAuthSurface.test.js
@@ -4,6 +4,7 @@ const ensureFirebase = vi.fn(async () => ({ auth: {} }));
 const requestAuthBoot = vi.fn();
 const kickAppCheckWarm = vi.fn();
 const prefetchRouteChunk = vi.fn();
+const reportLoginAuthSurfaceReady = vi.fn();
 
 vi.mock('../../../shared/lib/ensureFirebase.js', () => ({
   ensureFirebase: (...args) => ensureFirebase(...args),
@@ -16,6 +17,10 @@ vi.mock('../../../shared/lib/routeChunkPrefetch.js', () => ({
 }));
 
 vi.mock('../api/splashAuthApi.js', () => ({}));
+vi.mock('./completeGoogleSplashAuth.js', () => ({}));
+vi.mock('./authLoginTiming.js', () => ({
+  reportLoginAuthSurfaceReady: (...args) => reportLoginAuthSurfaceReady(...args),
+}));
 
 describe('warmLoginAuthSurface', () => {
   beforeEach(() => {
@@ -23,16 +28,16 @@ describe('warmLoginAuthSurface', () => {
     vi.clearAllMocks();
   });
 
-  it('warms Auth, App Check, and dashboard/setup once', async () => {
+  it('warms Auth, App Check, click modules, and dashboard/setup once', async () => {
     const { warmLoginAuthSurface } = await import('./warmLoginAuthSurface.js');
-    warmLoginAuthSurface();
-    warmLoginAuthSurface();
-    await Promise.resolve();
-    await Promise.resolve();
+    await warmLoginAuthSurface({ warmPath: 'idle' });
+    await warmLoginAuthSurface({ warmPath: 'intent' });
 
     expect(ensureFirebase).toHaveBeenCalledTimes(1);
     expect(kickAppCheckWarm).toHaveBeenCalledTimes(1);
     expect(prefetchRouteChunk).toHaveBeenCalledWith(['dashboard', 'setup']);
     expect(requestAuthBoot).toHaveBeenCalledTimes(1);
+    expect(reportLoginAuthSurfaceReady).toHaveBeenCalledTimes(1);
+    expect(reportLoginAuthSurfaceReady).toHaveBeenCalledWith({ warmPath: 'idle' });
   });
 });

--- a/src/features/auth/ui/LoginAuthScreen.jsx
+++ b/src/features/auth/ui/LoginAuthScreen.jsx
@@ -98,7 +98,9 @@ function LoginSignInPanel({
     <SplashAuthPanel
       title="Sign in"
       handleGoogle={handleGoogle}
-      onGoogleIntent={warmLoginAuthSurface}
+      onGoogleIntent={() => {
+        void warmLoginAuthSurface({ warmPath: 'intent' });
+      }}
       busy={busy}
       prependContent={prependContent}
       googleFootnote={
@@ -275,7 +277,9 @@ function LoginSignUpPanel({
     <SplashAuthPanel
       title="Create account"
       handleGoogle={handleGoogle}
-      onGoogleIntent={warmLoginAuthSurface}
+      onGoogleIntent={() => {
+        void warmLoginAuthSurface({ warmPath: 'intent' });
+      }}
       busy={busy}
       googleDisabled={busy || !legalAccepted}
       prependContent={prependContent}

--- a/src/pages/auth/LoginPage.jsx
+++ b/src/pages/auth/LoginPage.jsx
@@ -9,6 +9,7 @@ import {
 import {
   LoginAuthScreen,
   consumeSplashResumeAuthModal,
+  markLoginAuthPaint,
   useAuth,
   useGoogleRedirectCompletion,
   warmLoginAuthSurface,
@@ -77,8 +78,12 @@ export default function LoginPage() {
 
   // After form paint: warm Auth (+ parallel App Check) so Safari Google popup
   // stays inside the user gesture (#850). Marketing `/` stays Firebase-free.
+  // #857: mark paint for auth_surface_timing (paint_to_ready).
   useEffect(() => {
-    const start = () => warmLoginAuthSurface();
+    markLoginAuthPaint();
+    const start = () => {
+      void warmLoginAuthSurface({ warmPath: 'idle' });
+    };
     if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
       const id = window.requestIdleCallback(start, { timeout: 800 });
       return () => {

--- a/src/shared/lib/routeGroup.js
+++ b/src/shared/lib/routeGroup.js
@@ -1,14 +1,37 @@
 /**
- * Coarse route groups for field RUM / GA4 (#801).
+ * Coarse route groups for field RUM / GA4 (#801 / #857).
  * Keep values stable — they are Exploration dimensions.
  *
  * @param {string} [pathname]
- * @returns {'splash' | 'invite_join' | 'invite_site' | 'dashboard' | 'setup' | 'other'}
+ * @returns {
+ *   | 'splash'
+ *   | 'login'
+ *   | 'marketing'
+ *   | 'tour_stats'
+ *   | 'invite_join'
+ *   | 'invite_site'
+ *   | 'dashboard'
+ *   | 'setup'
+ *   | 'other'
+ * }
  */
 export function resolveRouteGroup(pathname) {
   if (typeof pathname !== 'string' || !pathname) return 'other';
   if (pathname === '/') return 'splash';
-  if (pathname === '/login' || pathname.startsWith('/login/')) return 'other';
+  if (pathname === '/login' || pathname.startsWith('/login/')) return 'login';
+  if (
+    pathname === '/how-it-works' ||
+    pathname.startsWith('/how-it-works/') ||
+    pathname === '/how-scoring-works' ||
+    pathname.startsWith('/how-scoring-works/') ||
+    pathname === '/phish-setlist-prediction-game' ||
+    pathname.startsWith('/phish-setlist-prediction-game/')
+  ) {
+    return 'marketing';
+  }
+  if (pathname === '/tour-stats' || pathname.startsWith('/tour-stats/')) {
+    return 'tour_stats';
+  }
   if (pathname === '/setup' || pathname.startsWith('/setup/')) return 'setup';
   if (pathname === '/dashboard' || pathname.startsWith('/dashboard/')) {
     return 'dashboard';

--- a/src/shared/lib/routeGroup.test.js
+++ b/src/shared/lib/routeGroup.test.js
@@ -12,8 +12,17 @@ describe('resolveRouteGroup', () => {
     expect(resolveRouteGroup('/setup')).toBe('setup');
   });
 
-  it('maps marketing / unknown to other', () => {
-    expect(resolveRouteGroup('/how-it-works')).toBe('other');
+  it('maps login, marketing, and public tour-stats (#857)', () => {
+    expect(resolveRouteGroup('/login')).toBe('login');
+    expect(resolveRouteGroup('/login/')).toBe('login');
+    expect(resolveRouteGroup('/how-it-works')).toBe('marketing');
+    expect(resolveRouteGroup('/how-scoring-works')).toBe('marketing');
+    expect(resolveRouteGroup('/phish-setlist-prediction-game')).toBe('marketing');
+    expect(resolveRouteGroup('/tour-stats')).toBe('tour_stats');
+    expect(resolveRouteGroup('/tour-stats/song/foo')).toBe('tour_stats');
+  });
+
+  it('maps unknown paths to other', () => {
     expect(resolveRouteGroup('/privacy')).toBe('other');
     expect(resolveRouteGroup('')).toBe('other');
     expect(resolveRouteGroup(undefined)).toBe('other');


### PR DESCRIPTION
Closes #857
Part of epic #856

## Summary
- Extend `resolveRouteGroup` with `login`, `marketing`, and `tour_stats` so content vs auth RUM can be split in GA4 Explorations
- Emit `auth_surface_timing` (paint→Auth warm ready) and `auth_google_timing` (click→OAuth / credential→nav) via existing prod-only `ga4Event` gate
- Wire marks from `/login` paint → warm ready → Google click → OAuth start
- Document events + GA4 registration checklist in `AUTH_TELEMETRY_RUNBOOK.md` / `WEB_VITALS_RUM.md` / `API.md`; add path doc `AUTH_SEAMLESS_PATH.md`
- SemVer **PATCH** `1.49.1` (telemetry)

## Test plan
- [x] Unit: `routeGroup`, `authAnalytics` builders/emitters, `warmLoginAuthSurface`
- [ ] Human: after promote, register new GA4 custom dims/metrics from runbook §2 (`phase`, `warm_path`, `auth_flow`, `outcome`, `auth_timing_ms`)
- [ ] Human: DebugView on prod `/login` — confirm `auth_surface_timing` once after warm; Google attempt emits `auth_google_timing`
- [ ] Human: Explore `web_vital` LCP filterable by `login` / `marketing` / `tour_stats`
- [ ] Confirm marketing `/` still Firebase-free on cold open (no behavior change intended)


Made with [Cursor](https://cursor.com)