### PR TITLE
docs: field-stop cold-open/auth-door train at v1.53.2

### DIFF
--- a/docs/AUTH_BOOT_PRACTICES.md
+++ b/docs/AUTH_BOOT_PRACTICES.md
@@ -3,7 +3,7 @@
 Standing rules for marketing, the **auth door** (`/login`), and the app SPA. Learned from Safari hotfix (#850), hard-ready Google (#858), redirect (#859), hop train (#860 / #880 / #881), and the 2026-08-05 recalibration: **HTML-first auth door** is the target — not another CSR hop tier.
 
 **Roadmap / architecture:** `docs/AUTH_SEAMLESS_PATH.md` (**§5 authoritative path** — Phase 0 reliability → Phase 2 HTML-first `/login`).  
-**Related:** `docs/OUTBOUND_AUTH_HANDOFF.md` · `docs/API.md` (`/login`) · code today: `ensureFirebase.js`, `warmLoginAuthSurface.js`, `prefetchLoginIntent.js` (HTML-first door in epic #889 Phase 2).
+**Related:** `docs/OUTBOUND_AUTH_HANDOFF.md` · `docs/API.md` (`/login`) · `docs/AUTH_SEAMLESS_PATH.md` (**field stop 2026-08-05** at v1.53.2 — do not resume hop/HTML-first work without a human go). Code today: `ensureFirebase.js`, `warmLoginAuthSurface.js`, `prefetchLoginIntent.js`.
 
 ---
 

--- a/docs/AUTH_SEAMLESS_PATH.md
+++ b/docs/AUTH_SEAMLESS_PATH.md
@@ -1,26 +1,31 @@
 # Seamless auth & no-lag entry — path to top-tier feel
 
-**Status:** Decision / roadmap doc — **recalibrated 2026-08-05**.  
-**Delivery epic:** [#889](https://github.com/pat792/set-picks/issues/889) — HTML-first auth door (three-surface).  
+**Status:** Decision / roadmap doc — **field stop 2026-08-05** (after v1.53.2).  
+**Delivery epic (parked):** [#889](https://github.com/pat792/set-picks/issues/889) — HTML-first auth door (three-surface).  
 **Predecessor (CSR hop / Google reliability train):** [#856](https://github.com/pat792/set-picks/issues/856) — historical; remaining hop work superseded by #889.
 
-### Authoritative next step (read this first)
+### Field stop (2026-08-05) — read this first
 
-**Do not start another CSR hop tier** (more prefetch / thinner Vite entry / speculative warm as the strategy).
+**Stop shipping further auth-door / cold-open / CSR-hop work until explicitly resumed.** Prod is at **v1.53.2**.
 
-T0–T2.5 optimized the **approach path** to a client-rendered `/login`. That closed Google first-tap reliability and improved download warm, but it did **not** produce a best-in-class marketing → auth door. Phase B (#881) thin CSR login entry shipped in v1.53.0 and **regressed** Safari private to an indefinite login loading hang — fail-closed boot, not a latency miss.
+| Shipped | Notes |
+|--------|--------|
+| **v1.53.1 (#890)** | Phase 0 reliability: retire #881 thin `login.html`; `/login` boots `app.html` + branded shell again |
+| **v1.53.2 (#899)** | Log Out hang: post-sign-out → marketing `/` (not race HardRedirect → `/login`) |
 
-**Target architecture:** three surfaces —
+**Do not start another CSR hop tier.** Do not re-thin `/login`. Do not “fix feel” with more prefetch experiments in this train.
+
+Parked (not cancelled): HTML-first auth door (#889 / #892), tour-stats CDN JSON (#869), email CTA flow matrix (#893). Resume only with an explicit human go — not as agent default.
+
+Standing rules still in force: `docs/AUTH_BOOT_PRACTICES.md` (Google gesture / App Check / Safari redirect).
+
+**Target architecture (when resumed):** three surfaces —
 
 | Surface | Job | Construction |
 |--------|-----|----------------|
 | **Marketing** | SEO/GEO, demand gen | Light document; Firebase-**execute**-free on first paint |
 | **Auth door** | Sign in / sign up only | **HTML-first form** + auth-only JS hydrate (keep Firebase) |
 | **App** | Live game | Existing dashboard SPA |
-
-**Immediate:** Phase 0 — restore a login boot that always paints a working form on WebKit private (rollback/hotfix #881 hang). Freeze hop experiments until that passes.  
-**Then:** Phase 1–2 — contract + HTML-first `/login` auth door (see §5).  
-**Standing rules (gesture / App Check / redirect):** `docs/AUTH_BOOT_PRACTICES.md` (still in force; rule 2 target updates with the auth door).
 
 **Related:** `docs/OUTBOUND_AUTH_HANDOFF.md` · `docs/RELEASE_TRAIN_COLD_OPEN.md` · `docs/API.md` (`/login`) · children T0–T2.5 below (historical).
 
@@ -169,9 +174,10 @@ DEFER          → GIS / hosted IdP only if product still wants more after Phase
 
 ### Phase 0 — Stop the bleeding
 
-1. Roll back or hotfix so Safari private marketing → Sign in shows an **interactive form** (no indefinite skeleton/hang). **Vehicle:** [#890](https://github.com/pat792/set-picks/issues/890) → **v1.53.1** — retire thin `login.html` entry; `/login` boots `app.html` + branded shell again.
-2. Freeze hop/preload experiments until Phase 0 passes.
+1. Roll back or hotfix so Safari private marketing → Sign in shows an **interactive form** (no indefinite skeleton/hang). **Shipped:** [#890](https://github.com/pat792/set-picks/issues/890) → **v1.53.1** — retire thin `login.html` entry; `/login` boots `app.html` + branded shell again.
+2. Freeze hop/preload experiments until Phase 0 passes. **Field stop 2026-08-05:** freeze remains in force after **v1.53.2** (#899 Log Out fix); do not auto-continue Phase 1–2.
 3. **Gate:** WebKit private (closest available) — form every time; Google first enabled tap works.
+4. **Collateral (#899 / v1.53.2):** intentional Log Out must hard-nav marketing `/`, not race dashboard unauth → `/login`.
 
 ### Phase 1 — Architecture contract
 

--- a/docs/AUTH_SEAMLESS_PATH.md
+++ b/docs/AUTH_SEAMLESS_PATH.md
@@ -242,7 +242,7 @@ Leave the live game as the SPA. Do not mount dashboard/react-query on the auth d
 - [x] Human / WebKit private is the release gate for auth-door work.
 - [x] T2–T2.5 CSR hop train: useful learnings; **not** the remaining strategy (§8).
 - [x] **2026-08-05:** Adopt HTML-first auth door (§5) as authoritative next solution.
-- [ ] Phase 0: prod Safari private login hang resolved.
+- [x] Phase 0: prod Safari private login hang resolved (v1.53.1 #890); Log Out race fixed (v1.53.2 #899). **Field stop.**
 - [ ] Phase 1: contract reflected in boot practices + delivery issue(s).
 - [ ] Phase 2: HTML-first `/login` shipped + WebKit private AC.
 

--- a/docs/OUTBOUND_AUTH_HANDOFF.md
+++ b/docs/OUTBOUND_AUTH_HANDOFF.md
@@ -34,7 +34,8 @@ After marketing cold opens stop booting `AuthProvider`, every outbound link must
 | Marketing shell Home | `MarketingPageShell` | `public-static` | **Done (1.48.1):** `<a href="/">` hard-nav so app-doc surfaces reload marketing `index.html` |
 | Password-reset success | `PasswordResetCompletePage` | `retarget-auth` | **Done (#881 / #890):** hard `<a href="/login">` |
 | `/?login=true` (+ optional `signup=1`) | Legacy deep links, older QA | `retarget-auth` | Compat hops: `marketingMain` + `SplashPage` → `/login` |
-| Unauth hard-open `/dashboard/*` or `/setup` | `DashboardRoute` / `SetupRoute` | `retarget-auth` | **#830 / #881:** hard-nav to `/login` thin entry (keeps `persistDashboardPath`) |
+| Unauth hard-open `/dashboard/*` or `/setup` | `DashboardRoute` / `SetupRoute` | `retarget-auth` | **#830 / #881 / #890:** hard-nav to `/login` (app.html boot; keeps `persistDashboardPath`) |
+| Account Log Out / delete → home | `useSignOut` | `public-static` | **#899 (v1.53.2):** mark post-sign-out → hard-nav marketing `/` (must not race unauth bounce to `/login`) |
 | Firebase Auth `%LINK%` → `/password-reset-complete` | Console email templates | `app-ok` | spa-boot / app path |
 
 ### Production emitters — no URL rewrites required

--- a/docs/RELEASE_TRAIN_COLD_OPEN.md
+++ b/docs/RELEASE_TRAIN_COLD_OPEN.md
@@ -5,11 +5,21 @@
 **Do not revive:** issue #831 hand-built HTML stub (lost branding, scoring graphics, live tour stats).
 
 **Auth / App Check sequencing (standing):** `docs/AUTH_BOOT_PRACTICES.md` — immediate warm + hard-ready Google CTA (#858); never await App Check before `signInWithPopup` (#850).  
-**Top-tier auth feel:** `docs/AUTH_SEAMLESS_PATH.md` · delivery epic [#856](https://github.com/pat792/set-picks/issues/856) (T0a–T3: #857–#861; T0b #858 hard-ready Google).
+**Top-tier auth feel:** `docs/AUTH_SEAMLESS_PATH.md` · epic [#889](https://github.com/pat792/set-picks/issues/889) (parked) · predecessor [#856](https://github.com/pat792/set-picks/issues/856).
+
+### Field stop (2026-08-05)
+
+**This train is paused in production at v1.53.2.** No further cold-open / auth-hop / thin-entry PRs until a human explicitly resumes.
+
+- **v1.53.1 (#890):** restore `/login` on `app.html` after #881 Safari hang  
+- **v1.53.2 (#899):** Log Out → marketing `/` (fix HardRedirect race to `/login`)  
+- **Open but not in this stop:** [#869](https://github.com/pat792/set-picks/issues/869) tour-stats data plane (CDN JSON), [#889](https://github.com/pat792/set-picks/issues/889) HTML-first auth door  
+
+Agents: do **not** continue Phase E / epic #856 hop work / epic #889 Phase 1–2 by default.
 
 ---
 
-## Train phases
+## Train phases (historical)
 
 | Phase | Issue | Scope | Status |
 |-------|-------|--------|--------|
@@ -24,12 +34,12 @@
 | **C login Safari hotfix** | #850 | Idle-warm Auth on `/login`; never await App Check before Google popup. | **v1.48.4** |
 | **D — Invite parity** | #844 | Inline auth on `/invite` + `/join` VIP (same panel chrome as `/login`). | **Held** — not in this promote |
 | **E1 — Public tour-stats** | #853 | Regression after #835 login firebase defer: move `/tour-stats*` to marketing entry; Firebase only at fetch. Bundle `AUTH_BOOT_PRACTICES.md`. | **Shipped** (v1.49.0) |
-| **E1b — Safari data gate** | #869 | Post-#853: chrome paints; Safari still extremely slow on `public_tour_stats` / App Check (Chrome mobile OK). | **Open** |
+| **E1b — Safari data gate** | #869 | Post-#853: chrome paints; Safari still extremely slow on `public_tour_stats` / App Check (Chrome mobile OK). | **Open — parked** (CDN JSON when resumed) |
 | **E2 — Auth residual** | #844 (+ feel) | Invite/join inline auth; further `/login` feel. | **Held** |
+| **E0 hotfix** | #890 | Restore `/login` app.html boot after #881 hang. | **v1.53.1** |
+| **E0 follow** | #899 | Log Out HardRedirect race → `/login`. | **v1.53.2** |
 
-**Field verdict (2026-08-04):** Marketing dual-entry worked. E1 (#853) restored marketing chrome on `/tour-stats*`. **Safari data load still slow** → [#869](https://github.com/pat792/set-picks/issues/869). Auth residual is E2 / epic #856.
-
-**Promote rule:** Ship A–C (+ C follow) `staging` → `main` when marketing soak is enough. Phase D (#844) and Phase E (#853 + auth residual) stay open and ship later.
+**Field verdict (2026-08-05):** Train **stopped** after v1.53.2. Dual-entry marketing stays. Do not resume hop tiers. Next construction (when resumed): HTML-first `/login` (#889) + tour-stats JSON (#869) — not another CSR entry.
 
 ---
 


### PR DESCRIPTION
## Summary
- Document **field stop** after prod **v1.53.2** (#899 Log Out + #890 login restore)
- Park further CSR hop / HTML-first (#889) / tour-stats JSON (#869) until human resumes
- No code or SemVer bump

## Test plan
- [x] Docs-only review


Made with [Cursor](https://cursor.com)