### PR TITLE
feat(marketing): polish keyword/tour-stats copy and scroll UX (#920)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.55.3] — 2026-08-06
+
+### Changed
+- **Keyword page copy (#920)** — refresh `/phish-setlist-prediction-game` educational copy (prediction framing, personal stats, spreadsheet origin story, how-to-play steps).
+- **Splash Game Format lede (#920)** — replace “Three steps—then you're in” with lock / live scores / board framing for every show night.
+- **Public tour-stats intro (#920)** — Sphere-through-today tracking + action prompts to use the filter / frequency / bustouts / gaps.
+
+### Fixed
+- **Marketing soft-nav scroll (#920)** — mount `ScrollToTop` on the marketing document; header/footer nav clicks reset scroll. Preserve scroll depth when switching `/tour-stats` ↔ `/tour-stats/:slug` only.
+- **Public tour filter default + chrome (#920)** — default to most recent tour by `lastShowDate`; always-on teal ring on the filter.
+- **Public tour-stats “X of Y tour dates” (#920)** — `tourShowCount` (Y) is the full post-launch calendar itinerary; `showsWithSetlist` (X) stays through-today nights with setlists. Dashboard Tour stats already used full-tour Y and is unchanged.
+
+---
+
 ## [1.55.2] — 2026-08-06
 
 ### Fixed

--- a/docs/API.md
+++ b/docs/API.md
@@ -162,10 +162,10 @@ Document ID is a kebab-case slug from the calendar tour label (`2026 Sphere` →
 |-------|------|-------|
 | `tourSlug` | string | Same as doc id |
 | `tourLabel` | string | Display label from `show_calendar` / Phish.net |
-| `showDates` | string[] | Eligible show dates (metadata; not setlists) |
-| `firstShowDate` / `lastShowDate` | string\|null | `YYYY-MM-DD` |
-| `tourShowCount` | number | Dates in scope |
-| `showsWithSetlist` | number | Dates with an `official_setlists` doc |
+| `showDates` | string[] | Through-today eligible show dates used for aggregates (metadata; not setlists) |
+| `firstShowDate` / `lastShowDate` | string\|null | `YYYY-MM-DD` — through-today range (for current-tour defaulting) |
+| `tourShowCount` | number | Full post-launch tour itinerary length (Y in “X of Y tour dates”); may include upcoming nights |
+| `showsWithSetlist` | number | Through-today dates with an `official_setlists` doc (X in “X of Y tour dates”) |
 | `uniqueSongs` / `totalSongPlays` | number | Aggregate counts |
 | `topSongs` | `{ title, timesPlayed, lastPlayed?, lifetimePlays?, debutYear? }[]` | Tour Frequency (UI label; formerly "Most played"), **full ranked list** as of v1.45.0 (#709; top-15 before) — **no** per-song `showDates` lists. `lastPlayed` = latest tour show date the song appeared (`YYYY-MM-DD`, v1.46.4) |
 | `bustouts` / `gapHighlights` | `{ title, gap, showDate?, lifetimePlays?, debutYear?, lastPlayed? }[]` | Single event date OK; never a full night setlist. `gapHighlights` uncapped as of v1.45.0 (#709). `lastPlayed` = `YYYY-MM-DD` last Phish play *before* that tour night (v1.46.0 / #709 follow-up) |
@@ -180,7 +180,7 @@ Document ID is a kebab-case slug from the calendar tour label (`2026 Sphere` →
 
 **`lastPlayed` on `topSongs` (v1.46.4):** latest eligible tour show date the song was played (`YYYY-MM-DD`). UI displays tour-scoped `mm-dd`.
 
-`_index` fields: `tours[]` (`tourSlug`, `tourLabel`, `firstShowDate`, `lastShowDate`, `showCount`), `defaultTourSlug` (current tour = newest `lastShowDate` among indexed tours), `writtenAt`, `schemaVersion`.
+`_index` fields: `tours[]` (`tourSlug`, `tourLabel`, `firstShowDate`, `lastShowDate`, `showCount`), `defaultTourSlug` (current tour = newest `lastShowDate` among indexed tours), `writtenAt`, `schemaVersion`. `showCount` matches doc `tourShowCount` (full post-launch itinerary). `firstShowDate` / `lastShowDate` remain through-today.
 
 Tour labels are ingested via **`scheduledPhishnetShowCalendar`** (daily 06:00 ET) from Phish.net as new dates publish; public stats rebuild after calendar sync and again at **07:30 ET** (`scheduledPublicTourStatsRefresh`).
 

--- a/functions/publicTourShowScope.test.js
+++ b/functions/publicTourShowScope.test.js
@@ -1,0 +1,42 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  resolvePublicTourShowScope,
+  GAME_LAUNCH_SHOW_DATE,
+} = require("./publicTourStats");
+
+describe("resolvePublicTourShowScope", () => {
+  const summer = [
+    { date: "2026-07-07" },
+    { date: "2026-08-01" },
+    { date: "2026-08-10" },
+    { date: "2026-08-12" },
+  ];
+
+  it("counts full post-launch itinerary as tourShowCount (Y)", () => {
+    const scope = resolvePublicTourShowScope(summer, "2026-08-06");
+    assert.equal(scope.tourShowCount, 4);
+  });
+
+  it("limits throughToday to launch..today for aggregation (X)", () => {
+    const scope = resolvePublicTourShowScope(summer, "2026-08-06");
+    assert.deepEqual(
+      scope.throughToday.map((s) => s.date),
+      ["2026-07-07", "2026-08-01"]
+    );
+  });
+
+  it("excludes pre-launch nights from Y", () => {
+    const scope = resolvePublicTourShowScope(
+      [{ date: "2026-04-01" }, { date: "2026-07-07" }, { date: "2026-08-10" }],
+      "2026-08-06",
+      GAME_LAUNCH_SHOW_DATE
+    );
+    assert.equal(scope.tourShowCount, 2);
+    assert.deepEqual(
+      scope.throughToday.map((s) => s.date),
+      ["2026-07-07"]
+    );
+  });
+});

--- a/functions/publicTourStats.js
+++ b/functions/publicTourStats.js
@@ -18,6 +18,33 @@ const {
 const GAME_LAUNCH_SHOW_DATE = "2026-04-16";
 
 /**
+ * Split a calendar tour into post-launch nights vs nights through `today`.
+ * Stats aggregate from through-today only; `tourShowCount` is the full
+ * post-launch itinerary so UI can show "X of Y tour dates" (played vs total).
+ *
+ * @param {Array<{ date?: string } | null | undefined>} shows
+ * @param {string} today YYYY-MM-DD
+ * @param {string} [launchDate]
+ * @returns {{ throughToday: Array<{ date: string }>, tourShowCount: number }}
+ */
+function resolvePublicTourShowScope(
+  shows,
+  today,
+  launchDate = GAME_LAUNCH_SHOW_DATE
+) {
+  const list = Array.isArray(shows) ? shows : [];
+  const postLaunch = [];
+  const throughToday = [];
+  for (const s of list) {
+    if (!s || typeof s.date !== "string" || !s.date) continue;
+    if (s.date < launchDate) continue;
+    postLaunch.push(s);
+    if (s.date <= today) throughToday.push(s);
+  }
+  return { throughToday, tourShowCount: postLaunch.length };
+}
+
+/**
  * #666 Phase 1: per-song lifetime enrichment from phish.net (server-side
  * fetch only — the API key never reaches clients). Best-effort: any upstream
  * failure logs and returns null so the public stats refresh itself never
@@ -545,21 +572,23 @@ async function refreshPublicTourStats(db, opts = {}) {
     ? data.showDatesByTour
     : [];
 
-  /** @type {Array<{ tour: string, shows: Array<{ date: string }> }>} */
+  /** @type {Array<{ tour: string, shows: Array<{ date: string }>, tourShowCount: number }>} */
   const selectable = [];
   for (const group of showDatesByTour) {
     if (!group || typeof group.tour !== "string" || !Array.isArray(group.shows)) {
       continue;
     }
-    const eligible = group.shows.filter(
-      (s) =>
-        s &&
-        typeof s.date === "string" &&
-        s.date >= GAME_LAUNCH_SHOW_DATE &&
-        s.date <= today
+    const { throughToday, tourShowCount } = resolvePublicTourShowScope(
+      group.shows,
+      today
     );
-    if (eligible.length === 0) continue;
-    selectable.push({ tour: group.tour.trim(), shows: eligible });
+    // Need at least one through-today night to publish a live aggregate.
+    if (throughToday.length === 0) continue;
+    selectable.push({
+      tour: group.tour.trim(),
+      shows: throughToday,
+      tourShowCount,
+    });
   }
 
   let toursWritten = 0;
@@ -608,7 +637,8 @@ async function refreshPublicTourStats(db, opts = {}) {
     accumulatePlayDatesFromSetlists(playDatesByTitle, docs);
 
     const stats = aggregateTourSetlistStats(docs, {
-      tourShowCount: showDates.length,
+      // Full post-launch itinerary (Y); showsWithSetlist stays through-today (X).
+      tourShowCount: group.tourShowCount,
     });
     const payload = toPublicTourStatsPayload(stats, enrichmentByTitle);
     pendingWrites.push({
@@ -728,13 +758,14 @@ async function refreshPublicTourStats(db, opts = {}) {
   // Index doc for public tour picker (no setlist payloads).
   const indexTours = selectable
     .map((g) => {
+      // first/last = through-today (for "current tour" default); showCount = full Y.
       const dates = g.shows.map((s) => s.date).filter(Boolean).sort();
       return {
         tourSlug: tourLabelToSlug(g.tour),
         tourLabel: g.tour,
         lastShowDate: dates[dates.length - 1] || null,
         firstShowDate: dates[0] || null,
-        showCount: dates.length,
+        showCount: g.tourShowCount,
       };
     })
     .sort((a, b) => {
@@ -770,6 +801,7 @@ function pickDefaultPublicTourSlug(indexTours) {
 
 module.exports = {
   refreshPublicTourStats,
+  resolvePublicTourShowScope,
   pickDefaultPublicTourSlug,
   stampLastPlayedDates,
   lastPlayedRowKey,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.55.2",
+  "version": "1.55.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/app/ScrollToTop.jsx
+++ b/src/app/ScrollToTop.jsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 
+import { isPublicTourStatsPath } from '../shared/lib/appBootPath';
 import { scrollAppToTop } from '../shared/lib/scrollAppToTop';
 
 /**
@@ -8,11 +9,25 @@ import { scrollAppToTop } from '../shared/lib/scrollAppToTop';
  * Dashboard routes scroll inside `#dashboard-scrollport`, not the window —
  * so window-only reset left Standings → Picks (etc.) stuck mid-page.
  * Primary nav also calls {@link scrollAppToTop} on click for same-tab re-taps.
+ *
+ * Exception: public `/tour-stats` ↔ `/tour-stats/:slug` filter changes stay at the
+ * current scroll depth (same page chrome). Other menu routes still jump to top.
  */
 export default function ScrollToTop() {
   const { pathname, search } = useLocation();
+  const prevPathnameRef = useRef(pathname);
 
   useEffect(() => {
+    const prevPathname = prevPathnameRef.current;
+    prevPathnameRef.current = pathname;
+
+    const tourStatsSlugHandoff =
+      prevPathname !== pathname &&
+      isPublicTourStatsPath(prevPathname) &&
+      isPublicTourStatsPath(pathname);
+
+    if (tourStatsSlugHandoff) return;
+
     scrollAppToTop();
   }, [pathname, search]);
 

--- a/src/features/landing/ui/MarketingSiteNav.jsx
+++ b/src/features/landing/ui/MarketingSiteNav.jsx
@@ -5,6 +5,7 @@ import {
   MARKETING_LEGAL_NAV,
   MARKETING_PRIMARY_NAV,
 } from '../model/marketingNav';
+import { scrollAppToTop } from '../../../shared/lib/scrollAppToTop';
 import {
   FOOTER_LINK_ON_DARK,
   HEADER_LINK_ACTIVE,
@@ -27,6 +28,7 @@ export function MarketingHeaderNav({ className = 'hidden lg:flex' }) {
           <Link
             key={to}
             to={to}
+            onClick={scrollAppToTop}
             className={`${HEADER_LINK_ON_DARK} ${active ? HEADER_LINK_ACTIVE : ''}`.trim()}
             aria-current={active ? 'page' : undefined}
           >
@@ -46,7 +48,7 @@ export function MarketingFooterNav({ className = '' }) {
   return (
     <p className={`mt-2 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 ${className}`.trim()}>
       {links.map(({ to, label }) => (
-        <Link key={to} to={to} className={FOOTER_LINK_ON_DARK}>
+        <Link key={to} to={to} onClick={scrollAppToTop} className={FOOTER_LINK_ON_DARK}>
           {label}
         </Link>
       ))}

--- a/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
+++ b/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
@@ -22,8 +22,8 @@ export default function PhishSetlistPredictionGamePageContent() {
           Setlist Pick&apos;Em is a free live{' '}
           <strong className="font-semibold text-slate-800">setlist picks game</strong> for fans who
           love predicting setlists—built first for Phish, and designed as a home for more bands soon.
-          Lock openers, closers, encore, and a wildcard before showtime, then score as the night
-          unfolds.
+          Lock openers, closers, encore, and a wildcard before showtime, then score points for correct
+          picks as the night unfolds.
         </p>
 
         <section className="mb-12 space-y-4 text-base leading-relaxed text-slate-700">
@@ -31,11 +31,17 @@ export default function PhishSetlistPredictionGamePageContent() {
             What is a setlist prediction game?
           </h2>
           <p>
-            For jam bands like Phish, every night is a new setlist. A setlist prediction game—sometimes
-            called a <strong className="font-semibold text-slate-800">fantasy setlist</strong> game—asks
-            you to call songs and slots before the lights go down, not dig through yesterday&apos;s
-            archives. You compete with friends in private pools and with everyone on the global board.
-            Scores update live as songs are played. Prefer a short walkthrough? See{' '}
+            For jam bands like Phish, every night is unique, but patterns emerge that help the astute
+            fan anticipate how the setlist will unfold. A setlist prediction game—sometimes called a{' '}
+            <strong className="font-semibold text-slate-800">fantasy setlist</strong> game—asks you to
+            call songs, and to predict where they will land in the setlist. The goal is simple: prove
+            you have mastered the art of setlist construction, earning points along the way to
+            &quot;put your money where your mouth is&quot; and win the night. You compete with
+            friends in private pools
+            and with everyone on the global leaderboard. Scores update as songs are played, along with
+            a live view of the setlist so you never miss the band&apos;s last move, even if you
+            couldn&apos;t make it to the venue or carve out time for the live stream. Prefer a short
+            walkthrough? See{' '}
             <Link to="/how-it-works" className={LINK_ON_LIGHT}>
               how it works
             </Link>
@@ -53,7 +59,11 @@ export default function PhishSetlistPredictionGamePageContent() {
               tour stats
             </Link>{' '}
             pages and refresh every night the band plays live—insights that help you stay sharp
-            between shows.
+            between shows. When you join the community, you&apos;ll have access to even more tour
+            data, along with your own personal stats like picking average (think batting average, but
+            for setlist picking accuracy), Bustout Boost™ hits to measure how often you predict
+            catalog rarities, and a heatmap with all of your most frequent picks to hone your setlist
+            prediction skills.
           </p>
         </section>
 
@@ -62,9 +72,12 @@ export default function PhishSetlistPredictionGamePageContent() {
             Fantasy setlists, without the spreadsheet
           </h2>
           <p>
-            Setlist archives are great for looking back. A fantasy setlist night is about the show
-            ahead: make your calls, earn points for slots and wildcards, and chase Bustout Boosts when
-            you nail the longshots. Full point values are on{' '}
+            Setlist games have always been fun, but just like paper in the early aughts, we&apos;ve
+            outgrown spreadsheets today. As fans ourselves, we set out to make it easier for our
+            friends to manage the setlist picks game we&apos;ve been playing for 25 years. We
+            automatically track the points you earn for hitting setlist slots and wildcards, and
+            Bustout Boosts when you call songs that are not heavy in the rotation. Full point values
+            are on{' '}
             <Link to="/how-scoring-works" className={LINK_ON_LIGHT}>
               how scoring works
             </Link>
@@ -73,7 +86,7 @@ export default function PhishSetlistPredictionGamePageContent() {
           <ul className="list-disc space-y-2 pl-5">
             <li>
               <strong className="text-slate-900">Before the show:</strong> lock picks before the
-              lights go down.
+              showtime.
             </li>
             <li>
               <strong className="text-slate-900">During the show:</strong> live scoring and
@@ -93,12 +106,13 @@ export default function PhishSetlistPredictionGamePageContent() {
         <section className="mb-12 space-y-4 text-base leading-relaxed text-slate-700">
           <h2 className="font-display text-2xl font-bold text-slate-900">How to play</h2>
           <ol className="list-decimal space-y-3 pl-5">
-            <li>Create a free account and open tonight&apos;s show.</li>
+            <li>Create a free account and tonight&apos;s setlist card opens.</li>
             <li>
-              Pick Set 1 opener/closer, Set 2 opener/closer, encore, and a wildcard.
+              Pick Set 1 opener/closer, Set 2 opener/closer, an encore, and a wildcard.
             </li>
             <li>
-              Watch scores update live; climb show and tour standings or invite friends to a pool.
+              Watch scores update live; climb show and tour leaderboards, or invite friends to a
+              private pool for crew-specific standings.
             </li>
           </ol>
           <p className="flex flex-wrap gap-x-4 gap-y-2">

--- a/src/features/landing/ui/SplashHowItWorksSection.jsx
+++ b/src/features/landing/ui/SplashHowItWorksSection.jsx
@@ -28,7 +28,8 @@ export default function SplashHowItWorksSection({
           Game Format
         </h2>
         <p className="mx-auto mb-12 max-w-2xl text-center text-base leading-relaxed text-slate-600">
-          Three steps—then you&apos;re in. Prefer the full walkthrough? See{' '}
+          Lock picks, live scores, and the board—every night the band is on stage.
+          Prefer the full walkthrough? See{' '}
           <Link to="/how-it-works" className={LINK_ON_LIGHT}>
             how it works
           </Link>

--- a/src/features/tour-stats/model/publicTourIndex.js
+++ b/src/features/tour-stats/model/publicTourIndex.js
@@ -1,0 +1,55 @@
+/**
+ * Public tour-stats index helpers (#665) — current tour = newest lastShowDate.
+ */
+
+/**
+ * @param {{ tourSlug?: string, tourLabel?: string, lastShowDate?: string | null }} a
+ * @param {{ tourSlug?: string, tourLabel?: string, lastShowDate?: string | null }} b
+ * @returns {number}
+ */
+export function comparePublicTourIndexEntries(a, b) {
+  const la = typeof a?.lastShowDate === 'string' ? a.lastShowDate : '';
+  const lb = typeof b?.lastShowDate === 'string' ? b.lastShowDate : '';
+  if (lb !== la) return lb > la ? 1 : -1;
+  return String(a?.tourLabel || a?.tourSlug || '').localeCompare(
+    String(b?.tourLabel || b?.tourSlug || ''),
+  );
+}
+
+/**
+ * @param {Array<{ tourSlug?: string, tourLabel?: string, lastShowDate?: string | null }>} tours
+ * @returns {Array<{ tourSlug: string, tourLabel?: string, lastShowDate?: string | null }>}
+ */
+export function sortPublicTourIndex(tours) {
+  const list = Array.isArray(tours)
+    ? tours.filter((t) => t && typeof t.tourSlug === 'string' && t.tourSlug.trim())
+    : [];
+  return [...list].sort(comparePublicTourIndexEntries);
+}
+
+/**
+ * Current / most-recent tour for the public filter default.
+ * Prefers newest `lastShowDate`; falls back to `preferredSlug` only when dates
+ * are missing and that slug is in the list.
+ *
+ * @param {Array<{ tourSlug?: string, tourLabel?: string, lastShowDate?: string | null }>} tours
+ * @param {string} [preferredSlug]
+ * @returns {string}
+ */
+export function resolveDefaultPublicTourSlug(tours, preferredSlug = '') {
+  const sorted = sortPublicTourIndex(tours);
+  if (sorted.length === 0) return '';
+
+  const hasAnyDate = sorted.some(
+    (t) => typeof t.lastShowDate === 'string' && t.lastShowDate.trim(),
+  );
+  if (hasAnyDate) {
+    return sorted[0].tourSlug;
+  }
+
+  const preferred = String(preferredSlug ?? '').trim();
+  if (preferred && sorted.some((t) => t.tourSlug === preferred)) {
+    return preferred;
+  }
+  return sorted[0].tourSlug;
+}

--- a/src/features/tour-stats/model/publicTourIndex.test.js
+++ b/src/features/tour-stats/model/publicTourIndex.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveDefaultPublicTourSlug,
+  sortPublicTourIndex,
+} from './publicTourIndex';
+
+describe('sortPublicTourIndex', () => {
+  it('orders by lastShowDate descending', () => {
+    const sorted = sortPublicTourIndex([
+      { tourSlug: '2026-sphere', tourLabel: '2026 Sphere', lastShowDate: '2026-05-02' },
+      {
+        tourSlug: '2026-summer-tour',
+        tourLabel: '2026 Summer Tour',
+        lastShowDate: '2026-08-01',
+      },
+    ]);
+    expect(sorted.map((t) => t.tourSlug)).toEqual([
+      '2026-summer-tour',
+      '2026-sphere',
+    ]);
+  });
+});
+
+describe('resolveDefaultPublicTourSlug', () => {
+  it('picks the most recent tour by lastShowDate over a stale preferred slug', () => {
+    const slug = resolveDefaultPublicTourSlug(
+      [
+        {
+          tourSlug: '2026-sphere',
+          tourLabel: '2026 Sphere',
+          lastShowDate: '2026-05-02',
+        },
+        {
+          tourSlug: '2026-summer-tour',
+          tourLabel: '2026 Summer Tour',
+          lastShowDate: '2026-08-01',
+        },
+      ],
+      '2026-sphere',
+    );
+    expect(slug).toBe('2026-summer-tour');
+  });
+
+  it('uses preferredSlug when no lastShowDate values exist', () => {
+    const slug = resolveDefaultPublicTourSlug(
+      [
+        { tourSlug: '2026-sphere', tourLabel: '2026 Sphere' },
+        { tourSlug: '2026-summer-tour', tourLabel: '2026 Summer Tour' },
+      ],
+      '2026-sphere',
+    );
+    expect(slug).toBe('2026-sphere');
+  });
+});

--- a/src/features/tour-stats/model/usePublicTourStatsScreen.js
+++ b/src/features/tour-stats/model/usePublicTourStatsScreen.js
@@ -5,11 +5,15 @@ import {
   fetchPublicTourStatsDoc,
   fetchPublicTourStatsIndex,
 } from '../api/fetchPublicTourStats';
+import {
+  resolveDefaultPublicTourSlug,
+  sortPublicTourIndex,
+} from './publicTourIndex';
 
 /**
  * Public tour-stats screen (#665) — aggregate docs only; no self overlay.
- * Default tour = `_index.defaultTourSlug` (current / most recent), not a
- * hardcoded Sphere or Summer preference.
+ * Default tour = current / most recent by `lastShowDate` (not a hardcoded
+ * Sphere preference).
  */
 export function usePublicTourStatsScreen() {
   const { tourSlug: routeSlug } = useParams();
@@ -33,13 +37,11 @@ export function usePublicTourStatsScreen() {
       try {
         const idx = await fetchPublicTourStatsIndex();
         if (cancelled) return;
-        const list = Array.isArray(idx.tours) ? idx.tours : [];
+        const list = sortPublicTourIndex(Array.isArray(idx.tours) ? idx.tours : []);
         setTours(list);
-        const fromIndex =
-          (typeof idx.defaultTourSlug === 'string' && idx.defaultTourSlug.trim()) ||
-          list[0]?.tourSlug ||
-          '';
-        setDefaultTourSlug(fromIndex);
+        setDefaultTourSlug(
+          resolveDefaultPublicTourSlug(list, idx.defaultTourSlug),
+        );
       } catch (err) {
         if (!cancelled) setError(err);
       } finally {

--- a/src/features/tour-stats/ui/PublicTourStatsPanel.jsx
+++ b/src/features/tour-stats/ui/PublicTourStatsPanel.jsx
@@ -29,10 +29,12 @@ export default function PublicTourStatsPanel({
           Phish tour setlist stats
         </h1>
         <p className="text-base leading-relaxed text-slate-300">
-          We track the setlist stories that help you make better picks—most-played
-          songs, bustouts, and gap highlights for each tour. Stats refresh every
-          night the band plays live, so the picture keeps getting sharper as the
-          tour rolls on.
+          Since Setlist Pick&apos;Em launched at the Sphere, we&apos;ve tracked
+          every song from every tour—an easy, fun way to sift through setlist
+          stats and sharpen your predictions. Flip the tour filter, scan what&apos;s
+          getting played, hunt the bustouts, and check the high-gap songs that
+          might be due. Stats refresh every night the band plays live, so the
+          picture keeps getting sharper as the tour rolls on.
         </p>
         <p className="text-sm leading-relaxed text-slate-400">
           We&apos;re starting with Phish and building toward more bands soon.
@@ -56,7 +58,7 @@ export default function PublicTourStatsPanel({
             Tour filter
           </span>
           <select
-            className="rounded-xl border border-white/10 bg-brand-bg-deep px-3 py-2.5 text-sm font-semibold text-white outline-none focus-visible:ring-2 focus-visible:ring-teal-400"
+            className="rounded-xl border border-white/10 bg-brand-bg-deep px-3 py-2.5 text-sm font-semibold text-white outline-none ring-2 ring-teal-400 focus-visible:ring-2 focus-visible:ring-teal-300"
             value={activeSlug}
             onChange={(e) => onSelectTour(e.target.value)}
             disabled={indexLoading}

--- a/src/marketingMain.jsx
+++ b/src/marketingMain.jsx
@@ -4,6 +4,7 @@ import { HelmetProvider } from 'react-helmet-async'
 import { BrowserRouter } from 'react-router-dom'
 
 import MarketingApp from './app/MarketingApp.jsx'
+import ScrollToTop from './app/ScrollToTop.jsx'
 import { PERSISTED_SESSION_HINT_STORAGE_KEY } from './shared/lib/persistedSessionHint'
 import './index.css'
 
@@ -45,6 +46,7 @@ root.render(
   <React.StrictMode>
     <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <HelmetProvider>
+        <ScrollToTop />
         <MarketingApp />
       </HelmetProvider>
     </BrowserRouter>


### PR DESCRIPTION
Closes #920

## Summary
- Refresh keyword-intent + splash Game Format + public tour-stats marketing copy
- Fix marketing soft-nav scroll-to-top; preserve scroll only across `/tour-stats` slug changes
- Default public tour filter to most recent tour; always-on filter ring
- Public `tourShowCount` = full post-launch itinerary (Y) so Summer reads **18 of 21** (functions already deployed + refreshed)

## Test plan
- [ ] `/phish-setlist-prediction-game` copy matches edited content
- [ ] Splash Game Format lede reads “Lock picks, live scores, and the board—every night the band is on stage.”
- [ ] Marketing header/footer nav between pages lands at top
- [ ] On `/tour-stats`, scroll mid-page, switch Summer ↔ Sphere — scroll depth preserved; leaving to another marketing page still jumps to top
- [ ] Tour filter defaults to Summer (most recent); teal ring always visible
- [ ] Summer shows **18 of 21 tour dates** (or current X of 21)
- [ ] Dashboard Tour stats still shows full-tour Y unchanged


Made with [Cursor](https://cursor.com)