### PR TITLE
promote: 1.55.0 (marketing legal + login focus)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 - **`/privacy` + `/terms` on marketing document (#908)** — Hard-nav from HTML-first `/login` no longer cold-boots `app.html` / spa-boot. Legal routes prerender on the marketing entry (no AuthProvider); soft routes remain on the app SPA for Profile/account. Docs: `API.md`, `AUTH_BOOT_PRACTICES` 1c, `OUTBOUND_AUTH_HANDOFF`, `AUTH_SEAMLESS_PATH`.
 
 ### Fixed
-- **Auth door email autofocus / Safari Keychain (#909)** — Credential fields start `readOnly` until intentional focus; HTML-first boot shell blurs any autofocused input so Face ID / Keychain does not steal the Google vs email choice on cold open.
+- **Auth door email autofocus / Safari Keychain (#909)** — Credential fields start `readOnly` until intentional focus; HTML-first boot shell blurs any autofocused input so Face ID / Keychain does not steal the Google vs email choice on cold open. QA `qa:cache` sign-in focuses fields before fill so Playwright can edit them.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.55.0] — 2026-08-06
+
+### Changed
+- **`/privacy` + `/terms` on marketing document (#908)** — Hard-nav from HTML-first `/login` no longer cold-boots `app.html` / spa-boot. Legal routes prerender on the marketing entry (no AuthProvider); soft routes remain on the app SPA for Profile/account. Docs: `API.md`, `AUTH_BOOT_PRACTICES` 1c, `OUTBOUND_AUTH_HANDOFF`, `AUTH_SEAMLESS_PATH`.
+
+### Fixed
+- **Auth door email autofocus / Safari Keychain (#909)** — Credential fields start `readOnly` until intentional focus; HTML-first boot shell blurs any autofocused input so Face ID / Keychain does not steal the Google vs email choice on cold open.
+
+---
+
 ## [1.54.2] — 2026-08-05
 
 ### Fixed

--- a/docs/API.md
+++ b/docs/API.md
@@ -385,8 +385,8 @@ These routes are part of the public surface. Renaming or removing them is a MAJO
 | `/join/:code` | None | Pool invite deep link; optional `?from={handle}` for inviter personalization; VIP landing stores code and prompts auth (#580); personalized OG (#582) |
 | `/invite/:handle` | None | Site VIP invite deep link; personalized landing when handle resolves; no pool join side effects (#580); personalized OG (#582) |
 | `/user/:userId` | None | Public player profile — **`noindex,follow`** (#661); not a sitemap target |
-| `/privacy` | None | Privacy policy |
-| `/terms` | None | Terms of service |
+| `/privacy` | None | Privacy policy. **v1.55.0 (#908):** marketing document (prerendered; no AuthProvider) — snappy hard-nav from HTML-first `/login`. Soft route remains on app SPA for Profile/account. |
+| `/terms` | None | Terms of service. **v1.55.0 (#908):** same marketing-document boot as `/privacy`. |
 | `/password-reset-complete` | None | Firebase Auth continue URL |
 | `/setup` | Auth | Profile setup (new users) |
 | `/dashboard/*` | Auth | Full game dashboard |

--- a/docs/AUTH_BOOT_PRACTICES.md
+++ b/docs/AUTH_BOOT_PRACTICES.md
@@ -13,9 +13,12 @@ Standing rules for marketing, the **auth door** (`/login`), and the app SPA. Lea
 
 1b. **Public `/tour-stats*` is marketing too (#853).** Paint chrome from the marketing entry; load App Check + Firestore only inside `fetchPublicTourStats*` (and a parallel page kick). Do not put tour-stats on `app.html` / `AuthProvider`.
 
+1c. **`/privacy` and `/terms` are marketing too (#908).** Serve from the marketing document (prerendered HTML). Do not park legal on `app.html` / spa-boot — signup from HTML-first `/login` hard-navs here and must stay snappy. Soft routes may remain on the app SPA for in-app Profile links.
+
 2. **Auth door `/login`: form in first HTML; auth-only hydrate (Phase 2 / #892).**  
    - **Today (v1.54.0):** `/login` boots `login.html` with **real form controls** in the first document; `loginMain.jsx` hydrates Auth + form wiring (not `app-*.js` / react-query). Suspense fallback keeps form chrome (anti-#881 blank hang). Session hint and Google redirect return stay eager. Success → hard-navigate to `/setup` or `/dashboard`.  
    - Do **not** reintroduce a skeleton-only / empty-`#root` CSR door as the prod strategy.
+   - **Neutral first focus (#909):** do not autofocus email/password on cold open (Safari Keychain / Face ID steals method choice). Credential fields may start `readOnly` until the user focuses them.
 
 2b. **Google CTA must not be enabled until Auth surface is ready (#858).** Disable Continue with Google (brief “Preparing sign-in…” OK) until Auth + click-path modules are ready. Ready click path: `signInWithPopup` / redirect with **no** `await ensureAuthReady()` or dynamic-import on the hot path.
 

--- a/docs/AUTH_SEAMLESS_PATH.md
+++ b/docs/AUTH_SEAMLESS_PATH.md
@@ -204,6 +204,8 @@ Treat as law (update issues/PRs against this, not against “finish hop bands”
 - [x] Signed-in `/login` hard-sends to dashboard/setup.
 - [x] Hop ms is a soak metric after reliability; not the design center.
 
+**Collateral (post–Phase 2):** `/privacy` + `/terms` ship on the **marketing** document (#908) — not `app.html` / spa-boot — so signup legal links from the auth door stay snappy.
+
 ### Phase 3 — Demand-gen polish (optional)
 
 Only after Phase 2 is green on WebKit private: leave chrome, download-only warm of auth-door assets from marketing.

--- a/docs/OUTBOUND_AUTH_HANDOFF.md
+++ b/docs/OUTBOUND_AUTH_HANDOFF.md
@@ -28,6 +28,7 @@ After marketing cold opens stop booting `AuthProvider`, every outbound link must
 | Push → `/dashboard/profile/notifications` | `fcmMessagingCore`, messaging SW | `app-ok` | |
 | `/`, `/how-it-works`, `/how-scoring-works`, `/phish-setlist-prediction-game` | Marketing entry; some email allowlist paths | `public-static` | No Firebase until CTA → `/login` |
 | `/tour-stats*` | Public Firestore UI | `public-static` | **#853:** marketing document; Firebase only at aggregate fetch (not AuthProvider) |
+| `/privacy`, `/terms` | Login signup legal links, marketing footer, Profile/account | `public-static` | **#908:** marketing document (prerendered); no Auth. Soft routes remain on app SPA for in-app links |
 | `/join/:code`, `/invite/:handle` | Invite kits, OG `api/invite` | `invite-shell` | Prefers `dist/app.html` |
 | Marketing splash CTAs | `MarketingHomePage` | `retarget-auth` | **Done (#832 / #834 / #835 / #872 / #860):** hard-nav `/login` / `/login?mode=signup` with leave chrome + intent prefetch of login UI (no Firebase on marketing). Mid-page Get Started chooser removed — hero/header/section CTAs go straight to auth. |
 | App-shell splash CTAs | `SplashPage` (after soft-nav / sign-out) | `retarget-auth` | **Done (1.48.1):** navigate to `/login` (no splash modals). Invite VIP still modal (#844). |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.54.2",
+  "version": "1.55.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/login-boot-shell.mjs
+++ b/scripts/login-boot-shell.mjs
@@ -304,6 +304,21 @@ function loginModeBootScript() {
       signupEl.hidden = true;
       if (eyebrow) eyebrow.textContent = 'Sign in to make picks';
     }
+    // #909: do not leave Keychain/Face ID owning first focus on cold open.
+    var ae = document.activeElement;
+    if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA')) {
+      ae.blur();
+    }
+    // Unlock credential fields only after intentional focus (pre-hydrate).
+    document.addEventListener(
+      'focusin',
+      function (ev) {
+        var t = ev.target;
+        if (!t || t.tagName !== 'INPUT') return;
+        if (t.readOnly) t.readOnly = false;
+      },
+      true,
+    );
   } catch (e) {}
 })();
 </script>`;
@@ -335,9 +350,10 @@ export function buildLoginBootShellMarkup() {
     `<div class="lbs-divider"><div class="lbs-divider-line"></div><span>or</span><div class="lbs-divider-line"></div></div>`,
     `<form action="/login" method="get" autocomplete="on">`,
     `<label class="lbs-label" for="si-email">Email</label>`,
-    `<input class="lbs-field" id="si-email" name="email" type="email" autocomplete="username" required />`,
+    // readonly until intentional focus — suppresses Safari Keychain sheet (#909)
+    `<input class="lbs-field" id="si-email" name="email" type="email" autocomplete="username" required readonly />`,
     `<label class="lbs-label" for="si-pass">Password</label>`,
-    `<input class="lbs-field" id="si-pass" name="password" type="password" autocomplete="current-password" required />`,
+    `<input class="lbs-field" id="si-pass" name="password" type="password" autocomplete="current-password" required readonly />`,
     `<button class="lbs-submit" type="submit">Continue with email</button>`,
     `</form>`,
     `<p class="lbs-switch">New here? <a href="/login?mode=signup">Create account</a></p>`,
@@ -357,11 +373,11 @@ export function buildLoginBootShellMarkup() {
     `<div class="lbs-divider"><div class="lbs-divider-line"></div><span>or</span><div class="lbs-divider-line"></div></div>`,
     `<form action="/login" method="get" autocomplete="on">`,
     `<label class="lbs-label" for="su-email">Email</label>`,
-    `<input class="lbs-field" id="su-email" name="email" type="email" autocomplete="email" required />`,
+    `<input class="lbs-field" id="su-email" name="email" type="email" autocomplete="email" required readonly />`,
     `<label class="lbs-label" for="su-pass">Password</label>`,
-    `<input class="lbs-field" id="su-pass" name="password" type="password" autocomplete="new-password" required minlength="6" />`,
+    `<input class="lbs-field" id="su-pass" name="password" type="password" autocomplete="new-password" required minlength="6" readonly />`,
     `<label class="lbs-label" for="su-confirm">Confirm password</label>`,
-    `<input class="lbs-field" id="su-confirm" name="confirm-password" type="password" autocomplete="new-password" required />`,
+    `<input class="lbs-field" id="su-confirm" name="confirm-password" type="password" autocomplete="new-password" required readonly />`,
     `<button class="lbs-submit" type="submit">Accept terms to continue</button>`,
     `</form>`,
     `<p class="lbs-switch">Already have an account? <a href="/login?mode=signin">Sign in</a></p>`,

--- a/scripts/qa/_lib/qaAuthSplash.mjs
+++ b/scripts/qa/_lib/qaAuthSplash.mjs
@@ -18,10 +18,14 @@ export async function signInViaSplashEmailPassword(page, origin, email, password
   });
 
   // #834: `/login` is a full-page form (no dialog). Invite VIP still uses modals.
+  // #909: credential fields start readOnly until focus (Safari Keychain guard).
   const emailField = page.locator('#si-email');
+  const passField = page.locator('#si-pass');
   await emailField.waitFor({ state: 'visible', timeout: 30_000 });
+  await emailField.click();
   await emailField.fill(email);
-  await page.locator('#si-pass').fill(password);
+  await passField.click();
+  await passField.fill(password);
   await page.locator('form button[type="submit"]').click();
 
   await page.waitForURL(/\/dashboard/, { timeout: 60_000 });

--- a/scripts/seo-strip-body.mjs
+++ b/scripts/seo-strip-body.mjs
@@ -47,8 +47,9 @@ export function stripPrerenderBodyFromSpaShell(spaHtml) {
 export const APP_BOOT_SHELL_REL_PATH = 'dashboard/index.html';
 
 /**
- * Branded skeleton without a fat route modulepreload — for legal / public
- * profile / bare-join hard opens that must not download DashboardRoute.
+ * Branded skeleton without a fat route modulepreload — for public profile /
+ * bare-join / password-reset hard opens that must not download DashboardRoute.
+ * Legal (`/privacy`, `/terms`) ships on the marketing document (#908).
  */
 export const LIGHT_SPA_BOOT_SHELL_REL_PATH = 'spa-boot/index.html';
 

--- a/scripts/verify-seo-prerender.mjs
+++ b/scripts/verify-seo-prerender.mjs
@@ -79,7 +79,7 @@ function assertRouteHtml(html, route, label) {
   }
 }
 
-assert(PRERENDER_ROUTES.length >= 6, 'expected marketing + tour-stats + keyword-intent routes');
+assert(PRERENDER_ROUTES.length >= 8, 'expected marketing + tour-stats + keyword + legal routes');
 assert(
   PRERENDER_ROUTES.some((r) => r.path === '/tour-stats'),
   'expected /tour-stats prerender entry',
@@ -91,6 +91,14 @@ assert(
 assert(
   PRERENDER_ROUTES.some((r) => r.path === '/phish-setlist-prediction-game'),
   'expected keyword-intent prerender entry',
+);
+assert(
+  PRERENDER_ROUTES.some((r) => r.path === '/privacy'),
+  'expected /privacy prerender entry (#908)',
+);
+assert(
+  PRERENDER_ROUTES.some((r) => r.path === '/terms'),
+  'expected /terms prerender entry (#908)',
 );
 assert(
   PRERENDER_ROUTES.every((r) => !r.path.startsWith('/dashboard')),
@@ -385,6 +393,25 @@ if (existsSync(distIndex) && existsSync(distHowItWorks)) {
     howItWorksHtml.includes(`${MARKETING_BOOT_SHELL_MARKER}="true"`),
     'marketing routes must include marketing boot overlay',
   );
+
+  // Legal pages: marketing document, not spa-boot / app SPA (#908).
+  for (const legalPath of ['privacy', 'terms']) {
+    const legalHtmlPath = join(root, 'dist', legalPath, 'index.html');
+    assert(existsSync(legalHtmlPath), `dist missing ${legalPath}/index.html — run npm run build`);
+    const legalHtml = readFileSync(legalHtmlPath, 'utf8');
+    assert(
+      /\/assets\/marketing-[^"]+\.js/.test(legalHtml),
+      `prerendered /${legalPath} must boot the marketing entry (#908)`,
+    );
+    assert(
+      !/\/assets\/app-[^"]+\.js/.test(legalHtml),
+      `prerendered /${legalPath} must not boot the authenticated SPA entry`,
+    );
+    assert(
+      !/\/assets\/firebase[^"]*\.js/.test(legalHtml),
+      `prerendered /${legalPath} must not modulepreload firebase`,
+    );
+  }
 
   const lightBootPath = join(root, 'dist', LIGHT_SPA_BOOT_SHELL_REL_PATH);
   assert(existsSync(lightBootPath), `dist missing ${LIGHT_SPA_BOOT_SHELL_REL_PATH} — run npm run build`);

--- a/src/app/LoginApp.jsx
+++ b/src/app/LoginApp.jsx
@@ -8,8 +8,9 @@ const LoginPage = lazy(() => import('../pages/auth/LoginPage'))
 
 /**
  * Soft-nav safety net for the auth-door document (#892).
- * Terms/Privacy should hard-nav via `<a href>`; if a soft route still lands
- * here, assign so hosting can serve the correct shell (not a stuck Suspense).
+ * Terms/Privacy hard-nav via `<a href>` to the marketing document (#908);
+ * if a soft route still lands here, assign so hosting can serve the correct
+ * shell (not a stuck Suspense).
  */
 function LeaveLoginDocument() {
   const { pathname, search, hash } = useLocation()

--- a/src/app/MarketingApp.jsx
+++ b/src/app/MarketingApp.jsx
@@ -20,10 +20,13 @@ const PhishSetlistPredictionGamePage = lazy(
 const PublicTourStatsPage = lazy(
   () => import('../pages/marketing/PublicTourStatsPage'),
 );
+const PrivacyPolicyPage = lazy(() => import('../pages/legal/PrivacyPolicyPage'));
+const TermsOfServicePage = lazy(() => import('../pages/legal/TermsOfServicePage'));
 
 /**
  * Paths that leave the marketing document (#832 / #892).
  * `/login` → HTML-first auth door (`login.html`); other app routes → `app.html`.
+ * `/privacy` + `/terms` stay here (#908) — no Auth/Firebase on legal cold open.
  */
 function isAppDocumentPath(pathname) {
   if (typeof pathname !== 'string' || !pathname) return false;
@@ -32,8 +35,6 @@ function isAppDocumentPath(pathname) {
     '/dashboard',
     '/setup',
     '/password-reset-complete',
-    '/privacy',
-    '/terms',
     '/join',
     '/comms-preview',
   ];
@@ -132,6 +133,23 @@ export default function MarketingApp() {
         element={
           <Suspense fallback={<MarketingRouteFallback />}>
             <PublicTourStatsPage />
+          </Suspense>
+        }
+      />
+      {/* Legal: marketing document, no Auth (#908) — snappy from HTML-first /login. */}
+      <Route
+        path="/privacy"
+        element={
+          <Suspense fallback={<MarketingRouteFallback />}>
+            <PrivacyPolicyPage />
+          </Suspense>
+        }
+      />
+      <Route
+        path="/terms"
+        element={
+          <Suspense fallback={<MarketingRouteFallback />}>
+            <TermsOfServicePage />
           </Suspense>
         }
       />

--- a/src/features/auth/model/deferPasswordManagerAutofill.js
+++ b/src/features/auth/model/deferPasswordManagerAutofill.js
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+
+/**
+ * Safari / iOS Keychain + Face ID often auto-focus the first email/password
+ * field on cold `/login`, stealing the choice between Google and email (#909).
+ *
+ * Start credential fields `readOnly`; unlock on intentional focus. Pair with
+ * HTML-first boot shell `readonly` + blur script in `login-boot-shell.mjs`.
+ */
+
+/**
+ * Per-field hook — call once per credential input (do not share across fields).
+ * @returns {{ readOnly: boolean, onFocus: () => void }}
+ */
+export function useDeferPasswordManagerAutofill() {
+  const [editable, setEditable] = useState(false);
+  return {
+    readOnly: !editable,
+    onFocus() {
+      setEditable(true);
+    },
+  };
+}
+
+/**
+ * @param {Element | null | undefined} el
+ * @returns {boolean}
+ */
+export function isCredentialAutofillTarget(el) {
+  if (!el || typeof el.tagName !== 'string') return false;
+  const tag = el.tagName;
+  if (tag !== 'INPUT' && tag !== 'TEXTAREA') return false;
+  const type = (
+    typeof el.getAttribute === 'function'
+      ? el.getAttribute('type') || ''
+      : el.type || ''
+  ).toLowerCase();
+  if (
+    type === 'email' ||
+    type === 'password' ||
+    type === 'text' ||
+    type === ''
+  ) {
+    return true;
+  }
+  const id = typeof el.id === 'string' ? el.id : '';
+  return (
+    id === 'si-email' ||
+    id === 'si-pass' ||
+    id === 'su-email' ||
+    id === 'su-pass' ||
+    id === 'su-confirm'
+  );
+}
+
+/**
+ * Blur an autofocused credential field after paint / hydrate.
+ * Safe no-op when nothing is focused or focus is already outside inputs.
+ */
+export function blurAutofocusedCredentialField() {
+  if (typeof document === 'undefined') return;
+  try {
+    const ae = document.activeElement;
+    if (!isCredentialAutofillTarget(ae)) return;
+    if (typeof ae.blur === 'function') ae.blur();
+  } catch {
+    // Private mode / odd DOM — ignore.
+  }
+}

--- a/src/features/auth/model/deferPasswordManagerAutofill.test.js
+++ b/src/features/auth/model/deferPasswordManagerAutofill.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  blurAutofocusedCredentialField,
+  isCredentialAutofillTarget,
+} from './deferPasswordManagerAutofill';
+
+describe('isCredentialAutofillTarget', () => {
+  it('matches email/password inputs', () => {
+    expect(
+      isCredentialAutofillTarget({
+        tagName: 'INPUT',
+        getAttribute: () => 'email',
+        id: 'si-email',
+      }),
+    ).toBe(true);
+    expect(
+      isCredentialAutofillTarget({
+        tagName: 'INPUT',
+        getAttribute: () => 'password',
+        id: 'si-pass',
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects buttons and null', () => {
+    expect(
+      isCredentialAutofillTarget({
+        tagName: 'BUTTON',
+        getAttribute: () => null,
+        id: '',
+      }),
+    ).toBe(false);
+    expect(isCredentialAutofillTarget(null)).toBe(false);
+  });
+});
+
+describe('blurAutofocusedCredentialField', () => {
+  it('is a no-op when document is unavailable (node vitest)', () => {
+    expect(() => blurAutofocusedCredentialField()).not.toThrow();
+  });
+
+  it('blurs document.activeElement when it is a credential field', () => {
+    const blur = vi.fn();
+    const prev = globalThis.document;
+    globalThis.document = {
+      activeElement: {
+        tagName: 'INPUT',
+        id: 'si-email',
+        getAttribute: () => 'email',
+        blur,
+      },
+    };
+    try {
+      blurAutofocusedCredentialField();
+      expect(blur).toHaveBeenCalled();
+    } finally {
+      if (prev === undefined) delete globalThis.document;
+      else globalThis.document = prev;
+    }
+  });
+});

--- a/src/features/auth/ui/LoginAuthScreen.jsx
+++ b/src/features/auth/ui/LoginAuthScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import Button from '../../../shared/ui/Button';
 import Input from '../../../shared/ui/Input';
@@ -11,6 +11,10 @@ import { AUTH_EMAIL_CTA } from './authCtaClasses';
 import GoogleAuthContinueOverlay from './GoogleAuthContinueOverlay';
 import { resolveGoogleCtaLabel } from './googleCtaLabel';
 import SplashAuthPanel from './SplashAuthPanel';
+import {
+  blurAutofocusedCredentialField,
+  useDeferPasswordManagerAutofill,
+} from '../model/deferPasswordManagerAutofill';
 import { useLoginAuthSurfaceReady } from '../model/useLoginAuthSurfaceReady';
 import { useSplashSignIn } from '../model/useSplashSignIn';
 import { useSplashSignUp } from '../model/useSplashSignUp';
@@ -33,6 +37,11 @@ export default function LoginAuthScreen({
   seedError = '',
 }) {
   const isSignup = mode === 'signup';
+
+  // #909: clear any Safari autofocus that survived HTML-first boot blur.
+  useEffect(() => {
+    blurAutofocusedCredentialField();
+  }, []);
 
   // Chrome (sticky header + marketing nav + footer) comes from MarketingPageShell
   // composed in LoginPage — same top-level surface as /how-it-works, etc. (#834).
@@ -68,6 +77,8 @@ function LoginSignInPanel({
   seedError,
 }) {
   const [showPassword, setShowPassword] = useState(false);
+  const emailGuard = useDeferPasswordManagerAutofill();
+  const passwordGuard = useDeferPasswordManagerAutofill();
   const authSurfaceReady = useLoginAuthSurfaceReady();
   const {
     email,
@@ -136,6 +147,7 @@ function LoginSignInPanel({
             onChange={(e) => setEmail(e.target.value)}
             required
             className="mt-1 font-medium text-white"
+            {...emailGuard}
           />
         </div>
         <div>
@@ -155,6 +167,7 @@ function LoginSignInPanel({
               onChange={(e) => setPassword(e.target.value)}
               required
               className={`w-full font-medium text-white ${revealVisible ? 'pr-10' : ''}`}
+              {...passwordGuard}
             />
             <PasswordRevealToggle
               visible={revealVisible}
@@ -212,6 +225,9 @@ function LoginSignUpPanel({
   seedError,
 }) {
   const [showPassword, setShowPassword] = useState(false);
+  const emailGuard = useDeferPasswordManagerAutofill();
+  const passwordGuard = useDeferPasswordManagerAutofill();
+  const confirmGuard = useDeferPasswordManagerAutofill();
   const authSurfaceReady = useLoginAuthSurfaceReady();
   const {
     email,
@@ -341,6 +357,7 @@ function LoginSignUpPanel({
               onChange={(e) => setEmail(e.target.value)}
               required
               className="mt-1 font-medium text-white"
+              {...emailGuard}
             />
           </div>
           <div>
@@ -361,6 +378,7 @@ function LoginSignUpPanel({
                 required
                 minLength={6}
                 className={`w-full font-medium text-white ${revealVisible ? 'pr-10' : ''}`}
+                {...passwordGuard}
               />
               <PasswordRevealToggle
                 visible={revealVisible}
@@ -387,6 +405,7 @@ function LoginSignUpPanel({
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 required
                 className={`w-full font-medium text-white ${revealVisible ? 'pr-10' : ''}`}
+                {...confirmGuard}
               />
               <PasswordRevealToggle
                 visible={revealVisible}

--- a/src/features/auth/ui/LoginFormShellFallback.jsx
+++ b/src/features/auth/ui/LoginFormShellFallback.jsx
@@ -1,5 +1,10 @@
 import React, { useEffect, useState } from 'react';
 
+import {
+  blurAutofocusedCredentialField,
+  useDeferPasswordManagerAutofill,
+} from '../model/deferPasswordManagerAutofill';
+
 /**
  * Suspense / leave-document fallback for the auth door (#892).
  * Keeps real form fields on screen so WebKit never fails closed to a blank
@@ -16,6 +21,7 @@ export default function LoginFormShellFallback() {
     } catch {
       setSignup(false);
     }
+    blurAutofocusedCredentialField();
   }, []);
 
   return (
@@ -55,6 +61,8 @@ export default function LoginFormShellFallback() {
 }
 
 function SigninPanelStatic() {
+  const emailGuard = useDeferPasswordManagerAutofill();
+  const passwordGuard = useDeferPasswordManagerAutofill();
   return (
     <section
       className="w-full max-w-md rounded-xl border border-border-subtle/60 bg-surface-panel/40 p-6"
@@ -89,6 +97,7 @@ function SigninPanelStatic() {
             autoComplete="username"
             required
             className="mt-1 w-full rounded-xl border-2 border-border-subtle bg-surface-field px-4 py-3 font-semibold text-white"
+            {...emailGuard}
           />
         </div>
         <div>
@@ -105,6 +114,7 @@ function SigninPanelStatic() {
             autoComplete="current-password"
             required
             className="mt-1 w-full rounded-xl border-2 border-border-subtle bg-surface-field px-4 py-3 font-semibold text-white"
+            {...passwordGuard}
           />
         </div>
         <button
@@ -128,6 +138,9 @@ function SigninPanelStatic() {
 }
 
 function SignupPanelStatic() {
+  const emailGuard = useDeferPasswordManagerAutofill();
+  const passwordGuard = useDeferPasswordManagerAutofill();
+  const confirmGuard = useDeferPasswordManagerAutofill();
   return (
     <section
       className="w-full max-w-md rounded-xl border border-border-subtle/60 bg-surface-panel/40 p-6"
@@ -176,6 +189,7 @@ function SignupPanelStatic() {
             autoComplete="email"
             required
             className="mt-1 w-full rounded-xl border-2 border-border-subtle bg-surface-field px-4 py-3 font-semibold text-white"
+            {...emailGuard}
           />
         </div>
         <div>
@@ -193,6 +207,7 @@ function SignupPanelStatic() {
             required
             minLength={6}
             className="mt-1 w-full rounded-xl border-2 border-border-subtle bg-surface-field px-4 py-3 font-semibold text-white"
+            {...passwordGuard}
           />
         </div>
         <div>
@@ -209,6 +224,7 @@ function SignupPanelStatic() {
             autoComplete="new-password"
             required
             className="mt-1 w-full rounded-xl border-2 border-border-subtle bg-surface-field px-4 py-3 font-semibold text-white"
+            {...confirmGuard}
           />
         </div>
         <button

--- a/src/features/legal/ui/LegalPageLayout.jsx
+++ b/src/features/legal/ui/LegalPageLayout.jsx
@@ -2,51 +2,63 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 
+import AppBackground from '../../../shared/ui/AppBackground';
+
 /**
  * Shared layout for /privacy and /terms — full-screen, public, no auth.
- * Mirrors the standalone page pattern from PasswordResetCompletePage.
+ * Owns ambient background so legal works on the marketing document (#908)
+ * without RootAppShell, and still looks correct on soft-nav from the app SPA.
  *
  * @param {{ title: string, lastUpdated: string, children: React.ReactNode }} props
  */
 export default function LegalPageLayout({ title, lastUpdated, children }) {
   return (
-    <div className="relative flex min-h-screen w-full flex-col bg-transparent text-white">
-      <div className="mx-auto w-full max-w-2xl flex-1 px-5 py-10 sm:px-8 md:py-16">
-        <nav className="mb-8">
-          <Link
-            to="/"
-            className="inline-flex items-center gap-1.5 text-sm font-bold text-slate-400 transition-colors hover:text-white"
-          >
-            <ArrowLeft className="h-4 w-4" aria-hidden />
-            Back to Setlist Pick &apos;Em
-          </Link>
-        </nav>
-
-        <header className="mb-10">
-          <h1 className="font-display text-display-xl md:text-display-xl-lg font-bold italic text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-emerald-400">
-            {title}
-          </h1>
-          <p className="mt-3 text-sm font-bold text-slate-500">
-            Last updated: {lastUpdated}
-          </p>
-        </header>
-
-        <article className="legal-prose space-y-6 text-sm leading-relaxed text-slate-300 [&_h2]:mt-10 [&_h2]:mb-4 [&_h2]:text-base [&_h2]:font-black [&_h2]:uppercase [&_h2]:tracking-widest [&_h2]:text-white [&_h3]:mt-6 [&_h3]:mb-2 [&_h3]:text-sm [&_h3]:font-bold [&_h3]:text-slate-200 [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:space-y-1 [&_a]:text-brand-primary [&_a]:underline [&_a]:decoration-brand-primary/40 [&_a]:underline-offset-2 hover:[&_a]:decoration-brand-primary">
-          {children}
-        </article>
-
-        <footer className="mt-16 border-t border-slate-800/60 pt-6 text-center text-xs font-medium text-slate-500">
-          <p>&copy; {new Date().getFullYear()} Road2 Media, LLC. All rights reserved.</p>
-          <p className="mt-2 space-x-4">
-            <Link to="/privacy" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200">
-              Privacy Policy
+    <>
+      <AppBackground />
+      <div className="relative z-[1] flex min-h-screen w-full flex-col bg-transparent text-white">
+        <div className="mx-auto w-full max-w-2xl flex-1 px-5 py-10 sm:px-8 md:py-16">
+          <nav className="mb-8">
+            <Link
+              to="/"
+              className="inline-flex items-center gap-1.5 text-sm font-bold text-slate-400 transition-colors hover:text-white"
+            >
+              <ArrowLeft className="h-4 w-4" aria-hidden />
+              Back to Setlist Pick &apos;Em
             </Link>
-            <Link to="/terms" className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200">
-              Terms of Service
-            </Link>
-          </p>
-        </footer>
+          </nav>
+
+          <header className="mb-10">
+            <h1 className="font-display text-display-xl md:text-display-xl-lg font-bold italic text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-emerald-400">
+              {title}
+            </h1>
+            <p className="mt-3 text-sm font-bold text-slate-500">
+              Last updated: {lastUpdated}
+            </p>
+          </header>
+
+          <article className="legal-prose space-y-6 text-sm leading-relaxed text-slate-300 [&_h2]:mt-10 [&_h2]:mb-4 [&_h2]:text-base [&_h2]:font-black [&_h2]:uppercase [&_h2]:tracking-widest [&_h2]:text-white [&_h3]:mt-6 [&_h3]:mb-2 [&_h3]:text-sm [&_h3]:font-bold [&_h3]:text-slate-200 [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:space-y-1 [&_a]:text-brand-primary [&_a]:underline [&_a]:decoration-brand-primary/40 [&_a]:underline-offset-2 hover:[&_a]:decoration-brand-primary">
+            {children}
+          </article>
+
+          <footer className="mt-16 border-t border-slate-800/60 pt-6 text-center text-xs font-medium text-slate-500">
+            <p>&copy; {new Date().getFullYear()} Road2 Media, LLC. All rights reserved.</p>
+            <p className="mt-2 space-x-4">
+              <Link
+                to="/privacy"
+                className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200"
+              >
+                Privacy Policy
+              </Link>
+              <Link
+                to="/terms"
+                className="text-slate-400 underline decoration-slate-600 underline-offset-2 transition-colors hover:text-slate-200"
+              >
+                Terms of Service
+              </Link>
+            </p>
+          </footer>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/marketingMain.jsx
+++ b/src/marketingMain.jsx
@@ -16,12 +16,15 @@ import './index.css'
 try {
   if (typeof window !== 'undefined') {
     const path = window.location.pathname || ''
-    // Public tour-stats is marketing (#853) but must stay reachable for
-    // returning sessions — do not bounce them to /dashboard.
-    const isPublicTourStats =
-      path === '/tour-stats' || path.startsWith('/tour-stats/')
+    // Public marketing surfaces that must stay reachable for returning
+    // sessions — do not bounce them to /dashboard (#853 tour-stats, #908 legal).
+    const stayOnMarketingDocument =
+      path === '/tour-stats' ||
+      path.startsWith('/tour-stats/') ||
+      path === '/privacy' ||
+      path === '/terms'
     if (
-      !isPublicTourStats &&
+      !stayOnMarketingDocument &&
       window.localStorage?.getItem(PERSISTED_SESSION_HINT_STORAGE_KEY) === '1'
     ) {
       window.location.replace('/dashboard')

--- a/src/pages/legal/PrivacyPolicyPage.jsx
+++ b/src/pages/legal/PrivacyPolicyPage.jsx
@@ -1,8 +1,25 @@
 import React from 'react';
+import { Helmet } from 'react-helmet-async';
 
 import { PrivacyPolicyContent } from '../../features/legal';
+import { SEO_CONFIG } from '../../shared/config/seo';
+import { getPrerenderRoute } from '../../shared/config/seoRoutes';
 
-/** Public route — no auth required. */
+const route = getPrerenderRoute('/privacy');
+
+/** Public route — marketing document (#908); soft-nav compat on app SPA. */
 export default function PrivacyPolicyPage() {
-  return <PrivacyPolicyContent />;
+  const jsonLd = route.buildJsonLd();
+  return (
+    <>
+      <Helmet>
+        <title>{route.title}</title>
+        <meta name="description" content={route.description} />
+        <meta name="author" content={SEO_CONFIG.publisherName} />
+        <link rel="canonical" href={route.canonicalUrl} />
+        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+      </Helmet>
+      <PrivacyPolicyContent />
+    </>
+  );
 }

--- a/src/pages/legal/TermsOfServicePage.jsx
+++ b/src/pages/legal/TermsOfServicePage.jsx
@@ -1,8 +1,25 @@
 import React from 'react';
+import { Helmet } from 'react-helmet-async';
 
 import { TermsOfServiceContent } from '../../features/legal';
+import { SEO_CONFIG } from '../../shared/config/seo';
+import { getPrerenderRoute } from '../../shared/config/seoRoutes';
 
-/** Public route — no auth required. */
+const route = getPrerenderRoute('/terms');
+
+/** Public route — marketing document (#908); soft-nav compat on app SPA. */
 export default function TermsOfServicePage() {
-  return <TermsOfServiceContent />;
+  const jsonLd = route.buildJsonLd();
+  return (
+    <>
+      <Helmet>
+        <title>{route.title}</title>
+        <meta name="description" content={route.description} />
+        <meta name="author" content={SEO_CONFIG.publisherName} />
+        <link rel="canonical" href={route.canonicalUrl} />
+        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+      </Helmet>
+      <TermsOfServiceContent />
+    </>
+  );
 }

--- a/src/shared/config/seoRoutes.js
+++ b/src/shared/config/seoRoutes.js
@@ -262,6 +262,32 @@ const KEYWORD_PAGE_DESCRIPTION =
   "Free Phish setlist prediction game and fantasy setlist picks—lock openers, closers, encore, and a wildcard before showtime, score live, and compete with friends. Built for jam bands; live with Phish today, more soon.";
 const KEYWORD_PAGE_URL = `${SEO_CONFIG.siteUrl}${KEYWORD_PAGE_PATH}`;
 
+const PRIVACY_TITLE = "Privacy Policy | Setlist Pick'Em";
+const PRIVACY_DESCRIPTION =
+  "Privacy Policy for Setlist Pick 'Em — what information we collect, why we collect it, and how you can manage it. Operated by Road2 Media, LLC.";
+const PRIVACY_URL = `${SEO_CONFIG.siteUrl}/privacy`;
+
+const TERMS_TITLE = "Terms of Service | Setlist Pick'Em";
+const TERMS_DESCRIPTION =
+  "Terms of Service for Setlist Pick 'Em — the free Phish setlist prediction game operated by Road2 Media, LLC. Entertainment only; no entry fees or cash prizes.";
+const TERMS_URL = `${SEO_CONFIG.siteUrl}/terms`;
+
+function buildLegalWebPageJsonLd({ url, title, description }) {
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebPage',
+        '@id': url,
+        url,
+        name: title,
+        description,
+        isPartOf: { '@id': `${SEO_CONFIG.siteUrl}/#website` },
+      },
+    ],
+  };
+}
+
 function buildKeywordIntentPageJsonLd() {
   return {
     '@context': 'https://schema.org',
@@ -485,6 +511,44 @@ export const PRERENDER_ROUTES = [
       'Tour stats refresh every night the band plays live. Playing unlocks personal stats as you accumulate points against other setlist pickers.',
     ],
     buildJsonLd: buildKeywordIntentPageJsonLd,
+  },
+  {
+    path: '/privacy',
+    title: PRIVACY_TITLE,
+    description: PRIVACY_DESCRIPTION,
+    canonicalUrl: PRIVACY_URL,
+    h1: 'Privacy Policy',
+    paragraphs: [
+      // Avoid early double-quotes — prerender HTML-escapes them to &quot; and
+      // verify:seo-prerender checks the first 40 chars as a literal substring.
+      "Setlist Pick 'Em privacy policy: operated by Road2 Media, LLC. This policy explains what information we collect, why we collect it, and how you can manage it.",
+      'When you create an account we store the email address you sign up with (or that your Google account provides) and a display handle you choose.',
+      'We retain your account and gameplay data for as long as your account is active. You can delete your account from your Profile page within the App.',
+    ],
+    buildJsonLd: () =>
+      buildLegalWebPageJsonLd({
+        url: PRIVACY_URL,
+        title: PRIVACY_TITLE,
+        description: PRIVACY_DESCRIPTION,
+      }),
+  },
+  {
+    path: '/terms',
+    title: TERMS_TITLE,
+    description: TERMS_DESCRIPTION,
+    canonicalUrl: TERMS_URL,
+    h1: 'Terms of Service',
+    paragraphs: [
+      "These Terms of Service govern your use of Setlist Pick 'Em, operated by Road2 Media, LLC. By creating an account or using the App you agree to these Terms.",
+      "Setlist Pick 'Em is an entertainment platform where players predict setlists for live Phish concerts. This is strictly an entertainment product. There are no entry fees, no cash prizes, and no wagering or gambling of any kind.",
+      'You must create an account to play. You are responsible for keeping your sign-in credentials secure. Each person may maintain one account.',
+    ],
+    buildJsonLd: () =>
+      buildLegalWebPageJsonLd({
+        url: TERMS_URL,
+        title: TERMS_TITLE,
+        description: TERMS_DESCRIPTION,
+      }),
   },
 ];
 

--- a/src/shared/lib/routeGroup.js
+++ b/src/shared/lib/routeGroup.js
@@ -25,7 +25,9 @@ export function resolveRouteGroup(pathname) {
     pathname === '/how-scoring-works' ||
     pathname.startsWith('/how-scoring-works/') ||
     pathname === '/phish-setlist-prediction-game' ||
-    pathname.startsWith('/phish-setlist-prediction-game/')
+    pathname.startsWith('/phish-setlist-prediction-game/') ||
+    pathname === '/privacy' ||
+    pathname === '/terms'
   ) {
     return 'marketing';
   }

--- a/src/shared/lib/routeGroup.test.js
+++ b/src/shared/lib/routeGroup.test.js
@@ -23,7 +23,8 @@ describe('resolveRouteGroup', () => {
   });
 
   it('maps unknown paths to other', () => {
-    expect(resolveRouteGroup('/privacy')).toBe('other');
+    expect(resolveRouteGroup('/privacy')).toBe('marketing');
+    expect(resolveRouteGroup('/terms')).toBe('marketing');
     expect(resolveRouteGroup('')).toBe('other');
     expect(resolveRouteGroup(undefined)).toBe('other');
   });

--- a/vercel.json
+++ b/vercel.json
@@ -65,14 +65,6 @@
       "destination": "/spa-boot/index.html"
     },
     {
-      "source": "/privacy",
-      "destination": "/spa-boot/index.html"
-    },
-    {
-      "source": "/terms",
-      "destination": "/spa-boot/index.html"
-    },
-    {
       "source": "/join",
       "destination": "/spa-boot/index.html"
     },

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,12 +12,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 /** Paths that must boot the authenticated SPA document (`app.html`) in dev (#832). */
 const APP_DOCUMENT_PATH_PREFIXES = [
   // `/login` is its own HTML-first document (#892) — see isLoginDocumentPath.
+  // `/privacy` + `/terms` are marketing (#908) — not app-document.
   '/dashboard',
   '/setup',
   '/user/',
   '/password-reset-complete',
-  '/privacy',
-  '/terms',
   '/join',
   '/invite/',
   '/comms-preview',
@@ -61,9 +60,9 @@ function rewriteAppDocumentRequest(req, _res, next) {
     next();
     return;
   }
-  // Serve `app.html` for dashboard/legal hard opens so they don't fall
+  // Serve `app.html` for dashboard/auth hard opens so they don't fall
   // through to the marketing document (which would location.replace-loop) (#832).
-  // Public `/tour-stats*` is marketing (#853).
+  // Public `/tour-stats*` (#853) and `/privacy`+`/terms` (#908) are marketing.
   if (isAppDocumentPath(pathname)) {
     req.url = `/app.html${query}`;
   }


### PR DESCRIPTION
## Summary
- Promote staging → main for **v1.55.0**
- `/privacy` + `/terms` on marketing document (#908) — snappy from HTML-first `/login`
- Neutral login focus / no Safari Keychain steal (#909)

## Test plan
- [x] #912 merged to staging (CI green including qa-runners)
- [ ] Vercel production deploy
- [ ] `/login?mode=signup` → Terms/Privacy boots marketing (not spa-boot)
- [ ] Safari www: cold `/login` — no Keychain sheet until email tap


Made with [Cursor](https://cursor.com)