### PR TITLE
fix(auth): stop Google redirect form flash before hard-nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.54.2] — 2026-08-05
+
+### Fixed
+- **Google redirect return form flash (#893 follow-up)** — Keep the “Logging you in…” continue overlay through successful `getRedirectResult` + profile load until hard-nav leaves `/login`. Previously intent consume / `onSettled` cleared the overlay and briefly showed Continue with Google before dashboard.
+
+---
+
 ## [1.54.1] — 2026-08-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.54.1",
+  "version": "1.54.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/auth/model/useGoogleRedirectCompletion.js
+++ b/src/features/auth/model/useGoogleRedirectCompletion.js
@@ -96,7 +96,12 @@ const EMPTY_REDIRECT_MESSAGE =
  *   onOpenSignIn?: () => void,
  *   onOpenSignUp?: () => void,
  *   onError?: (message: string, intent: 'signin' | 'signup' | null) => void,
- *   onSettled?: () => void,
+ *   onSettled?: (result: {
+ *     type: 'none' | 'empty' | 'done' | 'error',
+ *     intent?: 'signin' | 'signup' | null,
+ *     outcome?: { kind: string, message?: string },
+ *     hadIntent?: boolean,
+ *   }) => void,
  * }} [opts]
  */
 export function useGoogleRedirectCompletion({
@@ -143,9 +148,9 @@ export function useGoogleRedirectCompletion({
           else cbs.onOpenSignIn?.();
         }
       }
-      // Always settle — including after StrictMode cancelled the first subscriber —
-      // so LoginPage `googleReturnBusy` cannot stick forever on `:5173`.
-      cbs.onSettled?.();
+      // Always settle (incl. StrictMode cancelled first subscriber). Pass result
+      // so LoginPage can keep the continue overlay through post-auth hard-nav.
+      cbs.onSettled?.(result);
     });
 
     return () => {

--- a/src/pages/auth/LoginPage.jsx
+++ b/src/pages/auth/LoginPage.jsx
@@ -38,6 +38,13 @@ export function resolveLoginMode(searchParams) {
   return 'signin';
 }
 
+function isRedirectSuccess(result) {
+  return (
+    result?.type === 'done' &&
+    result?.outcome?.kind !== 'error'
+  );
+}
+
 /**
  * Authenticated-SPA login surface (#832 / #834).
  * Full-page inline forms — invite VIP landings keep modal chrome separately.
@@ -59,9 +66,11 @@ export default function LoginPage() {
   const [googleReturnBusy, setGoogleReturnBusy] = useState(
     () => Boolean(peekGoogleRedirectIntent()),
   );
-  const [googleReturnIntent] = useState(
+  const [googleReturnIntent, setGoogleReturnIntent] = useState(
     () => peekGoogleRedirectIntent() || 'signin',
   );
+  /** Keep continue chrome after successful redirect until hard-nav leaves. */
+  const [redirectNavPending, setRedirectNavPending] = useState(false);
   const didStripQueryRef = useRef(false);
   const didResumeRef = useRef(false);
 
@@ -78,10 +87,20 @@ export default function LoginPage() {
   }, []);
   const onRedirectError = useCallback((message, intent) => {
     setRedirectAuthError(message || '');
+    setRedirectNavPending(false);
     if (intent === 'signup') setMode('signup');
     else setMode('signin');
   }, []);
-  const onRedirectSettled = useCallback(() => {
+  const onRedirectSettled = useCallback((result) => {
+    if (isRedirectSuccess(result)) {
+      if (result.intent === 'signup' || result.intent === 'signin') {
+        setGoogleReturnIntent(result.intent);
+      }
+      setRedirectNavPending(true);
+      // Keep googleReturnBusy — do not flash the form before hard-nav.
+      return;
+    }
+    setRedirectNavPending(false);
     setGoogleReturnBusy(false);
   }, []);
 
@@ -91,14 +110,6 @@ export default function LoginPage() {
     onError: onRedirectError,
     onSettled: onRedirectSettled,
   });
-
-  // Dev StrictMode can cancel redirect completion while leaving this busy flag
-  // set — clear the overlay once the stash is gone (#885 follow-up).
-  useEffect(() => {
-    if (!googleReturnBusy) return;
-    if (peekGoogleRedirectIntent()) return;
-    setGoogleReturnBusy(false);
-  }, [googleReturnBusy]);
 
   // After form paint: warm Auth. Marketing idle/CTA warm → speculative|intent (#880/#860);
   // otherwise immediate (#858). App Check stays parallel (#850).
@@ -136,30 +147,31 @@ export default function LoginPage() {
     navigate('/login', { replace: true, state: {} });
   }, [location.state, navigate, searchParams]);
 
-  // Thin login document (#881): leave to app SPA via full navigation so
-  // hosting serves dashboard/setup shells (soft <Navigate> stays on login.js).
+  // Post-auth: hard-nav to app SPA (login document must not soft-route).
   useEffect(() => {
     if (loading || !user) return;
     window.location.replace(getDashboardEntryHref({ isAdminUser }));
   }, [loading, user, isAdminUser]);
 
-  if (!loading && user) {
-    return null;
-  }
+  // Cover redirect return + profile load + hard-nav gap (no form flash).
+  const showGoogleContinue =
+    googleReturnBusy || redirectNavPending || Boolean(user);
 
   return (
     <MarketingPageShell>
-      {googleReturnBusy ? (
+      {showGoogleContinue ? (
         <GoogleAuthContinueOverlay intent={googleReturnIntent} />
       ) : null}
-      <LoginAuthScreen
-        mode={mode}
-        onSwitchToSignIn={openSignIn}
-        onSwitchToSignUp={openSignUp}
-        onClose={goHome}
-        poolInvitePending={poolInvitePending}
-        seedError={redirectAuthError}
-      />
+      {!user ? (
+        <LoginAuthScreen
+          mode={mode}
+          onSwitchToSignIn={openSignIn}
+          onSwitchToSignUp={openSignUp}
+          onClose={goHome}
+          poolInvitePending={poolInvitePending}
+          seedError={redirectAuthError}
+        />
+      ) : null}
     </MarketingPageShell>
   );
 }


### PR DESCRIPTION
## Summary
- Prod Safari Google works on v1.54.1 but flashes Continue with Google after account pick, then logs in.
- **Cause:** overlay cleared on intent consume / `onSettled` while Auth profile was still loading before hard-nav.
- **Fix:** keep “Logging you in…” overlay through successful redirect until `/login` hard-navs away. PATCH **1.54.2**.

## Test plan
- [x] `npm test` / lint
- [ ] Safari www (after promote): Google → account → stay on continue chrome (no form flash) → dashboard


Made with [Cursor](https://cursor.com)