### PR TITLE
fix(auth): lock signup email fields until terms accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 ## [1.52.1] — 2026-08-05
 
 ### Fixed
-- **Create account Terms gate** — Email/password fields stay disabled until Terms & Privacy are accepted (matching Google CTA). Hint copy + locked CTA label (“Accept terms to continue”) make the requirement obvious.
+- **Create account Terms gate** — Email/password fields stay disabled until Terms & Privacy are accepted (matching Google CTA). Hint + locked CTA (“Accept terms to continue”) make the requirement obvious; removed confusing “full-page Google sign-in” footnote.
+- **Dev Google continue overlay stuck** — StrictMode remount on `:5173` no longer strands “Loading Google account sign-in options…” after a redirect stash.
+- **`vite preview` `/login` shell** — prerendered `login/index.html` is no longer rewritten to bare `app.html`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.52.1] — 2026-08-05
+
+### Fixed
+- **Create account Terms gate** — Email/password fields stay disabled until Terms & Privacy are accepted (matching Google CTA). Hint copy + locked CTA label (“Accept terms to continue”) make the requirement obvious.
+
+---
+
 ## [1.52.0] — 2026-08-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.52.0",
+  "version": "1.52.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/auth/model/signupLegalCopy.js
+++ b/src/features/auth/model/signupLegalCopy.js
@@ -4,7 +4,7 @@
 
 /** Shown under the consent checkbox while unchecked. */
 export const SIGNUP_LEGAL_GATE_HINT =
-  'Check the box above to unlock Google and email sign-up.';
+  'Check the box to continue setting up your account profile.';
 
 /** Fallback error if a submit slips through without consent. */
 export const SIGNUP_LEGAL_REQUIRED_ERROR =

--- a/src/features/auth/model/signupLegalCopy.js
+++ b/src/features/auth/model/signupLegalCopy.js
@@ -1,0 +1,14 @@
+/**
+ * Create-account Terms/Privacy gate copy — keep Login + splash modal in sync.
+ */
+
+/** Shown under the consent checkbox while unchecked. */
+export const SIGNUP_LEGAL_GATE_HINT =
+  'Check the box above to unlock Google and email sign-up.';
+
+/** Fallback error if a submit slips through without consent. */
+export const SIGNUP_LEGAL_REQUIRED_ERROR =
+  'Accept the Terms and Privacy Policy to create your account.';
+
+/** Disabled email CTA label while consent is unchecked. */
+export const SIGNUP_EMAIL_CTA_NEEDS_LEGAL = 'Accept terms to continue';

--- a/src/features/auth/model/signupLegalCopy.test.js
+++ b/src/features/auth/model/signupLegalCopy.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  SIGNUP_EMAIL_CTA_NEEDS_LEGAL,
+  SIGNUP_LEGAL_GATE_HINT,
+  SIGNUP_LEGAL_REQUIRED_ERROR,
+} from './signupLegalCopy.js';
+
+describe('signupLegalCopy', () => {
+  it('keeps gate strings non-empty and user-facing', () => {
+    expect(SIGNUP_LEGAL_GATE_HINT.length).toBeGreaterThan(10);
+    expect(SIGNUP_LEGAL_REQUIRED_ERROR.toLowerCase()).toMatch(/terms|privacy/);
+    expect(SIGNUP_EMAIL_CTA_NEEDS_LEGAL.toLowerCase()).toMatch(/accept|terms/);
+  });
+});

