### PR TITLE
feat(marketing): re-land #920 copy + tour-stats UX (slice 1 / #925)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.55.6] — 2026-08-08
+
+### Changed
+- **Re-land #920 copy + tour-stats UX (slice 1 / #925)** — keyword page, Game Format lede, public tour-stats intro; default public tour filter to most recent by `lastShowDate`; always-on teal filter ring. Does **not** remount shared `ScrollToTop` / `appBootPath` on the marketing cold-open graph (deferred to a later #925 slice).
+
+---
+
 ## [1.55.4] — 2026-08-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 ## [1.55.6] — 2026-08-08
 
 ### Changed
-- **Re-land #920 copy + tour-stats UX (slice 1 / #925)** — keyword page, Game Format lede, public tour-stats intro; default public tour filter to most recent by `lastShowDate`; always-on teal filter ring. Does **not** remount shared `ScrollToTop` / `appBootPath` on the marketing cold-open graph (deferred to a later #925 slice).
+- **Re-land #920 copy + tour-stats UX (slice 1 / #925)** — keyword page, Game Format lede (“Lock in picks, track live setlists and scores…”), public tour-stats intro; default public tour filter to most recent by `lastShowDate`; always-on teal filter ring. Does **not** remount shared `ScrollToTop` / `appBootPath` on the marketing cold-open graph (deferred to a later #925 slice).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.55.4",
+  "version": "1.55.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
+++ b/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
@@ -22,8 +22,8 @@ export default function PhishSetlistPredictionGamePageContent() {
           Setlist Pick&apos;Em is a free live{' '}
           <strong className="font-semibold text-slate-800">setlist picks game</strong> for fans who
           love predicting setlists—built first for Phish, and designed as a home for more bands soon.
-          Lock openers, closers, encore, and a wildcard before showtime, then score as the night
-          unfolds.
+          Lock openers, closers, encore, and a wildcard before showtime, then score points for correct
+          picks as the night unfolds.
         </p>
 
         <section className="mb-12 space-y-4 text-base leading-relaxed text-slate-700">
@@ -31,11 +31,17 @@ export default function PhishSetlistPredictionGamePageContent() {
             What is a setlist prediction game?
           </h2>
           <p>
-            For jam bands like Phish, every night is a new setlist. A setlist prediction game—sometimes
-            called a <strong className="font-semibold text-slate-800">fantasy setlist</strong> game—asks
-            you to call songs and slots before the lights go down, not dig through yesterday&apos;s
-            archives. You compete with friends in private pools and with everyone on the global board.
-            Scores update live as songs are played. Prefer a short walkthrough? See{' '}
+            For jam bands like Phish, every night is unique, but patterns emerge that help the astute
+            fan anticipate how the setlist will unfold. A setlist prediction game—sometimes called a{' '}
+            <strong className="font-semibold text-slate-800">fantasy setlist</strong> game—asks you to
+            call songs, and to predict where they will land in the setlist. The goal is simple: prove
+            you have mastered the art of setlist construction, earning points along the way to
+            &quot;put your money where your mouth is&quot; and win the night. You compete with
+            friends in private pools
+            and with everyone on the global leaderboard. Scores update as songs are played, along with
+            a live view of the setlist so you never miss the band&apos;s last move, even if you
+            couldn&apos;t make it to the venue or carve out time for the live stream. Prefer a short
+            walkthrough? See{' '}
             <Link to="/how-it-works" className={LINK_ON_LIGHT}>
               how it works
             </Link>
@@ -53,7 +59,11 @@ export default function PhishSetlistPredictionGamePageContent() {
               tour stats
             </Link>{' '}
             pages and refresh every night the band plays live—insights that help you stay sharp
-            between shows.
+            between shows. When you join the community, you&apos;ll have access to even more tour
+            data, along with your own personal stats like picking average (think batting average, but
+            for setlist picking accuracy), Bustout Boost™ hits to measure how often you predict
+            catalog rarities, and a heatmap with all of your most frequent picks to hone your setlist
+            prediction skills.
           </p>
         </section>
 
@@ -62,9 +72,12 @@ export default function PhishSetlistPredictionGamePageContent() {
             Fantasy setlists, without the spreadsheet
           </h2>
           <p>
-            Setlist archives are great for looking back. A fantasy setlist night is about the show
-            ahead: make your calls, earn points for slots and wildcards, and chase Bustout Boosts when
-            you nail the longshots. Full point values are on{' '}
+            Setlist games have always been fun, but just like paper in the early aughts, we&apos;ve
+            outgrown spreadsheets today. As fans ourselves, we set out to make it easier for our
+            friends to manage the setlist picks game we&apos;ve been playing for 25 years. We
+            automatically track the points you earn for hitting setlist slots and wildcards, and
+            Bustout Boosts when you call songs that are not heavy in the rotation. Full point values
+            are on{' '}
             <Link to="/how-scoring-works" className={LINK_ON_LIGHT}>
               how scoring works
             </Link>
@@ -73,7 +86,7 @@ export default function PhishSetlistPredictionGamePageContent() {
           <ul className="list-disc space-y-2 pl-5">
             <li>
               <strong className="text-slate-900">Before the show:</strong> lock picks before the
-              lights go down.
+              showtime.
             </li>
             <li>
               <strong className="text-slate-900">During the show:</strong> live scoring and
@@ -93,12 +106,13 @@ export default function PhishSetlistPredictionGamePageContent() {
         <section className="mb-12 space-y-4 text-base leading-relaxed text-slate-700">
           <h2 className="font-display text-2xl font-bold text-slate-900">How to play</h2>
           <ol className="list-decimal space-y-3 pl-5">
-            <li>Create a free account and open tonight&apos;s show.</li>
+            <li>Create a free account and tonight&apos;s setlist card opens.</li>
             <li>
-              Pick Set 1 opener/closer, Set 2 opener/closer, encore, and a wildcard.
+              Pick Set 1 opener/closer, Set 2 opener/closer, an encore, and a wildcard.
             </li>
             <li>
-              Watch scores update live; climb show and tour standings or invite friends to a pool.
+              Watch scores update live; climb show and tour leaderboards, or invite friends to a
+              private pool for crew-specific standings.
             </li>
           </ol>
           <p className="flex flex-wrap gap-x-4 gap-y-2">

--- a/src/features/landing/ui/SplashHowItWorksSection.jsx
+++ b/src/features/landing/ui/SplashHowItWorksSection.jsx
@@ -28,7 +28,8 @@ export default function SplashHowItWorksSection({
           Game Format
         </h2>
         <p className="mx-auto mb-12 max-w-2xl text-center text-base leading-relaxed text-slate-600">
-          Three steps—then you&apos;re in. Prefer the full walkthrough? See{' '}
+          Lock picks, live scores, and the board—every night the band is on stage.
+          Prefer the full walkthrough? See{' '}
           <Link to="/how-it-works" className={LINK_ON_LIGHT}>
             how it works
           </Link>

--- a/src/features/landing/ui/SplashHowItWorksSection.jsx
+++ b/src/features/landing/ui/SplashHowItWorksSection.jsx
@@ -28,8 +28,8 @@ export default function SplashHowItWorksSection({
           Game Format
         </h2>
         <p className="mx-auto mb-12 max-w-2xl text-center text-base leading-relaxed text-slate-600">
-          Lock picks, live scores, and the board—every night the band is on stage.
-          Prefer the full walkthrough? See{' '}
+          Lock in picks, track live setlists and scores, and watch the real-time
+          leaderboard. Prefer the full walkthrough? See{' '}
           <Link to="/how-it-works" className={LINK_ON_LIGHT}>
             how it works
           </Link>

--- a/src/features/tour-stats/model/publicTourIndex.js
+++ b/src/features/tour-stats/model/publicTourIndex.js
@@ -1,0 +1,55 @@
+/**
+ * Public tour-stats index helpers (#665) — current tour = newest lastShowDate.
+ */
+
+/**
+ * @param {{ tourSlug?: string, tourLabel?: string, lastShowDate?: string | null }} a
+ * @param {{ tourSlug?: string, tourLabel?: string, lastShowDate?: string | null }} b
+ * @returns {number}
+ */
+export function comparePublicTourIndexEntries(a, b) {
+  const la = typeof a?.lastShowDate === 'string' ? a.lastShowDate : '';
+  const lb = typeof b?.lastShowDate === 'string' ? b.lastShowDate : '';
+  if (lb !== la) return lb > la ? 1 : -1;
+  return String(a?.tourLabel || a?.tourSlug || '').localeCompare(
+    String(b?.tourLabel || b?.tourSlug || ''),
+  );
+}
+
+/**
+ * @param {Array<{ tourSlug?: string, tourLabel?: string, lastShowDate?: string | null }>} tours
+ * @returns {Array<{ tourSlug: string, tourLabel?: string, lastShowDate?: string | null }>}
+ */
+export function sortPublicTourIndex(tours) {
+  const list = Array.isArray(tours)
+    ? tours.filter((t) => t && typeof t.tourSlug === 'string' && t.tourSlug.trim())
+    : [];
+  return [...list].sort(comparePublicTourIndexEntries);
+}
+
+/**
+ * Current / most-recent tour for the public filter default.
+ * Prefers newest `lastShowDate`; falls back to `preferredSlug` only when dates
+ * are missing and that slug is in the list.
+ *
+ * @param {Array<{ tourSlug?: string, tourLabel?: string, lastShowDate?: string | null }>} tours
+ * @param {string} [preferredSlug]
+ * @returns {string}
+ */
+export function resolveDefaultPublicTourSlug(tours, preferredSlug = '') {
+  const sorted = sortPublicTourIndex(tours);
+  if (sorted.length === 0) return '';
+
+  const hasAnyDate = sorted.some(
+    (t) => typeof t.lastShowDate === 'string' && t.lastShowDate.trim(),
+  );
+  if (hasAnyDate) {
+    return sorted[0].tourSlug;
+  }
+
+  const preferred = String(preferredSlug ?? '').trim();
+  if (preferred && sorted.some((t) => t.tourSlug === preferred)) {
+    return preferred;
+  }
+  return sorted[0].tourSlug;
+}

--- a/src/features/tour-stats/model/publicTourIndex.test.js
+++ b/src/features/tour-stats/model/publicTourIndex.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveDefaultPublicTourSlug,
+  sortPublicTourIndex,
+} from './publicTourIndex';
+
+describe('sortPublicTourIndex', () => {
+  it('orders by lastShowDate descending', () => {
+    const sorted = sortPublicTourIndex([
+      { tourSlug: '2026-sphere', tourLabel: '2026 Sphere', lastShowDate: '2026-05-02' },
+      {
+        tourSlug: '2026-summer-tour',
+        tourLabel: '2026 Summer Tour',
+        lastShowDate: '2026-08-01',
+      },
+    ]);
+    expect(sorted.map((t) => t.tourSlug)).toEqual([
+      '2026-summer-tour',
+      '2026-sphere',
+    ]);
+  });
+});
+
+describe('resolveDefaultPublicTourSlug', () => {
+  it('picks the most recent tour by lastShowDate over a stale preferred slug', () => {
+    const slug = resolveDefaultPublicTourSlug(
+      [
+        {
+          tourSlug: '2026-sphere',
+          tourLabel: '2026 Sphere',
+          lastShowDate: '2026-05-02',
+        },
+        {
+          tourSlug: '2026-summer-tour',
+          tourLabel: '2026 Summer Tour',
+          lastShowDate: '2026-08-01',
+        },
+      ],
+      '2026-sphere',
+    );
+    expect(slug).toBe('2026-summer-tour');
+  });
+
+  it('uses preferredSlug when no lastShowDate values exist', () => {
+    const slug = resolveDefaultPublicTourSlug(
+      [
+        { tourSlug: '2026-sphere', tourLabel: '2026 Sphere' },
+        { tourSlug: '2026-summer-tour', tourLabel: '2026 Summer Tour' },
+      ],
+      '2026-sphere',
+    );
+    expect(slug).toBe('2026-sphere');
+  });
+});

--- a/src/features/tour-stats/model/usePublicTourStatsScreen.js
+++ b/src/features/tour-stats/model/usePublicTourStatsScreen.js
@@ -5,11 +5,15 @@ import {
   fetchPublicTourStatsDoc,
   fetchPublicTourStatsIndex,
 } from '../api/fetchPublicTourStats';
+import {
+  resolveDefaultPublicTourSlug,
+  sortPublicTourIndex,
+} from './publicTourIndex';
 
 /**
  * Public tour-stats screen (#665) — aggregate docs only; no self overlay.
- * Default tour = `_index.defaultTourSlug` (current / most recent), not a
- * hardcoded Sphere or Summer preference.
+ * Default tour = current / most recent by `lastShowDate` (not a hardcoded
+ * Sphere preference).
  */
 export function usePublicTourStatsScreen() {
   const { tourSlug: routeSlug } = useParams();
@@ -33,13 +37,11 @@ export function usePublicTourStatsScreen() {
       try {
         const idx = await fetchPublicTourStatsIndex();
         if (cancelled) return;
-        const list = Array.isArray(idx.tours) ? idx.tours : [];
+        const list = sortPublicTourIndex(Array.isArray(idx.tours) ? idx.tours : []);
         setTours(list);
-        const fromIndex =
-          (typeof idx.defaultTourSlug === 'string' && idx.defaultTourSlug.trim()) ||
-          list[0]?.tourSlug ||
-          '';
-        setDefaultTourSlug(fromIndex);
+        setDefaultTourSlug(
+          resolveDefaultPublicTourSlug(list, idx.defaultTourSlug),
+        );
       } catch (err) {
         if (!cancelled) setError(err);
       } finally {

--- a/src/features/tour-stats/ui/PublicTourStatsPanel.jsx
+++ b/src/features/tour-stats/ui/PublicTourStatsPanel.jsx
@@ -29,10 +29,12 @@ export default function PublicTourStatsPanel({
           Phish tour setlist stats
         </h1>
         <p className="text-base leading-relaxed text-slate-300">
-          We track the setlist stories that help you make better picks—most-played
-          songs, bustouts, and gap highlights for each tour. Stats refresh every
-          night the band plays live, so the picture keeps getting sharper as the
-          tour rolls on.
+          Since Setlist Pick&apos;Em launched at the Sphere, we&apos;ve tracked
+          every song from every tour—an easy, fun way to sift through setlist
+          stats and sharpen your predictions. Flip the tour filter, scan what&apos;s
+          getting played, hunt the bustouts, and check the high-gap songs that
+          might be due. Stats refresh every night the band plays live, so the
+          picture keeps getting sharper as the tour rolls on.
         </p>
         <p className="text-sm leading-relaxed text-slate-400">
           We&apos;re starting with Phish and building toward more bands soon.
@@ -56,7 +58,7 @@ export default function PublicTourStatsPanel({
             Tour filter
           </span>
           <select
-            className="rounded-xl border border-white/10 bg-brand-bg-deep px-3 py-2.5 text-sm font-semibold text-white outline-none focus-visible:ring-2 focus-visible:ring-teal-400"
+            className="rounded-xl border border-white/10 bg-brand-bg-deep px-3 py-2.5 text-sm font-semibold text-white outline-none ring-2 ring-teal-400 focus-visible:ring-2 focus-visible:ring-teal-300"
             value={activeSlug}
             onChange={(e) => onSelectTour(e.target.value)}
             disabled={indexLoading}


### PR DESCRIPTION
Part of #925 · re-lands safe subset of #920 / #921

## Summary
- Restore keyword-intent, Game Format lede, and public tour-stats intro copy from v1.55.3
- Restore public tour filter default (most recent by `lastShowDate`) + always-on teal ring
- **Explicitly omitted** from this PR (later #925 slice): shared `ScrollToTop` on `marketingMain`, `appBootPath` tour-stats slug exemption, `MarketingSiteNav` `scrollAppToTop` clicks
- PATCH **1.55.6** (1.55.5 reserved by #935 font preload fix)

## Test plan
- [ ] Safari private hard-open `/` — splash hydrates (not stuck on SEO prerender)
- [ ] Chrome `/` still fine
- [ ] `/phish-setlist-prediction-game` copy matches re-landed content
- [ ] Splash Game Format lede: “Lock picks, live scores, and the board—every night the band is on stage.”
- [ ] `/tour-stats` filter defaults to most recent tour; teal ring always visible
- [ ] Summer still shows full-itinerary Y (functions unchanged)
- [ ] Confirm this PR does **not** change `marketingMain.jsx`, `ScrollToTop.jsx`, or `MarketingSiteNav.jsx`


Made with [Cursor](https://cursor.com)