### PR TITLE
feat(marketing): re-land #920 scroll UX (slice 2 / #925)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.55.7] — 2026-08-08
+
+### Added
+- **Marketing-local scroll-to-top (#925 / #920 slice 2)** — `MarketingScrollToTop` + `scrollMarketingToTop` on the marketing document (nav clicks + route changes). Preserves scroll across `/tour-stats` ↔ `/tour-stats/:slug`. Does **not** import shared app `ScrollToTop` or `appBootPath`.
+
+---
+
 ## [1.55.6] — 2026-08-08
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.55.6",
+  "version": "1.55.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/app/MarketingApp.jsx
+++ b/src/app/MarketingApp.jsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 
 import {
   MarketingAuthLeaveOverlay,
+  MarketingScrollToTop,
   resolveMarketingAuthLeaveMessage,
   useSpeculativeLoginWarm,
 } from '../features/landing/splash';
@@ -93,68 +94,71 @@ export default function MarketingApp() {
   useSpeculativeLoginWarm();
 
   return (
-    <Routes>
-      <Route path="/" element={<MarketingHomePage />} />
-      <Route
-        path="/how-it-works"
-        element={
-          <Suspense fallback={<MarketingRouteFallback />}>
-            <HowItWorksPage />
-          </Suspense>
-        }
-      />
-      <Route
-        path="/how-scoring-works"
-        element={
-          <Suspense fallback={<MarketingRouteFallback />}>
-            <HowScoringWorksPage />
-          </Suspense>
-        }
-      />
-      <Route
-        path="/phish-setlist-prediction-game"
-        element={
-          <Suspense fallback={<MarketingRouteFallback />}>
-            <PhishSetlistPredictionGamePage />
-          </Suspense>
-        }
-      />
-      {/* Public tour-stats: marketing document + deferred Firestore (#853). */}
-      <Route
-        path="/tour-stats"
-        element={
-          <Suspense fallback={<MarketingRouteFallback />}>
-            <PublicTourStatsPage />
-          </Suspense>
-        }
-      />
-      <Route
-        path="/tour-stats/:tourSlug"
-        element={
-          <Suspense fallback={<MarketingRouteFallback />}>
-            <PublicTourStatsPage />
-          </Suspense>
-        }
-      />
-      {/* Legal: marketing document, no Auth (#908) — snappy from HTML-first /login. */}
-      <Route
-        path="/privacy"
-        element={
-          <Suspense fallback={<MarketingRouteFallback />}>
-            <PrivacyPolicyPage />
-          </Suspense>
-        }
-      />
-      <Route
-        path="/terms"
-        element={
-          <Suspense fallback={<MarketingRouteFallback />}>
-            <TermsOfServicePage />
-          </Suspense>
-        }
-      />
-      {/* App-document surfaces — full load so Firebase/AuthProvider can boot. */}
-      <Route path="*" element={<LoadAppDocument />} />
-    </Routes>
+    <>
+      <MarketingScrollToTop />
+      <Routes>
+        <Route path="/" element={<MarketingHomePage />} />
+        <Route
+          path="/how-it-works"
+          element={
+            <Suspense fallback={<MarketingRouteFallback />}>
+              <HowItWorksPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/how-scoring-works"
+          element={
+            <Suspense fallback={<MarketingRouteFallback />}>
+              <HowScoringWorksPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/phish-setlist-prediction-game"
+          element={
+            <Suspense fallback={<MarketingRouteFallback />}>
+              <PhishSetlistPredictionGamePage />
+            </Suspense>
+          }
+        />
+        {/* Public tour-stats: marketing document + deferred Firestore (#853). */}
+        <Route
+          path="/tour-stats"
+          element={
+            <Suspense fallback={<MarketingRouteFallback />}>
+              <PublicTourStatsPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/tour-stats/:tourSlug"
+          element={
+            <Suspense fallback={<MarketingRouteFallback />}>
+              <PublicTourStatsPage />
+            </Suspense>
+          }
+        />
+        {/* Legal: marketing document, no Auth (#908) — snappy from HTML-first /login. */}
+        <Route
+          path="/privacy"
+          element={
+            <Suspense fallback={<MarketingRouteFallback />}>
+              <PrivacyPolicyPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/terms"
+          element={
+            <Suspense fallback={<MarketingRouteFallback />}>
+              <TermsOfServicePage />
+            </Suspense>
+          }
+        />
+        {/* App-document surfaces — full load so Firebase/AuthProvider can boot. */}
+        <Route path="*" element={<LoadAppDocument />} />
+      </Routes>
+    </>
   );
 }

--- a/src/features/landing/model/scrollMarketingToTop.js
+++ b/src/features/landing/model/scrollMarketingToTop.js
@@ -1,0 +1,20 @@
+/**
+ * Marketing-document scroll helpers (#925 slice 2 / #920).
+ *
+ * Window-only — do not import `scrollAppToTop` (dashboard scrollport) or
+ * `appBootPath` onto the marketing cold-open graph (Safari hydrate regression).
+ */
+
+/**
+ * @param {string} [pathname]
+ * @returns {boolean}
+ */
+export function isMarketingTourStatsPath(pathname) {
+  if (typeof pathname !== 'string' || !pathname) return false;
+  return pathname === '/tour-stats' || pathname.startsWith('/tour-stats/');
+}
+
+/** Reset window scroll on marketing soft-nav (no dashboard scrollport). */
+export function scrollMarketingToTop() {
+  window.scrollTo(0, 0);
+}

--- a/src/features/landing/model/scrollMarketingToTop.test.js
+++ b/src/features/landing/model/scrollMarketingToTop.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { isMarketingTourStatsPath } from './scrollMarketingToTop';
+
+describe('isMarketingTourStatsPath', () => {
+  it('matches public tour-stats hub and slug routes', () => {
+    expect(isMarketingTourStatsPath('/tour-stats')).toBe(true);
+    expect(isMarketingTourStatsPath('/tour-stats/2026-summer-tour')).toBe(true);
+  });
+
+  it('rejects dashboard and other marketing paths', () => {
+    expect(isMarketingTourStatsPath('/')).toBe(false);
+    expect(isMarketingTourStatsPath('/how-it-works')).toBe(false);
+    expect(isMarketingTourStatsPath('/dashboard/tour-stats')).toBe(false);
+  });
+});

--- a/src/features/landing/splash.js
+++ b/src/features/landing/splash.js
@@ -29,3 +29,6 @@ export {
   markLoginHopCta,
 } from './model/prefetchLoginIntent';
 export { default as useSpeculativeLoginWarm } from './model/useSpeculativeLoginWarm';
+/** Marketing-local scroll reset — no shared app ScrollToTop / appBootPath (#925). */
+export { default as MarketingScrollToTop } from './ui/MarketingScrollToTop';
+export { scrollMarketingToTop } from './model/scrollMarketingToTop';

--- a/src/features/landing/ui/MarketingScrollToTop.jsx
+++ b/src/features/landing/ui/MarketingScrollToTop.jsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import {
+  isMarketingTourStatsPath,
+  scrollMarketingToTop,
+} from '../model/scrollMarketingToTop';
+
+/**
+ * Reset window scroll on marketing client-side navigation (#925 / #920).
+ *
+ * Exception: `/tour-stats` ↔ `/tour-stats/:slug` keeps scroll depth (filter chrome).
+ * Lives in `features/landing` so marketing never imports shared app `ScrollToTop`
+ * / `appBootPath` (v1.55.3 Safari prerender hang class).
+ */
+export default function MarketingScrollToTop() {
+  const { pathname, search } = useLocation();
+  const prevPathnameRef = useRef(pathname);
+
+  useEffect(() => {
+    const prevPathname = prevPathnameRef.current;
+    prevPathnameRef.current = pathname;
+
+    const tourStatsSlugHandoff =
+      prevPathname !== pathname &&
+      isMarketingTourStatsPath(prevPathname) &&
+      isMarketingTourStatsPath(pathname);
+
+    if (tourStatsSlugHandoff) return;
+
+    scrollMarketingToTop();
+  }, [pathname, search]);
+
+  return null;
+}

--- a/src/features/landing/ui/MarketingSiteNav.jsx
+++ b/src/features/landing/ui/MarketingSiteNav.jsx
@@ -5,6 +5,7 @@ import {
   MARKETING_LEGAL_NAV,
   MARKETING_PRIMARY_NAV,
 } from '../model/marketingNav';
+import { scrollMarketingToTop } from '../model/scrollMarketingToTop';
 import {
   FOOTER_LINK_ON_DARK,
   HEADER_LINK_ACTIVE,
@@ -27,6 +28,7 @@ export function MarketingHeaderNav({ className = 'hidden lg:flex' }) {
           <Link
             key={to}
             to={to}
+            onClick={scrollMarketingToTop}
             className={`${HEADER_LINK_ON_DARK} ${active ? HEADER_LINK_ACTIVE : ''}`.trim()}
             aria-current={active ? 'page' : undefined}
           >
@@ -46,7 +48,12 @@ export function MarketingFooterNav({ className = '' }) {
   return (
     <p className={`mt-2 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 ${className}`.trim()}>
       {links.map(({ to, label }) => (
-        <Link key={to} to={to} className={FOOTER_LINK_ON_DARK}>
+        <Link
+          key={to}
+          to={to}
+          onClick={scrollMarketingToTop}
+          className={FOOTER_LINK_ON_DARK}
+        >
           {label}
         </Link>
       ))}


### PR DESCRIPTION
Closes #925 · completes #920 scroll UX after slice 1 (#936)

## Summary
- Add marketing-local `MarketingScrollToTop` + `scrollMarketingToTop` (window-only)
- Wire into `MarketingApp` and header/footer nav clicks
- Preserve scroll across `/tour-stats` ↔ `/tour-stats/:slug`
- **Does not** import shared `app/ScrollToTop` or `appBootPath` (v1.55.3 hang class)
- PATCH **1.55.7**

## Test plan
- [ ] Safari private hard-open `/` — splash hydrates (not stuck on SEO prerender)
- [ ] Hard refresh after first paint still hydrates
- [ ] Marketing header/footer nav between pages lands at top
- [ ] On `/tour-stats`, scroll mid-page, switch Summer ↔ Sphere — scroll depth preserved
- [ ] Leaving tour-stats to another marketing page still jumps to top
- [ ] Chrome still fine


Made with [Cursor](https://cursor.com)