### PR TITLE
fix(tour-stats): above-fold copy + Bustouts tooltip (#965)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Public API is declared in [`docs/API.md`](docs/API.md).
 
 ---
 
+## [1.61.2] — 2026-08-09
+
+### Changed
+- **Tour stats above-fold copy** — public `/tour-stats*` hero is one short lede (plus a compact hub Current/Archive line) so the tour filter sits in the first viewport; onboarding/SEO deep links move below the stats.
+
+### Fixed
+- **Tour stats Bustouts section tooltip** — restore the header InfoTooltip using the same copy as the dashboard Bustouts tile; keep the public #929 SEO description under the header.
+
+---
+
 ## [1.61.1] — 2026-08-09
 
 ### Fixed

--- a/content/marketing/README.md
+++ b/content/marketing/README.md
@@ -6,6 +6,7 @@ Editable reference copy for public marketing / SEO surfaces (not lifecycle comms
 |-----|---------------|--------|
 | [`942-content-ia-drafts.md`](./942-content-ia-drafts.md) | [#942](https://github.com/pat792/set-picks/issues/942) — [#937](https://github.com/pat792/set-picks/issues/937), [#940](https://github.com/pat792/set-picks/issues/940), [#941](https://github.com/pat792/set-picks/issues/941) | EiC-approved L0 draft. **#940/#941** v1.56.0; **#937** v1.56.1 |
 | [`944-chrome-rule-review.md`](./944-chrome-rule-review.md) | [#944](https://github.com/pat792/set-picks/issues/944) | **APPROVED** — editorial light / product dark; Scoring `surface="light"`; title tokens in `src/shared/ui/marketingEditorialChrome.js` |
+| [`tour-stats-above-fold-copy.md`](./tour-stats-above-fold-copy.md) | Tour Insights above-fold tighten | Shipped **v1.61.2** — short lede + filter up; SEO body stays in prerender |
 
 ## Chrome rule (short)
 

--- a/content/marketing/tour-stats-above-fold-copy.md
+++ b/content/marketing/tour-stats-above-fold-copy.md
@@ -1,0 +1,83 @@
+# Tour stats above-fold copy tighten
+
+**Status:** Implemented in `PublicTourStatsPanel` (v1.61.2)  
+**Date:** 2026-08-09  
+**Pipeline:** marketing-specialist → editor-in-chief (brand-systems voice check)  
+**Surface:** `/tour-stats*` public product/data page (dark chrome)  
+**Related:** Content IA [#942](https://github.com/pat792/set-picks/issues/942) (tour-stats owns trends, not game walkthrough); tour-stats SEO [#926](https://github.com/pat792/set-picks/issues/926)
+
+## Problem
+
+The public Tour Insights header stacked three dense paragraphs before the tour filter. On typical viewports the filter sat barely below the fold, so the page’s primary job—browse live tour aggregates—lost to SEO/onboarding prose.
+
+## Editorial brief
+
+| Goal | Guidance |
+|------|----------|
+| Job of first viewport | H1 + one short lede + tour filter |
+| Voice | Fan-to-fan, direct; no corporate “window on…” throat-clearing |
+| SEO | Keep keyword density in meta + prerender `seoRoutes.paragraphs`; do not dump crawler essays into the interactive chrome |
+| IA | Deep-link how-it-works / keyword / scoring below the data, not above the filter |
+| Hub vs slug | Hub keeps current-tour + Sphere archive links as a single compact line; slug pages skip that line |
+
+## Approved UI copy
+
+### Eyebrow / H1
+
+Unchanged: `Tour Insights` · route `h1` from `seoRoutes` / live tour label.
+
+### Lede (all `/tour-stats*`)
+
+> Phish tour setlist statistics: most-played songs, song frequency, bustouts by tour, and gap highlights that help you stay sharp between shows—updated every night the band plays live.
+
+### Hub-only line (after lede, before filter)
+
+> **Current:** [2026 Summer Tour setlist statistics](/tour-stats/2026-summer-tour) · **Archive:** [2026 Sphere](/tour-stats/2026-sphere)
+
+(Labels stay dynamic from the default tour slug when available.)
+
+### Secondary note (below stats, above bottom CTA — not in the hero)
+
+> Tour-wide trends only—not a night-by-night archive. Playing unlocks personal stats. [How it works](/how-it-works) · [Phish setlist prediction game](/phish-setlist-prediction-game)
+
+### Bottom CTA row
+
+Unchanged intent: scoring deep link + “Make picks for this tour”.
+
+## Prerender / meta
+
+`seoRoutes` hub/slug `paragraphs` + meta descriptions stay keyword-rich for the **initial HTML** shell (`injectPrerenderHtml` → `#root` main).
+
+### SEO review (post-ship, 2026-08-09) — EiC / marketing-specialist
+
+**Pipeline gap on first pass:** marketing-specialist + EiC were skimmed; `comms-drafter` was the wrong squad skill (lifecycle templates, not marketing SEO). `docs/SEO_GEO_PLAYBOOK.md` §3 stats-intent (S1–S3) was not checked before implementing.
+
+**Architecture fact that matters:** prerender paragraphs live in `#root`, and React `createRoot` **replaces** that node on mount (`seo-prerender-lib.mjs`). Googlebot-with-JS therefore indexes the **CSR** chrome + `TourStatsView`, not the long prerender essay alone. Leaving `seoRoutes.paragraphs` untouched is necessary but **not sufficient**.
+
+| Still strong after tighten | Weakened / dropped from visible CSR |
+|----------------------------|-------------------------------------|
+| Title / meta / JSON-LD (Helmet + prerender) | “by tour (summer, fall, Sphere…)” phrasing |
+| H1: Phish / tour setlist statistics | Explicit “song frequency” |
+| Short lede: most-played, bustouts, gap highlights, nightly refresh | Longer “sharpen picks / high-gap songs due” intent copy |
+| Public `TourStatsView` H2s + aggregates (frequency, bustouts, gaps) | Hub prose that restated unique songs + 30+ gap |
+| Hub Current → summer + Archive → Sphere internal links | — |
+| Below-fold deep links to HIW + keyword page | — |
+| `llms.txt` tour-stats lines | — |
+
+**Verdict:** Above-fold UX fix stands. Do **not** restore three dense paragraphs. **Do** restore S1–S3 phrases into the single lede so post-render DOM still matches stats-intent queries.
+
+### Amended lede (applied)
+
+> Phish tour setlist statistics: most-played songs, song frequency, bustouts by tour, and gap highlights that help you stay sharp between shows—updated every night the band plays live.
+
+Keeps S1–S3 phrases + the original “stay sharp” / sharpen-picks intent. Still one sentence; filter stays above the fold. Meta/`seoRoutes.paragraphs` unchanged.
+
+## Implementation checklist
+
+- [x] Draft on disk (`content/marketing/tour-stats-above-fold-copy.md`)
+- [x] `PublicTourStatsPanel.jsx` — short hero; filter up; secondary note relocated
+- [x] `content/marketing/README.md` index row
+- [x] PATCH SemVer + CHANGELOG (`1.61.2`)
+- [x] SEO review vs playbook S1–S3 + prerender/`#root` replace behavior
+- [x] Apply amended lede (Phish + song frequency + by tour + stay sharp)
+- [x] Bustouts section: restore header tooltip (`TILE_DEFS.bustouts.long`); keep public SEO body under H2 (#929)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "setlistpickem",
   "private": true,
-  "version": "1.61.1",
+  "version": "1.61.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/features/tour-stats/ui/PublicTourStatsPanel.jsx
+++ b/src/features/tour-stats/ui/PublicTourStatsPanel.jsx
@@ -44,51 +44,31 @@ export default function PublicTourStatsPanel({
 
   return (
     <div className="mx-auto w-full max-w-3xl px-4 py-10 sm:px-6 lg:px-8">
-      <header className="mb-8 space-y-3 text-center sm:text-left">
+      <header className="mb-5 space-y-2 text-center sm:text-left">
         <p className="text-[10px] font-black uppercase tracking-widest text-teal-400">
           Tour Insights
         </p>
         <h1 className="font-display text-3xl font-bold text-white sm:text-4xl">
           {h1}
         </h1>
-        <p className="text-base leading-relaxed text-slate-300">
-          Tour Insights is our window on the latest Phish tour setlist
-          statistics—most-played songs, bustouts by tour (summer, fall, Sphere,
-          and more), and gap highlights that help you sharpen picks. Flip the
-          tour filter, scan what&apos;s getting played, hunt the bustouts, and
-          check the high-gap songs that might be due. Statistics refresh every
-          night the band plays live, so the picture keeps getting sharper as the
-          tour rolls on.
+        <p className="text-base leading-snug text-slate-300">
+          Phish tour setlist statistics: most-played songs, song frequency,
+          bustouts by tour, and gap highlights that help you stay sharp between
+          shows—updated every night the band plays live.
         </p>
         {isHub ? (
-          <p className="text-sm leading-relaxed text-slate-300">
-            <strong className="font-semibold text-white">Current tour:</strong>{' '}
-            open{' '}
+          <p className="text-sm leading-snug text-slate-400">
+            <strong className="font-semibold text-slate-300">Current:</strong>{' '}
             <Link to={currentTourPath} className={LINK_ON_DARK}>
               {currentTourLabel} setlist statistics
-            </Link>{' '}
-            for unique songs, song frequency, and bustouts (30+ show gap). Looking
-            for the Sphere residency as an archive? Browse{' '}
-            <Link to={SPHERE_TOUR_SEO_PATH} className={LINK_ON_DARK}>
-              2026 Sphere tour statistics
             </Link>
-            .
+            {' · '}
+            <strong className="font-semibold text-slate-300">Archive:</strong>{' '}
+            <Link to={SPHERE_TOUR_SEO_PATH} className={LINK_ON_DARK}>
+              2026 Sphere
+            </Link>
           </p>
         ) : null}
-        <p className="text-sm leading-relaxed text-slate-400">
-          We&apos;re starting with Phish and building toward more bands soon.
-          Playing the game unlocks your personal stats as you rack up points and
-          compete with other setlist pickers. New to the format? See{' '}
-          <Link to="/how-it-works" className={LINK_ON_DARK}>
-            how it works
-          </Link>{' '}
-          or what makes this a{' '}
-          <Link to="/phish-setlist-prediction-game" className={LINK_ON_DARK}>
-            Phish setlist prediction game
-          </Link>
-          . This page stays focused on tour-wide song trends—not a full
-          night-by-night setlist archive.
-        </p>
       </header>
 
       {tours.length > 0 ? (
@@ -157,7 +137,19 @@ export default function PublicTourStatsPanel({
         surface="public"
       />
 
-      <div className="mt-10 flex flex-col items-center gap-4 border-t border-white/10 pt-8 sm:flex-row sm:items-center sm:justify-between">
+      <p className="mt-8 text-center text-sm leading-snug text-slate-400 sm:text-left">
+        Tour-wide trends only—not a night-by-night archive. Playing unlocks
+        personal stats.{' '}
+        <Link to="/how-it-works" className={LINK_ON_DARK}>
+          How it works
+        </Link>
+        {' · '}
+        <Link to="/phish-setlist-prediction-game" className={LINK_ON_DARK}>
+          Phish setlist prediction game
+        </Link>
+      </p>
+
+      <div className="mt-6 flex flex-col items-center gap-4 border-t border-white/10 pt-8 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-sm text-slate-400">
           Ready to compete on the next show? Or skim{' '}
           <Link to="/how-scoring-works" className={LINK_ON_DARK}>

--- a/src/features/tour-stats/ui/TourStatsView.jsx
+++ b/src/features/tour-stats/ui/TourStatsView.jsx
@@ -391,6 +391,9 @@ export default function TourStatsView({
         <TourStatsSectionCard
           title={bustoutsTitle}
           titleAs={sectionHeading}
+          // Match dashboard Bustouts tile tooltip (`TILE_DEFS.bustouts.long`).
+          // Public body paragraph below stays — #929 fan-language SEO copy.
+          definition={TILE_DEFS.bustouts.long}
           headerTone="bustout"
         >
           {isPublic ? (


### PR DESCRIPTION
Closes #965

## Summary
- Tighten public `/tour-stats*` hero to one SEO-safe lede (S1–S3 + “stay sharp between shows”) plus a compact hub Current/Archive line so the tour filter sits in the first viewport
- Move onboarding deep links below the stats; leave `seoRoutes` prerender/meta untouched
- Restore Bustouts section header InfoTooltip using the same copy as the dashboard Bustouts tile; keep the #929 public SEO description under the H2
- PATCH **1.61.2**

## Test plan
- [ ] `/tour-stats` hub: short lede + Current/Archive line; tour filter visible without scrolling on a typical laptop viewport
- [ ] `/tour-stats/2026-summer-tour`: short lede (no hub line); filter above fold
- [ ] Bustouts section: header `?` tooltip matches dashboard tile (“pre-show gap ≥ 30…”)
- [ ] Bustouts SEO body paragraph still renders under the header on public
- [ ] Song frequency / High gaps tooltips unchanged
- [ ] Meta title/description for tour-stats routes unchanged (View Source / Helmet)


Made with [Cursor](https://cursor.com)