--- a/src/features/auth/model/useGoogleRedirectCompletion.js
+++ b/src/features/auth/model/useGoogleRedirectCompletion.js
@@ -13,6 +13,70 @@ import { getFirebaseAuthErrorMessage } from '../utils/firebaseAuthMessages';
 import { trackAuthError } from './authAnalytics';
 
 /**
+ * Shared in-flight completion so React StrictMode remounts (dev) join the same
+ * `getRedirectResult` instead of cancelling mid-flight and stranding the
+ * “Loading Google account sign-in options…” overlay on `:5173`.
+ *
+ * @type {Promise<{
+ *   type: 'none' | 'empty' | 'done' | 'error',
+ *   intent?: 'signin' | 'signup' | null,
+ *   outcome?: { kind: string, message?: string },
+ *   err?: unknown,
+ * }> | null}
+ */
+let inFlightCompletion = null;
+
+async function completePendingGoogleRedirect() {
+  if (!peekGoogleRedirectIntent()) {
+    return { type: 'none' };
+  }
+  if (inFlightCompletion) return inFlightCompletion;
+
+  inFlightCompletion = (async () => {
+    try {
+      const { auth } = await ensureAuthReady();
+      const [{ consumeGoogleRedirectResult }, { completeGoogleSplashAuth }] =
+        await Promise.all([
+          import('../api/splashAuthApi'),
+          import('./completeGoogleSplashAuth'),
+        ]);
+      const result = await consumeGoogleRedirectResult(auth);
+      if (!result) {
+        consumeGoogleRedirectIntent();
+        return { type: 'empty' };
+      }
+
+      const intent = consumeGoogleRedirectIntent() || 'signin';
+      setSplashGoogleModalInflight();
+      try {
+        const outcome = await completeGoogleSplashAuth({
+          intent,
+          isNewUser: result.isNewUser,
+          flow: 'redirect',
+        });
+        return { type: 'done', intent, outcome };
+      } finally {
+        clearSplashGoogleModalInflight();
+      }
+    } catch (err) {
+      console.error('Google redirect result:', err);
+      const intent = consumeGoogleRedirectIntent();
+      trackAuthError({
+        method: 'google',
+        error_code: err?.code || 'redirect_result_failed',
+        surface: intent === 'signup' ? 'create_account' : 'sign_in',
+        auth_flow: 'redirect',
+      });
+      return { type: 'error', intent, err };
+    } finally {
+      inFlightCompletion = null;
+    }
+  })();
+
+  return inFlightCompletion;
+}
+
+/**
  * Completes a pending Google `signInWithRedirect` on splash / invite landings.
  *
  * Skips Firebase load when there is no stashed redirect intent so anon `/login`
@@ -31,69 +95,62 @@ export function useGoogleRedirectCompletion({
   onError,
   onSettled,
 } = {}) {
-  const ranRef = useRef(false);
+  const cbsRef = useRef({
+    onOpenSignIn,
+    onOpenSignUp,
+    onError,
+    onSettled,
+  });
+  cbsRef.current = {
+    onOpenSignIn,
+    onOpenSignUp,
+    onError,
+    onSettled,
+  };
 
   useEffect(() => {
-    if (ranRef.current) return;
-    ranRef.current = true;
+    const hasIntent = Boolean(peekGoogleRedirectIntent());
+    if (!hasIntent && !inFlightCompletion) {
+      // Clear a stranded overlay after StrictMode consumed intent on a prior mount.
+      cbsRef.current.onSettled?.();
+      return undefined;
+    }
 
-    // No intent → do not pull firebase-core just to call getRedirectResult.
-    if (!peekGoogleRedirectIntent()) return;
+    let active = true;
 
-    let cancelled = false;
-
-    (async () => {
-      let result;
-      try {
-        const { auth } = await ensureAuthReady();
-        const [{ consumeGoogleRedirectResult }, { completeGoogleSplashAuth }] =
-          await Promise.all([
-            import('../api/splashAuthApi'),
-            import('./completeGoogleSplashAuth'),
-          ]);
-        result = await consumeGoogleRedirectResult(auth);
-        if (cancelled) return;
-        if (!result) {
-          consumeGoogleRedirectIntent();
-          return;
+    void completePendingGoogleRedirect().then((result) => {
+      const cbs = cbsRef.current;
+      if (active) {
+        if (result.type === 'done' && result.outcome?.kind === 'error') {
+          cbs.onError?.(result.outcome.message, result.intent ?? null);
+          if (result.intent === 'signup') cbs.onOpenSignUp?.();
+          else cbs.onOpenSignIn?.();
+        } else if (result.type === 'error') {
+          cbs.onError?.(
+            getFirebaseAuthErrorMessage(result.err?.code),
+            result.intent ?? null,
+          );
+          if (result.intent === 'signup') cbs.onOpenSignUp?.();
+          else if (result.intent === 'signin') cbs.onOpenSignIn?.();
         }
-
-        const intent = consumeGoogleRedirectIntent() || 'signin';
-        setSplashGoogleModalInflight();
-        try {
-          const outcome = await completeGoogleSplashAuth({
-            intent,
-            isNewUser: result.isNewUser,
-            flow: 'redirect',
-          });
-          if (cancelled) return;
-          if (outcome.kind === 'error') {
-            onError?.(outcome.message, intent);
-            if (intent === 'signup') onOpenSignUp?.();
-            else onOpenSignIn?.();
-          }
-        } finally {
-          clearSplashGoogleModalInflight();
-        }
-      } catch (err) {
-        console.error('Google redirect result:', err);
-        const intent = consumeGoogleRedirectIntent();
-        trackAuthError({
-          method: 'google',
-          error_code: err?.code || 'redirect_result_failed',
-          surface: intent === 'signup' ? 'create_account' : 'sign_in',
-          auth_flow: 'redirect',
-        });
-        onError?.(getFirebaseAuthErrorMessage(err?.code), intent);
-        if (intent === 'signup') onOpenSignUp?.();
-        else if (intent === 'signin') onOpenSignIn?.();
-      } finally {
-        if (!cancelled) onSettled?.();
       }
-    })();
+      // Always settle — including after StrictMode cancelled the first subscriber —
+      // so LoginPage `googleReturnBusy` cannot stick forever on `:5173`.
+      cbs.onSettled?.();
+    });
 
     return () => {
-      cancelled = true;
+      active = false;
     };
-  }, [onError, onOpenSignIn, onOpenSignUp, onSettled]);
+  }, []);
+}
+
+/** @visibleForTesting */
+export function resetGoogleRedirectCompletionForTests() {
+  inFlightCompletion = null;
+}
+
+/** @visibleForTesting */
+export function completePendingGoogleRedirectForTests() {
+  return completePendingGoogleRedirect();
 }

