### PR TITLE
promote: 1.51.1 (leave chrome signup copy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.51.1] — 2026-08-04
+
+### Fixed
+- **Marketing leave chrome matches CTA destination** — Jump on Tour / Make picks now / Play for Free show “Taking you to sign up…”; Sign In shows “Taking you to sign in…” (was one generic “sign-in” string for both).
+
+---
+
 ## [1.51.0] — 2026-08-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.51.0",
+  "version": "1.51.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/app/MarketingApp.jsx
+++ b/src/app/MarketingApp.jsx
@@ -1,7 +1,10 @@
 import React, { Suspense, lazy, useEffect } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
-import { MarketingAuthLeaveOverlay } from '../features/landing/splash';
+import {
+  MarketingAuthLeaveOverlay,
+  resolveMarketingAuthLeaveMessage,
+} from '../features/landing/splash';
 import MarketingHomePage from '../pages/marketing/MarketingHomePage';
 
 // Sibling marketing routes stay off the `/` cold-open graph (#835).
@@ -52,7 +55,16 @@ function LoadAppDocument() {
   }
 
   // Residual soft-nav safety net (#872) — primary CTAs hard-link past this hop.
-  return <MarketingAuthLeaveOverlay />;
+  const search =
+    typeof window !== 'undefined' ? window.location.search : '';
+  const params = new URLSearchParams(search);
+  const signup =
+    params.get('mode') === 'signup' || params.get('signup') === '1';
+  return (
+    <MarketingAuthLeaveOverlay
+      message={resolveMarketingAuthLeaveMessage({ signup })}
+    />
+  );
 }
 
 function MarketingRouteFallback() {

--- a/src/features/landing/index.js
+++ b/src/features/landing/index.js
@@ -20,6 +20,9 @@ export {
   prefetchLoginIntent,
   consumeLoginWarmIntent,
   markLoginWarmIntent,
+  resolveMarketingAuthLeaveMessage,
+  MARKETING_LEAVE_SIGN_IN,
+  MARKETING_LEAVE_SIGN_UP,
 } from './splash';
 export { default as SplashHeader } from './ui/SplashHeader';
 export { default as SplashHeroSection } from './ui/SplashHeroSection';

--- a/src/features/landing/model/marketingAuthLeaveCopy.js
+++ b/src/features/landing/model/marketingAuthLeaveCopy.js
@@ -1,0 +1,12 @@
+/** Destination-aware leave chrome while marketing hard-navs to `/login` (#872). */
+
+export const MARKETING_LEAVE_SIGN_IN = 'Taking you to sign in…';
+export const MARKETING_LEAVE_SIGN_UP = 'Taking you to sign up…';
+
+/**
+ * @param {{ signup?: boolean }} [opts]
+ * @returns {string}
+ */
+export function resolveMarketingAuthLeaveMessage({ signup = false } = {}) {
+  return signup ? MARKETING_LEAVE_SIGN_UP : MARKETING_LEAVE_SIGN_IN;
+}

--- a/src/features/landing/model/marketingAuthLeaveCopy.test.js
+++ b/src/features/landing/model/marketingAuthLeaveCopy.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MARKETING_LEAVE_SIGN_IN,
+  MARKETING_LEAVE_SIGN_UP,
+  resolveMarketingAuthLeaveMessage,
+} from './marketingAuthLeaveCopy.js';
+
+describe('resolveMarketingAuthLeaveMessage', () => {
+  it('uses sign-up copy for create-account CTAs', () => {
+    expect(resolveMarketingAuthLeaveMessage({ signup: true })).toBe(
+      MARKETING_LEAVE_SIGN_UP,
+    );
+  });
+
+  it('uses sign-in copy for Sign In / default', () => {
+    expect(resolveMarketingAuthLeaveMessage({ signup: false })).toBe(
+      MARKETING_LEAVE_SIGN_IN,
+    );
+    expect(resolveMarketingAuthLeaveMessage()).toBe(MARKETING_LEAVE_SIGN_IN);
+  });
+});

--- a/src/features/landing/model/useMarketingAuthLeave.js
+++ b/src/features/landing/model/useMarketingAuthLeave.js
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import { flushSync } from 'react-dom';
 
 import { loginPath } from './appAuthPaths';
