### PR TITLE
fix(auth): stop Log Out hang racing HardRedirect to /login (#899)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.53.2] — 2026-08-05
+
+### Fixed
+- **Log Out hang (#899)** — After #881 unauth dashboard → `/login` hard-nav, Account Log Out raced a blank `HardRedirect` to `/login` instead of marketing home. Intentional sign-out now marks post-sign-out, guards to `/`, hard-navs marketing `index.html`, and caps FCM cleanup so revoke cannot block forever. Email CTA unauth `/dashboard/*` → `/login` unchanged.
+
+---
+
 ## [1.53.1] — 2026-08-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.53.1",
+  "version": "1.53.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/app/routes/DashboardRoute.jsx
+++ b/src/app/routes/DashboardRoute.jsx
@@ -2,9 +2,11 @@ import React, { useEffect } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 
 import {
+  consumePostSignOutHome,
   trackAuthPartialProfile,
   useAuth,
 } from '../../features/auth';
+
 
 import { ShowCalendarProvider } from '../../features/show-calendar';
 import { ensureAppCheckNow } from '../../shared/lib/firebaseAppCheck';
@@ -43,7 +45,11 @@ export default function DashboardRoute() {
   // lands on /dashboard/picks (etc.), not generic /dashboard. Do not send
   // unauthenticated visitors to marketing `/` (no AuthProvider there).
   // #830 / #881: hard-nav to `/login` (not soft SPA stay); #890 boots app.html again.
+  // #899: intentional Log Out marks post-sign-out → marketing `/` (not /login race).
   if (decision.kind === 'redirect-home') {
+    if (consumePostSignOutHome()) {
+      return <HardRedirect to="/" />;
+    }
     persistDashboardPath(location.pathname, location.search);
     return <HardRedirect to="/login" />;
   }

--- a/src/features/account/ui/DeleteAccountSection.jsx
+++ b/src/features/account/ui/DeleteAccountSection.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { useDeleteAccount } from '../model/useDeleteAccount';
 import { DELETE_ACCOUNT_CONFIRMATION_PHRASE } from '../api/deleteAccountCallable';
@@ -9,14 +9,13 @@ import Button from '../../../shared/ui/Button';
  * Last-resort account deletion: collapsed by default; checkbox + exact phrase + confirm.
  */
 export default function DeleteAccountSection() {
-  const navigate = useNavigate();
   const [expanded, setExpanded] = useState(false);
   const [ack, setAck] = useState(false);
   const [phrase, setPhrase] = useState('');
 
-  const { isDeleting, error, clearError, requestDelete } = useDeleteAccount({
-    onAfterDelete: () => navigate('/'),
-  });
+  // useSignOut (via delete) hard-navs marketing `/` (#899).
+  const { isDeleting, error, clearError, requestDelete } = useDeleteAccount({});
+
 
   const phraseOk = phrase.trim() === DELETE_ACCOUNT_CONFIRMATION_PHRASE;
   const canSubmit = ack && phraseOk && !isDeleting;

--- a/src/features/auth/index.js
+++ b/src/features/auth/index.js
@@ -24,6 +24,11 @@ export { usePasswordReset } from './model/usePasswordReset';
 export { usePasswordResetCompleteState } from './model/usePasswordResetCompleteState';
 export { useProfileSetup } from './model/useProfileSetup';
 export { useSignOut } from './model/useSignOut';
+export {
+  consumePostSignOutHome,
+  markPostSignOutHome,
+} from './model/postSignOutHome';
+
 export { getFirebaseAuthErrorMessage } from './utils/firebaseAuthMessages';
 export { getPasswordResetActionCodeSettings } from './utils/passwordResetActionSettings';
 export {

--- a/src/features/auth/model/postSignOutHome.js
+++ b/src/features/auth/model/postSignOutHome.js
@@ -1,0 +1,29 @@
+/**
+ * Intentional sign-out → marketing home (#899).
+ *
+ * After #881, unauth `/dashboard/*` hard-navs to `/login`. During Log Out the
+ * auth listener clears `user` while still on the dashboard, so that bounce
+ * races AccountPage soft `navigate('/')` and shows a blank HardRedirect.
+ * Set this flag synchronously before `signOut` so the guard sends `/` instead.
+ */
+
+export const POST_SIGNOUT_HOME_KEY = 'sp_post_signout_home';
+
+export function markPostSignOutHome() {
+  try {
+    sessionStorage.setItem(POST_SIGNOUT_HOME_KEY, '1');
+  } catch {
+    // Private mode / blocked storage — hard-nav after signOut is the fallback.
+  }
+}
+
+/** @returns {boolean} true once when a post-sign-out home redirect is pending */
+export function consumePostSignOutHome() {
+  try {
+    if (sessionStorage.getItem(POST_SIGNOUT_HOME_KEY) !== '1') return false;
+    sessionStorage.removeItem(POST_SIGNOUT_HOME_KEY);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/features/auth/model/postSignOutHome.test.js
+++ b/src/features/auth/model/postSignOutHome.test.js
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  POST_SIGNOUT_HOME_KEY,
+  consumePostSignOutHome,
+  markPostSignOutHome,
+} from './postSignOutHome';
+
+function createMemoryStorage() {
+  const map = new Map();
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => {
+      map.set(k, String(v));
+    },
+    removeItem: (k) => {
+      map.delete(k);
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal('sessionStorage', createMemoryStorage());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('postSignOutHome', () => {
+  it('consume is false until marked', () => {
+    expect(consumePostSignOutHome()).toBe(false);
+  });
+
+  it('mark then consume once', () => {
+    markPostSignOutHome();
+    expect(sessionStorage.getItem(POST_SIGNOUT_HOME_KEY)).toBe('1');
+    expect(consumePostSignOutHome()).toBe(true);
+    expect(consumePostSignOutHome()).toBe(false);
+    expect(sessionStorage.getItem(POST_SIGNOUT_HOME_KEY)).toBe(null);
+  });
+});

--- a/src/features/auth/model/useSignOut.js
+++ b/src/features/auth/model/useSignOut.js
@@ -6,23 +6,47 @@ import { revokeFcmDeviceToken } from '../../../shared/lib/firebaseMessaging';
 import { removeLocalStorageItem } from '../../../shared/lib/local-storage';
 import { auth } from '../../../shared/lib/firebase';
 import { signOutUser } from '../api/authApi';
+import { markPostSignOutHome } from './postSignOutHome';
+
+const CLEANUP_MS = 2500;
+
+/**
+ * @param {Promise<unknown>} promise
+ * @param {number} ms
+ */
+function withTimeout(promise, ms) {
+  return Promise.race([
+    promise,
+    new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    }),
+  ]);
+}
 
 export function useSignOut() {
   return useCallback(async () => {
+    // Before auth clears: dashboard guard must not HardRedirect to /login (#899).
+    markPostSignOutHome();
+
     const uid = auth.currentUser?.uid;
     try {
-      await revokeFcmDeviceToken();
+      await withTimeout(revokeFcmDeviceToken(), CLEANUP_MS);
     } catch {
       // Best-effort: SW / messaging may be unavailable after a prior error.
     }
     if (uid) {
       try {
-        await clearWebPushTokenDocsForUser(uid);
+        await withTimeout(clearWebPushTokenDocsForUser(uid), CLEANUP_MS);
       } catch {
         // Tokens may already be cleared; still proceed with sign-out.
       }
     }
     await signOutUser();
     removeLocalStorageItem(POOL_INVITE_STORAGE_KEY);
+
+    // Marketing document (not app soft-nav `/` splash). Wins over /login bounce.
+    if (typeof window !== 'undefined') {
+      window.location.assign('/');
+    }
   }, []);
 }

--- a/src/pages/profile/AccountPage.jsx
+++ b/src/pages/profile/AccountPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useNavigate, useOutletContext } from 'react-router-dom';
+import { Link, useOutletContext } from 'react-router-dom';
 
 import { useSignOut } from '../../features/auth';
 import { AccountSecurity, DeleteAccountSection } from '../../features/account';
@@ -12,7 +12,6 @@ import Button from '../../shared/ui/Button';
 export default function AccountPage({ user: userProp }) {
   const outlet = useOutletContext();
   const user = userProp ?? outlet?.user;
-  const navigate = useNavigate();
   const signOut = useSignOut();
 
   const providerIds =
@@ -25,8 +24,8 @@ export default function AccountPage({ user: userProp }) {
 
   const handleLogout = async () => {
     try {
+      // useSignOut hard-navs to marketing `/` (#899); do not soft-nav under dashboard.
       await signOut();
-      navigate('/');
     } catch (error) {
       console.error('Error logging out: ', error);
     }

--- a/src/shared/ui/HardRedirect.jsx
+++ b/src/shared/ui/HardRedirect.jsx
@@ -11,5 +11,14 @@ export default function HardRedirect({ to }) {
     if (typeof to !== 'string' || !to) return;
     window.location.replace(to);
   }, [to]);
-  return null;
+  // Avoid a blank frame while replace runs (#899 logout race).
+  return (
+    <div
+      className="flex min-h-[40vh] items-center justify-center px-4 text-sm text-content-secondary"
+      role="status"
+      aria-live="polite"
+    >
+      Taking you there…
+    </div>
+  );
 }


### PR DESCRIPTION
Closes #899

## Summary
- After #881/#890, unauth `/dashboard/*` hard-navs to `/login`. Log Out cleared session while still on Account → blank `HardRedirect` raced soft `navigate('/')`.
- Intentional sign-out marks post-sign-out; guard sends marketing `/`; `useSignOut` hard-navs `index.html` and timeouts FCM cleanup.
- Email CTA unauth `/dashboard/*` → `/login` + persist path unchanged.
- PATCH **1.53.2**

## Test plan
- [x] `npm test` + lint
- [ ] Account → Log Out → marketing `/` promptly (no blank /login hang)
- [ ] Signed-out hard-open `/dashboard/picks` still → `/login` then restore path after sign-in


Made with [Cursor](https://cursor.com)