### PR TITLE
feat(legal): HTML-first /terms + /privacy door (#916)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.61.0] — 2026-08-09
+
+### Added
+- **HTML-first `/privacy` + `/terms` door (#916 / epic #889)** — zero-JS shells bake full policy markdown into first HTML (back control + title + body); Vercel rewrites + Vite dev middleware; no marketing CSR / Auth / Firebase on legal cold open.
+
+### Changed
+- **Legal document owner** — hard-nav from `/login` signup and marketing footer serve `dist/privacy|terms/index.html`; soft SPA routes remain for Profile/account. Docs: `API.md`, `AUTH_BOOT_PRACTICES` 1c, `OUTBOUND_AUTH_HANDOFF` (`legal-static`), `AUTH_SEAMLESS_PATH`.
+
+---
+
 ## [1.60.0] — 2026-08-09
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -387,8 +387,8 @@ These routes are part of the public surface. Renaming or removing them is a MAJO
 | `/join/:code` | None | Pool invite deep link; optional `?from={handle}` for inviter personalization; VIP landing stores code and prompts auth (#580); personalized OG (#582) |
 | `/invite/:handle` | None | Site VIP invite deep link; personalized landing when handle resolves; no pool join side effects (#580); personalized OG (#582) |
 | `/user/:userId` | None | Public player profile — **`noindex,follow`** (#661); not a sitemap target |
-| `/privacy` | None | Privacy policy. **v1.55.0 (#908):** marketing document (prerendered; no AuthProvider) — snappy hard-nav from HTML-first `/login`. Soft route remains on app SPA for Profile/account. |
-| `/terms` | None | Terms of service. **v1.55.0 (#908):** same marketing-document boot as `/privacy`. |
+| `/privacy` | None | Privacy policy. **v1.61.0 (#916):** HTML-first legal door — full policy body in first HTML; no marketing CSR / Auth / Firebase. Soft route remains on app SPA for Profile/account. |
+| `/terms` | None | Terms of service. **v1.61.0 (#916):** same HTML-first legal-door boot as `/privacy`. |
 | `/password-reset-complete` | None | Firebase Auth continue URL |
 | `/setup` | Auth | Profile setup (new users) |
 | `/dashboard/*` | Auth | Full game dashboard |

--- a/docs/AUTH_BOOT_PRACTICES.md
+++ b/docs/AUTH_BOOT_PRACTICES.md
@@ -13,7 +13,7 @@ Standing rules for marketing, the **auth door** (`/login`), and the app SPA. Lea
 
 1b. **Public `/tour-stats*` is marketing too (#853).** Paint chrome from the marketing entry; load App Check + Firestore only inside `fetchPublicTourStats*` (and a parallel page kick). Do not put tour-stats on `app.html` / `AuthProvider`.
 
-1c. **`/privacy` and `/terms` are marketing too (#908).** Serve from the marketing document (prerendered HTML). Do not park legal on `app.html` / spa-boot — signup from HTML-first `/login` hard-navs here and must stay snappy. Soft routes may remain on the app SPA for in-app Profile links.
+1c. **`/privacy` and `/terms` are an HTML-first legal door (#916).** Serve zero-JS shells with readable chrome + full policy body in the first HTML (`dist/privacy|terms/index.html`). No marketing CSR, no AuthProvider, no Firebase. Do not park legal on `app.html` / spa-boot. Soft routes may remain on the app SPA for in-app Profile links. Marketing footer uses hard `<a href>`.
 
 2. **Auth door `/login`: form in first HTML; auth-only hydrate (Phase 2 / #892).**  
    - **Today (v1.54.0):** `/login` boots `login.html` with **real form controls** in the first document; `loginMain.jsx` hydrates Auth + form wiring (not `app-*.js` / react-query). Suspense fallback keeps form chrome (anti-#881 blank hang). Session hint and Google redirect return stay eager. Success → hard-navigate to `/setup` or `/dashboard`.  

--- a/docs/AUTH_SEAMLESS_PATH.md
+++ b/docs/AUTH_SEAMLESS_PATH.md
@@ -13,8 +13,9 @@ Field stop after **v1.53.2** lifted with explicit human go. Phase 2 (#892 / #894
 | **v1.53.1 (#890)** | Phase 0 reliability: retire #881 thin CSR entry hang |
 | **v1.53.2 (#899)** | Log Out hang: post-sign-out → marketing `/` |
 | **v1.54.0 (#892 / #894)** | Phase 2: form-in-first-HTML + auth-only hydrate |
+| **v1.61.0 (#916)** | HTML-first `/privacy` + `/terms` door; Phase 3 (#895) deferred |
 
-**Do not start another CSR hop tier.** Phase 3 warm polish (#895) stays gated on WebKit green.
+**Do not start another CSR hop tier.** Phase 3 warm polish (#895) deferred — HTML-first door + legal door meet the product bar without marketing download-warm complexity.
 
 Standing rules still in force: `docs/AUTH_BOOT_PRACTICES.md` (Google gesture / App Check / Safari redirect).
 
@@ -166,8 +167,9 @@ Lesson: hop polish on a CSR login document can improve download and still leave 
 DONE (Phase 0)  → Restore login reliability on WebKit private (#890 / v1.53.1)
 DONE (Phase 1)  → Lock three-surface contract in docs/issues
 DONE (Phase 2)  → HTML-first /login + auth-only Firebase hydrate (#892 / v1.54.0)
-NEXT (Phase 2b) → Flow matrix QA (#893) — WebKit private human gate
-LATER(Phase 3)  → Re-attach download-only warm / leave chrome polish if still useful (#895)
+DONE (Phase 2b) → Flow matrix QA (#893) — WebKit private human gate
+DONE (legal)    → HTML-first /privacy + /terms door (#916) — zero-JS first HTML
+DEFER (Phase 3) → Marketing download-warm polish (#895) — not needed; door feels fast enough
 KEEP (Phase 4)  → Dashboard stays the SPA; don’t pull app graph into the auth door
 DEFER          → GIS / hosted IdP only if product still wants more after Phase 2
 ```
@@ -204,11 +206,11 @@ Treat as law (update issues/PRs against this, not against “finish hop bands”
 - [x] Signed-in `/login` hard-sends to dashboard/setup.
 - [x] Hop ms is a soak metric after reliability; not the design center.
 
-**Collateral (post–Phase 2):** `/privacy` + `/terms` ship on the **marketing** document (#908) — not `app.html` / spa-boot — so signup legal links from the auth door stay snappy.
+**Collateral (post–Phase 2):** `/privacy` + `/terms` left `app.html` (#908), then graduated to a **zero-JS HTML-first legal door** (#916 / v1.61.0) with full policy body in first HTML — signup legal links stay snappy without marketing CSR.
 
-### Phase 3 — Demand-gen polish (optional)
+### Phase 3 — Demand-gen polish (deferred)
 
-Only after Phase 2 is green on WebKit private: leave chrome, download-only warm of auth-door assets from marketing.
+**Deferred / not planned (#895):** leave chrome + download-only warm of auth-door assets from marketing. HTML-first `/login` and legal door already meet the acquisition-path bar; warm complexity is not worth re-attaching.
 
 ### Phase 4 — App surface
 

--- a/docs/OUTBOUND_AUTH_HANDOFF.md
+++ b/docs/OUTBOUND_AUTH_HANDOFF.md
@@ -15,6 +15,7 @@ After marketing cold opens stop booting `AuthProvider`, every outbound link must
 | `app-ok` | Hard-open on authenticated SPA (`app.html` / dashboard boot / spa-boot). No change needed for dual-doc. |
 | `retarget-auth` | Was splash-modal (`/?login=true`) or unauth bounce to `/`. Emit or redirect to `/login` (HTML-first auth door — #892 / epic [#889](https://github.com/pat792/set-picks/issues/889)). |
 | `public-static` | Marketing document (`index.html` → `marketingMain`). No Firebase on cold open. |
+| `legal-static` | Zero-JS HTML-first legal door (`dist/privacy|terms/index.html` — #916). No module graph / Auth. |
 | `invite-shell` | `/join/*` / `/invite/*` via OG API → prefer `dist/app.html`. Auth modals stay on app shell. |
 
 ---
@@ -28,7 +29,7 @@ After marketing cold opens stop booting `AuthProvider`, every outbound link must
 | Push → `/dashboard/profile/notifications` | `fcmMessagingCore`, messaging SW | `app-ok` | |
 | `/`, `/how-it-works`, `/how-scoring-works`, `/phish-setlist-prediction-game` | Marketing entry; some email allowlist paths | `public-static` | No Firebase until CTA → `/login` |
 | `/tour-stats*` | Public Firestore UI | `public-static` | **#853:** marketing document; Firebase only at aggregate fetch (not AuthProvider) |
-| `/privacy`, `/terms` | Login signup legal links, marketing footer, Profile/account | `public-static` | **#908:** marketing document (prerendered); no Auth. Soft routes remain on app SPA for in-app links. From signup, stash `splashResumeAuthModal=signup` — legal in-page back → `/login?mode=signup`; browser Back also resumes via consume on LoginPage |
+| `/privacy`, `/terms` | Login signup legal links, marketing footer, Profile/account | `legal-static` | **#916:** HTML-first legal door (full body in first HTML; no marketing CSR / Auth). Soft routes remain on app SPA for in-app Profile links. From signup, stash `splashResumeAuthModal=signup` — legal in-page back → `/login?mode=signup`; browser Back also resumes via consume on LoginPage |
 | `/join/:code`, `/invite/:handle` | Invite kits, OG `api/invite` | `invite-shell` | Prefers `dist/app.html` |
 | Marketing splash CTAs | `MarketingHomePage` | `retarget-auth` | **Done (#832 / #834 / #835 / #872 / #860):** hard-nav `/login` / `/login?mode=signup` with leave chrome + intent prefetch of login UI (no Firebase on marketing). Mid-page Get Started chooser removed — hero/header/section CTAs go straight to auth. |
 | App-shell splash CTAs | `SplashPage` (after soft-nav / sign-out) | `retarget-auth` | **Done (1.48.1):** navigate to `/login` (no splash modals). Invite VIP still modal (#844). |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.60.0",
+  "version": "1.61.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/legal-boot-shell.mjs
+++ b/scripts/legal-boot-shell.mjs
@@ -1,0 +1,354 @@
+/**
+ * HTML-first `/privacy` + `/terms` door (#916 / epic #889).
+ *
+ * Zero-JS cold open: first document includes readable legal chrome + full
+ * markdown body. No marketing CSR, no AuthProvider, no Firebase.
+ * Soft SPA routes remain on the app document for Profile/account.
+ *
+ * Pure build helpers — no src/ React imports.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { SEO_CONFIG } from '../src/shared/config/seo.js';
+import {
+  SEO_FAVICON_VERSION,
+  getPrerenderRoute,
+} from '../src/shared/config/seoRoutes.js';
+import {
+  extractLegalLastUpdated,
+  legalMarkdownToHtml,
+  stripLegalFrontmatter,
+} from './lib/legalMarkdownToHtml.mjs';
+import { SPACE_GROTESK_FONT_FACE_CSS } from './space-grotesk-font-face.mjs';
+
+/** Asserted by `verify:seo-prerender`. */
+export const LEGAL_BOOT_SHELL_MARKER = 'data-legal-boot-shell';
+/** Marks the article body that must be present in first HTML. */
+export const LEGAL_BOOT_BODY_MARKER = 'data-legal-boot-body';
+
+const ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+const MD_BY_PATH = {
+  '/privacy': 'docs/PRIVACY_POLICY.md',
+  '/terms': 'docs/TERMS_OF_SERVICE.md',
+};
+
+/**
+ * @param {string} path `/privacy` | `/terms`
+ * @returns {string}
+ */
+export function legalMarkdownRelPath(path) {
+  return MD_BY_PATH[path] || '';
+}
+
+/**
+ * @param {string} str
+ * @returns {string}
+ */
+function escapeHtml(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function legalBootShellCriticalCss() {
+  return `
+${SPACE_GROTESK_FONT_FACE_CSS}
+html, body {
+  margin: 0;
+  min-height: 100%;
+  background: #0f172a;
+}
+.lbs-legal-shell {
+  position: relative;
+  display: flex;
+  min-height: 100dvh;
+  width: 100%;
+  flex-direction: column;
+  color: #fff;
+  background: transparent;
+  font-family: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+}
+.lbs-legal-ambient {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  background: #0f172a;
+}
+.lbs-legal-ambient::before,
+.lbs-legal-ambient::after {
+  content: "";
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(100px);
+}
+.lbs-legal-ambient::before {
+  top: -20%;
+  left: 50%;
+  width: min(100vw, 36rem);
+  height: min(100vw, 36rem);
+  transform: translateX(-50%);
+  background: rgb(45 212 191 / 0.12);
+}
+.lbs-legal-ambient::after {
+  bottom: -10%;
+  right: -15%;
+  width: min(85vw, 28rem);
+  height: min(70vh, 32rem);
+  background: rgb(59 130 246 / 0.12);
+}
+.lbs-legal-inner {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  width: 100%;
+  max-width: 42rem;
+  margin: 0 auto;
+  flex: 1;
+  flex-direction: column;
+  padding: 2.5rem 1.25rem;
+}
+@media (min-width: 640px) {
+  .lbs-legal-inner { padding-left: 2rem; padding-right: 2rem; }
+}
+@media (min-width: 768px) {
+  .lbs-legal-inner { padding-top: 4rem; padding-bottom: 4rem; }
+}
+.lbs-legal-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin-bottom: 2rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: #94a3b8;
+  text-decoration: none;
+}
+.lbs-legal-back:hover { color: #fff; }
+.lbs-legal-back svg { width: 1rem; height: 1rem; flex-shrink: 0; }
+.lbs-legal-h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+  font-weight: 700;
+  font-style: italic;
+  line-height: 1.15;
+  background: linear-gradient(to right, #60a5fa, #34d399);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.lbs-legal-updated {
+  margin: 0.75rem 0 0;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: #64748b;
+}
+.lbs-legal-article {
+  margin-top: 2.5rem;
+  font-size: 0.875rem;
+  line-height: 1.625;
+  color: #cbd5e1;
+}
+.lbs-legal-article h2 {
+  margin: 2.5rem 0 1rem;
+  font-size: 1rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #fff;
+}
+.lbs-legal-article h3 {
+  margin: 1.5rem 0 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: #e2e8f0;
+}
+.lbs-legal-article p { margin: 0 0 1rem; }
+.lbs-legal-article ul {
+  margin: 0 0 1rem;
+  padding-left: 1.25rem;
+  list-style: disc;
+}
+.lbs-legal-article li { margin: 0.25rem 0; }
+.lbs-legal-article a {
+  color: #2dd4bf;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: rgb(45 212 191 / 0.4);
+}
+.lbs-legal-article a:hover {
+  text-decoration-color: #2dd4bf;
+}
+.lbs-legal-footer {
+  margin-top: 4rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgb(30 41 59 / 0.6);
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #64748b;
+}
+.lbs-legal-footer p { margin: 0; }
+.lbs-legal-footer-links { margin-top: 0.5rem; }
+.lbs-legal-footer-links a {
+  margin: 0 0.75rem;
+  color: #94a3b8;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: #475569;
+}
+.lbs-legal-footer-links a:hover { color: #e2e8f0; }
+`.trim();
+}
+
+/** Inline: peek signup/signin stash and set back control (no React). */
+function legalBackNavScript() {
+  return `<script ${LEGAL_BOOT_SHELL_MARKER}-back="true">
+(function () {
+  try {
+    var el = document.getElementById('legal-boot-back');
+    var label = document.getElementById('legal-boot-back-label');
+    if (!el || !label) return;
+    var kind = null;
+    try { kind = sessionStorage.getItem('splashResumeAuthModal'); } catch (e) {}
+    if (kind === 'signup') {
+      el.setAttribute('href', '/login?mode=signup');
+      label.textContent = 'Back to create account';
+    } else if (kind === 'signin') {
+      el.setAttribute('href', '/login');
+      label.textContent = 'Back to sign in';
+    }
+  } catch (e) {}
+})();
+</script>`;
+}
+
+/**
+ * @param {{
+ *   title: string,
+ *   lastUpdated: string,
+ *   bodyHtml: string,
+ *   path: '/privacy' | '/terms',
+ * }} opts
+ * @returns {string}
+ */
+export function buildLegalBootShellMarkup(opts) {
+  const title = opts.title || 'Legal';
+  const lastUpdated = opts.lastUpdated || '';
+  const bodyHtml = opts.bodyHtml || '';
+  const year = new Date().getFullYear();
+
+  return [
+    `<style id="legal-boot-shell-css">${legalBootShellCriticalCss()}</style>`,
+    `<div ${LEGAL_BOOT_SHELL_MARKER}="true" class="lbs-legal-shell">`,
+    `<div class="lbs-legal-ambient" aria-hidden="true"></div>`,
+    `<div class="lbs-legal-inner">`,
+    `<nav>`,
+    `<a id="legal-boot-back" class="lbs-legal-back" href="/">`,
+    `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 18-6-6 6-6"/></svg>`,
+    `<span id="legal-boot-back-label">Back to Setlist Pick 'Em</span>`,
+    `</a>`,
+    `</nav>`,
+    `<header>`,
+    `<h1 class="lbs-legal-h1">${escapeHtml(title)}</h1>`,
+    lastUpdated
+      ? `<p class="lbs-legal-updated">Last updated: ${escapeHtml(lastUpdated)}</p>`
+      : '',
+    `</header>`,
+    `<article ${LEGAL_BOOT_BODY_MARKER}="true" class="lbs-legal-article">`,
+    bodyHtml,
+    `</article>`,
+    `<footer class="lbs-legal-footer">`,
+    `<p>&copy; ${year} Road2 Media, LLC. All rights reserved.</p>`,
+    `<p class="lbs-legal-footer-links">`,
+    `<a href="/privacy">Privacy Policy</a>`,
+    `<a href="/terms">Terms of Service</a>`,
+    `</p>`,
+    `</footer>`,
+    `</div>`,
+    `</div>`,
+    legalBackNavScript(),
+  ].join('');
+}
+
+/**
+ * @param {string} path `/privacy` | `/terms`
+ * @param {{ rootDir?: string, markdown?: string }} [opts]
+ * @returns {{ route: object, markdown: string, lastUpdated: string, bodyHtml: string }}
+ */
+export function loadLegalBootSource(path, opts = {}) {
+  const route = getPrerenderRoute(path);
+  if (!route) {
+    throw new Error(`legal-boot-shell: unknown route ${path}`);
+  }
+  const rootDir = opts.rootDir || ROOT;
+  let markdown = opts.markdown;
+  if (typeof markdown !== 'string') {
+    const rel = legalMarkdownRelPath(path);
+    markdown = readFileSync(join(rootDir, rel), 'utf8');
+  }
+  const lastUpdated =
+    extractLegalLastUpdated(markdown) || 'See document';
+  const bodyHtml = legalMarkdownToHtml(stripLegalFrontmatter(markdown));
+  return { route, markdown, lastUpdated, bodyHtml };
+}
+
+/**
+ * Full standalone HTML document for `/privacy` or `/terms` (#916).
+ * No module scripts — zero marketing/app/login JS on cold open.
+ *
+ * @param {'/privacy' | '/terms'} path
+ * @param {{ rootDir?: string, markdown?: string }} [opts]
+ * @returns {string}
+ */
+export function buildLegalBootDocumentHtml(path, opts = {}) {
+  const { route, lastUpdated, bodyHtml } = loadLegalBootSource(path, opts);
+  const v = SEO_FAVICON_VERSION;
+  const jsonLd = JSON.stringify(route.buildJsonLd()).replace(/</g, '\\u003c');
+  const markup = buildLegalBootShellMarkup({
+    title: route.h1,
+    lastUpdated,
+    bodyHtml,
+    path,
+  });
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <title>${escapeHtml(route.title)}</title>
+  <meta name="description" content="${escapeHtml(route.description)}" />
+  <meta name="author" content="${escapeHtml(SEO_CONFIG.publisherName)}" />
+  <link rel="canonical" href="${escapeHtml(route.canonicalUrl)}" />
+  <meta property="og:site_name" content="${escapeHtml(SEO_CONFIG.siteName)}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="${escapeHtml(route.title)}" />
+  <meta property="og:description" content="${escapeHtml(route.description)}" />
+  <meta property="og:url" content="${escapeHtml(route.canonicalUrl)}" />
+  <meta property="og:image" content="${escapeHtml(SEO_CONFIG.ogImageUrl)}" />
+  <meta property="og:image:secure_url" content="${escapeHtml(SEO_CONFIG.ogImageUrl)}" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="${escapeHtml(route.title)}" />
+  <meta name="twitter:description" content="${escapeHtml(route.description)}" />
+  <meta name="twitter:image" content="${escapeHtml(SEO_CONFIG.ogImageUrl)}" />
+  <link rel="icon" type="image/png" href="/favicon/favicon-96x96.png?v=${v}" sizes="96x96" />
+  <link rel="shortcut icon" href="/favicon/favicon.ico?v=${v}" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png?v=${v}" />
+  <link rel="manifest" href="/favicon/site.webmanifest?v=${v}" />
+  <link rel="preload" href="/fonts/space-grotesk/SpaceGrotesk-VariableFont_wght.woff2" as="font" type="font/woff2" crossorigin>
+  <script type="application/ld+json" data-seo-prerender="true">${jsonLd}</script>
+</head>
+<body>
+  <div id="root">${markup}</div>
+</body>
+</html>
+`;
+}

--- a/scripts/lib/legalMarkdownToHtml.mjs
+++ b/scripts/lib/legalMarkdownToHtml.mjs
@@ -1,0 +1,157 @@
+/**
+ * Minimal markdown → HTML for legal boot shells (#916).
+ * Supports the subset used by docs/TERMS_OF_SERVICE.md + docs/PRIVACY_POLICY.md:
+ * headings, paragraphs, unordered lists, links, bold, italics.
+ * No HTML passthrough (matches react-markdown skipHtml).
+ */
+
+/**
+ * Strip leading `# Title` and `**Last updated:** …` so layout header isn't duplicated.
+ * Mirrors src/features/legal/ui/LegalMarkdownRenderer.jsx stripFrontmatter.
+ *
+ * @param {string} md
+ * @returns {string}
+ */
+export function stripLegalFrontmatter(md) {
+  if (typeof md !== 'string') return '';
+  const lines = md.split('\n');
+  let start = 0;
+  const maxScan = Math.min(lines.length, 25);
+  for (let i = 0; i < maxScan; i++) {
+    const line = lines[i].trim();
+    if (line === '') {
+      start = i + 1;
+      continue;
+    }
+    if (line.startsWith('# ')) {
+      start = i + 1;
+      continue;
+    }
+    if (line.startsWith('**Last updated')) {
+      start = i + 1;
+      continue;
+    }
+    break;
+  }
+  return lines.slice(start).join('\n');
+}
+
+/**
+ * @param {string} md
+ * @returns {string | null} e.g. "May 8, 2026"
+ */
+export function extractLegalLastUpdated(md) {
+  if (typeof md !== 'string') return null;
+  const m = md.match(/\*\*Last updated:\*\*\s*(.+)/i);
+  if (!m) return null;
+  return m[1].trim() || null;
+}
+
+/**
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeHtml(text) {
+  return String(text ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Inline: links, bold, italics (order: links first, then bold, then italics).
+ * @param {string} text
+ * @returns {string}
+ */
+function renderInline(text) {
+  let s = escapeHtml(text);
+  // [label](url)
+  s = s.replace(
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    (_m, label, href) => {
+      const safeHref =
+        typeof href === 'string' && href.trim() ? href.trim() : '#';
+      return `<a href="${escapeHtml(safeHref)}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+    },
+  );
+  s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  // Single-asterisk italics after bold so ** is not re-matched.
+  s = s.replace(/\*([^*]+)\*/g, '<em>$1</em>');
+  return s;
+}
+
+/**
+ * @param {string} md body without frontmatter
+ * @returns {string} HTML fragment
+ */
+export function legalMarkdownToHtml(md) {
+  const body = typeof md === 'string' ? md.replace(/\r\n/g, '\n').trim() : '';
+  if (!body) return '';
+
+  const lines = body.split('\n');
+  /** @type {string[]} */
+  const out = [];
+  /** @type {string[]} */
+  let para = [];
+  /** @type {string[]} */
+  let listItems = [];
+
+  function flushPara() {
+    if (!para.length) return;
+    const text = para.join(' ').trim();
+    para = [];
+    if (text) out.push(`<p>${renderInline(text)}</p>`);
+  }
+
+  function flushList() {
+    if (!listItems.length) return;
+    out.push('<ul>');
+    for (const item of listItems) {
+      out.push(`<li>${renderInline(item)}</li>`);
+    }
+    out.push('</ul>');
+    listItems = [];
+  }
+
+  for (const raw of lines) {
+    const line = raw.trimEnd();
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      flushPara();
+      flushList();
+      continue;
+    }
+
+    const h2 = trimmed.match(/^##\s+(.+)$/);
+    if (h2) {
+      flushPara();
+      flushList();
+      out.push(`<h2>${renderInline(h2[1])}</h2>`);
+      continue;
+    }
+
+    const h3 = trimmed.match(/^###\s+(.+)$/);
+    if (h3) {
+      flushPara();
+      flushList();
+      out.push(`<h3>${renderInline(h3[1])}</h3>`);
+      continue;
+    }
+
+    const li = trimmed.match(/^-\s+(.+)$/);
+    if (li) {
+      flushPara();
+      listItems.push(li[1]);
+      continue;
+    }
+
+    flushList();
+    para.push(trimmed);
+  }
+
+  flushPara();
+  flushList();
+  return out.join('\n');
+}

--- a/scripts/lib/legalMarkdownToHtml.test.mjs
+++ b/scripts/lib/legalMarkdownToHtml.test.mjs
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  extractLegalLastUpdated,
+  legalMarkdownToHtml,
+  stripLegalFrontmatter,
+} from './legalMarkdownToHtml.mjs';
+
+describe('legalMarkdownToHtml', () => {
+  it('strips title + last-updated frontmatter', () => {
+    const md = `# Terms of Service
+
+**Last updated:** May 8, 2026
+
+Hello world.
+`;
+    assert.equal(stripLegalFrontmatter(md).trim(), 'Hello world.');
+    assert.equal(extractLegalLastUpdated(md), 'May 8, 2026');
+  });
+
+  it('renders headings, lists, links, and bold', () => {
+    const html = legalMarkdownToHtml(`## Accounts
+You must create an account.
+
+### Nested
+- **Bold** item
+- See [Phish.Net](https://phish.net).
+`);
+    assert.match(html, /<h2>Accounts<\/h2>/);
+    assert.match(html, /<h3>Nested<\/h3>/);
+    assert.match(html, /<strong>Bold<\/strong>/);
+    assert.match(html, /href="https:\/\/phish\.net"/);
+    assert.match(html, /rel="noopener noreferrer"/);
+  });
+});

--- a/scripts/prerender-seo.mjs
+++ b/scripts/prerender-seo.mjs
@@ -8,7 +8,8 @@
  * #928: tour-stats SEO slugs fetch `public_tour_stats/{slug}` (REST) and embed
  * bustout/frequency facts + FAQ/ItemList JSON-LD for crawlers.
  * Boot shells: `dashboard` / `spa-boot` use `dist/app.html`;
- * `login` uses HTML-first `dist/login.html` (#892).
+ * `login` uses HTML-first `dist/login.html` (#892);
+ * `/privacy` + `/terms` use zero-JS legal door shells (#916).
  */
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -20,12 +21,12 @@ import {
   LOGIN_BOOT_SHELL_REL_PATH,
   PRERENDER_ROUTES,
   buildDashboardBootShellHtml,
+  buildLegalBootDocumentHtml,
   buildLoginBootShellHtml,
   injectDashboardBootModulepreloads,
   injectLoginBootModulepreloads,
   injectPrerenderHtml,
   injectTourStatsBootModulepreloads,
-  injectLegalBootModulepreloads,
   prerenderOutputRelPath,
 } from './seo-prerender-lib.mjs';
 import { fetchFirestoreRestDocument } from './lib/firestoreRestDecode.mjs';
@@ -114,6 +115,9 @@ async function loadTourStatsEnrichment(route) {
 }
 
 for (const route of PRERENDER_ROUTES) {
+  // Legal door shells are written separately (zero-JS; #916) — not marketing CSR.
+  if (isLegalPrerenderRoute(route.path)) continue;
+
   const shell = marketingShell;
   const enrichment = await loadTourStatsEnrichment(route);
   let html = injectPrerenderHtml(shell, route, enrichment);
@@ -124,10 +128,6 @@ for (const route of PRERENDER_ROUTES) {
   if (isTourStatsPrerenderRoute(route.path)) {
     html = injectTourStatsBootModulepreloads(html, distDir);
   }
-  // /privacy + /terms: preload legal page + markdown closure (#908 soak).
-  if (isLegalPrerenderRoute(route.path)) {
-    html = injectLegalBootModulepreloads(html, distDir, route.path);
-  }
   const rel = prerenderOutputRelPath(route.path);
   const outPath = join(distDir, rel);
   mkdirSync(dirname(outPath), { recursive: true });
@@ -135,6 +135,18 @@ for (const route of PRERENDER_ROUTES) {
   const factNote = enrichment.factsHtml ? ' +aggregate-facts' : '';
   console.log(
     `prerender-seo: wrote dist/${rel} (${Buffer.byteLength(html, 'utf8')} bytes)${factNote}`,
+  );
+}
+
+// HTML-first legal door (#916): full policy body in first HTML, no module graph.
+for (const legalPath of ['/privacy', '/terms']) {
+  const html = buildLegalBootDocumentHtml(legalPath, { rootDir: root });
+  const rel = prerenderOutputRelPath(legalPath);
+  const outPath = join(distDir, rel);
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, html, 'utf8');
+  console.log(
+    `prerender-seo: wrote dist/${rel} (HTML-first legal door, ${Buffer.byteLength(html, 'utf8')} bytes)`,
   );
 }
 
@@ -149,7 +161,7 @@ console.log(
   `prerender-seo: wrote dist/${APP_BOOT_SHELL_REL_PATH} (branded #root boot shell + modulepreload)`,
 );
 
-// Light spa boot: same branded skeleton, no DashboardRoute preload — legal,
+// Light spa boot: same branded skeleton, no DashboardRoute preload —
 // public profile, bare /join, etc. must not contend for the dashboard graph.
 const lightBootPath = join(distDir, LIGHT_SPA_BOOT_SHELL_REL_PATH);
 mkdirSync(dirname(lightBootPath), { recursive: true });
@@ -169,5 +181,5 @@ console.log(
 );
 
 console.log(
-  `prerender-seo: OK (${PRERENDER_ROUTES.length} routes + app boot + light spa + login boot)`,
+  `prerender-seo: OK (${PRERENDER_ROUTES.length} routes + legal door + app boot + light spa + login boot)`,
 );

--- a/scripts/seo-prerender-lib.mjs
+++ b/scripts/seo-prerender-lib.mjs
@@ -25,6 +25,12 @@ import {
   buildLoginBootShellMarkup,
 } from './login-boot-shell.mjs';
 import {
+  LEGAL_BOOT_BODY_MARKER,
+  LEGAL_BOOT_SHELL_MARKER,
+  buildLegalBootDocumentHtml,
+  buildLegalBootShellMarkup,
+} from './legal-boot-shell.mjs';
+import {
   MARKETING_BOOT_SHELL_MARKER,
   buildMarketingBootShellMarkup,
 } from './marketing-boot-shell.mjs';
@@ -51,6 +57,8 @@ export {
   DASHBOARD_BOOT_SHELL_MARKER,
   LOGIN_BOOT_SHELL_MARKER,
   LOGIN_FORM_SHELL_MARKER,
+  LEGAL_BOOT_SHELL_MARKER,
+  LEGAL_BOOT_BODY_MARKER,
   MARKETING_BOOT_SHELL_MARKER,
   DASHBOARD_BOOT_PRELOAD_MARKER,
   LOGIN_BOOT_PRELOAD_MARKER,
@@ -61,6 +69,8 @@ export {
   buildDashboardBootShellMarkup,
   buildLoginBootShellHtml,
   buildLoginBootShellMarkup,
+  buildLegalBootDocumentHtml,
+  buildLegalBootShellMarkup,
   buildMarketingBootShellMarkup,
   injectDashboardBootModulepreloads,
   injectLoginBootModulepreloads,

--- a/scripts/seo-strip-body.mjs
+++ b/scripts/seo-strip-body.mjs
@@ -49,7 +49,7 @@ export const APP_BOOT_SHELL_REL_PATH = 'dashboard/index.html';
 /**
  * Branded skeleton without a fat route modulepreload — for public profile /
  * bare-join / password-reset hard opens that must not download DashboardRoute.
- * Legal (`/privacy`, `/terms`) ships on the marketing document (#908).
+ * Legal (`/privacy`, `/terms`) ships as zero-JS HTML-first door shells (#916).
  */
 export const LIGHT_SPA_BOOT_SHELL_REL_PATH = 'spa-boot/index.html';
 

--- a/scripts/verify-seo-prerender.mjs
+++ b/scripts/verify-seo-prerender.mjs
@@ -27,20 +27,21 @@ import {
   LOGIN_BOOT_SHELL_MARKER,
   LOGIN_BOOT_SHELL_REL_PATH,
   LOGIN_FORM_SHELL_MARKER,
+  LEGAL_BOOT_BODY_MARKER,
+  LEGAL_BOOT_SHELL_MARKER,
   MARKETING_BOOT_SHELL_MARKER,
   PRERENDER_ROUTES,
   SPLASH_BOOT_PRELOAD_MARKER,
   TOUR_STATS_BOOT_PRELOAD_MARKER,
-  LEGAL_BOOT_PRELOAD_MARKER,
   buildDashboardBootShellHtml,
   buildFixtureShellHtml,
+  buildLegalBootDocumentHtml,
   buildLoginBootShellHtml,
   injectDashboardBootModulepreloads,
   injectLoginBootModulepreloads,
   injectPrerenderHtml,
   injectSplashBootModulepreloads,
   injectTourStatsBootModulepreloads,
-  injectLegalBootModulepreloads,
   prerenderOutputRelPath,
 } from './seo-prerender-lib.mjs';
 import { TOUR_STATS_SEO_FACT_SLUGS } from '../src/shared/config/seoRoutes.js';
@@ -106,11 +107,11 @@ assert(
 );
 assert(
   PRERENDER_ROUTES.some((r) => r.path === '/privacy'),
-  'expected /privacy prerender entry (#908)',
+  'expected /privacy prerender entry (#916 legal door)',
 );
 assert(
   PRERENDER_ROUTES.some((r) => r.path === '/terms'),
-  'expected /terms prerender entry (#908)',
+  'expected /terms prerender entry (#916 legal door)',
 );
 assert(
   PRERENDER_ROUTES.every((r) => !r.path.startsWith('/dashboard')),
@@ -120,10 +121,54 @@ assert(
 const titles = new Set(PRERENDER_ROUTES.map((r) => r.title));
 assert(titles.size === PRERENDER_ROUTES.length, 'each prerender route needs a unique title');
 
+function isLegalPrerenderRoute(path) {
+  return path === '/privacy' || path === '/terms';
+}
+
 const shell = buildFixtureShellHtml();
 for (const route of PRERENDER_ROUTES) {
+  // Legal routes use zero-JS door shells — not marketing CSR overlay (#916).
+  if (isLegalPrerenderRoute(route.path)) continue;
   const html = injectPrerenderHtml(shell, route);
   assertRouteHtml(html, route, `fixture ${route.path}`);
+}
+
+// HTML-first legal door fixtures (no marketing/app/login module graph).
+for (const legalPath of ['/privacy', '/terms']) {
+  const route = PRERENDER_ROUTES.find((r) => r.path === legalPath);
+  const html = buildLegalBootDocumentHtml(legalPath, { rootDir: root });
+  const label = `legal door fixture ${legalPath}`;
+  assert(html.includes(`<title>${route.title}</title>`), `${label}: missing title`);
+  assert(html.includes(route.description), `${label}: missing description`);
+  assert(html.includes(route.h1), `${label}: missing H1`);
+  assert(html.includes('application/ld+json'), `${label}: missing JSON-LD`);
+  assert(
+    html.includes(`${LEGAL_BOOT_SHELL_MARKER}="true"`),
+    `${label}: missing legal boot shell marker`,
+  );
+  assert(
+    html.includes(`${LEGAL_BOOT_BODY_MARKER}="true"`),
+    `${label}: missing legal body marker`,
+  );
+  assert(html.includes('rel="icon"'), `${label}: missing favicon link`);
+  assert(html.includes(route.canonicalUrl), `${label}: missing canonical`);
+  assert(
+    !/type="module"/.test(html),
+    `${label}: must not include module scripts (#916)`,
+  );
+  assert(
+    !/\/assets\/(marketing|app|login)-/.test(html),
+    `${label}: must not reference marketing/app/login entry chunks`,
+  );
+  assert(
+    !/\/assets\/firebase/.test(html),
+    `${label}: must not reference firebase chunks`,
+  );
+  const bodyPhrase =
+    legalPath === '/terms'
+      ? 'entertainment platform where players predict setlists'
+      : 'what information we collect, why we collect it';
+  assert(html.includes(bodyPhrase), `${label}: missing full policy body excerpt`);
 }
 
 assert(
@@ -329,6 +374,8 @@ const distHowItWorks = join(root, 'dist', 'how-it-works', 'index.html');
 // Only validate dist when post-build prerender has clearly run (subdir artifact).
 if (existsSync(distIndex) && existsSync(distHowItWorks)) {
   for (const route of PRERENDER_ROUTES) {
+    // Legal door shells asserted separately (#916) — not marketing CSR overlay.
+    if (isLegalPrerenderRoute(route.path)) continue;
     const outPath = join(root, 'dist', prerenderOutputRelPath(route.path));
     assert(existsSync(outPath), `dist missing ${prerenderOutputRelPath(route.path)} — run npm run build`);
     const html = readFileSync(outPath, 'utf8');
@@ -471,29 +518,46 @@ if (existsSync(distIndex) && existsSync(distHowItWorks)) {
     'marketing routes must include marketing boot overlay',
   );
 
-  // Legal pages: marketing document, not spa-boot / app SPA (#908).
+  // Legal door: zero-JS HTML-first shells (#916) — not marketing CSR / spa-boot.
   for (const legalPath of ['privacy', 'terms']) {
     const legalHtmlPath = join(root, 'dist', legalPath, 'index.html');
     assert(existsSync(legalHtmlPath), `dist missing ${legalPath}/index.html — run npm run build`);
     const legalHtml = readFileSync(legalHtmlPath, 'utf8');
     assert(
-      /\/assets\/marketing-[^"]+\.js/.test(legalHtml),
-      `prerendered /${legalPath} must boot the marketing entry (#908)`,
+      legalHtml.includes(`${LEGAL_BOOT_SHELL_MARKER}="true"`),
+      `prerendered /${legalPath} must include legal boot shell marker (#916)`,
+    );
+    assert(
+      legalHtml.includes(`${LEGAL_BOOT_BODY_MARKER}="true"`),
+      `prerendered /${legalPath} must include legal body in first HTML (#916)`,
+    );
+    assert(
+      !/type="module"/.test(legalHtml),
+      `prerendered /${legalPath} must not include module scripts (#916)`,
+    );
+    assert(
+      !/\/assets\/marketing-[^"]+\.js/.test(legalHtml),
+      `prerendered /${legalPath} must not boot the marketing entry (#916)`,
     );
     assert(
       !/\/assets\/app-[^"]+\.js/.test(legalHtml),
       `prerendered /${legalPath} must not boot the authenticated SPA entry`,
     );
     assert(
-      !/\/assets\/firebase[^"]*\.js/.test(legalHtml),
-      `prerendered /${legalPath} must not modulepreload firebase`,
+      !/\/assets\/login-[^"]+\.js/.test(legalHtml),
+      `prerendered /${legalPath} must not boot the login entry`,
     );
-    const pageChunk =
-      legalPath === 'terms' ? 'TermsOfServicePage-' : 'PrivacyPolicyPage-';
     assert(
-      legalHtml.includes(LEGAL_BOOT_PRELOAD_MARKER) &&
-        legalHtml.includes(pageChunk),
-      `prerendered /${legalPath} must modulepreload ${pageChunk} (#908)`,
+      !/\/assets\/firebase[^"]*\.js/.test(legalHtml),
+      `prerendered /${legalPath} must not reference firebase`,
+    );
+    const bodyPhrase =
+      legalPath === 'terms'
+        ? 'entertainment platform where players predict setlists'
+        : 'what information we collect, why we collect it';
+    assert(
+      legalHtml.includes(bodyPhrase),
+      `prerendered /${legalPath} must include full policy body (#916)`,
     );
   }
 

--- a/src/app/MarketingApp.jsx
+++ b/src/app/MarketingApp.jsx
@@ -22,16 +22,16 @@ const PhishSetlistPredictionGamePage = lazy(
 const PublicTourStatsPage = lazy(
   () => import('../pages/marketing/PublicTourStatsPage'),
 );
-const PrivacyPolicyPage = lazy(() => import('../pages/legal/PrivacyPolicyPage'));
-const TermsOfServicePage = lazy(() => import('../pages/legal/TermsOfServicePage'));
 
 /**
- * Paths that leave the marketing document (#832 / #892).
- * `/login` → HTML-first auth door (`login.html`); other app routes → `app.html`.
- * `/privacy` + `/terms` stay here (#908) — no Auth/Firebase on legal cold open.
+ * Paths that leave the marketing document (#832 / #892 / #916).
+ * `/login` → HTML-first auth door (`login.html`);
+ * `/privacy` + `/terms` → zero-JS legal door shells;
+ * other app routes → `app.html`.
  */
-function isAppDocumentPath(pathname) {
+function isLeaveMarketingDocumentPath(pathname) {
   if (typeof pathname !== 'string' || !pathname) return false;
+  if (pathname === '/privacy' || pathname === '/terms') return true;
   const prefixes = [
     '/login',
     '/dashboard',
@@ -48,16 +48,19 @@ function isAppDocumentPath(pathname) {
 
 /**
  * Full navigation out of the marketing document.
- * Used when a marketing-shell Link targets login / Firebase-backed routes.
+ * Used when a marketing-shell Link targets login / legal / Firebase-backed routes.
  */
-function LoadAppDocument() {
+function LoadLeaveMarketingDocument() {
   useEffect(() => {
     const { pathname, search, hash } = window.location;
-    if (!isAppDocumentPath(pathname)) return;
+    if (!isLeaveMarketingDocumentPath(pathname)) return;
     window.location.replace(`${pathname}${search}${hash}`);
   }, []);
 
-  if (typeof window !== 'undefined' && !isAppDocumentPath(window.location.pathname)) {
+  if (
+    typeof window !== 'undefined' &&
+    !isLeaveMarketingDocumentPath(window.location.pathname)
+  ) {
     return <Navigate to="/" replace />;
   }
 
@@ -148,25 +151,8 @@ export default function MarketingApp() {
             </Suspense>
           }
         />
-        {/* Legal: marketing document, no Auth (#908) — snappy from HTML-first /login. */}
-        <Route
-          path="/privacy"
-          element={
-            <Suspense fallback={<MarketingRouteFallback />}>
-              <PrivacyPolicyPage />
-            </Suspense>
-          }
-        />
-        <Route
-          path="/terms"
-          element={
-            <Suspense fallback={<MarketingRouteFallback />}>
-              <TermsOfServicePage />
-            </Suspense>
-          }
-        />
-        {/* App-document surfaces — full load so Firebase/AuthProvider can boot. */}
-        <Route path="*" element={<LoadAppDocument />} />
+        {/* Legal + app-document surfaces — hard leave to legal door / app / login (#916). */}
+        <Route path="*" element={<LoadLeaveMarketingDocument />} />
       </Routes>
     </>
   );

--- a/src/features/landing/model/marketingNav.js
+++ b/src/features/landing/model/marketingNav.js
@@ -12,8 +12,11 @@ export const MARKETING_PRIMARY_NAV = [
   { to: '/about', label: 'About' },
 ];
 
-/** Legal links — footer only. */
+/**
+ * Legal links — footer only.
+ * `hard: true` → `<a href>` so hosting serves the zero-JS legal door (#916).
+ */
 export const MARKETING_LEGAL_NAV = [
-  { to: '/privacy', label: 'Privacy Policy' },
-  { to: '/terms', label: 'Terms of Service' },
+  { to: '/privacy', label: 'Privacy Policy', hard: true },
+  { to: '/terms', label: 'Terms of Service', hard: true },
 ];

--- a/src/features/landing/ui/MarketingSiteNav.jsx
+++ b/src/features/landing/ui/MarketingSiteNav.jsx
@@ -130,16 +130,26 @@ export function MarketingFooterNav({ className = '', variant = 'all' }) {
       aria-label={variant === 'legal' ? 'Legal' : 'Site'}
       className={`flex flex-wrap items-center justify-center gap-x-3 gap-y-1 ${className}`.trim()}
     >
-      {links.map(({ to, label }) => (
-        <Link
-          key={to}
-          to={to}
-          onClick={scrollMarketingToTop}
-          className={`text-sm ${FOOTER_LINK_ON_DARK}`}
-        >
-          {label}
-        </Link>
-      ))}
+      {links.map(({ to, label, hard }) =>
+        hard ? (
+          <a
+            key={to}
+            href={to}
+            className={`text-sm ${FOOTER_LINK_ON_DARK}`}
+          >
+            {label}
+          </a>
+        ) : (
+          <Link
+            key={to}
+            to={to}
+            onClick={scrollMarketingToTop}
+            className={`text-sm ${FOOTER_LINK_ON_DARK}`}
+          >
+            {label}
+          </Link>
+        ),
+      )}
     </nav>
   );
 }

--- a/src/features/legal/ui/LegalPageLayout.jsx
+++ b/src/features/legal/ui/LegalPageLayout.jsx
@@ -7,8 +7,9 @@ import { resolveLegalBackNav } from '../model/legalBackNav';
 
 /**
  * Shared layout for /privacy and /terms — full-screen, public, no auth.
- * Owns ambient background so legal works on the marketing document (#908)
- * without RootAppShell, and still looks correct on soft-nav from the app SPA.
+ * Owns ambient background so soft-nav from the app SPA (Profile/account)
+ * looks correct without RootAppShell. Hard-nav cold open uses the zero-JS
+ * legal door shell (#916).
  *
  * @param {{
  *   title: string,

--- a/src/marketingMain.jsx
+++ b/src/marketingMain.jsx
@@ -17,12 +17,10 @@ try {
   if (typeof window !== 'undefined') {
     const path = window.location.pathname || ''
     // Public marketing surfaces that must stay reachable for returning
-    // sessions — do not bounce them to /dashboard (#853 tour-stats, #908 legal).
+    // sessions — do not bounce them to /dashboard (#853 tour-stats).
+    // Legal (`/privacy`|/terms`) is a separate zero-JS document (#916).
     const stayOnMarketingDocument =
-      path === '/tour-stats' ||
-      path.startsWith('/tour-stats/') ||
-      path === '/privacy' ||
-      path === '/terms'
+      path === '/tour-stats' || path.startsWith('/tour-stats/')
     if (
       !stayOnMarketingDocument &&
       window.localStorage?.getItem(PERSISTED_SESSION_HINT_STORAGE_KEY) === '1'

--- a/src/pages/legal/PrivacyPolicyPage.jsx
+++ b/src/pages/legal/PrivacyPolicyPage.jsx
@@ -10,7 +10,7 @@ import { getPrerenderRoute } from '../../shared/config/seoRoutes';
 
 const route = getPrerenderRoute('/privacy');
 
-/** Public route — marketing document (#908); soft-nav compat on app SPA. */
+/** Soft-nav compat on app SPA; hard-nav cold open uses HTML-first legal door (#916). */
 export default function PrivacyPolicyPage() {
   const jsonLd = route.buildJsonLd();
   const resumeKind = peekAuthDoorResume();

--- a/src/pages/legal/TermsOfServicePage.jsx
+++ b/src/pages/legal/TermsOfServicePage.jsx
@@ -10,7 +10,7 @@ import { getPrerenderRoute } from '../../shared/config/seoRoutes';
 
 const route = getPrerenderRoute('/terms');
 
-/** Public route — marketing document (#908); soft-nav compat on app SPA. */
+/** Soft-nav compat on app SPA; hard-nav cold open uses HTML-first legal door (#916). */
 export default function TermsOfServicePage() {
   const jsonLd = route.buildJsonLd();
   const resumeKind = peekAuthDoorResume();

--- a/src/shared/lib/routeGroup.js
+++ b/src/shared/lib/routeGroup.js
@@ -6,6 +6,7 @@
  * @returns {
  *   | 'splash'
  *   | 'login'
+ *   | 'legal'
  *   | 'marketing'
  *   | 'tour_stats'
  *   | 'invite_join'
@@ -19,6 +20,7 @@ export function resolveRouteGroup(pathname) {
   if (typeof pathname !== 'string' || !pathname) return 'other';
   if (pathname === '/') return 'splash';
   if (pathname === '/login' || pathname.startsWith('/login/')) return 'login';
+  if (pathname === '/privacy' || pathname === '/terms') return 'legal';
   if (
     pathname === '/how-it-works' ||
     pathname.startsWith('/how-it-works/') ||
@@ -27,9 +29,7 @@ export function resolveRouteGroup(pathname) {
     pathname === '/phish-setlist-prediction-game' ||
     pathname.startsWith('/phish-setlist-prediction-game/') ||
     pathname === '/about' ||
-    pathname.startsWith('/about/') ||
-    pathname === '/privacy' ||
-    pathname === '/terms'
+    pathname.startsWith('/about/')
   ) {
     return 'marketing';
   }

--- a/src/shared/lib/routeGroup.test.js
+++ b/src/shared/lib/routeGroup.test.js
@@ -23,9 +23,12 @@ describe('resolveRouteGroup', () => {
     expect(resolveRouteGroup('/tour-stats/song/foo')).toBe('tour_stats');
   });
 
+  it('maps legal door paths (#916)', () => {
+    expect(resolveRouteGroup('/privacy')).toBe('legal');
+    expect(resolveRouteGroup('/terms')).toBe('legal');
+  });
+
   it('maps unknown paths to other', () => {
-    expect(resolveRouteGroup('/privacy')).toBe('marketing');
-    expect(resolveRouteGroup('/terms')).toBe('marketing');
     expect(resolveRouteGroup('')).toBe('other');
     expect(resolveRouteGroup(undefined)).toBe('other');
   });

--- a/vercel.json
+++ b/vercel.json
@@ -60,6 +60,14 @@
       "destination": "/login/index.html"
     },
     {
+      "source": "/privacy",
+      "destination": "/privacy/index.html"
+    },
+    {
+      "source": "/terms",
+      "destination": "/terms/index.html"
+    },
+    {
       "source": "/user/(.*)",
       "destination": "/spa-boot/index.html"
     },

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+import { buildLegalBootDocumentHtml } from './scripts/legal-boot-shell.mjs';
 import { buildLoginBootShellMarkup } from './scripts/login-boot-shell.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,7 +13,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 /** Paths that must boot the authenticated SPA document (`app.html`) in dev (#832). */
 const APP_DOCUMENT_PATH_PREFIXES = [
   // `/login` is its own HTML-first document (#892) — see isLoginDocumentPath.
-  // `/privacy` + `/terms` are marketing (#908) — not app-document.
+  // `/privacy` + `/terms` are zero-JS legal door shells (#916) — see isLegalDocumentPath.
   '/dashboard',
   '/setup',
   '/user/',
@@ -32,6 +33,15 @@ function isAppDocumentPath(pathname) {
 
 function isLoginDocumentPath(pathname) {
   return pathname === '/login' || pathname.startsWith('/login/');
+}
+
+function isLegalDocumentPath(pathname) {
+  return (
+    pathname === '/privacy' ||
+    pathname === '/privacy/' ||
+    pathname === '/terms' ||
+    pathname === '/terms/'
+  );
 }
 
 function rewriteAppDocumentRequest(req, _res, next) {
@@ -60,13 +70,46 @@ function rewriteAppDocumentRequest(req, _res, next) {
     next();
     return;
   }
+  // Legal door is served by legalDocumentDevMiddleware (not marketing/app).
+  if (isLegalDocumentPath(pathname)) {
+    next();
+    return;
+  }
   // Serve `app.html` for dashboard/auth hard opens so they don't fall
   // through to the marketing document (which would location.replace-loop) (#832).
-  // Public `/tour-stats*` (#853) and `/privacy`+`/terms` (#908) are marketing.
+  // Public `/tour-stats*` (#853) stays marketing.
   if (isAppDocumentPath(pathname)) {
     req.url = `/app.html${query}`;
   }
   next();
+}
+
+/**
+ * Dev: serve zero-JS HTML-first legal shells (#916).
+ * Preview uses prerendered `dist/privacy|terms/index.html` via rewrite below.
+ */
+function legalDocumentDevMiddleware() {
+  return function legalDocumentDevMiddlewareHandler(req, res, next) {
+    const raw = req.url || '';
+    const pathname = raw.split('?')[0];
+    if (!isLegalDocumentPath(pathname)) {
+      next();
+      return;
+    }
+    const pathKey = pathname.replace(/\/$/, '') || pathname;
+    if (pathKey !== '/privacy' && pathKey !== '/terms') {
+      next();
+      return;
+    }
+    try {
+      const html = buildLegalBootDocumentHtml(pathKey, { rootDir: __dirname });
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.statusCode = 200;
+      res.end(html);
+    } catch (err) {
+      next(err);
+    }
+  };
 }
 
 /**
@@ -126,6 +169,8 @@ function appDocumentDevMiddleware() {
   return {
     name: 'app-document-dev-middleware',
     configureServer(server) {
+      // Legal door before SPA fallback so /privacy|/terms never hit marketingMain (#916).
+      server.middlewares.use(legalDocumentDevMiddleware());
       server.middlewares.use(rewriteAppDocumentRequest);
     },
     // qa:chunks / `vite preview` need the same rewrites as `npm run dev`.
@@ -133,8 +178,8 @@ function appDocumentDevMiddleware() {
       const distDir = server.config.build?.outDir
         ? path.resolve(server.config.root || process.cwd(), server.config.build.outDir)
         : path.join(__dirname, 'dist');
-      // Prerender HTML before app-doc rewrite so /tour-stats stays marketing (#853)
-      // and /login serves dist/login/index.html (#892).
+      // Prerender HTML before app-doc rewrite so /tour-stats stays marketing (#853),
+      // /login serves dist/login/index.html (#892), and legal door shells win (#916).
       server.middlewares.use(rewritePrerenderedMarketingHtml(distDir));
       server.middlewares.use(rewriteAppDocumentRequest);
     },


### PR DESCRIPTION
Closes #916

## Summary
- Ship zero-JS HTML-first `/privacy` + `/terms` shells with full policy body in first HTML (no marketing CSR / Auth / Firebase)
- Vercel rewrites + Vite dev middleware; marketing footer hard-navs; App SPA soft routes kept for Profile
- Docs + SemVer **1.61.0**; epic #889 close path includes deferring Phase 3 warm polish (#895)

## Test plan
- [ ] `npm run build && npm run verify:seo-prerender` — legal shells have `data-legal-boot-shell` + body, no `marketing-*.js`
- [ ] Local preview: `/login?mode=signup` → Terms / Privacy paints readable body immediately; “Back to create account” works
- [ ] Marketing footer Privacy/Terms hard-nav to legal door
- [ ] Profile/account soft-nav to legal still works on app SPA
- [ ] View Source on `/terms` / `/privacy` shows full article (not progress-only `#root`)


Made with [Cursor](https://cursor.com)