### PR TITLE
fix(fonts): Space Grotesk preload via early @font-face (v1.55.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.55.8] — 2026-08-08
+
+### Fixed
+- **Safari Space Grotesk preload warning** — early `@font-face` in entry HTML and boot-shell critical CSS so the preloaded display font is applied before the Vite CSS bundle arrives.
+
+---
+
 ## [1.55.7] — 2026-08-08
 
 ### Added

--- a/app.html
+++ b/app.html
@@ -40,8 +40,22 @@
     />
     <meta name="author" content="Road2 Media LLC" />
     <!-- Space Grotesk only: Inter (~344KB variable) loads via @font-face +
-         font-display:swap so it does not contend with entry JS on cold opens. -->
+         font-display:swap so it does not contend with entry JS on cold opens.
+         Early @font-face required so the preload is actually applied (Safari).
+         Keep in sync with scripts/space-grotesk-font-face.mjs and src/index.css. -->
     <link rel="preload" href="/fonts/space-grotesk/SpaceGrotesk-VariableFont_wght.woff2" as="font" type="font/woff2" crossorigin>
+    <style>
+      @font-face {
+        font-family: "Space Grotesk";
+        src: url("/fonts/space-grotesk/SpaceGrotesk-VariableFont_wght.woff2") format("woff2");
+        font-weight: 300 700;
+        font-style: normal;
+        font-display: swap;
+      }
+      html {
+        font-family: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+      }
+    </style>
     <title>Setlist Pick'em | The Ultimate Live Music Prediction Game</title>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -41,8 +41,22 @@
     />
     <meta name="author" content="Road2 Media LLC" />
     <!-- Space Grotesk only: Inter (~344KB variable) loads via @font-face +
-         font-display:swap so it does not contend with entry JS on cold opens. -->
+         font-display:swap so it does not contend with entry JS on cold opens.
+         Early @font-face required so the preload is actually applied (Safari).
+         Keep in sync with scripts/space-grotesk-font-face.mjs and src/index.css. -->
     <link rel="preload" href="/fonts/space-grotesk/SpaceGrotesk-VariableFont_wght.woff2" as="font" type="font/woff2" crossorigin>
+    <style>
+      @font-face {
+        font-family: "Space Grotesk";
+        src: url("/fonts/space-grotesk/SpaceGrotesk-VariableFont_wght.woff2") format("woff2");
+        font-weight: 300 700;
+        font-style: normal;
+        font-display: swap;
+      }
+      html {
+        font-family: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+      }
+    </style>
     <title>Setlist Pick'em | The Ultimate Live Music Prediction Game</title>
   </head>
   <body>

--- a/login.html
+++ b/login.html
@@ -37,7 +37,23 @@
       content="Sign in or create an account to play Setlist Pick 'Em — free live setlist prediction for Phish fans."
     />
     <meta name="author" content="Road2 Media LLC" />
+    <!-- Preload + early @font-face so Safari applies the file before Vite CSS
+         (preload alone does not count as "used"). Keep in sync with
+         scripts/space-grotesk-font-face.mjs and src/index.css. -->
     <link rel="preload" href="/fonts/space-grotesk/SpaceGrotesk-VariableFont_wght.woff2" as="font" type="font/woff2" crossorigin>
+    <style>
+      @font-face {
+        font-family: "Space Grotesk";
+        src: url("/fonts/space-grotesk/SpaceGrotesk-VariableFont_wght.woff2") format("woff2");
+        font-weight: 300 700;
+        font-style: normal;
+        font-display: swap;
+      }
+      /* Consume the preload before React/Vite CSS mounts (dev has no boot shell). */
+      html {
+        font-family: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+      }
+    </style>
     <title>Sign in | Setlist Pick'em</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.55.7",
+  "version": "1.55.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/dashboard-boot-shell.mjs
+++ b/scripts/dashboard-boot-shell.mjs
@@ -7,6 +7,7 @@
  */
 
 import { stripPrerenderBodyFromSpaShell } from './seo-strip-body.mjs';