+import { resolveMarketingAuthLeaveMessage } from './marketingAuthLeaveCopy';
 import { prefetchLoginIntent } from './prefetchLoginIntent';
 
 /**
@@ -10,6 +11,9 @@ import { prefetchLoginIntent } from './prefetchLoginIntent';
  */
 export default function useMarketingAuthLeave() {
   const [leaving, setLeaving] = useState(false);
+  const [leaveMessage, setLeaveMessage] = useState(
+    resolveMarketingAuthLeaveMessage({ signup: false }),
+  );
 
   const onAuthCtaIntent = useCallback(() => {
     prefetchLoginIntent();
@@ -19,10 +23,12 @@ export default function useMarketingAuthLeave() {
     ({ signup = false } = {}) => {
       if (leaving) return;
       const href = loginPath({ signup });
+      const message = resolveMarketingAuthLeaveMessage({ signup });
       // Start cache warm before/during leave paint (#860).
       prefetchLoginIntent();
       // Commit overlay to the DOM before starting the document navigation.
       flushSync(() => {
+        setLeaveMessage(message);
         setLeaving(true);
       });
       // Yield so Safari can paint the overlay, then hard-nav (skip MarketingApp hop).
@@ -35,6 +41,7 @@ export default function useMarketingAuthLeave() {
 
   return {
     leaving,
+    leaveMessage,
     onAuthCtaIntent,
     openSignUp: useCallback(() => leaveToLogin({ signup: true }), [leaveToLogin]),
     openSignIn: useCallback(() => leaveToLogin({ signup: false }), [leaveToLogin]),

--- a/src/features/landing/splash.js
+++ b/src/features/landing/splash.js
@@ -10,6 +10,11 @@ export { default as useMarketingAuthLeave } from './model/useMarketingAuthLeave'
 export { default as MarketingAuthLeaveOverlay } from './ui/MarketingAuthLeaveOverlay';
 export { default as AppDocumentAuthLink } from './ui/AppDocumentAuthLink';
 export { loginPath, LOGIN_PATH, LOGIN_SIGNUP_PATH } from './model/appAuthPaths';
+export {
+  resolveMarketingAuthLeaveMessage,
+  MARKETING_LEAVE_SIGN_IN,
+  MARKETING_LEAVE_SIGN_UP,
+} from './model/marketingAuthLeaveCopy';
 /** Intent prefetch + warm_path=intent flag (#860). */
 export {
   prefetchLoginIntent,

--- a/src/features/landing/ui/AppDocumentAuthLink.jsx
+++ b/src/features/landing/ui/AppDocumentAuthLink.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { flushSync } from 'react-dom';
 
 import { loginPath } from '../model/appAuthPaths';
+import { resolveMarketingAuthLeaveMessage } from '../model/marketingAuthLeaveCopy';
 import { prefetchLoginIntent } from '../model/prefetchLoginIntent';
 import MarketingAuthLeaveOverlay from './MarketingAuthLeaveOverlay';
 
@@ -24,11 +25,13 @@ export default function AppDocumentAuthLink({
 }) {
   const [leaving, setLeaving] = useState(false);
   const resolvedHref = href || loginPath({ signup });
+  const resolvedLeaveMessage =
+    leaveMessage || resolveMarketingAuthLeaveMessage({ signup });
 
   return (
     <>
       {leaving ? (
-        <MarketingAuthLeaveOverlay message={leaveMessage} />
+        <MarketingAuthLeaveOverlay message={resolvedLeaveMessage} />
       ) : null}
       <a
         href={resolvedHref}

--- a/src/features/landing/ui/MarketingAuthLeaveOverlay.jsx
+++ b/src/features/landing/ui/MarketingAuthLeaveOverlay.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 
+import { MARKETING_LEAVE_SIGN_IN } from '../model/marketingAuthLeaveCopy';
+
 /**
  * Immediate leave chrome while marketing hard-navs to `/login` (#872).
  * Paints before document swap so Jump on Tour / Make picks now never feel dead.
+ * Pass destination-aware copy via `message` (sign up vs sign in).
  */
 export default function MarketingAuthLeaveOverlay({
-  message = 'Taking you to sign-in…',
+  message = MARKETING_LEAVE_SIGN_IN,
 }) {
   return (
     <div

--- a/src/pages/marketing/MarketingHomePage.jsx
+++ b/src/pages/marketing/MarketingHomePage.jsx
@@ -13,7 +13,7 @@ import {
  * but auth CTAs hard-navigate to `/login` instead of a mid-page chooser.
  */
 export default function MarketingHomePage() {
-  const { leaving, openSignUp, openSignIn, onAuthCtaIntent } =
+  const { leaving, leaveMessage, openSignUp, openSignIn, onAuthCtaIntent } =
     useMarketingAuthLeave();
 
   const {
@@ -35,7 +35,7 @@ export default function MarketingHomePage() {
         onOpenSignIn={openSignIn}
         onAuthCtaIntent={onAuthCtaIntent}
       />
-      {leaving ? <MarketingAuthLeaveOverlay /> : null}
+      {leaving ? <MarketingAuthLeaveOverlay message={leaveMessage} /> : null}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Roll up **staging → main** for **v1.51.1**
- Includes [#878](https://github.com/pat792/set-picks/pull/878): destination-aware marketing leave chrome (“sign up…” vs “sign in…”)

## Test plan
- [ ] CI green
- [ ] Prod smoke: Jump on Tour → sign up copy; Sign In → sign in copy


Made with [Cursor](https://cursor.com)