### PR TITLE
promote: 1.55.1 (login focus + legal back)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ### Fixed
 - **Auth door neutral focus on Safari private (#909)** — Keychain sheet was already suppressed, but Safari still left a blinking cursor in email. Reject pre-gesture autofocus (document `focusin` guard), park focus on a non-editable target, and retry neutralize after hydrate when private WebKit refocuses late.
+- **Legal back from signup (#908)** — When Terms/Privacy were opened from create-account, the in-page control said “Back to Setlist Pick 'Em” and sent visitors to marketing `/`. It now reads the auth-door resume stash and hard-navs to `/login?mode=signup` (“Back to create account”). Prefetch legal docs on signup; modulepreload legal page chunks on prerendered shells.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.55.1] — 2026-08-06
+
+### Fixed
+- **Auth door neutral focus on Safari private (#909)** — Keychain sheet was already suppressed, but Safari still left a blinking cursor in email. Reject pre-gesture autofocus (document `focusin` guard), park focus on a non-editable target, and retry neutralize after hydrate when private WebKit refocuses late.
+
+---
+
 ## [1.55.0] — 2026-08-06
 
 ### Changed

--- a/docs/AUTH_BOOT_PRACTICES.md
+++ b/docs/AUTH_BOOT_PRACTICES.md
@@ -18,7 +18,7 @@ Standing rules for marketing, the **auth door** (`/login`), and the app SPA. Lea
 2. **Auth door `/login`: form in first HTML; auth-only hydrate (Phase 2 / #892).**  
    - **Today (v1.54.0):** `/login` boots `login.html` with **real form controls** in the first document; `loginMain.jsx` hydrates Auth + form wiring (not `app-*.js` / react-query). Suspense fallback keeps form chrome (anti-#881 blank hang). Session hint and Google redirect return stay eager. Success → hard-navigate to `/setup` or `/dashboard`.  
    - Do **not** reintroduce a skeleton-only / empty-`#root` CSR door as the prod strategy.
-   - **Neutral first focus (#909):** do not autofocus email/password on cold open (Safari Keychain / Face ID steals method choice). Credential fields may start `readOnly` until the user focuses them.
+   - **Neutral first focus (#909):** do not autofocus email/password on cold open (Safari Keychain / Face ID steals method choice). Credential fields start `readOnly` until a real user gesture; pre-gesture autofocus is blurred and parked on a non-editable target (no blinking cursor).
 
 2b. **Google CTA must not be enabled until Auth surface is ready (#858).** Disable Continue with Google (brief “Preparing sign-in…” OK) until Auth + click-path modules are ready. Ready click path: `signInWithPopup` / redirect with **no** `await ensureAuthReady()` or dynamic-import on the hot path.
 

--- a/docs/OUTBOUND_AUTH_HANDOFF.md
+++ b/docs/OUTBOUND_AUTH_HANDOFF.md
@@ -28,7 +28,7 @@ After marketing cold opens stop booting `AuthProvider`, every outbound link must
 | Push → `/dashboard/profile/notifications` | `fcmMessagingCore`, messaging SW | `app-ok` | |
 | `/`, `/how-it-works`, `/how-scoring-works`, `/phish-setlist-prediction-game` | Marketing entry; some email allowlist paths | `public-static` | No Firebase until CTA → `/login` |
 | `/tour-stats*` | Public Firestore UI | `public-static` | **#853:** marketing document; Firebase only at aggregate fetch (not AuthProvider) |
-| `/privacy`, `/terms` | Login signup legal links, marketing footer, Profile/account | `public-static` | **#908:** marketing document (prerendered); no Auth. Soft routes remain on app SPA for in-app links |
+| `/privacy`, `/terms` | Login signup legal links, marketing footer, Profile/account | `public-static` | **#908:** marketing document (prerendered); no Auth. Soft routes remain on app SPA for in-app links. From signup, stash `splashResumeAuthModal=signup` — legal in-page back → `/login?mode=signup`; browser Back also resumes via consume on LoginPage |
 | `/join/:code`, `/invite/:handle` | Invite kits, OG `api/invite` | `invite-shell` | Prefers `dist/app.html` |
 | Marketing splash CTAs | `MarketingHomePage` | `retarget-auth` | **Done (#832 / #834 / #835 / #872 / #860):** hard-nav `/login` / `/login?mode=signup` with leave chrome + intent prefetch of login UI (no Firebase on marketing). Mid-page Get Started chooser removed — hero/header/section CTAs go straight to auth. |
 | App-shell splash CTAs | `SplashPage` (after soft-nav / sign-out) | `retarget-auth` | **Done (1.48.1):** navigate to `/login` (no splash modals). Invite VIP still modal (#844). |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.55.0",
+  "version": "1.55.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/boot-modulepreload.mjs
+++ b/scripts/boot-modulepreload.mjs
@@ -25,6 +25,10 @@ export const SPLASH_BOOT_MODULEPRELOAD_PREFIXES = ['HomeRoute-'];
 /** Chunk filename prefixes for prerendered public `/tour-stats*` (#827). */
 export const TOUR_STATS_BOOT_MODULEPRELOAD_PREFIXES = ['PublicTourStatsPage-'];
 
+/** Chunk filename prefixes for prerendered `/privacy` + `/terms` (#908). */
+export const LEGAL_PRIVACY_BOOT_MODULEPRELOAD_PREFIXES = ['PrivacyPolicyPage-'];
+export const LEGAL_TERMS_BOOT_MODULEPRELOAD_PREFIXES = ['TermsOfServicePage-'];
+
 /** Chunk filename prefixes for `/login` boot shell (#835 / #892) — form UI hydrate. */
 export const LOGIN_BOOT_MODULEPRELOAD_PREFIXES = ['LoginPage-'];
 
@@ -32,6 +36,7 @@ export const LOGIN_BOOT_MODULEPRELOAD_PREFIXES = ['LoginPage-'];
 export const DASHBOARD_BOOT_PRELOAD_MARKER = 'data-dashboard-boot-preload';
 export const SPLASH_BOOT_PRELOAD_MARKER = 'data-splash-boot-preload';
 export const TOUR_STATS_BOOT_PRELOAD_MARKER = 'data-tour-stats-boot-preload';
+export const LEGAL_BOOT_PRELOAD_MARKER = 'data-legal-boot-preload';
 export const LOGIN_BOOT_PRELOAD_MARKER = 'data-login-boot-preload';
 
 /**
@@ -198,6 +203,28 @@ export function injectTourStatsBootModulepreloads(html, distDir) {
   return injectBootModulepreloads(base, distDir, {
     prefixes: TOUR_STATS_BOOT_MODULEPRELOAD_PREFIXES,
     marker: TOUR_STATS_BOOT_PRELOAD_MARKER,
+    hrefFilter: (href) => !/\/assets\/firebase/.test(href),
+  });
+}
+
+/**
+ * Legal pages on the marketing document (#908) — preload route + markdown
+ * closure so signup → Terms/Privacy skips the lazy waterfall.
+ *
+ * @param {string} html
+ * @param {string} distDir
+ * @param {'/privacy' | '/terms'} path
+ * @returns {string}
+ */
+export function injectLegalBootModulepreloads(html, distDir, path) {
+  const prefixes =
+    path === '/terms'
+      ? LEGAL_TERMS_BOOT_MODULEPRELOAD_PREFIXES
+      : LEGAL_PRIVACY_BOOT_MODULEPRELOAD_PREFIXES;
+  const base = stripFirebaseModulepreloads(html);
+  return injectBootModulepreloads(base, distDir, {
+    prefixes,
+    marker: LEGAL_BOOT_PRELOAD_MARKER,
     hrefFilter: (href) => !/\/assets\/firebase/.test(href),
   });
 }

--- a/scripts/login-boot-shell.mjs
+++ b/scripts/login-boot-shell.mjs
@@ -304,21 +304,51 @@ function loginModeBootScript() {
       signupEl.hidden = true;
       if (eyebrow) eyebrow.textContent = 'Sign in to make picks';
     }
-    // #909: do not leave Keychain/Face ID owning first focus on cold open.
-    var ae = document.activeElement;
-    if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA')) {
-      ae.blur();
-    }
-    // Unlock credential fields only after intentional focus (pre-hydrate).
-    document.addEventListener(
-      'focusin',
-      function (ev) {
+
+    // #909: neutral focus — reject Safari autofocus until a real gesture.
+    // Listeners are on document so they survive React replacing #root.
+    if (document.documentElement.dataset.loginFocusGuard !== '1') {
+      document.documentElement.dataset.loginFocusGuard = '1';
+      var gestured = false;
+      function markGesture() { gestured = true; }
+      document.addEventListener('pointerdown', markGesture, true);
+      document.addEventListener('touchstart', markGesture, true);
+      document.addEventListener('keydown', markGesture, true);
+      function isCred(el) {
+        if (!el || el.tagName !== 'INPUT') return false;
+        var t = (el.getAttribute('type') || '').toLowerCase();
+        if (t === 'checkbox' || t === 'radio' || t === 'hidden' || t === 'submit') return false;
+        return t === 'email' || t === 'password' || t === 'text' || t === '' ||
+          el.id === 'si-email' || el.id === 'si-pass' ||
+          el.id === 'su-email' || el.id === 'su-pass' || el.id === 'su-confirm';
+      }
+      function parkFocus() {
+        var park = document.getElementById('login-focus-park');
+        if (park && park.focus) park.focus({ preventScroll: true });
+      }
+      function neutralize() {
+        var ae = document.activeElement;
+        if (!isCred(ae)) return;
+        ae.blur();
+        parkFocus();
+      }
+      document.addEventListener('focusin', function (ev) {
         var t = ev.target;
-        if (!t || t.tagName !== 'INPUT') return;
-        if (t.readOnly) t.readOnly = false;
-      },
-      true,
-    );
+        if (!isCred(t)) return;
+        if (gestured) {
+          if (t.readOnly) t.readOnly = false;
+          return;
+        }
+        t.blur();
+        parkFocus();
+      }, true);
+      neutralize();
+      if (window.requestAnimationFrame) requestAnimationFrame(neutralize);
+      setTimeout(neutralize, 0);
+      setTimeout(neutralize, 50);
+      setTimeout(neutralize, 150);
+      setTimeout(neutralize, 400);
+    }
   } catch (e) {}
 })();
 </script>`;
@@ -329,6 +359,8 @@ export function buildLoginBootShellMarkup() {
   return [
     `<style id="login-boot-shell-css">${loginBootShellCriticalCss()}</style>`,
     `<div ${LOGIN_BOOT_SHELL_MARKER}="true" ${LOGIN_FORM_SHELL_MARKER}="true" class="lbs-shell">`,
+    // Non-editable focus park so Safari autofocus has somewhere non-credential to land (#909).
+    `<button type="button" id="login-focus-park" tabindex="-1" aria-hidden="true" style="position:fixed;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;opacity:0;pointer-events:none"></button>`,
     `<div class="lbs-ambient" aria-hidden="true"></div>`,
     `<div class="lbs-progress" aria-hidden="true"></div>`,
     `<header class="lbs-header">`,

--- a/scripts/login-boot-shell.mjs
+++ b/scripts/login-boot-shell.mjs
@@ -396,7 +396,7 @@ export function buildLoginBootShellMarkup() {
     `<h1 class="lbs-title">Create account</h1>`,
     `<label class="lbs-legal">`,
     `<input type="checkbox" name="legal" value="1" disabled />`,
-    `<span>I agree to the <a href="/terms">Terms of Service</a> and <a href="/privacy">Privacy Policy</a>.</span>`,
+    `<span>I agree to the <a href="/terms" onclick="try{sessionStorage.setItem('splashResumeAuthModal','signup')}catch(e){}">Terms of Service</a> and <a href="/privacy" onclick="try{sessionStorage.setItem('splashResumeAuthModal','signup')}catch(e){}">Privacy Policy</a>.</span>`,
     `</label>`,
     `<button type="button" class="lbs-google" disabled aria-disabled="true">`,
     `<img class="lbs-google-icon" src="${GOOGLE_ICON_SRC}" alt="" width="18" height="18" />`,

--- a/scripts/prerender-seo.mjs
+++ b/scripts/prerender-seo.mjs
@@ -23,6 +23,7 @@ import {
   injectLoginBootModulepreloads,
   injectPrerenderHtml,
   injectTourStatsBootModulepreloads,
+  injectLegalBootModulepreloads,
   prerenderOutputRelPath,
 } from './seo-prerender-lib.mjs';
 
@@ -53,6 +54,10 @@ function isTourStatsPrerenderRoute(path) {
   return typeof path === 'string' && path.startsWith('/tour-stats');
 }
 
+function isLegalPrerenderRoute(path) {
+  return path === '/privacy' || path === '/terms';
+}
+
 for (const route of PRERENDER_ROUTES) {
   const shell = marketingShell;
   let html = injectPrerenderHtml(shell, route);
@@ -62,6 +67,10 @@ for (const route of PRERENDER_ROUTES) {
   // preload (#853 — fetch-time ensureFirebase after #835 login defer regression).
   if (isTourStatsPrerenderRoute(route.path)) {
     html = injectTourStatsBootModulepreloads(html, distDir);
+  }
+  // /privacy + /terms: preload legal page + markdown closure (#908 soak).
+  if (isLegalPrerenderRoute(route.path)) {
+    html = injectLegalBootModulepreloads(html, distDir, route.path);
   }
   const rel = prerenderOutputRelPath(route.path);
   const outPath = join(distDir, rel);

--- a/scripts/seo-prerender-lib.mjs
+++ b/scripts/seo-prerender-lib.mjs
@@ -33,10 +33,12 @@ import {
   LOGIN_BOOT_PRELOAD_MARKER,
   SPLASH_BOOT_PRELOAD_MARKER,
   TOUR_STATS_BOOT_PRELOAD_MARKER,
+  LEGAL_BOOT_PRELOAD_MARKER,
   injectDashboardBootModulepreloads,
   injectLoginBootModulepreloads,
   injectSplashBootModulepreloads,
   injectTourStatsBootModulepreloads,
+  injectLegalBootModulepreloads,
 } from './boot-modulepreload.mjs';
 
 export {
@@ -54,6 +56,7 @@ export {
   LOGIN_BOOT_PRELOAD_MARKER,
   SPLASH_BOOT_PRELOAD_MARKER,
   TOUR_STATS_BOOT_PRELOAD_MARKER,
+  LEGAL_BOOT_PRELOAD_MARKER,
   buildDashboardBootShellHtml,
   buildDashboardBootShellMarkup,
   buildLoginBootShellHtml,
@@ -63,6 +66,7 @@ export {
   injectLoginBootModulepreloads,
   injectSplashBootModulepreloads,
   injectTourStatsBootModulepreloads,
+  injectLegalBootModulepreloads,
 };
 
 function escapeHtml(str) {

--- a/scripts/verify-seo-prerender.mjs
+++ b/scripts/verify-seo-prerender.mjs
@@ -26,6 +26,7 @@ import {
   PRERENDER_ROUTES,
   SPLASH_BOOT_PRELOAD_MARKER,
   TOUR_STATS_BOOT_PRELOAD_MARKER,
+  LEGAL_BOOT_PRELOAD_MARKER,
   buildDashboardBootShellHtml,
   buildFixtureShellHtml,
   buildLoginBootShellHtml,
@@ -34,6 +35,7 @@ import {
   injectPrerenderHtml,
   injectSplashBootModulepreloads,
   injectTourStatsBootModulepreloads,
+  injectLegalBootModulepreloads,
   prerenderOutputRelPath,
 } from './seo-prerender-lib.mjs';
 
@@ -410,6 +412,13 @@ if (existsSync(distIndex) && existsSync(distHowItWorks)) {
     assert(
       !/\/assets\/firebase[^"]*\.js/.test(legalHtml),
       `prerendered /${legalPath} must not modulepreload firebase`,
+    );
+    const pageChunk =
+      legalPath === 'terms' ? 'TermsOfServicePage-' : 'PrivacyPolicyPage-';
+    assert(
+      legalHtml.includes(LEGAL_BOOT_PRELOAD_MARKER) &&
+        legalHtml.includes(pageChunk),
+      `prerendered /${legalPath} must modulepreload ${pageChunk} (#908)`,
     );
   }
 

--- a/src/app/LoginApp.jsx
+++ b/src/app/LoginApp.jsx
@@ -1,7 +1,12 @@
 import React, { Suspense, lazy, useEffect } from 'react'
 import { Route, Routes, useLocation } from 'react-router-dom'
 
-import { LoginFormShellFallback } from '../features/auth/login'
+import {
+  LoginFocusPark,
+  LoginFormShellFallback,
+  ensureNeutralLoginFocusGuards,
+  scheduleNeutralLoginFocus,
+} from '../features/auth/login'
 import AppBackground from '../shared/ui/AppBackground'
 
 const LoginPage = lazy(() => import('../pages/auth/LoginPage'))
@@ -29,9 +34,16 @@ function LeaveLoginDocument() {
  * replace HTML-first form with a blank spinner).
  */
 export default function LoginApp() {
+  // #909: document guards + post-mount retries (Safari private refocuses late).
+  useEffect(() => {
+    ensureNeutralLoginFocusGuards()
+    return scheduleNeutralLoginFocus()
+  }, [])
+
   return (
     <>
       <AppBackground />
+      <LoginFocusPark />
       <div className="relative z-[1] min-h-screen">
         <Suspense fallback={<LoginFormShellFallback />}>
           <Routes>

--- a/src/features/auth/index.js
+++ b/src/features/auth/index.js
@@ -7,6 +7,7 @@ export {
   LoginAuthScreen,
   useGoogleRedirectCompletion,
   stashSplashResumeAuthModal,
+  peekSplashResumeAuthModal,
   consumeSplashResumeAuthModal,
 } from './login';
 // SplashSignInModal / SplashSignUpModal intentionally do NOT re-export here:

--- a/src/features/auth/login.js
+++ b/src/features/auth/login.js
@@ -23,6 +23,7 @@ export { markLoginAuthPaint } from './model/authLoginTiming';
 export { trackAuthHopTiming } from './model/authAnalytics';
 export {
   stashSplashResumeAuthModal,
+  peekSplashResumeAuthModal,
   consumeSplashResumeAuthModal,
 } from './utils/splashAuthResumeStorage';
 export { peekGoogleRedirectIntent } from './utils/googleRedirectIntent';

--- a/src/features/auth/login.js
+++ b/src/features/auth/login.js
@@ -5,7 +5,12 @@
  */
 export { default as LoginAuthScreen } from './ui/LoginAuthScreen';
 export { default as LoginFormShellFallback } from './ui/LoginFormShellFallback';
+export { default as LoginFocusPark } from './ui/LoginFocusPark';
 export { default as GoogleAuthContinueOverlay } from './ui/GoogleAuthContinueOverlay';
+export {
+  ensureNeutralLoginFocusGuards,
+  scheduleNeutralLoginFocus,
+} from './model/deferPasswordManagerAutofill';
 export { AuthProvider, useAuth } from './provider.js';
 export { useGoogleRedirectCompletion } from './model/useGoogleRedirectCompletion';
 export {

--- a/src/features/auth/model/deferPasswordManagerAutofill.js
+++ b/src/features/auth/model/deferPasswordManagerAutofill.js
@@ -1,12 +1,17 @@
 import { useState } from 'react';
 
 /**
- * Safari / iOS Keychain + Face ID often auto-focus the first email/password
- * field on cold `/login`, stealing the choice between Google and email (#909).
+ * Safari / iOS often auto-focuses the first email field on cold `/login`
+ * (#909). Keychain may be suppressed by `readOnly`, but a blinking cursor
+ * still steals the Google vs email choice.
  *
- * Start credential fields `readOnly`; unlock on intentional focus. Pair with
- * HTML-first boot shell `readonly` + blur script in `login-boot-shell.mjs`.
+ * Strategy:
+ * - Credential fields start `readOnly` until a real user gesture
+ * - Reject pre-gesture autofocus (blur + park on a non-input)
+ * - Document-level listeners survive React replacing `#root`
  */
+
+export const LOGIN_FOCUS_PARK_ID = 'login-focus-park';
 
 /**
  * Per-field hook — call once per credential input (do not share across fields).
@@ -35,11 +40,24 @@ export function isCredentialAutofillTarget(el) {
       ? el.getAttribute('type') || ''
       : el.type || ''
   ).toLowerCase();
+  // Never treat checkbox / submit / hidden as credential autofill targets.
+  if (
+    type === 'checkbox' ||
+    type === 'radio' ||
+    type === 'button' ||
+    type === 'submit' ||
+    type === 'hidden'
+  ) {
+    return false;
+  }
   if (
     type === 'email' ||
     type === 'password' ||
     type === 'text' ||
-    type === ''
+    type === '' ||
+    type === 'search' ||
+    type === 'tel' ||
+    type === 'url'
   ) {
     return true;
   }
@@ -54,16 +72,83 @@ export function isCredentialAutofillTarget(el) {
 }
 
 /**
- * Blur an autofocused credential field after paint / hydrate.
- * Safe no-op when nothing is focused or focus is already outside inputs.
+ * Move focus off credential fields onto a non-editable park node.
+ * @returns {boolean} true if a credential field was neutralized
  */
 export function blurAutofocusedCredentialField() {
-  if (typeof document === 'undefined') return;
+  if (typeof document === 'undefined') return false;
   try {
     const ae = document.activeElement;
-    if (!isCredentialAutofillTarget(ae)) return;
+    if (!isCredentialAutofillTarget(ae)) return false;
     if (typeof ae.blur === 'function') ae.blur();
+    const park = document.getElementById(LOGIN_FOCUS_PARK_ID);
+    if (park && typeof park.focus === 'function') {
+      park.focus({ preventScroll: true });
+    }
+    return true;
   } catch {
-    // Private mode / odd DOM — ignore.
+    return false;
   }
+}
+
+/**
+ * After hydrate: retry neutralize — Safari private often focuses after paint.
+ * Stops early once focus is no longer on a credential field.
+ */
+export function scheduleNeutralLoginFocus() {
+  if (typeof window === 'undefined') return () => {};
+  const delays = [0, 50, 150, 400];
+  const ids = [];
+  const run = () => {
+    blurAutofocusedCredentialField();
+  };
+  run();
+  if (typeof window.requestAnimationFrame === 'function') {
+    const raf = window.requestAnimationFrame(run);
+    ids.push(() => window.cancelAnimationFrame(raf));
+  }
+  for (const ms of delays) {
+    const t = window.setTimeout(run, ms);
+    ids.push(() => window.clearTimeout(t));
+  }
+  return () => {
+    for (const cancel of ids) cancel();
+  };
+}
+
+/**
+ * Install document listeners once (idempotent). Survives `#root` remounts.
+ * Pre-gesture focus on credential fields is rejected; gesture unlocks readonly.
+ */
+export function ensureNeutralLoginFocusGuards() {
+  if (typeof document === 'undefined') return;
+  if (document.documentElement.dataset.loginFocusGuard === '1') return;
+  document.documentElement.dataset.loginFocusGuard = '1';
+
+  let gestured = false;
+  const markGesture = () => {
+    gestured = true;
+  };
+  document.addEventListener('pointerdown', markGesture, true);
+  document.addEventListener('touchstart', markGesture, true);
+  document.addEventListener('keydown', markGesture, true);
+
+  document.addEventListener(
+    'focusin',
+    (ev) => {
+      const t = ev.target;
+      if (!isCredentialAutofillTarget(t)) return;
+      if (gestured) {
+        if (t.readOnly) t.readOnly = false;
+        return;
+      }
+      // Autofocus before any user gesture — keep neutral door.
+      if (typeof t.blur === 'function') t.blur();
+      const park = document.getElementById(LOGIN_FOCUS_PARK_ID);
+      if (park && typeof park.focus === 'function') {
+        park.focus({ preventScroll: true });
+      }
+    },
+    true,
+  );
 }

--- a/src/features/auth/model/deferPasswordManagerAutofill.test.js
+++ b/src/features/auth/model/deferPasswordManagerAutofill.test.js
@@ -23,12 +23,19 @@ describe('isCredentialAutofillTarget', () => {
     ).toBe(true);
   });
 
-  it('rejects buttons and null', () => {
+  it('rejects buttons, checkboxes, and null', () => {
     expect(
       isCredentialAutofillTarget({
         tagName: 'BUTTON',
         getAttribute: () => null,
         id: '',
+      }),
+    ).toBe(false);
+    expect(
+      isCredentialAutofillTarget({
+        tagName: 'INPUT',
+        getAttribute: () => 'checkbox',
+        id: 'legal',
       }),
     ).toBe(false);
     expect(isCredentialAutofillTarget(null)).toBe(false);
@@ -40,8 +47,9 @@ describe('blurAutofocusedCredentialField', () => {
     expect(() => blurAutofocusedCredentialField()).not.toThrow();
   });
 
-  it('blurs document.activeElement when it is a credential field', () => {
+  it('blurs credential focus and parks on focus park', () => {
     const blur = vi.fn();
+    const parkFocus = vi.fn();
     const prev = globalThis.document;
     globalThis.document = {
       activeElement: {
@@ -50,10 +58,15 @@ describe('blurAutofocusedCredentialField', () => {
         getAttribute: () => 'email',
         blur,
       },
+      getElementById: (id) =>
+        id === 'login-focus-park'
+          ? { focus: parkFocus }
+          : null,
     };
     try {
-      blurAutofocusedCredentialField();
+      expect(blurAutofocusedCredentialField()).toBe(true);
       expect(blur).toHaveBeenCalled();
+      expect(parkFocus).toHaveBeenCalledWith({ preventScroll: true });
     } finally {
       if (prev === undefined) delete globalThis.document;
       else globalThis.document = prev;

--- a/src/features/auth/ui/LoginAuthScreen.jsx
+++ b/src/features/auth/ui/LoginAuthScreen.jsx
@@ -12,7 +12,7 @@ import GoogleAuthContinueOverlay from './GoogleAuthContinueOverlay';
 import { resolveGoogleCtaLabel } from './googleCtaLabel';
 import SplashAuthPanel from './SplashAuthPanel';
 import {
-  blurAutofocusedCredentialField,
+  scheduleNeutralLoginFocus,
   useDeferPasswordManagerAutofill,
 } from '../model/deferPasswordManagerAutofill';
 import { useLoginAuthSurfaceReady } from '../model/useLoginAuthSurfaceReady';
@@ -38,10 +38,8 @@ export default function LoginAuthScreen({
 }) {
   const isSignup = mode === 'signup';
 
-  // #909: clear any Safari autofocus that survived HTML-first boot blur.
-  useEffect(() => {
-    blurAutofocusedCredentialField();
-  }, []);
+  // #909: Safari private often focuses email after hydrate — retry neutralize.
+  useEffect(() => scheduleNeutralLoginFocus(), []);
 
   // Chrome (sticky header + marketing nav + footer) comes from MarketingPageShell
   // composed in LoginPage — same top-level surface as /how-it-works, etc. (#834).

--- a/src/features/auth/ui/LoginAuthScreen.jsx
+++ b/src/features/auth/ui/LoginAuthScreen.jsx
@@ -41,6 +41,22 @@ export default function LoginAuthScreen({
   // #909: Safari private often focuses email after hydrate — retry neutralize.
   useEffect(() => scheduleNeutralLoginFocus(), []);
 
+  // #908: warm legal documents while the visitor is on signup (hard-nav next).
+  useEffect(() => {
+    if (!isSignup || typeof document === 'undefined') return undefined;
+    const links = ['/terms', '/privacy'].map((href) => {
+      const el = document.createElement('link');
+      el.rel = 'prefetch';
+      el.href = href;
+      el.as = 'document';
+      document.head.appendChild(el);
+      return el;
+    });
+    return () => {
+      for (const el of links) el.remove();
+    };
+  }, [isSignup]);
+
   // Chrome (sticky header + marketing nav + footer) comes from MarketingPageShell
   // composed in LoginPage — same top-level surface as /how-it-works, etc. (#834).
   return (

--- a/src/features/auth/ui/LoginFocusPark.jsx
+++ b/src/features/auth/ui/LoginFocusPark.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { LOGIN_FOCUS_PARK_ID } from '../model/deferPasswordManagerAutofill';
+
+/**
+ * Non-editable focus target for #909 — Safari autofocus parks here instead of
+ * leaving a blinking cursor in the email field.
+ */
+export default function LoginFocusPark() {
+  return (
+    <button
+      type="button"
+      id={LOGIN_FOCUS_PARK_ID}
+      tabIndex={-1}
+      aria-hidden="true"
+      className="pointer-events-none fixed h-px w-px -m-px overflow-hidden border-0 p-0 opacity-0"
+      style={{ clip: 'rect(0, 0, 0, 0)' }}
+    />
+  );
+}

--- a/src/features/auth/ui/LoginFormShellFallback.jsx
+++ b/src/features/auth/ui/LoginFormShellFallback.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import {
-  blurAutofocusedCredentialField,
+  scheduleNeutralLoginFocus,
   useDeferPasswordManagerAutofill,
 } from '../model/deferPasswordManagerAutofill';
 
@@ -21,7 +21,7 @@ export default function LoginFormShellFallback() {
     } catch {
       setSignup(false);
     }
-    blurAutofocusedCredentialField();
+    return scheduleNeutralLoginFocus();
   }, []);
 
   return (

--- a/src/features/auth/utils/splashAuthResumeStorage.js
+++ b/src/features/auth/utils/splashAuthResumeStorage.js
@@ -1,4 +1,6 @@
-const STORAGE_KEY = 'splashResumeAuthModal';
+/** Session key shared with legal back-nav (`features/legal` peeks the same key). */
+export const SPLASH_RESUME_AUTH_MODAL_KEY = 'splashResumeAuthModal';
+const STORAGE_KEY = SPLASH_RESUME_AUTH_MODAL_KEY;
 
 /**
  * Call before navigating away from splash/login auth to Terms/Privacy so
@@ -13,6 +15,21 @@ export function stashSplashResumeAuthModal(kind) {
   } catch {
     // ignore quota / private mode
   }
+}
+
+/**
+ * Read without clearing — legal pages use this for “Back to create account”
+ * while browser Back still consumes on `/login` (#908 follow-up).
+ * @returns {'signup' | 'signin' | null}
+ */
+export function peekSplashResumeAuthModal() {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (raw === 'signup' || raw === 'signin') return raw;
+  } catch {
+    // ignore
+  }
+  return null;
 }
 
 /**

--- a/src/features/legal/index.js
+++ b/src/features/legal/index.js
@@ -1,3 +1,5 @@
 export { default as LegalPageLayout } from './ui/LegalPageLayout';
 export { default as PrivacyPolicyContent } from './ui/PrivacyPolicyContent';
 export { default as TermsOfServiceContent } from './ui/TermsOfServiceContent';
+export { resolveLegalBackNav } from './model/legalBackNav';
+export { peekAuthDoorResume } from './model/peekAuthDoorResume';

--- a/src/features/legal/model/legalBackNav.js
+++ b/src/features/legal/model/legalBackNav.js
@@ -1,0 +1,31 @@
+/**
+ * In-page back control for /terms + /privacy.
+ * When the visitor came from HTML-first `/login` signup/signin, send them
+ * back to the auth door (not marketing home). Browser Back still uses the
+ * sessionStorage stash consumed on LoginPage (#908).
+ *
+ * @param {'signup' | 'signin' | null | undefined} resumeKind
+ * @returns {{ href: string, label: string, hardNav: boolean }}
+ */
+export function resolveLegalBackNav(resumeKind) {
+  if (resumeKind === 'signup') {
+    return {
+      href: '/login?mode=signup',
+      label: 'Back to create account',
+      hardNav: true,
+    };
+  }
+  if (resumeKind === 'signin') {
+    return {
+      href: '/login',
+      label: 'Back to sign in',
+      hardNav: true,
+    };
+  }
+  return {
+    href: '/',
+    label: "Back to Setlist Pick 'Em",
+    // Soft Link OK on marketing doc; hard <a> also fine from app SPA.
+    hardNav: false,
+  };
+}

--- a/src/features/legal/model/legalBackNav.test.js
+++ b/src/features/legal/model/legalBackNav.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveLegalBackNav } from './legalBackNav';
+
+describe('resolveLegalBackNav', () => {
+  it('returns create-account for signup resume', () => {
+    expect(resolveLegalBackNav('signup')).toEqual({
+      href: '/login?mode=signup',
+      label: 'Back to create account',
+      hardNav: true,
+    });
+  });
+
+  it('returns sign-in for signin resume', () => {
+    expect(resolveLegalBackNav('signin')).toEqual({
+      href: '/login',
+      label: 'Back to sign in',
+      hardNav: true,
+    });
+  });
+
+  it('defaults to marketing home', () => {
+    expect(resolveLegalBackNav(null).href).toBe('/');
+    expect(resolveLegalBackNav(undefined).hardNav).toBe(false);
+  });
+});

--- a/src/features/legal/model/peekAuthDoorResume.js
+++ b/src/features/legal/model/peekAuthDoorResume.js
@@ -1,0 +1,18 @@
+/**
+ * Peek auth-door resume kind without importing the auth feature graph
+ * (legal pages boot on the marketing document — keep the chunk light).
+ *
+ * Storage key must stay in sync with
+ * `features/auth/utils/splashAuthResumeStorage.js` (`splashResumeAuthModal`).
+ *
+ * @returns {'signup' | 'signin' | null}
+ */
+export function peekAuthDoorResume() {
+  try {
+    const raw = sessionStorage.getItem('splashResumeAuthModal');
+    if (raw === 'signup' || raw === 'signin') return raw;
+  } catch {
+    // Private mode / blocked storage.
+  }
+  return null;
+}

--- a/src/features/legal/ui/LegalPageLayout.jsx
+++ b/src/features/legal/ui/LegalPageLayout.jsx
@@ -3,28 +3,47 @@ import { Link } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 
 import AppBackground from '../../../shared/ui/AppBackground';
+import { resolveLegalBackNav } from '../model/legalBackNav';
 
 /**
  * Shared layout for /privacy and /terms — full-screen, public, no auth.
  * Owns ambient background so legal works on the marketing document (#908)
  * without RootAppShell, and still looks correct on soft-nav from the app SPA.
  *
- * @param {{ title: string, lastUpdated: string, children: React.ReactNode }} props
+ * @param {{
+ *   title: string,
+ *   lastUpdated: string,
+ *   children: React.ReactNode,
+ *   resumeKind?: 'signup' | 'signin' | null,
+ * }} props
  */
-export default function LegalPageLayout({ title, lastUpdated, children }) {
+export default function LegalPageLayout({
+  title,
+  lastUpdated,
+  children,
+  resumeKind = null,
+}) {
+  const back = resolveLegalBackNav(resumeKind);
+  const backClassName =
+    'inline-flex items-center gap-1.5 text-sm font-bold text-slate-400 transition-colors hover:text-white';
+
   return (
     <>
       <AppBackground />
       <div className="relative z-[1] flex min-h-screen w-full flex-col bg-transparent text-white">
         <div className="mx-auto w-full max-w-2xl flex-1 px-5 py-10 sm:px-8 md:py-16">
           <nav className="mb-8">
-            <Link
-              to="/"
-              className="inline-flex items-center gap-1.5 text-sm font-bold text-slate-400 transition-colors hover:text-white"
-            >
-              <ArrowLeft className="h-4 w-4" aria-hidden />
-              Back to Setlist Pick &apos;Em
-            </Link>
+            {back.hardNav ? (
+              <a href={back.href} className={backClassName}>
+                <ArrowLeft className="h-4 w-4" aria-hidden />
+                {back.label}
+              </a>
+            ) : (
+              <Link to={back.href} className={backClassName}>
+                <ArrowLeft className="h-4 w-4" aria-hidden />
+                {back.label}
+              </Link>
+            )}
           </nav>
 
           <header className="mb-10">

--- a/src/features/legal/ui/PrivacyPolicyContent.jsx
+++ b/src/features/legal/ui/PrivacyPolicyContent.jsx
@@ -4,9 +4,13 @@ import LegalPageLayout from './LegalPageLayout';
 import LegalMarkdownRenderer from './LegalMarkdownRenderer';
 import privacyMd from '../../../../docs/PRIVACY_POLICY.md?raw';
 
-export default function PrivacyPolicyContent() {
+export default function PrivacyPolicyContent({ resumeKind = null }) {
   return (
-    <LegalPageLayout title="Privacy Policy" lastUpdated="May 8, 2026">
+    <LegalPageLayout
+      title="Privacy Policy"
+      lastUpdated="May 8, 2026"
+      resumeKind={resumeKind}
+    >
       <LegalMarkdownRenderer content={privacyMd} />
     </LegalPageLayout>
   );

--- a/src/features/legal/ui/TermsOfServiceContent.jsx
+++ b/src/features/legal/ui/TermsOfServiceContent.jsx
@@ -4,9 +4,13 @@ import LegalPageLayout from './LegalPageLayout';
 import LegalMarkdownRenderer from './LegalMarkdownRenderer';
 import termsMd from '../../../../docs/TERMS_OF_SERVICE.md?raw';
 
-export default function TermsOfServiceContent() {
+export default function TermsOfServiceContent({ resumeKind = null }) {
   return (
-    <LegalPageLayout title="Terms of Service" lastUpdated="May 8, 2026">
+    <LegalPageLayout
+      title="Terms of Service"
+      lastUpdated="May 8, 2026"
+      resumeKind={resumeKind}
+    >
       <LegalMarkdownRenderer content={termsMd} />
     </LegalPageLayout>
   );

--- a/src/pages/legal/PrivacyPolicyPage.jsx
+++ b/src/pages/legal/PrivacyPolicyPage.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
 
-import { PrivacyPolicyContent } from '../../features/legal';
+import {
+  PrivacyPolicyContent,
+  peekAuthDoorResume,
+} from '../../features/legal';
 import { SEO_CONFIG } from '../../shared/config/seo';
 import { getPrerenderRoute } from '../../shared/config/seoRoutes';
 
@@ -10,6 +13,7 @@ const route = getPrerenderRoute('/privacy');
 /** Public route — marketing document (#908); soft-nav compat on app SPA. */
 export default function PrivacyPolicyPage() {
   const jsonLd = route.buildJsonLd();
+  const resumeKind = peekAuthDoorResume();
   return (
     <>
       <Helmet>
@@ -19,7 +23,7 @@ export default function PrivacyPolicyPage() {
         <link rel="canonical" href={route.canonicalUrl} />
         <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
       </Helmet>
-      <PrivacyPolicyContent />
+      <PrivacyPolicyContent resumeKind={resumeKind} />
     </>
   );
 }

--- a/src/pages/legal/TermsOfServicePage.jsx
+++ b/src/pages/legal/TermsOfServicePage.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
 
-import { TermsOfServiceContent } from '../../features/legal';
+import {
+  TermsOfServiceContent,
+  peekAuthDoorResume,
+} from '../../features/legal';
 import { SEO_CONFIG } from '../../shared/config/seo';
 import { getPrerenderRoute } from '../../shared/config/seoRoutes';
 
@@ -10,6 +13,7 @@ const route = getPrerenderRoute('/terms');
 /** Public route — marketing document (#908); soft-nav compat on app SPA. */
 export default function TermsOfServicePage() {
   const jsonLd = route.buildJsonLd();
+  const resumeKind = peekAuthDoorResume();
   return (
     <>
       <Helmet>
@@ -19,7 +23,7 @@ export default function TermsOfServicePage() {
         <link rel="canonical" href={route.canonicalUrl} />
         <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
       </Helmet>
-      <TermsOfServiceContent />
+      <TermsOfServiceContent resumeKind={resumeKind} />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Promote staging → main for **v1.55.1**
- Safari private: park autofocus off login email (#909)
- Legal from signup: Back to create account + legal chunk preload (#908)

## Test plan
- [x] #914 merged to staging (CI green)
- [ ] Vercel production deploy
- [ ] Safari private `/login`: no blinking cursor until email tap
- [ ] Signup → Terms → Back to create account


Made with [Cursor](https://cursor.com)