--- a/src/features/auth/model/useGoogleRedirectCompletion.test.js
+++ b/src/features/auth/model/useGoogleRedirectCompletion.test.js
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ensureAuthReady = vi.fn(async () => ({ auth: { name: 'auth' } }));
+const consumeGoogleRedirectResult = vi.fn(async () => null);
+const completeGoogleSplashAuth = vi.fn();
+const peekGoogleRedirectIntent = vi.fn(() => null);
+const consumeGoogleRedirectIntent = vi.fn(() => null);
+
+vi.mock('../../../shared/lib/ensureFirebase.js', () => ({
+  ensureAuthReady: (...args) => ensureAuthReady(...args),
+}));
+
+vi.mock('../api/splashAuthApi.js', () => ({
+  consumeGoogleRedirectResult: (...args) =>
+    consumeGoogleRedirectResult(...args),
+}));
+
+vi.mock('./completeGoogleSplashAuth.js', () => ({
+  completeGoogleSplashAuth: (...args) => completeGoogleSplashAuth(...args),
+}));
+
+vi.mock('../utils/googleRedirectIntent.js', () => ({
+  peekGoogleRedirectIntent: (...args) => peekGoogleRedirectIntent(...args),
+  consumeGoogleRedirectIntent: (...args) =>
+    consumeGoogleRedirectIntent(...args),
+}));
+
+vi.mock('../utils/splashGoogleModalInflight.js', () => ({
+  setSplashGoogleModalInflight: vi.fn(),
+  clearSplashGoogleModalInflight: vi.fn(),
+}));
+
+vi.mock('./authAnalytics.js', () => ({
+  trackAuthError: vi.fn(),
+}));
+
+describe('completePendingGoogleRedirect', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    peekGoogleRedirectIntent.mockReturnValue(null);
+    consumeGoogleRedirectResult.mockResolvedValue(null);
+  });
+
+  afterEach(async () => {
+    const { resetGoogleRedirectCompletionForTests } = await import(
+      './useGoogleRedirectCompletion.js'
+    );
+    resetGoogleRedirectCompletionForTests();
+  });
+
+  it('no-ops when no redirect intent is stashed', async () => {
+    const { completePendingGoogleRedirectForTests } = await import(
+      './useGoogleRedirectCompletion.js'
+    );
+    await expect(completePendingGoogleRedirectForTests()).resolves.toEqual({
+      type: 'none',
+    });
+    expect(ensureAuthReady).not.toHaveBeenCalled();
+  });
+
+  it('shares one in-flight getRedirectResult across concurrent callers', async () => {
+    peekGoogleRedirectIntent.mockReturnValue('signup');
+    consumeGoogleRedirectIntent.mockReturnValue('signup');
+
+    const { completePendingGoogleRedirectForTests } = await import(
+      './useGoogleRedirectCompletion.js'
+    );
+
+    const [a, b] = await Promise.all([
+      completePendingGoogleRedirectForTests(),
+      completePendingGoogleRedirectForTests(),
+    ]);
+
+    expect(a).toEqual({ type: 'empty' });
+    expect(b).toEqual({ type: 'empty' });
+    expect(ensureAuthReady).toHaveBeenCalledTimes(1);
+    expect(consumeGoogleRedirectResult).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/auth/model/useSplashSignUp.js
+++ b/src/features/auth/model/useSplashSignUp.js
@@ -15,7 +15,7 @@ import {
 import { markGoogleAuthClick } from './authLoginTiming';
 import { shouldPreferGoogleRedirectAuth } from './preferGoogleRedirectAuth';
 import { runGoogleSplashAuth } from './runGoogleSplashAuth';
-
+import { SIGNUP_LEGAL_REQUIRED_ERROR } from './signupLegalCopy';
 export function useSplashSignUp(isOpen, onClose, { seedError = '' } = {}) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -66,7 +66,7 @@ export function useSplashSignUp(isOpen, onClose, { seedError = '' } = {}) {
   const handleGoogle = useCallback(async () => {
     setError('');
     if (!legalAccepted) {
-      setError('Confirm you agree to the Terms of Service and Privacy Policy to continue.');
+      setError(SIGNUP_LEGAL_REQUIRED_ERROR);
       return;
     }
     setBusy(true);
@@ -124,7 +124,7 @@ export function useSplashSignUp(isOpen, onClose, { seedError = '' } = {}) {
       e.preventDefault();
       setError('');
       if (!legalAccepted) {
-        setError('Confirm you agree to the Terms of Service and Privacy Policy to continue.');
+        setError(SIGNUP_LEGAL_REQUIRED_ERROR);
         return;
       }
       if (password !== confirmPassword) {

--- a/src/features/auth/ui/LoginAuthScreen.jsx
+++ b/src/features/auth/ui/LoginAuthScreen.jsx
@@ -82,7 +82,6 @@ function LoginSignInPanel({
     handleGoogle,
     handleEmailSignIn,
     handleSendPasswordResetEmail,
-    preferGoogleRedirect,
   } = useSplashSignIn(true, onClose, { seedError });
 
   const revealVisible = shouldShowPasswordReveal(email, password);
@@ -120,11 +119,6 @@ function LoginSignInPanel({
           googleBusy,
         })}
         prependContent={prependContent}
-        googleFootnote={
-          preferGoogleRedirect
-            ? 'Continues with a full-page Google sign-in (more reliable in this browser).'
-            : undefined
-        }
       >
       <form onSubmit={handleEmailSignIn} className="space-y-4 text-left">
         <div>
@@ -234,7 +228,6 @@ function LoginSignUpPanel({
     error,
     handleGoogle,
     handleEmailSignUp,
-    preferGoogleRedirect,
   } = useSplashSignUp(true, onClose, { seedError });
 
   const revealVisible = shouldShowPasswordReveal(
@@ -288,7 +281,7 @@ function LoginSignUpPanel({
       {fieldsLocked ? (
         <p
           id="signup-legal-gate-hint"
-          className="px-0.5 text-xs font-medium leading-snug text-slate-400"
+          className="px-0.5 text-center text-xs font-semibold leading-snug text-brand-primary"
           role="status"
         >
           {SIGNUP_LEGAL_GATE_HINT}
@@ -326,11 +319,7 @@ function LoginSignUpPanel({
           googleBusy,
         })}
         prependContent={prependContent}
-        googleFootnote={
-          preferGoogleRedirect
-            ? "Continues with a full-page Google sign-in. You'll set your username/handle next. Your email is never shared with other users."
-            : "You'll set your username/handle on the next page. Your email address is never shared or visible to other users."
-        }
+        googleFootnote="You'll set your username/handle on the next page. Your email address is never shared or visible to other users."
       >
       <form onSubmit={handleEmailSignUp} className="space-y-4 text-left">
         <fieldset

--- a/src/features/auth/ui/LoginAuthScreen.jsx
+++ b/src/features/auth/ui/LoginAuthScreen.jsx
@@ -15,6 +15,10 @@ import SplashAuthPanel from './SplashAuthPanel';
 import { useLoginAuthSurfaceReady } from '../model/useLoginAuthSurfaceReady';
 import { useSplashSignIn } from '../model/useSplashSignIn';
 import { useSplashSignUp } from '../model/useSplashSignUp';
+import {
+  SIGNUP_EMAIL_CTA_NEEDS_LEGAL,
+  SIGNUP_LEGAL_GATE_HINT,
+} from '../model/signupLegalCopy';
 import { warmLoginAuthSurface } from '../model/warmLoginAuthSurface';
 import { stashSplashResumeAuthModal } from '../utils/splashAuthResumeStorage';
 
@@ -239,42 +243,58 @@ function LoginSignUpPanel({
     confirmPassword,
   );
   const googlePreparing = !authSurfaceReady;
+  const fieldsLocked = !legalAccepted;
 
   const consentBlock = (
-    <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-border-subtle/60 bg-surface-inset/60 p-3.5 text-left text-sm font-semibold leading-snug text-slate-200">
-      <input
-        type="checkbox"
-        checked={legalAccepted}
-        onChange={(e) => setLegalAccepted(e.target.checked)}
-        className="mt-1 h-4 w-4 shrink-0 rounded border-slate-500 bg-surface-panel text-brand-primary focus-visible:ring-2 focus-visible:ring-brand"
-        aria-describedby="signup-legal-hint"
-      />
-      <span id="signup-legal-hint">
-        I agree to the{' '}
-        <Link
-          to="/terms"
-          className="text-teal-300 underline decoration-teal-500/60 underline-offset-2 hover:text-white"
-          onClick={(e) => {
-            e.stopPropagation();
-            stashSplashResumeAuthModal('signup');
-          }}
+    <div className="space-y-2">
+      <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-border-subtle/60 bg-surface-inset/60 p-3.5 text-left text-sm font-semibold leading-snug text-slate-200">
+        <input
+          type="checkbox"
+          checked={legalAccepted}
+          onChange={(e) => setLegalAccepted(e.target.checked)}
+          className="mt-1 h-4 w-4 shrink-0 rounded border-slate-500 bg-surface-panel text-brand-primary focus-visible:ring-2 focus-visible:ring-brand"
+          aria-describedby={
+            fieldsLocked
+              ? 'signup-legal-hint signup-legal-gate-hint'
+              : 'signup-legal-hint'
+          }
+        />
+        <span id="signup-legal-hint">
+          I agree to the{' '}
+          <Link
+            to="/terms"
+            className="text-teal-300 underline decoration-teal-500/60 underline-offset-2 hover:text-white"
+            onClick={(e) => {
+              e.stopPropagation();
+              stashSplashResumeAuthModal('signup');
+            }}
+          >
+            Terms of Service
+          </Link>{' '}
+          and{' '}
+          <Link
+            to="/privacy"
+            className="text-teal-300 underline decoration-teal-500/60 underline-offset-2 hover:text-white"
+            onClick={(e) => {
+              e.stopPropagation();
+              stashSplashResumeAuthModal('signup');
+            }}
+          >
+            Privacy Policy
+          </Link>
+          .
+        </span>
+      </label>
+      {fieldsLocked ? (
+        <p
+          id="signup-legal-gate-hint"
+          className="px-0.5 text-xs font-medium leading-snug text-slate-400"
+          role="status"
         >
-          Terms of Service
-        </Link>{' '}
-        and{' '}
-        <Link
-          to="/privacy"
-          className="text-teal-300 underline decoration-teal-500/60 underline-offset-2 hover:text-white"
-          onClick={(e) => {
-            e.stopPropagation();
-            stashSplashResumeAuthModal('signup');
-          }}
-        >
-          Privacy Policy
-        </Link>
-        .
-      </span>
-    </label>
+          {SIGNUP_LEGAL_GATE_HINT}
+        </p>
+      ) : null}
+    </div>
   );
 
   const prependContent = (
@@ -313,83 +333,95 @@ function LoginSignUpPanel({
         }
       >
       <form onSubmit={handleEmailSignUp} className="space-y-4 text-left">
-        <div>
-          <label
-            htmlFor="su-email"
-            className="text-xs font-bold uppercase tracking-wider text-slate-400"
-          >
-            Email
-          </label>
-          <Input
-            id="su-email"
-            type="email"
-            name="email"
-            autoComplete="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            className="mt-1 font-medium text-white"
-          />
-        </div>
-        <div>
-          <label
-            htmlFor="su-pass"
-            className="text-xs font-bold uppercase tracking-wider text-slate-400"
-          >
-            Password
-          </label>
-          <div className="relative mt-1">
-            <Input
-              id="su-pass"
-              type={showPassword ? 'text' : 'password'}
-              name="password"
-              autoComplete="new-password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              minLength={6}
-              className={`w-full font-medium text-white ${revealVisible ? 'pr-10' : ''}`}
-            />
-            <PasswordRevealToggle
-              visible={revealVisible}
-              showPassword={showPassword}
-              onToggle={() => setShowPassword((v) => !v)}
-            />
-          </div>
-        </div>
-        <div>
-          <label
-            htmlFor="su-confirm"
-            className="text-xs font-bold uppercase tracking-wider text-slate-400"
-          >
-            Confirm password
-          </label>
-          <div className="relative mt-1">
-            <Input
-              id="su-confirm"
-              type={showPassword ? 'text' : 'password'}
-              name="confirm-password"
-              autoComplete="new-password"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              required
-              className={`w-full font-medium text-white ${revealVisible ? 'pr-10' : ''}`}
-            />
-            <PasswordRevealToggle
-              visible={revealVisible}
-              showPassword={showPassword}
-              onToggle={() => setShowPassword((v) => !v)}
-            />
-          </div>
-        </div>
-        {error ? <StatusBanner type="error" message={error} /> : null}
-        <button
-          type="submit"
-          disabled={busy || !legalAccepted}
-          className={AUTH_EMAIL_CTA}
+        <fieldset
+          disabled={fieldsLocked || busy}
+          className="min-w-0 space-y-4 border-0 p-0 disabled:opacity-100"
         >
-          {busy ? 'Creating…' : 'Continue with email'}
-        </button>
+          <div>
+            <label
+              htmlFor="su-email"
+              className="text-xs font-bold uppercase tracking-wider text-slate-400"
+            >
+              Email
+            </label>
+            <Input
+              id="su-email"
+              type="email"
+              name="email"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="mt-1 font-medium text-white"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="su-pass"
+              className="text-xs font-bold uppercase tracking-wider text-slate-400"
+            >
+              Password
+            </label>
+            <div className="relative mt-1">
+              <Input
+                id="su-pass"
+                type={showPassword ? 'text' : 'password'}
+                name="password"
+                autoComplete="new-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={6}
+                className={`w-full font-medium text-white ${revealVisible ? 'pr-10' : ''}`}
+              />
+              <PasswordRevealToggle
+                visible={revealVisible}
+                showPassword={showPassword}
+                onToggle={() => setShowPassword((v) => !v)}
+                disabled={fieldsLocked || busy}
+              />
+            </div>
+          </div>
+          <div>
+            <label
+              htmlFor="su-confirm"
+              className="text-xs font-bold uppercase tracking-wider text-slate-400"
+            >
+              Confirm password
+            </label>
+            <div className="relative mt-1">
+              <Input
+                id="su-confirm"
+                type={showPassword ? 'text' : 'password'}
+                name="confirm-password"
+                autoComplete="new-password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                className={`w-full font-medium text-white ${revealVisible ? 'pr-10' : ''}`}
+              />
+              <PasswordRevealToggle
+                visible={revealVisible}
+                showPassword={showPassword}
+                onToggle={() => setShowPassword((v) => !v)}
+                disabled={fieldsLocked || busy}
+              />
+            </div>
+          </div>
+          {error ? <StatusBanner type="error" message={error} /> : null}
+          <button
+            type="submit"
+            disabled={busy || fieldsLocked}
+            className={AUTH_EMAIL_CTA}
+            title={fieldsLocked ? SIGNUP_LEGAL_GATE_HINT : undefined}
+          >
+            {busy
+              ? 'Creating…'
+              : fieldsLocked
+                ? SIGNUP_EMAIL_CTA_NEEDS_LEGAL
+                : 'Continue with email'}
+          </button>
+        </fieldset>
       </form>
       {typeof onSwitchToSignIn === 'function' ? (
         <p className="mt-6 text-center text-sm font-semibold text-slate-400">

--- a/src/features/auth/ui/PasswordRevealToggle.jsx
+++ b/src/features/auth/ui/PasswordRevealToggle.jsx
@@ -11,6 +11,7 @@ export default function PasswordRevealToggle({
   visible,
   showPassword,
   onToggle,
+  disabled = false,
 }) {
   if (!visible) return null;
 
@@ -19,10 +20,11 @@ export default function PasswordRevealToggle({
       variant="text"
       size="none"
       type="button"
+      disabled={disabled}
       aria-label={showPassword ? 'Hide password' : 'Show password'}
       aria-pressed={showPassword}
       onClick={onToggle}
-      className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1.5 text-slate-400 hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+      className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1.5 text-slate-400 hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand disabled:pointer-events-none disabled:opacity-40"
     >
       {showPassword ? (
         <EyeOff className="h-4 w-4" aria-hidden />

--- a/src/features/auth/ui/SplashSignInModal.jsx
+++ b/src/features/auth/ui/SplashSignInModal.jsx
@@ -34,7 +34,6 @@ export default function SplashSignInModal({
     handleGoogle,
     handleEmailSignIn,
     handleSendPasswordResetEmail,
-    preferGoogleRedirect,
   } = useSplashSignIn(isOpen, onClose, { seedError });
 
   const revealVisible = shouldShowPasswordReveal(email, password);
@@ -68,11 +67,6 @@ export default function SplashSignInModal({
         busy={busy}
         googleLabel={resolveGoogleCtaLabel({ googleBusy })}
         prependContent={prependContent}
-        googleFootnote={
-          preferGoogleRedirect
-            ? 'Continues with a full-page Google sign-in (more reliable in this browser).'
-            : undefined
-        }
         closeOnBackdropClick={false}
       >
       <form onSubmit={handleEmailSignIn} className="space-y-4 text-left">

--- a/src/features/auth/ui/SplashSignUpModal.jsx
+++ b/src/features/auth/ui/SplashSignUpModal.jsx
@@ -11,6 +11,10 @@ import PasswordRevealToggle, {
   shouldShowPasswordReveal,
 } from './PasswordRevealToggle';
 import SplashAuthModalShell from './SplashAuthModalShell';
+import {
+  SIGNUP_EMAIL_CTA_NEEDS_LEGAL,
+  SIGNUP_LEGAL_GATE_HINT,
+} from '../model/signupLegalCopy';
 import { useSplashSignUp } from '../model/useSplashSignUp';
 import { stashSplashResumeAuthModal } from '../utils/splashAuthResumeStorage';
 
@@ -45,42 +49,58 @@ export default function SplashSignUpModal({
     password,
     confirmPassword,
   );
+  const fieldsLocked = !legalAccepted;
 
   const consentBlock = (
-    <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-border-subtle/60 bg-surface-inset/60 p-3.5 text-left text-sm font-semibold leading-snug text-slate-200">
-      <input
-        type="checkbox"
-        checked={legalAccepted}
-        onChange={(e) => setLegalAccepted(e.target.checked)}
-        className="mt-1 h-4 w-4 shrink-0 rounded border-slate-500 bg-surface-panel text-brand-primary focus-visible:ring-2 focus-visible:ring-brand"
-        aria-describedby="signup-legal-hint"
-      />
-      <span id="signup-legal-hint">
-        I agree to the{' '}
-        <Link
-          to="/terms"
-          className="text-teal-300 underline decoration-teal-500/60 underline-offset-2 hover:text-white"
-          onClick={(e) => {
-            e.stopPropagation();
-            stashSplashResumeAuthModal('signup');
-          }}
+    <div className="space-y-2">
+      <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-border-subtle/60 bg-surface-inset/60 p-3.5 text-left text-sm font-semibold leading-snug text-slate-200">
+        <input
+          type="checkbox"
+          checked={legalAccepted}
+          onChange={(e) => setLegalAccepted(e.target.checked)}
+          className="mt-1 h-4 w-4 shrink-0 rounded border-slate-500 bg-surface-panel text-brand-primary focus-visible:ring-2 focus-visible:ring-brand"
+          aria-describedby={
+            fieldsLocked
+              ? 'signup-legal-hint signup-legal-gate-hint'
+              : 'signup-legal-hint'
+          }
+        />
+        <span id="signup-legal-hint">
+          I agree to the{' '}
+          <Link
+            to="/terms"
+            className="text-teal-300 underline decoration-teal-500/60 underline-offset-2 hover:text-white"
+            onClick={(e) => {
+              e.stopPropagation();
+              stashSplashResumeAuthModal('signup');
+            }}
+          >
+            Terms of Service
+          </Link>{' '}
+          and{' '}
+          <Link
+            to="/privacy"
+            className="text-teal-300 underline decoration-teal-500/60 underline-offset-2 hover:text-white"
+            onClick={(e) => {
+              e.stopPropagation();
+              stashSplashResumeAuthModal('signup');
+            }}
+          >
+            Privacy Policy
+          </Link>
+          .
+        </span>
+      </label>
+      {fieldsLocked ? (
+        <p
+          id="signup-legal-gate-hint"
+          className="px-0.5 text-xs font-medium leading-snug text-slate-400"
+          role="status"
         >
-          Terms of Service
-        </Link>{' '}
-        and{' '}
-        <Link
-          to="/privacy"
-          className="text-teal-300 underline decoration-teal-500/60 underline-offset-2 hover:text-white"
-          onClick={(e) => {
-            e.stopPropagation();
-            stashSplashResumeAuthModal('signup');
-          }}
-        >
-          Privacy Policy
-        </Link>
-        .
-      </span>
-    </label>
+          {SIGNUP_LEGAL_GATE_HINT}
+        </p>
+      ) : null}
+    </div>
   );
 
   const prependContent = (
@@ -118,83 +138,95 @@ export default function SplashSignUpModal({
         closeOnBackdropClick={false}
       >
       <form onSubmit={handleEmailSignUp} className="space-y-4 text-left">
-        <div>
-          <label
-            htmlFor="su-email"
-            className="text-xs font-bold uppercase tracking-wider text-slate-400"
-          >
-            Email
-          </label>
-          <Input
-            id="su-email"
-            type="email"
-            name="email"
-            autoComplete="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            className="mt-1 font-medium text-white"
-          />
-        </div>
-        <div>
-          <label
-            htmlFor="su-pass"
-            className="text-xs font-bold uppercase tracking-wider text-slate-400"
-          >
-            Password
-          </label>
-          <div className="relative mt-1">
-            <Input
-              id="su-pass"
-              type={showPassword ? 'text' : 'password'}
-              name="password"
-              autoComplete="new-password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              minLength={6}
-              className={`w-full font-medium text-white ${revealVisible ? 'pr-10' : ''}`}
-            />
-            <PasswordRevealToggle
-              visible={revealVisible}
-              showPassword={showPassword}
-              onToggle={() => setShowPassword((v) => !v)}
-            />
-          </div>
-        </div>
-        <div>
-          <label
-            htmlFor="su-confirm"
-            className="text-xs font-bold uppercase tracking-wider text-slate-400"
-          >
-            Confirm password
-          </label>
-          <div className="relative mt-1">
-            <Input
-              id="su-confirm"
-              type={showPassword ? 'text' : 'password'}
-              name="confirm-password"
-              autoComplete="new-password"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              required
-              className={`w-full font-medium text-white ${revealVisible ? 'pr-10' : ''}`}
-            />
-            <PasswordRevealToggle
-              visible={revealVisible}
-              showPassword={showPassword}
-              onToggle={() => setShowPassword((v) => !v)}
-            />
-          </div>
-        </div>
-        {error ? <StatusBanner type="error" message={error} /> : null}
-        <button
-          type="submit"
-          disabled={busy || !legalAccepted}
-          className={AUTH_EMAIL_CTA}
+        <fieldset
+          disabled={fieldsLocked || busy}
+          className="min-w-0 space-y-4 border-0 p-0 disabled:opacity-100"
         >
-          {busy ? 'Creating…' : 'Continue with email'}
-        </button>
+          <div>
+            <label
+              htmlFor="su-email"
+              className="text-xs font-bold uppercase tracking-wider text-slate-400"
+            >
+              Email
+            </label>
+            <Input
+              id="su-email"
+              type="email"
+              name="email"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="mt-1 font-medium text-white"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="su-pass"
+              className="text-xs font-bold uppercase tracking-wider text-slate-400"
+            >
+              Password
+            </label>
+            <div className="relative mt-1">
+              <Input
+                id="su-pass"
+                type={showPassword ? 'text' : 'password'}
+                name="password"
+                autoComplete="new-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={6}
+                className={`w-full font-medium text-white ${revealVisible ? 'pr-10' : ''}`}
+              />
+              <PasswordRevealToggle
+                visible={revealVisible}
+                showPassword={showPassword}
+                onToggle={() => setShowPassword((v) => !v)}
+                disabled={fieldsLocked || busy}
+              />
+            </div>
+          </div>
+          <div>
+            <label
+              htmlFor="su-confirm"
+              className="text-xs font-bold uppercase tracking-wider text-slate-400"
+            >
+              Confirm password
+            </label>
+            <div className="relative mt-1">
+              <Input
+                id="su-confirm"
+                type={showPassword ? 'text' : 'password'}
+                name="confirm-password"
+                autoComplete="new-password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                className={`w-full font-medium text-white ${revealVisible ? 'pr-10' : ''}`}
+              />
+              <PasswordRevealToggle
+                visible={revealVisible}
+                showPassword={showPassword}
+                onToggle={() => setShowPassword((v) => !v)}
+                disabled={fieldsLocked || busy}
+              />
+            </div>
+          </div>
+          {error ? <StatusBanner type="error" message={error} /> : null}
+          <button
+            type="submit"
+            disabled={busy || fieldsLocked}
+            className={AUTH_EMAIL_CTA}
+            title={fieldsLocked ? SIGNUP_LEGAL_GATE_HINT : undefined}
+          >
+            {busy
+              ? 'Creating…'
+              : fieldsLocked
+                ? SIGNUP_EMAIL_CTA_NEEDS_LEGAL
+                : 'Continue with email'}
+          </button>
+        </fieldset>
       </form>
       {typeof onSwitchToSignIn === 'function' ? (
         <p className="mt-6 text-center text-sm font-semibold text-slate-400">

--- a/src/features/auth/ui/SplashSignUpModal.jsx
+++ b/src/features/auth/ui/SplashSignUpModal.jsx
@@ -41,7 +41,6 @@ export default function SplashSignUpModal({
     closeModal,
     handleGoogle,
     handleEmailSignUp,
-    preferGoogleRedirect,
   } = useSplashSignUp(isOpen, onClose, { seedError });
 
   const revealVisible = shouldShowPasswordReveal(
@@ -94,7 +93,7 @@ export default function SplashSignUpModal({
       {fieldsLocked ? (
         <p
           id="signup-legal-gate-hint"
-          className="px-0.5 text-xs font-medium leading-snug text-slate-400"
+          className="px-0.5 text-center text-xs font-semibold leading-snug text-brand-primary"
           role="status"
         >
           {SIGNUP_LEGAL_GATE_HINT}
@@ -130,11 +129,7 @@ export default function SplashSignUpModal({
         googleDisabled={busy || !legalAccepted}
         googleLabel={resolveGoogleCtaLabel({ googleBusy })}
         prependContent={prependContent}
-        googleFootnote={
-          preferGoogleRedirect
-            ? "Continues with a full-page Google sign-in. You'll set your username/handle next. Your email is never shared with other users."
-            : "You'll set your username/handle on the next page. Your email address is never shared or visible to other users."
-        }
+        googleFootnote="You'll set your username/handle on the next page. Your email address is never shared or visible to other users."
         closeOnBackdropClick={false}
       >
       <form onSubmit={handleEmailSignUp} className="space-y-4 text-left">

--- a/src/pages/auth/LoginPage.jsx
+++ b/src/pages/auth/LoginPage.jsx
@@ -93,6 +93,14 @@ export default function LoginPage() {
     onSettled: onRedirectSettled,
   });
 
+  // Dev StrictMode can cancel redirect completion while leaving this busy flag
+  // set — clear the overlay once the stash is gone (#885 follow-up).
+  useEffect(() => {
+    if (!googleReturnBusy) return;
+    if (peekGoogleRedirectIntent()) return;
+    setGoogleReturnBusy(false);
+  }, [googleReturnBusy]);
+
   // After form paint: warm Auth. Marketing idle/CTA warm → speculative|intent (#880/#860);
   // otherwise immediate (#858). App Check stays parallel (#850).
   useEffect(() => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -34,6 +34,9 @@ function rewriteAppDocumentRequest(req, _res, next) {
   const pathname = raw.split('?')[0];
   if (
     pathname === '/app.html' ||
+    // Prerendered shells (e.g. /login/index.html) must not be rewritten again —
+    // `startsWith('/login/')` would otherwise stomp them with bare app.html.
+    pathname.endsWith('.html') ||
     pathname.startsWith('/src/') ||
     pathname.startsWith('/@') ||
     pathname.startsWith('/node_modules') ||


### PR DESCRIPTION
## Summary
- Create account: email/password locked until Terms & Privacy accepted (parity with Google)
- Teal centered hint: “Check the box to continue setting up your account profile.”
- Locked CTA label: “Accept terms to continue”
- Remove confusing “full-page Google sign-in” footnote
- Fix `:5173` stranded Google continue overlay (StrictMode + redirect stash)
- Fix `vite preview` stomping prerendered `/login` shell
- **v1.52.1** PATCH

## Test plan
- [x] Unit tests for legal copy + redirect completion sharing
- [x] Lint green
- [ ] `/login?mode=signup`: fields locked → check terms → unlock
- [ ] Hard refresh `:5173/login` after prior Google redirect does not stick on continue overlay
- [ ] `vite preview` `/login` shows login boot shell (not bare app root)