### PR TITLE
promote: 1.55.8 (#920 re-land + Space Grotesk preload)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.55.6] — 2026-08-08
+
+### Changed
+- **Re-land #920 copy + tour-stats UX (slice 1 / #925)** — keyword page, Game Format lede, public tour-stats intro; default public tour filter to most recent by `lastShowDate`; always-on teal filter ring. Does **not** remount shared `ScrollToTop` / `appBootPath` on the marketing cold-open graph (deferred to a later #925 slice).
+
+---
+
 ## [1.55.4] — 2026-08-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.55.8] — 2026-08-08
+
+### Fixed
+- **Safari Space Grotesk preload warning** — early `@font-face` in entry HTML and boot-shell critical CSS so the preloaded display font is applied before the Vite CSS bundle arrives.
+
+---
+
 ## [1.55.7] — 2026-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 ## [1.55.6] — 2026-08-08
 
 ### Changed
-- **Re-land #920 copy + tour-stats UX (slice 1 / #925)** — keyword page, Game Format lede, public tour-stats intro; default public tour filter to most recent by `lastShowDate`; always-on teal filter ring. Does **not** remount shared `ScrollToTop` / `appBootPath` on the marketing cold-open graph (deferred to a later #925 slice).
+- **Re-land #920 copy + tour-stats UX (slice 1 / #925)** — keyword page, Game Format lede (“Lock in picks, track live setlists and scores…”), public tour-stats intro; default public tour filter to most recent by `lastShowDate`; always-on teal filter ring. Does **not** remount shared `ScrollToTop` / `appBootPath` on the marketing cold-open graph (deferred to a later #925 slice).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.55.7] — 2026-08-08
+
+### Added
+- **Marketing-local scroll-to-top (#925 / #920 slice 2)** — `MarketingScrollToTop` + `scrollMarketingToTop` on the marketing document (nav clicks + route changes). Preserves scroll across `/tour-stats` ↔ `/tour-stats/:slug`. Does **not** import shared app `ScrollToTop` or `appBootPath`.
+
+---
+
 ## [1.55.6] — 2026-08-08
 
 ### Changed

--- a/app.html
+++ b/app.html
@@ -40,8 +40,22 @@
     />
     <meta name="author" content="Road2 Media LLC" />
     <!-- Space Grotesk only: Inter (~344KB variable) loads via @font-face +
-         font-display:swap so it does not contend with entry JS on cold opens. -->
+         font-display:swap so it does not contend with entry JS on cold opens.
+         Early @font-face required so the preload is actually applied (Safari).
+         Keep in sync with scripts/space-grotesk-font-face.mjs and src/index.css. -->
     <link rel="preload" href="/fonts/space-grotesk/SpaceGrotesk-VariableFont_wght.woff2" as="font" type="font/woff2" crossorigin>
+    <style>
+      @font-face {
+        font-family: "Space Grotesk";
+        src: url("/fonts/space-grotesk/SpaceGrotesk-VariableFont_wght.woff2") format("woff2");
+        font-weight: 300 700;
+        font-style: normal;
+        font-display: swap;
+      }
+      html {
+        font-family: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+      }
+    </style>
     <title>Setlist Pick'em | The Ultimate Live Music Prediction Game</title>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -41,8 +41,22 @@
     />
     <meta name="author" content="Road2 Media LLC" />
     <!-- Space Grotesk only: Inter (~344KB variable) loads via @font-face +
-         font-display:swap so it does not contend with entry JS on cold opens. -->
+         font-display:swap so it does not contend with entry JS on cold opens.
+         Early @font-face required so the preload is actually applied (Safari).
+         Keep in sync with scripts/space-grotesk-font-face.mjs and src/index.css. -->
     <link rel="preload" href="/fonts/space-grotesk/SpaceGrotesk-VariableFont_wght.woff2" as="font" type="font/woff2" crossorigin>
+    <style>
+      @font-face {
+        font-family: "Space Grotesk";
+        src: url("/fonts/space-grotesk/SpaceGrotesk-VariableFont_wght.woff2") format("woff2");
+        font-weight: 300 700;
+        font-style: normal;
+        font-display: swap;
+      }
+      html {
+        font-family: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+      }
+    </style>
     <title>Setlist Pick'em | The Ultimate Live Music Prediction Game</title>
   </head>
   <body>

--- a/login.html
+++ b/login.html
@@ -37,7 +37,23 @@
       content="Sign in or create an account to play Setlist Pick 'Em — free live setlist prediction for Phish fans."
     />
     <meta name="author" content="Road2 Media LLC" />
+    <!-- Preload + early @font-face so Safari applies the file before Vite CSS
+         (preload alone does not count as "used"). Keep in sync with
+         scripts/space-grotesk-font-face.mjs and src/index.css. -->
     <link rel="preload" href="/fonts/space-grotesk/SpaceGrotesk-VariableFont_wght.woff2" as="font" type="font/woff2" crossorigin>
+    <style>
+      @font-face {
+        font-family: "Space Grotesk";
+        src: url("/fonts/space-grotesk/SpaceGrotesk-VariableFont_wght.woff2") format("woff2");
+        font-weight: 300 700;
+        font-style: normal;
+        font-display: swap;
+      }
+      /* Consume the preload before React/Vite CSS mounts (dev has no boot shell). */
+      html {
+        font-family: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+      }
+    </style>
     <title>Sign in | Setlist Pick'em</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.55.6",
+  "version": "1.55.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.55.4",
+  "version": "1.55.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.55.7",
+  "version": "1.55.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/dashboard-boot-shell.mjs
+++ b/scripts/dashboard-boot-shell.mjs
@@ -7,6 +7,7 @@
  */
 
 import { stripPrerenderBodyFromSpaShell } from './seo-strip-body.mjs';
+import { SPACE_GROTESK_FONT_FACE_CSS } from './space-grotesk-font-face.mjs';
 
 /** Attribute marker asserted by `verify:seo-prerender`. */
 export const DASHBOARD_BOOT_SHELL_MARKER = 'data-dashboard-boot-shell';
@@ -20,6 +21,7 @@ const VINYL_MARK_SRC = '/branding/splash-vinyl-mark.webp';
  */
 function bootShellCriticalCss() {
   return `
+${SPACE_GROTESK_FONT_FACE_CSS}
 /* Paint brand canvas before the Vite CSS bundle arrives (email hard opens). */
 html, body {
   margin: 0;

--- a/scripts/login-boot-shell.mjs
+++ b/scripts/login-boot-shell.mjs
@@ -8,6 +8,7 @@
  */
 
 import { stripPrerenderBodyFromSpaShell } from './seo-strip-body.mjs';
+import { SPACE_GROTESK_FONT_FACE_CSS } from './space-grotesk-font-face.mjs';
 
 /** Attribute marker asserted by `verify:seo-prerender`. */
 export const LOGIN_BOOT_SHELL_MARKER = 'data-login-boot-shell';
@@ -21,6 +22,7 @@ const GOOGLE_ICON_SRC =
 
 function loginBootShellCriticalCss() {
   return `
+${SPACE_GROTESK_FONT_FACE_CSS}
 html, body {
   margin: 0;
   min-height: 100%;

--- a/scripts/marketing-boot-shell.mjs
+++ b/scripts/marketing-boot-shell.mjs
@@ -8,6 +8,8 @@
  * Pure HTML/CSS — no src/ imports (safe for build scripts).
  */
 
+import { SPACE_GROTESK_FONT_FACE_CSS } from './space-grotesk-font-face.mjs';
+
 /** Attribute marker asserted by `verify:seo-prerender`. */
 export const MARKETING_BOOT_SHELL_MARKER = 'data-marketing-boot-shell';
 
@@ -17,6 +19,7 @@ export const MARKETING_BOOT_SHELL_MARKER = 'data-marketing-boot-shell';
  */
 export function buildMarketingBootShellMarkup() {
   const css = `
+${SPACE_GROTESK_FONT_FACE_CSS}
 html, body {
   margin: 0;
   min-height: 100%;

--- a/scripts/space-grotesk-font-face.mjs
+++ b/scripts/space-grotesk-font-face.mjs
@@ -1,0 +1,17 @@
+/**
+ * Early @font-face for Space Grotesk — must match the `<link rel="preload">`
+ * URL in login.html / index.html / app.html and `src/index.css`.
+ *
+ * Preload alone does not apply the file; without this rule in critical CSS,
+ * Safari warns that the font was preloaded but not used (boot shells name
+ * the family before the Vite CSS bundle arrives).
+ */
+export const SPACE_GROTESK_FONT_FACE_CSS = `
+@font-face {
+  font-family: "Space Grotesk";
+  src: url("/fonts/space-grotesk/SpaceGrotesk-VariableFont_wght.woff2") format("woff2");
+  font-weight: 300 700;
+  font-style: normal;
+  font-display: swap;
+}
+`.trim();

--- a/src/app/MarketingApp.jsx
+++ b/src/app/MarketingApp.jsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 
 import {
   MarketingAuthLeaveOverlay,
+  MarketingScrollToTop,
   resolveMarketingAuthLeaveMessage,
   useSpeculativeLoginWarm,
 } from '../features/landing/splash';
@@ -93,68 +94,71 @@ export default function MarketingApp() {
   useSpeculativeLoginWarm();
 
   return (
-    <Routes>
-      <Route path="/" element={<MarketingHomePage />} />
-      <Route
-        path="/how-it-works"
-        element={
-          <Suspense fallback={<MarketingRouteFallback />}>
-            <HowItWorksPage />
-          </Suspense>
-        }
-      />
-      <Route
-        path="/how-scoring-works"
-        element={
-          <Suspense fallback={<MarketingRouteFallback />}>
-            <HowScoringWorksPage />
-          </Suspense>
-        }
-      />
-      <Route
-        path="/phish-setlist-prediction-game"
-        element={
-          <Suspense fallback={<MarketingRouteFallback />}>
-            <PhishSetlistPredictionGamePage />
-          </Suspense>
-        }
-      />
-      {/* Public tour-stats: marketing document + deferred Firestore (#853). */}
-      <Route
-        path="/tour-stats"
-        element={
-          <Suspense fallback={<MarketingRouteFallback />}>
-            <PublicTourStatsPage />
-          </Suspense>
-        }
-      />
-      <Route
-        path="/tour-stats/:tourSlug"
-        element={
-          <Suspense fallback={<MarketingRouteFallback />}>
-            <PublicTourStatsPage />
-          </Suspense>
-        }
-      />
-      {/* Legal: marketing document, no Auth (#908) — snappy from HTML-first /login. */}
-      <Route
-        path="/privacy"
-        element={
-          <Suspense fallback={<MarketingRouteFallback />}>
-            <PrivacyPolicyPage />
-          </Suspense>
-        }
-      />
-      <Route
-        path="/terms"
-        element={
-          <Suspense fallback={<MarketingRouteFallback />}>
-            <TermsOfServicePage />
-          </Suspense>
-        }
-      />
-      {/* App-document surfaces — full load so Firebase/AuthProvider can boot. */}
-      <Route path="*" element={<LoadAppDocument />} />
-    </Routes>
+    <>
+      <MarketingScrollToTop />
+      <Routes>
+        <Route path="/" element={<MarketingHomePage />} />
+        <Route
+          path="/how-it-works"
+          element={
+            <Suspense fallback={<MarketingRouteFallback />}>
+              <HowItWorksPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/how-scoring-works"
+          element={
+            <Suspense fallback={<MarketingRouteFallback />}>
+              <HowScoringWorksPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/phish-setlist-prediction-game"
+          element={
+            <Suspense fallback={<MarketingRouteFallback />}>
+              <PhishSetlistPredictionGamePage />
+            </Suspense>
+          }
+        />
+        {/* Public tour-stats: marketing document + deferred Firestore (#853). */}
+        <Route
+          path="/tour-stats"
+          element={
+            <Suspense fallback={<MarketingRouteFallback />}>
+              <PublicTourStatsPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/tour-stats/:tourSlug"
+          element={
+            <Suspense fallback={<MarketingRouteFallback />}>
+              <PublicTourStatsPage />
+            </Suspense>
+          }
+        />
+        {/* Legal: marketing document, no Auth (#908) — snappy from HTML-first /login. */}
+        <Route
+          path="/privacy"
+          element={
+            <Suspense fallback={<MarketingRouteFallback />}>
+              <PrivacyPolicyPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/terms"
+          element={
+            <Suspense fallback={<MarketingRouteFallback />}>
+              <TermsOfServicePage />
+            </Suspense>
+          }
+        />
+        {/* App-document surfaces — full load so Firebase/AuthProvider can boot. */}
+        <Route path="*" element={<LoadAppDocument />} />
+      </Routes>
+    </>
   );
 }

--- a/src/features/landing/model/scrollMarketingToTop.js
+++ b/src/features/landing/model/scrollMarketingToTop.js
@@ -1,0 +1,20 @@
+/**
+ * Marketing-document scroll helpers (#925 slice 2 / #920).
+ *
+ * Window-only — do not import `scrollAppToTop` (dashboard scrollport) or
+ * `appBootPath` onto the marketing cold-open graph (Safari hydrate regression).
+ */
+
+/**
+ * @param {string} [pathname]
+ * @returns {boolean}
+ */
+export function isMarketingTourStatsPath(pathname) {
+  if (typeof pathname !== 'string' || !pathname) return false;
+  return pathname === '/tour-stats' || pathname.startsWith('/tour-stats/');
+}
+
+/** Reset window scroll on marketing soft-nav (no dashboard scrollport). */
+export function scrollMarketingToTop() {
+  window.scrollTo(0, 0);
+}

--- a/src/features/landing/model/scrollMarketingToTop.test.js
+++ b/src/features/landing/model/scrollMarketingToTop.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { isMarketingTourStatsPath } from './scrollMarketingToTop';
+
+describe('isMarketingTourStatsPath', () => {
+  it('matches public tour-stats hub and slug routes', () => {
+    expect(isMarketingTourStatsPath('/tour-stats')).toBe(true);
+    expect(isMarketingTourStatsPath('/tour-stats/2026-summer-tour')).toBe(true);
+  });
+
+  it('rejects dashboard and other marketing paths', () => {
+    expect(isMarketingTourStatsPath('/')).toBe(false);
+    expect(isMarketingTourStatsPath('/how-it-works')).toBe(false);
+    expect(isMarketingTourStatsPath('/dashboard/tour-stats')).toBe(false);
+  });
+});

--- a/src/features/landing/splash.js
+++ b/src/features/landing/splash.js
@@ -29,3 +29,6 @@ export {
   markLoginHopCta,
 } from './model/prefetchLoginIntent';
 export { default as useSpeculativeLoginWarm } from './model/useSpeculativeLoginWarm';
+/** Marketing-local scroll reset — no shared app ScrollToTop / appBootPath (#925). */
+export { default as MarketingScrollToTop } from './ui/MarketingScrollToTop';
+export { scrollMarketingToTop } from './model/scrollMarketingToTop';

--- a/src/features/landing/ui/MarketingScrollToTop.jsx
+++ b/src/features/landing/ui/MarketingScrollToTop.jsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import {
+  isMarketingTourStatsPath,
+  scrollMarketingToTop,
+} from '../model/scrollMarketingToTop';
+
+/**
+ * Reset window scroll on marketing client-side navigation (#925 / #920).
+ *
+ * Exception: `/tour-stats` ↔ `/tour-stats/:slug` keeps scroll depth (filter chrome).
+ * Lives in `features/landing` so marketing never imports shared app `ScrollToTop`
+ * / `appBootPath` (v1.55.3 Safari prerender hang class).
+ */
+export default function MarketingScrollToTop() {
+  const { pathname, search } = useLocation();
+  const prevPathnameRef = useRef(pathname);
+
+  useEffect(() => {
+    const prevPathname = prevPathnameRef.current;
+    prevPathnameRef.current = pathname;
+
+    const tourStatsSlugHandoff =
+      prevPathname !== pathname &&
+      isMarketingTourStatsPath(prevPathname) &&
+      isMarketingTourStatsPath(pathname);
+
+    if (tourStatsSlugHandoff) return;
+
+    scrollMarketingToTop();
+  }, [pathname, search]);
+
+  return null;
+}

--- a/src/features/landing/ui/MarketingSiteNav.jsx
+++ b/src/features/landing/ui/MarketingSiteNav.jsx
@@ -5,6 +5,7 @@ import {
   MARKETING_LEGAL_NAV,
   MARKETING_PRIMARY_NAV,
 } from '../model/marketingNav';
+import { scrollMarketingToTop } from '../model/scrollMarketingToTop';
 import {
   FOOTER_LINK_ON_DARK,
   HEADER_LINK_ACTIVE,
@@ -27,6 +28,7 @@ export function MarketingHeaderNav({ className = 'hidden lg:flex' }) {
           <Link
             key={to}
             to={to}
+            onClick={scrollMarketingToTop}
             className={`${HEADER_LINK_ON_DARK} ${active ? HEADER_LINK_ACTIVE : ''}`.trim()}
             aria-current={active ? 'page' : undefined}
           >
@@ -46,7 +48,12 @@ export function MarketingFooterNav({ className = '' }) {
   return (
     <p className={`mt-2 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 ${className}`.trim()}>
       {links.map(({ to, label }) => (
-        <Link key={to} to={to} className={FOOTER_LINK_ON_DARK}>
+        <Link
+          key={to}
+          to={to}
+          onClick={scrollMarketingToTop}
+          className={FOOTER_LINK_ON_DARK}
+        >
           {label}
         </Link>
       ))}

--- a/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
+++ b/src/features/landing/ui/PhishSetlistPredictionGamePageContent.jsx
@@ -22,8 +22,8 @@ export default function PhishSetlistPredictionGamePageContent() {
           Setlist Pick&apos;Em is a free live{' '}
           <strong className="font-semibold text-slate-800">setlist picks game</strong> for fans who
           love predicting setlists—built first for Phish, and designed as a home for more bands soon.
-          Lock openers, closers, encore, and a wildcard before showtime, then score as the night
-          unfolds.
+          Lock openers, closers, encore, and a wildcard before showtime, then score points for correct
+          picks as the night unfolds.
         </p>
 
         <section className="mb-12 space-y-4 text-base leading-relaxed text-slate-700">
@@ -31,11 +31,17 @@ export default function PhishSetlistPredictionGamePageContent() {
             What is a setlist prediction game?
           </h2>
           <p>
-            For jam bands like Phish, every night is a new setlist. A setlist prediction game—sometimes
-            called a <strong className="font-semibold text-slate-800">fantasy setlist</strong> game—asks
-            you to call songs and slots before the lights go down, not dig through yesterday&apos;s
-            archives. You compete with friends in private pools and with everyone on the global board.
-            Scores update live as songs are played. Prefer a short walkthrough? See{' '}
+            For jam bands like Phish, every night is unique, but patterns emerge that help the astute
+            fan anticipate how the setlist will unfold. A setlist prediction game—sometimes called a{' '}
+            <strong className="font-semibold text-slate-800">fantasy setlist</strong> game—asks you to
+            call songs, and to predict where they will land in the setlist. The goal is simple: prove
+            you have mastered the art of setlist construction, earning points along the way to
+            &quot;put your money where your mouth is&quot; and win the night. You compete with
+            friends in private pools
+            and with everyone on the global leaderboard. Scores update as songs are played, along with
+            a live view of the setlist so you never miss the band&apos;s last move, even if you
+            couldn&apos;t make it to the venue or carve out time for the live stream. Prefer a short
+            walkthrough? See{' '}
             <Link to="/how-it-works" className={LINK_ON_LIGHT}>
               how it works
             </Link>
@@ -53,7 +59,11 @@ export default function PhishSetlistPredictionGamePageContent() {
               tour stats
             </Link>{' '}
             pages and refresh every night the band plays live—insights that help you stay sharp
-            between shows.
+            between shows. When you join the community, you&apos;ll have access to even more tour
+            data, along with your own personal stats like picking average (think batting average, but
+            for setlist picking accuracy), Bustout Boost™ hits to measure how often you predict
+            catalog rarities, and a heatmap with all of your most frequent picks to hone your setlist
+            prediction skills.
           </p>
         </section>
 
@@ -62,9 +72,12 @@ export default function PhishSetlistPredictionGamePageContent() {
             Fantasy setlists, without the spreadsheet
           </h2>
           <p>
-            Setlist archives are great for looking back. A fantasy setlist night is about the show
-            ahead: make your calls, earn points for slots and wildcards, and chase Bustout Boosts when
-            you nail the longshots. Full point values are on{' '}
+            Setlist games have always been fun, but just like paper in the early aughts, we&apos;ve
+            outgrown spreadsheets today. As fans ourselves, we set out to make it easier for our
+            friends to manage the setlist picks game we&apos;ve been playing for 25 years. We
+            automatically track the points you earn for hitting setlist slots and wildcards, and
+            Bustout Boosts when you call songs that are not heavy in the rotation. Full point values
+            are on{' '}
             <Link to="/how-scoring-works" className={LINK_ON_LIGHT}>
               how scoring works
             </Link>
@@ -73,7 +86,7 @@ export default function PhishSetlistPredictionGamePageContent() {
           <ul className="list-disc space-y-2 pl-5">
             <li>
               <strong className="text-slate-900">Before the show:</strong> lock picks before the
-              lights go down.
+              showtime.
             </li>
             <li>
               <strong className="text-slate-900">During the show:</strong> live scoring and
@@ -93,12 +106,13 @@ export default function PhishSetlistPredictionGamePageContent() {
         <section className="mb-12 space-y-4 text-base leading-relaxed text-slate-700">
           <h2 className="font-display text-2xl font-bold text-slate-900">How to play</h2>
           <ol className="list-decimal space-y-3 pl-5">
-            <li>Create a free account and open tonight&apos;s show.</li>
+            <li>Create a free account and tonight&apos;s setlist card opens.</li>
             <li>
-              Pick Set 1 opener/closer, Set 2 opener/closer, encore, and a wildcard.
+              Pick Set 1 opener/closer, Set 2 opener/closer, an encore, and a wildcard.
             </li>
             <li>
-              Watch scores update live; climb show and tour standings or invite friends to a pool.
+              Watch scores update live; climb show and tour leaderboards, or invite friends to a
+              private pool for crew-specific standings.
             </li>
           </ol>
           <p className="flex flex-wrap gap-x-4 gap-y-2">

--- a/src/features/landing/ui/SplashHowItWorksSection.jsx
+++ b/src/features/landing/ui/SplashHowItWorksSection.jsx
@@ -28,7 +28,8 @@ export default function SplashHowItWorksSection({
           Game Format
         </h2>
         <p className="mx-auto mb-12 max-w-2xl text-center text-base leading-relaxed text-slate-600">
-          Three steps—then you&apos;re in. Prefer the full walkthrough? See{' '}
+          Lock picks, live scores, and the board—every night the band is on stage.
+          Prefer the full walkthrough? See{' '}
           <Link to="/how-it-works" className={LINK_ON_LIGHT}>
             how it works
           </Link>

--- a/src/features/landing/ui/SplashHowItWorksSection.jsx
+++ b/src/features/landing/ui/SplashHowItWorksSection.jsx
@@ -28,8 +28,8 @@ export default function SplashHowItWorksSection({
           Game Format
         </h2>
         <p className="mx-auto mb-12 max-w-2xl text-center text-base leading-relaxed text-slate-600">
-          Lock picks, live scores, and the board—every night the band is on stage.
-          Prefer the full walkthrough? See{' '}
+          Lock in picks, track live setlists and scores, and watch the real-time
+          leaderboard. Prefer the full walkthrough? See{' '}
           <Link to="/how-it-works" className={LINK_ON_LIGHT}>
             how it works
           </Link>

--- a/src/features/tour-stats/model/publicTourIndex.js
+++ b/src/features/tour-stats/model/publicTourIndex.js
@@ -1,0 +1,55 @@
+/**
+ * Public tour-stats index helpers (#665) — current tour = newest lastShowDate.
+ */
+
+/**
+ * @param {{ tourSlug?: string, tourLabel?: string, lastShowDate?: string | null }} a
+ * @param {{ tourSlug?: string, tourLabel?: string, lastShowDate?: string | null }} b
+ * @returns {number}
+ */
+export function comparePublicTourIndexEntries(a, b) {
+  const la = typeof a?.lastShowDate === 'string' ? a.lastShowDate : '';
+  const lb = typeof b?.lastShowDate === 'string' ? b.lastShowDate : '';
+  if (lb !== la) return lb > la ? 1 : -1;
+  return String(a?.tourLabel || a?.tourSlug || '').localeCompare(
+    String(b?.tourLabel || b?.tourSlug || ''),
+  );
+}
+
+/**
+ * @param {Array<{ tourSlug?: string, tourLabel?: string, lastShowDate?: string | null }>} tours
+ * @returns {Array<{ tourSlug: string, tourLabel?: string, lastShowDate?: string | null }>}
+ */
+export function sortPublicTourIndex(tours) {
+  const list = Array.isArray(tours)
+    ? tours.filter((t) => t && typeof t.tourSlug === 'string' && t.tourSlug.trim())
+    : [];
+  return [...list].sort(comparePublicTourIndexEntries);
+}
+
+/**
+ * Current / most-recent tour for the public filter default.
+ * Prefers newest `lastShowDate`; falls back to `preferredSlug` only when dates
+ * are missing and that slug is in the list.
+ *
+ * @param {Array<{ tourSlug?: string, tourLabel?: string, lastShowDate?: string | null }>} tours
+ * @param {string} [preferredSlug]
+ * @returns {string}
+ */
+export function resolveDefaultPublicTourSlug(tours, preferredSlug = '') {
+  const sorted = sortPublicTourIndex(tours);
+  if (sorted.length === 0) return '';
+
+  const hasAnyDate = sorted.some(
+    (t) => typeof t.lastShowDate === 'string' && t.lastShowDate.trim(),
+  );
+  if (hasAnyDate) {
+    return sorted[0].tourSlug;
+  }
+
+  const preferred = String(preferredSlug ?? '').trim();
+  if (preferred && sorted.some((t) => t.tourSlug === preferred)) {
+    return preferred;
+  }
+  return sorted[0].tourSlug;
+}

--- a/src/features/tour-stats/model/publicTourIndex.test.js
+++ b/src/features/tour-stats/model/publicTourIndex.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveDefaultPublicTourSlug,
+  sortPublicTourIndex,
+} from './publicTourIndex';
+
+describe('sortPublicTourIndex', () => {
+  it('orders by lastShowDate descending', () => {
+    const sorted = sortPublicTourIndex([
+      { tourSlug: '2026-sphere', tourLabel: '2026 Sphere', lastShowDate: '2026-05-02' },
+      {
+        tourSlug: '2026-summer-tour',
+        tourLabel: '2026 Summer Tour',
+        lastShowDate: '2026-08-01',
+      },
+    ]);
+    expect(sorted.map((t) => t.tourSlug)).toEqual([
+      '2026-summer-tour',
+      '2026-sphere',
+    ]);
+  });
+});
+
+describe('resolveDefaultPublicTourSlug', () => {
+  it('picks the most recent tour by lastShowDate over a stale preferred slug', () => {
+    const slug = resolveDefaultPublicTourSlug(
+      [
+        {
+          tourSlug: '2026-sphere',
+          tourLabel: '2026 Sphere',
+          lastShowDate: '2026-05-02',
+        },
+        {
+          tourSlug: '2026-summer-tour',
+          tourLabel: '2026 Summer Tour',
+          lastShowDate: '2026-08-01',
+        },
+      ],
+      '2026-sphere',
+    );
+    expect(slug).toBe('2026-summer-tour');
+  });
+
+  it('uses preferredSlug when no lastShowDate values exist', () => {
+    const slug = resolveDefaultPublicTourSlug(
+      [
+        { tourSlug: '2026-sphere', tourLabel: '2026 Sphere' },
+        { tourSlug: '2026-summer-tour', tourLabel: '2026 Summer Tour' },
+      ],
+      '2026-sphere',
+    );
+    expect(slug).toBe('2026-sphere');
+  });
+});

--- a/src/features/tour-stats/model/usePublicTourStatsScreen.js
+++ b/src/features/tour-stats/model/usePublicTourStatsScreen.js
@@ -5,11 +5,15 @@ import {
   fetchPublicTourStatsDoc,
   fetchPublicTourStatsIndex,
 } from '../api/fetchPublicTourStats';
+import {
+  resolveDefaultPublicTourSlug,
+  sortPublicTourIndex,
+} from './publicTourIndex';
 
 /**
  * Public tour-stats screen (#665) — aggregate docs only; no self overlay.
- * Default tour = `_index.defaultTourSlug` (current / most recent), not a
- * hardcoded Sphere or Summer preference.
+ * Default tour = current / most recent by `lastShowDate` (not a hardcoded
+ * Sphere preference).
  */
 export function usePublicTourStatsScreen() {
   const { tourSlug: routeSlug } = useParams();
@@ -33,13 +37,11 @@ export function usePublicTourStatsScreen() {
       try {
         const idx = await fetchPublicTourStatsIndex();
         if (cancelled) return;
-        const list = Array.isArray(idx.tours) ? idx.tours : [];
+        const list = sortPublicTourIndex(Array.isArray(idx.tours) ? idx.tours : []);
         setTours(list);
-        const fromIndex =
-          (typeof idx.defaultTourSlug === 'string' && idx.defaultTourSlug.trim()) ||
-          list[0]?.tourSlug ||
-          '';
-        setDefaultTourSlug(fromIndex);
+        setDefaultTourSlug(
+          resolveDefaultPublicTourSlug(list, idx.defaultTourSlug),
+        );
       } catch (err) {
         if (!cancelled) setError(err);
       } finally {

--- a/src/features/tour-stats/ui/PublicTourStatsPanel.jsx
+++ b/src/features/tour-stats/ui/PublicTourStatsPanel.jsx
@@ -29,10 +29,12 @@ export default function PublicTourStatsPanel({
           Phish tour setlist stats
         </h1>
         <p className="text-base leading-relaxed text-slate-300">
-          We track the setlist stories that help you make better picks—most-played
-          songs, bustouts, and gap highlights for each tour. Stats refresh every
-          night the band plays live, so the picture keeps getting sharper as the
-          tour rolls on.
+          Since Setlist Pick&apos;Em launched at the Sphere, we&apos;ve tracked
+          every song from every tour—an easy, fun way to sift through setlist
+          stats and sharpen your predictions. Flip the tour filter, scan what&apos;s
+          getting played, hunt the bustouts, and check the high-gap songs that
+          might be due. Stats refresh every night the band plays live, so the
+          picture keeps getting sharper as the tour rolls on.
         </p>
         <p className="text-sm leading-relaxed text-slate-400">
           We&apos;re starting with Phish and building toward more bands soon.
@@ -56,7 +58,7 @@ export default function PublicTourStatsPanel({
             Tour filter
           </span>
           <select
-            className="rounded-xl border border-white/10 bg-brand-bg-deep px-3 py-2.5 text-sm font-semibold text-white outline-none focus-visible:ring-2 focus-visible:ring-teal-400"
+            className="rounded-xl border border-white/10 bg-brand-bg-deep px-3 py-2.5 text-sm font-semibold text-white outline-none ring-2 ring-teal-400 focus-visible:ring-2 focus-visible:ring-teal-300"
             value={activeSlug}
             onChange={(e) => onSelectTour(e.target.value)}
             disabled={indexLoading}


### PR DESCRIPTION
## Summary
Promote `staging` → `main` for **v1.55.8**: safe re-land of #920 marketing polish after the Safari prerender rollback, plus Space Grotesk preload fix.

## Includes
- **v1.55.6** — #920 slice 1: keyword / Game Format / tour-stats copy + filter defaults (#936)
- **v1.55.7** — #920 slice 2: marketing-local scroll-to-top (no shared `ScrollToTop` / `appBootPath`) (#938)
- **v1.55.8** — Safari Space Grotesk preload `@font-face` (#935)

## Test plan
- [x] Safari private: `/` hydrates splash (staging spot-check)
- [x] Marketing scroll + tour-stats slug preserve (preview AC)
- [ ] Prod smoke after deploy: `/`, `/login`, `/tour-stats`
- [ ] Confirm Space Grotesk preload warning stayed gone on `/login`


Made with [Cursor](https://cursor.com)