+import { SPACE_GROTESK_FONT_FACE_CSS } from './space-grotesk-font-face.mjs';
 
 /** Attribute marker asserted by `verify:seo-prerender`. */
 export const DASHBOARD_BOOT_SHELL_MARKER = 'data-dashboard-boot-shell';
@@ -20,6 +21,7 @@ const VINYL_MARK_SRC = '/branding/splash-vinyl-mark.webp';
  */
 function bootShellCriticalCss() {
   return `
+${SPACE_GROTESK_FONT_FACE_CSS}
 /* Paint brand canvas before the Vite CSS bundle arrives (email hard opens). */
 html, body {
   margin: 0;

--- a/scripts/login-boot-shell.mjs
+++ b/scripts/login-boot-shell.mjs
@@ -8,6 +8,7 @@
  */
 
 import { stripPrerenderBodyFromSpaShell } from './seo-strip-body.mjs';
+import { SPACE_GROTESK_FONT_FACE_CSS } from './space-grotesk-font-face.mjs';
 
 /** Attribute marker asserted by `verify:seo-prerender`. */
 export const LOGIN_BOOT_SHELL_MARKER = 'data-login-boot-shell';
@@ -21,6 +22,7 @@ const GOOGLE_ICON_SRC =
 
 function loginBootShellCriticalCss() {
   return `
+${SPACE_GROTESK_FONT_FACE_CSS}
 html, body {
   margin: 0;
   min-height: 100%;

--- a/scripts/marketing-boot-shell.mjs
+++ b/scripts/marketing-boot-shell.mjs
@@ -8,6 +8,8 @@
  * Pure HTML/CSS — no src/ imports (safe for build scripts).
  */
 
+import { SPACE_GROTESK_FONT_FACE_CSS } from './space-grotesk-font-face.mjs';
+
 /** Attribute marker asserted by `verify:seo-prerender`. */
 export const MARKETING_BOOT_SHELL_MARKER = 'data-marketing-boot-shell';
 
@@ -17,6 +19,7 @@ export const MARKETING_BOOT_SHELL_MARKER = 'data-marketing-boot-shell';
  */
 export function buildMarketingBootShellMarkup() {
   const css = `
+${SPACE_GROTESK_FONT_FACE_CSS}
 html, body {
   margin: 0;
   min-height: 100%;

--- a/scripts/space-grotesk-font-face.mjs
+++ b/scripts/space-grotesk-font-face.mjs
@@ -1,0 +1,17 @@
+/**
+ * Early @font-face for Space Grotesk — must match the `<link rel="preload">`
+ * URL in login.html / index.html / app.html and `src/index.css`.
+ *
+ * Preload alone does not apply the file; without this rule in critical CSS,
+ * Safari warns that the font was preloaded but not used (boot shells name
+ * the family before the Vite CSS bundle arrives).
+ */
+export const SPACE_GROTESK_FONT_FACE_CSS = `
+@font-face {
+  font-family: "Space Grotesk";
+  src: url("/fonts/space-grotesk/SpaceGrotesk-VariableFont_wght.woff2") format("woff2");
+  font-weight: 300 700;
+  font-style: normal;
+  font-display: swap;
+}
+`.trim();


### PR DESCRIPTION
## Summary
- Add early `@font-face` for Space Grotesk in `login.html` / `index.html` / `app.html` so Safari applies the preloaded display font before the Vite CSS bundle arrives
- Share the same rule into login / marketing / dashboard boot-shell critical CSS
- Rebased onto staging after #936/#938; PATCH **1.55.8** (was 1.55.5)

## Test plan
- [ ] Hard-refresh `/` and `/login` in Safari DevTools — no “preloaded using link preload but not used” warning for Space Grotesk
- [ ] Sign in / Create account CTAs still navigate and paint auth door headings in Space Grotesk
- [ ] Chrome still loads fonts normally