### PR TITLE
fix(auth): Safari Google redirect completion on /login (#893)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.54.1] — 2026-08-05
+
+### Fixed
+- **Safari Google redirect return on `/login` (#893)** — Always call `getRedirectResult` after Auth is ready; do not gate completion on sessionStorage intent (Safari can drop the stash after account picker). Dual-write redirect intent to `localStorage` as a return hint. Empty result after a stashed intent shows a retry error instead of a silent form reset.
+
+---
+
 ## [1.54.0] — 2026-08-05
 
 ### Added

--- a/docs/AUTH_BOOT_PRACTICES.md
+++ b/docs/AUTH_BOOT_PRACTICES.md
@@ -25,7 +25,7 @@ Standing rules for marketing, the **auth door** (`/login`), and the app SPA. Lea
 
 5. **Await App Check only before Firestore.** Profile/consent/`public_tour_stats` go through `whenFirebaseReady` / `ensureAppCheckNow`.
 
-6. **Safari / iOS / in-app prefer redirect (#859).** Desktop Chromium/Firefox keep popup; `auth/popup-blocked` → one-shot redirect.
+6. **Safari / iOS / in-app prefer redirect (#859).** Desktop Chromium/Firefox keep popup; `auth/popup-blocked` → one-shot redirect. On return, **always** call `getRedirectResult` after Auth is ready — do not require sessionStorage intent (Safari may drop the stash; #893).
 
 7. **WebKit private is the auth-door merge gate.** `scripts/qa/*` is Chromium-only. Auth-door / gesture / boot changes need a human WebKit private check on marketing → `/login` (or closest available WebKit private). Do not claim Safari verified from `qa:*` alone.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.54.0",
+  "version": "1.54.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/auth/model/useGoogleRedirectCompletion.js
+++ b/src/features/auth/model/useGoogleRedirectCompletion.js
@@ -22,17 +22,24 @@ import { trackAuthError } from './authAnalytics';
  *   intent?: 'signin' | 'signup' | null,
  *   outcome?: { kind: string, message?: string },
  *   err?: unknown,
+ *   hadIntent?: boolean,
  * }> | null}
  */
 let inFlightCompletion = null;
 
+/**
+ * Always call `getRedirectResult` after Auth is ready (#893 / Safari return).
+ *
+ * Do **not** gate on sessionStorage intent: Safari private / ITP / storage
+ * quota can drop the stash after Google returns, and skipping
+ * `getRedirectResult` leaves the user on `/login` with no session (HTML-first
+ * door soak). Intent is only used for mode/overlay + empty-result error copy.
+ */
 async function completePendingGoogleRedirect() {
-  if (!peekGoogleRedirectIntent()) {
-    return { type: 'none' };
-  }
   if (inFlightCompletion) return inFlightCompletion;
 
   inFlightCompletion = (async () => {
+    const hadIntent = Boolean(peekGoogleRedirectIntent());
     try {
       const { auth } = await ensureAuthReady();
       const [{ consumeGoogleRedirectResult }, { completeGoogleSplashAuth }] =
@@ -42,8 +49,8 @@ async function completePendingGoogleRedirect() {
         ]);
       const result = await consumeGoogleRedirectResult(auth);
       if (!result) {
-        consumeGoogleRedirectIntent();
-        return { type: 'empty' };
+        const stashed = hadIntent ? consumeGoogleRedirectIntent() : null;
+        return { type: 'empty', hadIntent, intent: stashed };
       }
 
       const intent = consumeGoogleRedirectIntent() || 'signin';
@@ -54,7 +61,7 @@ async function completePendingGoogleRedirect() {
           isNewUser: result.isNewUser,
           flow: 'redirect',
         });
-        return { type: 'done', intent, outcome };
+        return { type: 'done', intent, outcome, hadIntent: true };
       } finally {
         clearSplashGoogleModalInflight();
       }
@@ -67,7 +74,7 @@ async function completePendingGoogleRedirect() {
         surface: intent === 'signup' ? 'create_account' : 'sign_in',
         auth_flow: 'redirect',
       });
-      return { type: 'error', intent, err };
+      return { type: 'error', intent, err, hadIntent };
     } finally {
       inFlightCompletion = null;
     }
@@ -76,11 +83,14 @@ async function completePendingGoogleRedirect() {
   return inFlightCompletion;
 }
 
+const EMPTY_REDIRECT_MESSAGE =
+  'Google sign-in did not finish. Please try Continue with Google again.';
+
 /**
- * Completes a pending Google `signInWithRedirect` on splash / invite landings.
+ * Completes a pending Google `signInWithRedirect` on `/login`, splash, invite.
  *
- * Skips Firebase load when there is no stashed redirect intent so anon `/login`
- * paint stays firebase-free (#835) unless the user is mid-redirect return.
+ * Always loads Auth + `getRedirectResult` once (safe when no pending redirect).
+ * SessionStorage intent is optional UX context, not a gate (#893).
  *
  * @param {{
  *   onOpenSignIn?: () => void,
@@ -109,13 +119,6 @@ export function useGoogleRedirectCompletion({
   };
 
   useEffect(() => {
-    const hasIntent = Boolean(peekGoogleRedirectIntent());
-    if (!hasIntent && !inFlightCompletion) {
-      // Clear a stranded overlay after StrictMode consumed intent on a prior mount.
-      cbsRef.current.onSettled?.();
-      return undefined;
-    }
-
     let active = true;
 
     void completePendingGoogleRedirect().then((result) => {
@@ -132,6 +135,12 @@ export function useGoogleRedirectCompletion({
           );
           if (result.intent === 'signup') cbs.onOpenSignUp?.();
           else if (result.intent === 'signin') cbs.onOpenSignIn?.();
+        } else if (result.type === 'empty' && result.hadIntent) {
+          // Stash said we were mid-redirect, but Firebase returned no credential.
+          const intent = result.intent === 'signup' ? 'signup' : 'signin';
+          cbs.onError?.(EMPTY_REDIRECT_MESSAGE, intent);
+          if (intent === 'signup') cbs.onOpenSignUp?.();
+          else cbs.onOpenSignIn?.();
         }
       }
       // Always settle — including after StrictMode cancelled the first subscriber —
@@ -153,4 +162,9 @@ export function resetGoogleRedirectCompletionForTests() {
 /** @visibleForTesting */
 export function completePendingGoogleRedirectForTests() {
   return completePendingGoogleRedirect();
+}
+
+/** @visibleForTesting */
+export function emptyGoogleRedirectMessageForTests() {
+  return EMPTY_REDIRECT_MESSAGE;
 }

--- a/src/features/auth/model/useGoogleRedirectCompletion.test.js
+++ b/src/features/auth/model/useGoogleRedirectCompletion.test.js
@@ -40,6 +40,7 @@ describe('completePendingGoogleRedirect', () => {
     vi.clearAllMocks();
     peekGoogleRedirectIntent.mockReturnValue(null);
     consumeGoogleRedirectResult.mockResolvedValue(null);
+    consumeGoogleRedirectIntent.mockReturnValue(null);
   });
 
   afterEach(async () => {
@@ -49,14 +50,40 @@ describe('completePendingGoogleRedirect', () => {
     resetGoogleRedirectCompletionForTests();
   });
 
-  it('no-ops when no redirect intent is stashed', async () => {
+  it('still calls getRedirectResult when no intent is stashed (#893)', async () => {
     const { completePendingGoogleRedirectForTests } = await import(
       './useGoogleRedirectCompletion.js'
     );
     await expect(completePendingGoogleRedirectForTests()).resolves.toEqual({
-      type: 'none',
+      type: 'empty',
+      hadIntent: false,
+      intent: null,
     });
-    expect(ensureAuthReady).not.toHaveBeenCalled();
+    expect(ensureAuthReady).toHaveBeenCalledTimes(1);
+    expect(consumeGoogleRedirectResult).toHaveBeenCalledTimes(1);
+    expect(consumeGoogleRedirectIntent).not.toHaveBeenCalled();
+  });
+
+  it('completes redirect when intent was dropped but credential exists', async () => {
+    peekGoogleRedirectIntent.mockReturnValue(null);
+    consumeGoogleRedirectResult.mockResolvedValue({ isNewUser: false });
+    completeGoogleSplashAuth.mockResolvedValue({ kind: 'success' });
+
+    const { completePendingGoogleRedirectForTests } = await import(
+      './useGoogleRedirectCompletion.js'
+    );
+
+    await expect(completePendingGoogleRedirectForTests()).resolves.toEqual({
+      type: 'done',
+      intent: 'signin',
+      outcome: { kind: 'success' },
+      hadIntent: true,
+    });
+    expect(completeGoogleSplashAuth).toHaveBeenCalledWith({
+      intent: 'signin',
+      isNewUser: false,
+      flow: 'redirect',
+    });
   });
 
   it('shares one in-flight getRedirectResult across concurrent callers', async () => {
@@ -72,8 +99,8 @@ describe('completePendingGoogleRedirect', () => {
       completePendingGoogleRedirectForTests(),
     ]);
 
-    expect(a).toEqual({ type: 'empty' });
-    expect(b).toEqual({ type: 'empty' });
+    expect(a).toEqual({ type: 'empty', hadIntent: true, intent: 'signup' });
+    expect(b).toEqual({ type: 'empty', hadIntent: true, intent: 'signup' });
     expect(ensureAuthReady).toHaveBeenCalledTimes(1);
     expect(consumeGoogleRedirectResult).toHaveBeenCalledTimes(1);
   });

--- a/src/features/auth/utils/googleRedirectIntent.js
+++ b/src/features/auth/utils/googleRedirectIntent.js
@@ -1,29 +1,67 @@
 const STORAGE_KEY = 'setpicks_google_redirect_intent_v1';
 
 /**
- * Stash which splash modal started a Google redirect (#773 Phase 2b).
- * @param {'signin' | 'signup'} intent
+ * @param {Storage | undefined} store
+ * @param {string} key
+ * @param {string} value
  */
-export function stashGoogleRedirectIntent(intent) {
-  if (intent !== 'signin' && intent !== 'signup') return;
+function safeSet(store, key, value) {
   try {
-    sessionStorage.setItem(STORAGE_KEY, intent);
+    store?.setItem(key, value);
   } catch {
     // ignore quota / private mode
   }
 }
 
 /**
- * @returns {'signin' | 'signup' | null}
+ * @param {Storage | undefined} store
+ * @param {string} key
+ * @returns {string | null}
  */
-export function consumeGoogleRedirectIntent() {
+function safeGet(store, key) {
   try {
-    const raw = sessionStorage.getItem(STORAGE_KEY);
-    sessionStorage.removeItem(STORAGE_KEY);
-    if (raw === 'signin' || raw === 'signup') return raw;
+    return store?.getItem(key) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {Storage | undefined} store
+ * @param {string} key
+ */
+function safeRemove(store, key) {
+  try {
+    store?.removeItem(key);
   } catch {
     // ignore
   }
+}
+
+/**
+ * Stash which splash modal started a Google redirect (#773 Phase 2b).
+ * Dual-write session + local so Safari private / ITP drops of sessionStorage
+ * still leave a return hint for overlay / error copy (#893). Credential
+ * completion must not depend on this stash — see useGoogleRedirectCompletion.
+ * @param {'signin' | 'signup'} intent
+ */
+export function stashGoogleRedirectIntent(intent) {
+  if (intent !== 'signin' && intent !== 'signup') return;
+  // Prefer globals (vitest stubs) — `window` may be absent in node tests.
+  safeSet(globalThis.sessionStorage, STORAGE_KEY, intent);
+  safeSet(globalThis.localStorage, STORAGE_KEY, intent);
+}
+
+/**
+ * @returns {'signin' | 'signup' | null}
+ */
+export function consumeGoogleRedirectIntent() {
+  const raw =
+    safeGet(globalThis.sessionStorage, STORAGE_KEY) ||
+    safeGet(globalThis.localStorage, STORAGE_KEY);
+  safeRemove(globalThis.sessionStorage, STORAGE_KEY);
+  safeRemove(globalThis.localStorage, STORAGE_KEY);
+  if (raw === 'signin' || raw === 'signup') return raw;
   return null;
 }
 
@@ -31,11 +69,9 @@ export function consumeGoogleRedirectIntent() {
  * @returns {'signin' | 'signup' | null}
  */
 export function peekGoogleRedirectIntent() {
-  try {
-    const raw = sessionStorage.getItem(STORAGE_KEY);
-    if (raw === 'signin' || raw === 'signup') return raw;
-  } catch {
-    // ignore
-  }
+  const raw =
+    safeGet(globalThis.sessionStorage, STORAGE_KEY) ||
+    safeGet(globalThis.localStorage, STORAGE_KEY);
+  if (raw === 'signin' || raw === 'signup') return raw;
   return null;
 }

--- a/src/features/auth/utils/googleRedirectIntent.test.js
+++ b/src/features/auth/utils/googleRedirectIntent.test.js
@@ -6,11 +6,9 @@ import {
   stashGoogleRedirectIntent,
 } from './googleRedirectIntent.js';
 
-const store = new Map();
-
-beforeEach(() => {
-  store.clear();
-  vi.stubGlobal('sessionStorage', {
+function createMemoryStorage() {
+  const store = new Map();
+  return {
     getItem: (k) => (store.has(k) ? store.get(k) : null),
     setItem: (k, v) => {
       store.set(k, String(v));
@@ -19,7 +17,12 @@ beforeEach(() => {
       store.delete(k);
     },
     clear: () => store.clear(),
-  });
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal('sessionStorage', createMemoryStorage());
+  vi.stubGlobal('localStorage', createMemoryStorage());
 });
 
 afterEach(() => {
@@ -32,6 +35,16 @@ describe('googleRedirectIntent', () => {
     expect(peekGoogleRedirectIntent()).toBe('signin');
     expect(consumeGoogleRedirectIntent()).toBe('signin');
     expect(consumeGoogleRedirectIntent()).toBe(null);
+  });
+
+  it('falls back to localStorage when sessionStorage is empty (#893)', () => {
+    stashGoogleRedirectIntent('signup');
+    sessionStorage.removeItem('setpicks_google_redirect_intent_v1');
+    expect(peekGoogleRedirectIntent()).toBe('signup');
+    expect(consumeGoogleRedirectIntent()).toBe('signup');
+    expect(localStorage.getItem('setpicks_google_redirect_intent_v1')).toBe(
+      null,
+    );
   });
 
   it('ignores invalid intents', () => {


### PR DESCRIPTION
Closes #893 (WebKit redirect return row)

## Summary
- Safari mobile on Vercel preview: first Google tap + account pick worked, then “Preparing sign-in…” and back to the form with no session.
- **Cause:** redirect completion was gated on sessionStorage intent; when Safari drops that stash, `getRedirectResult` never runs.
- **Fix:** always call `getRedirectResult` after Auth is ready; dual-write intent to `localStorage`; show a retry error if a stashed intent returns empty.

## Test plan
- [x] Unit tests for always-`getRedirectResult` + localStorage fallback
- [x] `npm test` / lint
- [ ] **Human Safari (same preview path):** marketing → Sign in → Continue with Google → pick account → should land on dashboard/setup (not reset to form)


Made with [Cursor](https://cursor.com)