### PR TITLE
promote: staging → main (v1.50.1 marketing auth CTA leave)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.50.1] — 2026-08-04
+
+### Fixed
+- **Marketing auth CTAs no longer feel dead before `/login` (#872)** — Jump on Tour / Make picks now / Play for Free / Make picks for this tour (and siblings) paint immediate leave chrome + button press nudge, then hard-nav to app `/login` (skips MarketingApp soft-nav → “Loading…” hop). Bonus: Google CTA on `/login` shows “Opening Google…” while redirect/popup starts.
+
+---
+
 ## [1.50.0] — 2026-08-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.50.0",
+  "version": "1.50.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/app/MarketingApp.jsx
+++ b/src/app/MarketingApp.jsx
@@ -1,6 +1,7 @@
 import React, { Suspense, lazy, useEffect } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
+import { MarketingAuthLeaveOverlay } from '../features/landing/splash';
 import MarketingHomePage from '../pages/marketing/MarketingHomePage';
 
 // Sibling marketing routes stay off the `/` cold-open graph (#835).
@@ -50,14 +51,8 @@ function LoadAppDocument() {
     return <Navigate to="/" replace />;
   }
 
-  return (
-    <div
-      className="flex min-h-screen items-center justify-center bg-brand-bg text-sm font-medium text-slate-400"
-      aria-busy="true"
-    >
-      Loading…
-    </div>
-  );
+  // Residual soft-nav safety net (#872) — primary CTAs hard-link past this hop.
+  return <MarketingAuthLeaveOverlay />;
 }
 
 function MarketingRouteFallback() {

--- a/src/features/auth/model/useSplashSignIn.js
+++ b/src/features/auth/model/useSplashSignIn.js
@@ -15,6 +15,8 @@ export function useSplashSignIn(isOpen, onClose, { seedError = '' } = {}) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [busy, setBusy] = useState(false);
+  /** Google-only pending — keeps email busy from showing “Opening Google…”. */
+  const [googleBusy, setGoogleBusy] = useState(false);
   const [error, setError] = useState('');
   const [resetLinkNotice, setResetLinkNotice] = useState({ text: '', type: '' });
   const preferGoogleRedirect = shouldPreferGoogleRedirectAuth();
@@ -34,6 +36,7 @@ export function useSplashSignIn(isOpen, onClose, { seedError = '' } = {}) {
     onClose?.();
     resetForm();
     setBusy(false);
+    setGoogleBusy(false);
   }, [onClose, resetForm]);
 
   useEffect(() => {
@@ -49,12 +52,14 @@ export function useSplashSignIn(isOpen, onClose, { seedError = '' } = {}) {
     if (!isOpen) {
       resetForm();
       setBusy(false);
+      setGoogleBusy(false);
     }
   }, [isOpen, resetForm]);
 
   const handleGoogle = useCallback(async () => {
     setError('');
     setBusy(true);
+    setGoogleBusy(true);
     setSplashGoogleModalInflight();
     markGoogleAuthClick();
     let authFlow = preferGoogleRedirect ? 'redirect' : 'popup';
@@ -99,6 +104,7 @@ export function useSplashSignIn(isOpen, onClose, { seedError = '' } = {}) {
       if (!leftViaRedirect) {
         clearSplashGoogleModalInflight();
         setBusy(false);
+        setGoogleBusy(false);
       }
     }
   }, [closeModal, preferGoogleRedirect]);
@@ -166,6 +172,7 @@ export function useSplashSignIn(isOpen, onClose, { seedError = '' } = {}) {
     password,
     setPassword,
     busy,
+    googleBusy,
     error,
     resetLinkNotice,
     closeModal,

--- a/src/features/auth/model/useSplashSignUp.js
+++ b/src/features/auth/model/useSplashSignUp.js
@@ -22,6 +22,8 @@ export function useSplashSignUp(isOpen, onClose, { seedError = '' } = {}) {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [legalAccepted, setLegalAccepted] = useState(false);
   const [busy, setBusy] = useState(false);
+  /** Google-only pending — keeps email busy from showing “Opening Google…”. */
+  const [googleBusy, setGoogleBusy] = useState(false);
   const [error, setError] = useState('');
   const preferGoogleRedirect = shouldPreferGoogleRedirectAuth();
 
@@ -41,6 +43,7 @@ export function useSplashSignUp(isOpen, onClose, { seedError = '' } = {}) {
     onClose?.();
     resetForm();
     setBusy(false);
+    setGoogleBusy(false);
   }, [onClose, resetForm]);
 
   useEffect(() => {
@@ -56,6 +59,7 @@ export function useSplashSignUp(isOpen, onClose, { seedError = '' } = {}) {
     if (!isOpen) {
       resetForm();
       setBusy(false);
+      setGoogleBusy(false);
     }
   }, [isOpen, resetForm]);
 
@@ -66,6 +70,7 @@ export function useSplashSignUp(isOpen, onClose, { seedError = '' } = {}) {
       return;
     }
     setBusy(true);
+    setGoogleBusy(true);
     setSplashGoogleModalInflight();
     markGoogleAuthClick();
     let authFlow = preferGoogleRedirect ? 'redirect' : 'popup';
@@ -109,6 +114,7 @@ export function useSplashSignUp(isOpen, onClose, { seedError = '' } = {}) {
       if (!leftViaRedirect) {
         clearSplashGoogleModalInflight();
         setBusy(false);
+        setGoogleBusy(false);
       }
     }
   }, [closeModal, legalAccepted, preferGoogleRedirect]);
@@ -184,6 +190,7 @@ export function useSplashSignUp(isOpen, onClose, { seedError = '' } = {}) {
     legalAccepted,
     setLegalAccepted,
     busy,
+    googleBusy,
     error,
     closeModal,
     handleGoogle,

--- a/src/features/auth/ui/LoginAuthScreen.jsx
+++ b/src/features/auth/ui/LoginAuthScreen.jsx
@@ -9,6 +9,7 @@ import PasswordRevealToggle, {
   shouldShowPasswordReveal,
 } from './PasswordRevealToggle';
 import { AUTH_EMAIL_CTA } from './authCtaClasses';
+import { resolveGoogleCtaLabel } from './googleCtaLabel';
 import SplashAuthPanel from './SplashAuthPanel';
 import { useLoginAuthSurfaceReady } from '../model/useLoginAuthSurfaceReady';
 import { useSplashSignIn } from '../model/useSplashSignIn';
@@ -70,6 +71,7 @@ function LoginSignInPanel({
     password,
     setPassword,
     busy,
+    googleBusy,
     error,
     resetLinkNotice,
     handleGoogle,
@@ -106,7 +108,10 @@ function LoginSignInPanel({
       }}
       busy={busy}
       googleDisabled={busy || googlePreparing}
-      googleLabel={googlePreparing ? 'Preparing sign-in…' : undefined}
+      googleLabel={resolveGoogleCtaLabel({
+        preparing: googlePreparing,
+        googleBusy,
+      })}
       prependContent={prependContent}
       googleFootnote={
         preferGoogleRedirect
@@ -217,6 +222,7 @@ function LoginSignUpPanel({
     legalAccepted,
     setLegalAccepted,
     busy,
+    googleBusy,
     error,
     handleGoogle,
     handleEmailSignUp,
@@ -289,7 +295,10 @@ function LoginSignUpPanel({
       }}
       busy={busy}
       googleDisabled={busy || !legalAccepted || googlePreparing}
-      googleLabel={googlePreparing ? 'Preparing sign-in…' : undefined}
+      googleLabel={resolveGoogleCtaLabel({
+        preparing: googlePreparing,
+        googleBusy,
+      })}
       prependContent={prependContent}
       googleFootnote={
         preferGoogleRedirect

--- a/src/features/auth/ui/SplashAuthModalShell.jsx
+++ b/src/features/auth/ui/SplashAuthModalShell.jsx
@@ -10,6 +10,8 @@ export default function SplashAuthModalShell({
   busy,
   /** When set, overrides default Google disabled state (`busy` only). */
   googleDisabled,
+  /** Pending / preparing label override (e.g. “Opening Google…”). */
+  googleLabel,
   /** Rendered after the title row and before “Continue with Google” (e.g. sign-up legal consent). */
   prependContent,
   googleFootnote,
@@ -45,6 +47,7 @@ export default function SplashAuthModalShell({
           handleGoogle={handleGoogle}
           busy={busy}
           googleDisabled={googleDisabled}
+          googleLabel={googleLabel}
           prependContent={prependContent}
           googleFootnote={googleFootnote}
         >

--- a/src/features/auth/ui/SplashAuthPanel.jsx
+++ b/src/features/auth/ui/SplashAuthPanel.jsx
@@ -6,6 +6,7 @@ import {
   DASHBOARD_CARD_RADIUS,
 } from '../../../shared/ui/dashboardCardClasses';
 import { AUTH_GOOGLE_CTA } from './authCtaClasses';
+import { GOOGLE_CTA_DEFAULT } from './googleCtaLabel';
 
 /**
  * Shared auth credentials chrome (#834) — Google CTA, divider, and form slot.
@@ -33,7 +34,8 @@ export default function SplashAuthPanel({
   const ctaLabel =
     typeof googleLabel === 'string' && googleLabel.trim()
       ? googleLabel
-      : 'Continue with Google';
+      : GOOGLE_CTA_DEFAULT;
+  const googlePending = isGoogleDisabled && ctaLabel !== GOOGLE_CTA_DEFAULT;
   // Desktop intent warm (#850) — `/login` also immediate-warms after paint (#858).
   const intentProps =
     typeof onGoogleIntent === 'function'
@@ -71,11 +73,22 @@ export default function SplashAuthPanel({
         type="button"
         onClick={handleGoogle}
         disabled={isGoogleDisabled}
-        aria-busy={isGoogleDisabled && ctaLabel !== 'Continue with Google'}
+        aria-busy={googlePending}
         className={AUTH_GOOGLE_CTA}
         {...intentProps}
       >
-        <img src="https://www.google.com/favicon.ico" alt="" className="h-5 w-5" />
+        {googlePending ? (
+          <span
+            className="h-5 w-5 shrink-0 animate-spin rounded-full border-2 border-slate-400 border-t-slate-900"
+            aria-hidden
+          />
+        ) : (
+          <img
+            src="https://www.google.com/favicon.ico"
+            alt=""
+            className="h-5 w-5"
+          />
+        )}
         {ctaLabel}
       </button>
 

--- a/src/features/auth/ui/SplashSignInModal.jsx
+++ b/src/features/auth/ui/SplashSignInModal.jsx
@@ -4,6 +4,7 @@ import Button from '../../../shared/ui/Button';
 import Input from '../../../shared/ui/Input';
 import { StatusBanner } from '../../../shared';
 import { AUTH_EMAIL_CTA } from './authCtaClasses';
+import { resolveGoogleCtaLabel } from './googleCtaLabel';
 import PasswordRevealToggle, {
   shouldShowPasswordReveal,
 } from './PasswordRevealToggle';
@@ -25,6 +26,7 @@ export default function SplashSignInModal({
     password,
     setPassword,
     busy,
+    googleBusy,
     error,
     resetLinkNotice,
     closeModal,
@@ -59,6 +61,7 @@ export default function SplashSignInModal({
       title="Sign in"
       handleGoogle={handleGoogle}
       busy={busy}
+      googleLabel={resolveGoogleCtaLabel({ googleBusy })}
       prependContent={prependContent}
       googleFootnote={
         preferGoogleRedirect

--- a/src/features/auth/ui/SplashSignUpModal.jsx
+++ b/src/features/auth/ui/SplashSignUpModal.jsx
@@ -5,6 +5,7 @@ import Button from '../../../shared/ui/Button';
 import Input from '../../../shared/ui/Input';
 import { StatusBanner } from '../../../shared';
 import { AUTH_EMAIL_CTA } from './authCtaClasses';
+import { resolveGoogleCtaLabel } from './googleCtaLabel';
 import PasswordRevealToggle, {
   shouldShowPasswordReveal,
 } from './PasswordRevealToggle';
@@ -30,6 +31,7 @@ export default function SplashSignUpModal({
     legalAccepted,
     setLegalAccepted,
     busy,
+    googleBusy,
     error,
     closeModal,
     handleGoogle,
@@ -101,6 +103,7 @@ export default function SplashSignUpModal({
       handleGoogle={handleGoogle}
       busy={busy}
       googleDisabled={busy || !legalAccepted}
+      googleLabel={resolveGoogleCtaLabel({ googleBusy })}
       prependContent={prependContent}
       googleFootnote={
         preferGoogleRedirect

--- a/src/features/auth/ui/googleCtaLabel.js
+++ b/src/features/auth/ui/googleCtaLabel.js
@@ -1,0 +1,14 @@
+/** Labels for Google CTA pending states (#872). */
+export const GOOGLE_CTA_DEFAULT = 'Continue with Google';
+export const GOOGLE_CTA_PREPARING = 'Preparing sign-in…';
+export const GOOGLE_CTA_OPENING = 'Opening Google…';
+
+/**
+ * @param {{ preparing?: boolean, googleBusy?: boolean }} opts
+ * @returns {string | undefined} Override label, or undefined for default CTA copy
+ */
+export function resolveGoogleCtaLabel({ preparing = false, googleBusy = false } = {}) {
+  if (preparing) return GOOGLE_CTA_PREPARING;
+  if (googleBusy) return GOOGLE_CTA_OPENING;
+  return undefined;
+}

--- a/src/features/auth/ui/googleCtaLabel.test.js
+++ b/src/features/auth/ui/googleCtaLabel.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  GOOGLE_CTA_OPENING,
+  GOOGLE_CTA_PREPARING,
+  resolveGoogleCtaLabel,
+} from './googleCtaLabel.js';
+
+describe('resolveGoogleCtaLabel', () => {
+  it('prefers preparing over googleBusy', () => {
+    expect(
+      resolveGoogleCtaLabel({ preparing: true, googleBusy: true }),
+    ).toBe(GOOGLE_CTA_PREPARING);
+  });
+
+  it('returns Opening Google… while Google OAuth is in flight', () => {
+    expect(resolveGoogleCtaLabel({ googleBusy: true })).toBe(GOOGLE_CTA_OPENING);
+  });
+
+  it('returns undefined for the default Continue with Google label', () => {
+    expect(resolveGoogleCtaLabel()).toBeUndefined();
+    expect(resolveGoogleCtaLabel({ preparing: false, googleBusy: false })).toBe(
+      undefined,
+    );
+  });
+});

--- a/src/features/landing/index.js
+++ b/src/features/landing/index.js
@@ -11,6 +11,12 @@ export {
   LandingSeo,
   SplashPageShell,
   useScrollToSectionFocus,
+  useMarketingAuthLeave,
+  MarketingAuthLeaveOverlay,
+  AppDocumentAuthLink,
+  loginPath,
+  LOGIN_PATH,
+  LOGIN_SIGNUP_PATH,
 } from './splash';
 export { default as SplashHeader } from './ui/SplashHeader';
 export { default as SplashHeroSection } from './ui/SplashHeroSection';

--- a/src/features/landing/model/appAuthPaths.js
+++ b/src/features/landing/model/appAuthPaths.js
@@ -1,0 +1,15 @@
+/**
+ * App-document auth entry URLs (#832 / #872).
+ * Marketing must hard-nav here — never soft-route through MarketingApp.
+ */
+
+export const LOGIN_PATH = '/login';
+export const LOGIN_SIGNUP_PATH = '/login?mode=signup';
+
+/**
+ * @param {{ signup?: boolean }} [opts]
+ * @returns {string}
+ */
+export function loginPath({ signup = false } = {}) {
+  return signup ? LOGIN_SIGNUP_PATH : LOGIN_PATH;
+}

--- a/src/features/landing/model/appAuthPaths.test.js
+++ b/src/features/landing/model/appAuthPaths.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { LOGIN_PATH, LOGIN_SIGNUP_PATH, loginPath } from './appAuthPaths.js';
+
+describe('loginPath', () => {
+  it('defaults to sign-in', () => {
+    expect(loginPath()).toBe(LOGIN_PATH);
+    expect(loginPath({ signup: false })).toBe(LOGIN_PATH);
+  });
+
+  it('returns signup query for create-account CTAs', () => {
+    expect(loginPath({ signup: true })).toBe(LOGIN_SIGNUP_PATH);
+  });
+});

--- a/src/features/landing/model/useMarketingAuthLeave.js
+++ b/src/features/landing/model/useMarketingAuthLeave.js
@@ -1,0 +1,34 @@
+import { useCallback, useState } from 'react';
+import { flushSync } from 'react-dom';
+
+import { loginPath } from './appAuthPaths';
+
+/**
+ * Hard-nav to app `/login` with a paint of leave chrome first (#872).
+ * Use on marketing home button CTAs (Jump on Tour, Make picks now, …).
+ */
+export default function useMarketingAuthLeave() {
+  const [leaving, setLeaving] = useState(false);
+
+  const leaveToLogin = useCallback(
+    ({ signup = false } = {}) => {
+      if (leaving) return;
+      const href = loginPath({ signup });
+      // Commit overlay to the DOM before starting the document navigation.
+      flushSync(() => {
+        setLeaving(true);
+      });
+      // Yield so Safari can paint the overlay, then hard-nav (skip MarketingApp hop).
+      requestAnimationFrame(() => {
+        window.location.assign(href);
+      });
+    },
+    [leaving],
+  );
+
+  return {
+    leaving,
+    openSignUp: useCallback(() => leaveToLogin({ signup: true }), [leaveToLogin]),
+    openSignIn: useCallback(() => leaveToLogin({ signup: false }), [leaveToLogin]),
+  };
+}

--- a/src/features/landing/splash.js
+++ b/src/features/landing/splash.js
@@ -5,3 +5,8 @@
 export { default as LandingSeo } from './ui/LandingSeo';
 export { default as SplashPageShell } from './ui/SplashPageShell';
 export { default as useScrollToSectionFocus } from './model/useScrollToSectionFocus';
+/** Hard-nav leave chrome for marketing → `/login` (#872). */
+export { default as useMarketingAuthLeave } from './model/useMarketingAuthLeave';
+export { default as MarketingAuthLeaveOverlay } from './ui/MarketingAuthLeaveOverlay';
+export { default as AppDocumentAuthLink } from './ui/AppDocumentAuthLink';
+export { loginPath, LOGIN_PATH, LOGIN_SIGNUP_PATH } from './model/appAuthPaths';

--- a/src/features/landing/ui/AppDocumentAuthLink.jsx
+++ b/src/features/landing/ui/AppDocumentAuthLink.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { flushSync } from 'react-dom';
+
+import { loginPath } from '../model/appAuthPaths';
+import MarketingAuthLeaveOverlay from './MarketingAuthLeaveOverlay';
+
+/**
+ * Hard link into the authenticated SPA document (#872).
+ *
+ * Prefer this over React Router `<Link to="/login">` on the marketing entry —
+ * soft-nav hits MarketingApp `LoadAppDocument` (“Loading…”) then `location.replace`,
+ * which is the dead-static → spinner → form sequence.
+ */
+export default function AppDocumentAuthLink({
+  signup = false,
+  href,
+  className = '',
+  children,
+  leaveMessage,
+  ...rest
+}) {
+  const [leaving, setLeaving] = useState(false);
+  const resolvedHref = href || loginPath({ signup });
+
+  return (
+    <>
+      {leaving ? (
+        <MarketingAuthLeaveOverlay message={leaveMessage} />
+      ) : null}
+      <a
+        href={resolvedHref}
+        className={className}
+        aria-busy={leaving || undefined}
+        onClick={(e) => {
+          // New-tab / modified clicks: let the browser handle without leave overlay.
+          if (
+            e.defaultPrevented ||
+            e.button !== 0 ||
+            e.metaKey ||
+            e.ctrlKey ||
+            e.shiftKey ||
+            e.altKey
+          ) {
+            return;
+          }
+          // Paint leave chrome; allow default hard navigation (do not preventDefault).
+          flushSync(() => {
+            setLeaving(true);
+          });
+        }}
+        {...rest}
+      >
+        {children}
+      </a>
+    </>
+  );
+}

--- a/src/features/landing/ui/HowItWorksPageContent.jsx
+++ b/src/features/landing/ui/HowItWorksPageContent.jsx
@@ -6,6 +6,7 @@ import {
   CARD_LINK_ON_LIGHT,
   LINK_ON_LIGHT,
 } from '../../../shared/ui/surfaceLinkStyles';
+import AppDocumentAuthLink from './AppDocumentAuthLink';
 
 /**
  * Standalone "How It Works" content for the `/how-it-works` public page.
@@ -71,12 +72,12 @@ export default function HowItWorksPageContent() {
           anytime—then play to unlock the personal side of the story.
         </p>
         <div className="mt-10 flex justify-center">
-          <Link
-            to="/login?mode=signup"
-            className="inline-flex items-center gap-2 rounded-xl bg-brand-primary px-10 py-3.5 text-base font-bold text-white shadow-[0_10px_20px_-10px_rgba(16,185,129,0.5)] transition-all hover:bg-brand-primary-hover hover:shadow-[0_15px_30px_-15px_rgba(16,185,129,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue"
+          <AppDocumentAuthLink
+            signup
+            className="inline-flex items-center gap-2 rounded-xl bg-brand-primary px-10 py-3.5 text-base font-bold text-white shadow-[0_10px_20px_-10px_rgba(16,185,129,0.5)] transition-all hover:bg-brand-primary-hover hover:shadow-[0_15px_30px_-15px_rgba(16,185,129,0.6)] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue"
           >
             Play for Free
-          </Link>
+          </AppDocumentAuthLink>
         </div>
       </div>
     </section>

--- a/src/features/landing/ui/MarketingAuthLeaveOverlay.jsx
+++ b/src/features/landing/ui/MarketingAuthLeaveOverlay.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+/**
+ * Immediate leave chrome while marketing hard-navs to `/login` (#872).
+ * Paints before document swap so Jump on Tour / Make picks now never feel dead.
+ */
+export default function MarketingAuthLeaveOverlay({
+  message = 'Taking you to sign-in…',
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-[200] flex items-center justify-center bg-brand-bg/85 px-6 backdrop-blur-sm"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <div className="flex flex-col items-center gap-4 text-center">
+        <span
+          className="h-8 w-8 animate-spin rounded-full border-2 border-slate-500 border-t-teal-400"
+          aria-hidden
+        />
+        <p className="text-sm font-semibold text-slate-300">{message}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
+++ b/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { ArrowRight } from 'lucide-react';
 
 import { LINK_ON_LIGHT } from '../../../shared/ui/surfaceLinkStyles';
+import AppDocumentAuthLink from './AppDocumentAuthLink';
 
 /**
  * Keyword-intent educational page for `/phish-setlist-prediction-game` (#660).
@@ -123,12 +124,12 @@ export default function PhishSetlistPredictionGamePageContent() {
         </section>
 
         <div className="flex justify-center border-t border-slate-200 pt-10">
-          <Link
-            to="/login?mode=signup"
-            className="inline-flex items-center gap-2 rounded-xl bg-brand-primary px-10 py-3.5 text-base font-bold text-white shadow-[0_10px_20px_-10px_rgba(16,185,129,0.5)] transition-all hover:bg-brand-primary-hover hover:shadow-[0_15px_30px_-15px_rgba(16,185,129,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue"
+          <AppDocumentAuthLink
+            signup
+            className="inline-flex items-center gap-2 rounded-xl bg-brand-primary px-10 py-3.5 text-base font-bold text-white shadow-[0_10px_20px_-10px_rgba(16,185,129,0.5)] transition-all hover:bg-brand-primary-hover hover:shadow-[0_15px_30px_-15px_rgba(16,185,129,0.6)] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent-blue"
           >
             Start predicting setlists
-          </Link>
+          </AppDocumentAuthLink>
         </div>
       </div>
     </article>

--- a/src/features/tour-stats/ui/PublicTourStatsPanel.jsx
+++ b/src/features/tour-stats/ui/PublicTourStatsPanel.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
+import { AppDocumentAuthLink } from '../../landing';
 import TourStatsView from '../ui/TourStatsView';
 import { LINK_ON_DARK } from '../../../shared/ui/surfaceLinkStyles';
 
@@ -100,12 +101,12 @@ export default function PublicTourStatsPanel({
           </Link>{' '}
           first.
         </p>
-        <Link
-          to="/login?mode=signup"
-          className="inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-xl bg-gradient-to-r from-teal-400 to-teal-500 px-8 py-3.5 text-base font-black text-slate-900 shadow-[0_0_40px_-10px_rgba(45,212,191,0.5)] transition-all hover:-translate-y-0.5 hover:shadow-[0_0_60px_-15px_rgba(45,212,191,0.7)]"
+        <AppDocumentAuthLink
+          signup
+          className="inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-xl bg-gradient-to-r from-teal-400 to-teal-500 px-8 py-3.5 text-base font-black text-slate-900 shadow-[0_0_40px_-10px_rgba(45,212,191,0.5)] transition-all hover:-translate-y-0.5 hover:shadow-[0_0_60px_-15px_rgba(45,212,191,0.7)] active:translate-y-0 active:scale-[0.98]"
         >
           Make picks for this tour
-        </Link>
+        </AppDocumentAuthLink>
       </div>
     </div>
   );

--- a/src/pages/marketing/HowScoringWorksPage.jsx
+++ b/src/pages/marketing/HowScoringWorksPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
 
-import { MarketingPageShell } from '../../features/landing';
+import { AppDocumentAuthLink, MarketingPageShell } from '../../features/landing';
 import { ScoringRulesContent } from '../../features/scoring/marketing';
 import { SEO_CONFIG } from '../../shared/config/seo';
 import { getPrerenderRoute } from '../../shared/config/seoRoutes';
@@ -46,9 +46,9 @@ export default function HowScoringWorksPage() {
               tour stats
             </Link>
             , or{' '}
-            <Link to="/login?mode=signup" className={LINK_ON_DARK}>
+            <AppDocumentAuthLink signup className={LINK_ON_DARK}>
               start playing
-            </Link>
+            </AppDocumentAuthLink>
             .
           </p>
         </div>

--- a/src/pages/marketing/MarketingHomePage.jsx
+++ b/src/pages/marketing/MarketingHomePage.jsx
@@ -1,22 +1,19 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 
 import {
   LandingSeo,
+  MarketingAuthLeaveOverlay,
   SplashPageShell,
+  useMarketingAuthLeave,
   useScrollToSectionFocus,
 } from '../../features/landing/splash';
-
-function goLogin({ signup = false } = {}) {
-  window.location.assign(signup ? '/login?mode=signup' : '/login');
-}
 
 /**
  * Marketing-document splash (#832). Same shell/UI as the app Landing splash,
  * but auth CTAs hard-navigate to `/login` instead of a mid-page chooser.
  */
 export default function MarketingHomePage() {
-  const openSignUp = useCallback(() => goLogin({ signup: true }), []);
-  const openSignIn = useCallback(() => goLogin(), []);
+  const { leaving, openSignUp, openSignIn } = useMarketingAuthLeave();
 
   const {
     howItWorksSectionRef,
@@ -36,6 +33,7 @@ export default function MarketingHomePage() {
         onOpenSignUp={openSignUp}
         onOpenSignIn={openSignIn}
       />
+      {leaving ? <MarketingAuthLeaveOverlay /> : null}
     </>
   );
 }

--- a/src/shared/ui/Button.jsx
+++ b/src/shared/ui/Button.jsx
@@ -6,18 +6,19 @@ const baseStyles =
 
 // 2. Removed `px-8 py-4` and text sizes from here (variants are now ONLY colors/effects)
 const variantStyles = {
+  // `active:` press nudge (#872) — touch has no hover lift, so taps need motion.
   primary:
-    'bg-gradient-to-r from-teal-400 to-teal-500 text-slate-900 shadow-[0_0_40px_-10px_rgba(45,212,191,0.5)] hover:shadow-[0_0_60px_-15px_rgba(45,212,191,0.7)] hover:-translate-y-0.5',
+    'bg-gradient-to-r from-teal-400 to-teal-500 text-slate-900 shadow-[0_0_40px_-10px_rgba(45,212,191,0.5)] hover:shadow-[0_0_60px_-15px_rgba(45,212,191,0.7)] hover:-translate-y-0.5 active:translate-y-0 active:scale-[0.98] active:shadow-[0_0_24px_-12px_rgba(45,212,191,0.45)]',
   secondary:
-    'border-2 border-teal-400/70 bg-transparent text-teal-300 shadow-none hover:bg-teal-400/10 hover:border-teal-300 hover:-translate-y-0.5',
+    'border-2 border-teal-400/70 bg-transparent text-teal-300 shadow-none hover:bg-teal-400/10 hover:border-teal-300 hover:-translate-y-0.5 active:translate-y-0 active:scale-[0.98]',
   ghost:
-    'border border-border-venue/70 bg-surface-panel text-slate-300 hover:bg-surface-panel-strong hover:text-brand-primary',
+    'border border-border-venue/70 bg-surface-panel text-slate-300 hover:bg-surface-panel-strong hover:text-brand-primary active:scale-[0.98]',
   danger:
-    'bg-gradient-to-r from-red-500 to-red-600 text-white shadow-[0_0_40px_-10px_rgba(239,68,68,0.45)] hover:shadow-[0_0_60px_-15px_rgba(239,68,68,0.6)] hover:-translate-y-0.5',
+    'bg-gradient-to-r from-red-500 to-red-600 text-white shadow-[0_0_40px_-10px_rgba(239,68,68,0.45)] hover:shadow-[0_0_60px_-15px_rgba(239,68,68,0.6)] hover:-translate-y-0.5 active:translate-y-0 active:scale-[0.98]',
   glass:
-    'border border-border-venue/70 bg-surface-glass backdrop-blur-xl text-white ring-1 ring-border-glass/55 shadow-inset-glass hover:bg-surface-panel-strong',
-  text: 'text-slate-300 hover:text-white',
-  link: 'text-slate-400 hover:text-white underline underline-offset-2 decoration-slate-500 hover:decoration-white',
+    'border border-border-venue/70 bg-surface-glass backdrop-blur-xl text-white ring-1 ring-border-glass/55 shadow-inset-glass hover:bg-surface-panel-strong active:scale-[0.98]',
+  text: 'text-slate-300 hover:text-white active:opacity-80',
+  link: 'text-slate-400 hover:text-white underline underline-offset-2 decoration-slate-500 hover:decoration-white active:opacity-80',
 };
 
 // 3. NEW: Added a dedicated sizes dictionary for padding, text size, and rounding


### PR DESCRIPTION
## Summary
- Roll up `staging` → `main` for **v1.50.1**
- [#872](https://github.com/pat792/set-picks/issues/872) / [#873](https://github.com/pat792/set-picks/pull/873): marketing auth CTAs (Jump on Tour, Make picks now, siblings) immediate leave chrome + hard-nav to `/login`; Google CTA Opening Google… bonus
- Epic [#856](https://github.com/pat792/set-picks/issues/856) child

## Test plan
- [x] #873 CI green (verify + qa-runners + Vercel)
- [ ] Promote CI / Vercel prod deploy
- [ ] Private Safari: Jump on Tour / Make picks now — immediate overlay, then `/login` (no static dead pause)
- [ ] Marketing `/` still Firebase-free
- [ ] First enabled Google redirect still clean (T1 gate)


Made with [Cursor](https://cursor.com)